### PR TITLE
Add wordpress example for demonstrating variable reference

### DIFF
--- a/examples/wordpress/kustomization.yaml
+++ b/examples/wordpress/kustomization.yaml
@@ -1,0 +1,19 @@
+bases:
+  - wordpress
+  - mysql
+patches:
+  - patch.yaml
+namePrefix: demo-
+
+vars:
+  - name: WORDPRESS_SERVICE
+    objref:
+      kind: Service
+      name: wordpress
+      apiVersion: v1
+  - name: MYSQL_SERVICE
+    objref:
+      kind: Service
+      name: mysql
+      apiVersion: v1
+

--- a/examples/wordpress/mysql/deployment.yaml
+++ b/examples/wordpress/mysql/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        emptyDir: {}

--- a/examples/wordpress/mysql/kustomization.yaml
+++ b/examples/wordpress/mysql/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployment.yaml
+- service.yaml
+- secret.yaml

--- a/examples/wordpress/mysql/secret.yaml
+++ b/examples/wordpress/mysql/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-pass
+type: Opaque
+data:
+  # Default password is "admin".
+  password: YWRtaW4=

--- a/examples/wordpress/mysql/service.yaml
+++ b/examples/wordpress/mysql/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql

--- a/examples/wordpress/patch.yaml
+++ b/examples/wordpress/patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: init-command
+        image: debian
+        command:
+        - "echo $(WORDPRESS_SERVICE)"
+        - "echo $(MYSQL_SERVICE)"
+      containers:
+      - name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password

--- a/examples/wordpress/wordpress/deployment.yaml
+++ b/examples/wordpress/wordpress/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - image: wordpress:4.8-apache
+        name: wordpress
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        emptyDir: {}

--- a/examples/wordpress/wordpress/kustomization.yaml
+++ b/examples/wordpress/wordpress/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- service.yaml

--- a/examples/wordpress/wordpress/service.yaml
+++ b/examples/wordpress/wordpress/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: wordpress
+  type: LoadBalancer

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -27,6 +27,14 @@ func NewRefVarTransformer(vars map[string]string) (Transformer, error) {
 				Path:             []string{"spec", "template", "spec", "containers", "command"},
 			},
 			{
+				GroupVersionKind: &schema.GroupVersionKind{Kind: "Deployment"},
+				Path:             []string{"spec", "template", "spec", "initContainers", "command"},
+			},
+			{
+				GroupVersionKind: &schema.GroupVersionKind{Kind: "Deployment"},
+				Path:             []string{"spec", "template", "spec", "containers", "command"},
+			},
+			{
 				GroupVersionKind: &schema.GroupVersionKind{Kind: "Job"},
 				Path:             []string{"spec", "template", "spec", "containers", "command"},
 			},


### PR DESCRIPTION
Add an initcontroller in WordPress  deployment. The initcontroller required the name of mysql, WordPress services. 
Will add readme file in different PR