### PR TITLE
Skip adding nameprefix for CRD

### DIFF
--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -31,6 +31,7 @@ var cmap = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 var deploy = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
 var statefulset = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 var foo = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{

--- a/pkg/transformers/prefixname_test.go
+++ b/pkg/transformers/prefixname_test.go
@@ -42,6 +42,14 @@ func TestPrefixNameRun(t *testing.T) {
 					"name": "cm2",
 				},
 			}),
+		resource.NewResId(crd, "crd"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1beta1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]interface{}{
+					"name": "crd",
+				},
+			}),
 	}
 	expected := resmap.ResMap{
 		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
@@ -58,6 +66,14 @@ func TestPrefixNameRun(t *testing.T) {
 				"kind":       "ConfigMap",
 				"metadata": map[string]interface{}{
 					"name": "someprefix-cm2",
+				},
+			}),
+		resource.NewResId(crd, "crd"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1beta1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]interface{}{
+					"name": "crd",
 				},
 			}),
 	}


### PR DESCRIPTION
For CRD
```
metadata:
  # name must match the spec fields below, and be in the form: <plural>.<group>
```

Considering a `kustomization.yaml` as
```
resources:
- crd.yaml
namePrefix: my-
```
The `metadata.name` of the CRD will be added a prefix `my-`. 
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: mysqlbackups.mysql.oracle.com
spec:
  group: mysql.oracle.com
  version: v1alpha1
  scope: Namespaced
  names:
    kind: MySQLBackup
    singular: mysqlbackup
    plural: mysqlbackups
```
becomes
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: my-mysqlbackups.mysql.oracle.com
spec:
  group: mysql.oracle.com
  version: v1alpha1
  scope: Namespaced
  names:
    kind: MySQLBackup
    singular: mysqlbackup
    plural: mysqlbackups
```