### PR TITLE
Reduce unstruct notation noise in Resource construction.

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -88,99 +87,91 @@ var ns = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
 
 func TestResources(t *testing.T) {
 	expected := resmap.ResMap{
-		resource.NewResId(deploy, "dply1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name":      "foo-dply1",
-						"namespace": "ns1",
-						"labels": map[string]interface{}{
+		resource.NewResId(deploy, "dply1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "foo-dply1",
+					"namespace": "ns1",
+					"labels": map[string]interface{}{
+						"app": "nginx",
+					},
+					"annotations": map[string]interface{}{
+						"note": "This is a test annotation",
+					},
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
 							"app": "nginx",
 						},
-						"annotations": map[string]interface{}{
-							"note": "This is a test annotation",
-						},
 					},
-					"spec": map[string]interface{}{
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"note": "This is a test annotation",
+							},
+							"labels": map[string]interface{}{
 								"app": "nginx",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"annotations": map[string]interface{}{
-									"note": "This is a test annotation",
-								},
-								"labels": map[string]interface{}{
-									"app": "nginx",
-								},
-							},
-						},
 					},
 				},
 			}),
-		resource.NewResId(cmap, "literalConfigMap"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name":      "foo-literalConfigMap-mc92bgcbh5",
-						"namespace": "ns1",
-						"labels": map[string]interface{}{
-							"app": "nginx",
-						},
-						"annotations": map[string]interface{}{
-							"note": "This is a test annotation",
-						},
-						"creationTimestamp": nil,
+		resource.NewResId(cmap, "literalConfigMap"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "foo-literalConfigMap-mc92bgcbh5",
+					"namespace": "ns1",
+					"labels": map[string]interface{}{
+						"app": "nginx",
 					},
-					"data": map[string]interface{}{
-						"DB_USERNAME": "admin",
-						"DB_PASSWORD": "somepw",
+					"annotations": map[string]interface{}{
+						"note": "This is a test annotation",
 					},
+					"creationTimestamp": nil,
+				},
+				"data": map[string]interface{}{
+					"DB_USERNAME": "admin",
+					"DB_PASSWORD": "somepw",
 				},
 			}),
-		resource.NewResId(secret, "secret"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name":      "foo-secret-877fcfhgt5",
-						"namespace": "ns1",
-						"labels": map[string]interface{}{
-							"app": "nginx",
-						},
-						"annotations": map[string]interface{}{
-							"note": "This is a test annotation",
-						},
-						"creationTimestamp": nil,
+		resource.NewResId(secret, "secret"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":      "foo-secret-877fcfhgt5",
+					"namespace": "ns1",
+					"labels": map[string]interface{}{
+						"app": "nginx",
 					},
-					"type": string(corev1.SecretTypeOpaque),
-					"data": map[string]interface{}{
-						"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
-						"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
+					"annotations": map[string]interface{}{
+						"note": "This is a test annotation",
 					},
+					"creationTimestamp": nil,
+				},
+				"type": string(corev1.SecretTypeOpaque),
+				"data": map[string]interface{}{
+					"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
+					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			}),
-		resource.NewResId(ns, "ns1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Namespace",
-					"metadata": map[string]interface{}{
-						"name":      "foo-ns1",
-						"namespace": "ns1",
-						"labels": map[string]interface{}{
-							"app": "nginx",
-						},
-						"annotations": map[string]interface{}{
-							"note": "This is a test annotation",
-						},
+		resource.NewResId(ns, "ns1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name":      "foo-ns1",
+					"namespace": "ns1",
+					"labels": map[string]interface{}{
+						"app": "nginx",
+					},
+					"annotations": map[string]interface{}{
+						"note": "This is a test annotation",
 					},
 				},
 			}),
@@ -203,24 +194,20 @@ func TestResources(t *testing.T) {
 
 func TestRawResources(t *testing.T) {
 	expected := resmap.ResMap{
-		resource.NewResId(deploy, "dply1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "dply1",
-					},
+		resource.NewResId(deploy, "dply1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "dply1",
 				},
 			}),
-		resource.NewResId(ns, "ns1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Namespace",
-					"metadata": map[string]interface{}{
-						"name": "ns1",
-					},
+		resource.NewResId(ns, "ns1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "ns1",
 				},
 			}),
 	}

--- a/pkg/resmap/configmap_test.go
+++ b/pkg/resmap/configmap_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/internal/loadertest"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -53,19 +52,17 @@ func TestNewFromConfigMaps(t *testing.T) {
 			filepath: "/home/seans/project/app.env",
 			content:  "DB_USERNAME=admin\nDB_PASSWORD=somepw",
 			expected: ResMap{
-				resource.NewResId(cmap, "envConfigMap"): resource.NewBehaviorlessResource(
-					&unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"apiVersion": "v1",
-							"kind":       "ConfigMap",
-							"metadata": map[string]interface{}{
-								"name":              "envConfigMap",
-								"creationTimestamp": nil,
-							},
-							"data": map[string]interface{}{
-								"DB_USERNAME": "admin",
-								"DB_PASSWORD": "somepw",
-							},
+				resource.NewResId(cmap, "envConfigMap"): resource.NewResourceFromMap(
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":              "envConfigMap",
+							"creationTimestamp": nil,
+						},
+						"data": map[string]interface{}{
+							"DB_USERNAME": "admin",
+							"DB_PASSWORD": "somepw",
 						},
 					}),
 			},
@@ -82,20 +79,18 @@ func TestNewFromConfigMaps(t *testing.T) {
 			filepath: "/home/seans/project/app-init.ini",
 			content:  "FOO=bar\nBAR=baz\n",
 			expected: ResMap{
-				resource.NewResId(cmap, "fileConfigMap"): resource.NewBehaviorlessResource(
-					&unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"apiVersion": "v1",
-							"kind":       "ConfigMap",
-							"metadata": map[string]interface{}{
-								"name":              "fileConfigMap",
-								"creationTimestamp": nil,
-							},
-							"data": map[string]interface{}{
-								"app-init.ini": `FOO=bar
+				resource.NewResId(cmap, "fileConfigMap"): resource.NewResourceFromMap(
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":              "fileConfigMap",
+							"creationTimestamp": nil,
+						},
+						"data": map[string]interface{}{
+							"app-init.ini": `FOO=bar
 BAR=baz
 `,
-							},
 						},
 					}),
 			},
@@ -111,19 +106,17 @@ BAR=baz
 				},
 			},
 			expected: ResMap{
-				resource.NewResId(cmap, "literalConfigMap"): resource.NewBehaviorlessResource(
-					&unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"apiVersion": "v1",
-							"kind":       "ConfigMap",
-							"metadata": map[string]interface{}{
-								"name":              "literalConfigMap",
-								"creationTimestamp": nil,
-							},
-							"data": map[string]interface{}{
-								"a": "x",
-								"b": "y",
-							},
+				resource.NewResId(cmap, "literalConfigMap"): resource.NewResourceFromMap(
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":              "literalConfigMap",
+							"creationTimestamp": nil,
+						},
+						"data": map[string]interface{}{
+							"a": "x",
+							"b": "y",
 						},
 					}),
 			},

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -101,7 +101,7 @@ func (m ResMap) insert(newName string, obj *unstructured.Unstructured) error {
 		return fmt.Errorf("The <name: %q, GroupVersionKind: %v> already exists in the map", oldName, gvk)
 	}
 	obj.SetName(newName)
-	m[id] = resource.NewBehaviorlessResource(obj)
+	m[id] = resource.NewResourceFromUnstruct(*obj)
 	return nil
 }
 
@@ -183,7 +183,7 @@ func newResourceSliceFromBytes(in []byte) ([]*resource.Resource, error) {
 		if err != nil {
 			break
 		}
-		result = append(result, resource.NewBehaviorlessResource(&out))
+		result = append(result, resource.NewResourceFromUnstruct(out))
 	}
 	if err != io.EOF {
 		return nil, err

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/internal/loadertest"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -42,24 +41,20 @@ metadata:
   name: cm2
 `)
 	input := ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm2",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
 				},
 			}),
 	}
@@ -89,24 +84,20 @@ metadata:
 	if ferr := l.AddFile("/home/seans/project/deployment.yaml", []byte(resourceStr)); ferr != nil {
 		t.Fatalf("Error adding fake file: %v\n", ferr)
 	}
-	expected := ResMap{resource.NewResId(deploy, "dply1"): resource.NewBehaviorlessResource(
-		&unstructured.Unstructured{
-			Object: map[string]interface{}{
+	expected := ResMap{resource.NewResId(deploy, "dply1"): resource.NewResourceFromMap(
+		map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "dply1",
+			},
+		}),
+		resource.NewResId(deploy, "dply2"): resource.NewResourceFromMap(
+			map[string]interface{}{
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
 				"metadata": map[string]interface{}{
-					"name": "dply1",
-				},
-			},
-		}),
-		resource.NewResId(deploy, "dply2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "dply2",
-					},
+					"name": "dply2",
 				},
 			}),
 	}
@@ -133,24 +124,20 @@ metadata:
   name: cm2
 `)
 	expected := ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm2",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
 				},
 			}),
 	}
@@ -166,49 +153,41 @@ metadata:
 
 func TestMerge(t *testing.T) {
 	input1 := ResMap{
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "foo-deploy1",
-					},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "foo-deploy1",
 				},
 			}),
 	}
 	input2 := ResMap{
-		resource.NewResId(statefulset, "stateful1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "StatefulSet",
-					"metadata": map[string]interface{}{
-						"name": "bar-stateful",
-					},
+		resource.NewResId(statefulset, "stateful1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "StatefulSet",
+				"metadata": map[string]interface{}{
+					"name": "bar-stateful",
 				},
 			}),
 	}
 	input := []ResMap{input1, input2}
 	expected := ResMap{
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "foo-deploy1",
-					},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "foo-deploy1",
 				},
 			}),
-		resource.NewResId(statefulset, "stateful1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "StatefulSet",
-					"metadata": map[string]interface{}{
-						"name": "bar-stateful",
-					},
+		resource.NewResId(statefulset, "stateful1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "StatefulSet",
+				"metadata": map[string]interface{}{
+					"name": "bar-stateful",
 				},
 			}),
 	}

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -48,20 +47,18 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	}
 
 	expected := ResMap{
-		resource.NewResId(secret, "apple"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name":              "apple",
-						"creationTimestamp": nil,
-					},
-					"type": string(corev1.SecretTypeOpaque),
-					"data": map[string]interface{}{
-						"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
-						"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
-					},
+		resource.NewResId(secret, "apple"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":              "apple",
+					"creationTimestamp": nil,
+				},
+				"type": string(corev1.SecretTypeOpaque),
+				"data": map[string]interface{}{
+					"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
+					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			}),
 	}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -46,16 +46,14 @@ func NewResourceWithBehavior(obj runtime.Object, b GenerationBehavior) (*Resourc
 	return &Resource{Unstructured: u, b: b}, nil
 }
 
-// NewBehaviorlessResource returns a new instance of Resource.
-func NewBehaviorlessResource(u *unstructured.Unstructured) *Resource {
-	return &Resource{Unstructured: *u, b: BehaviorUnspecified}
+// NewResourceFromMap returns a new instance of Resource.
+func NewResourceFromMap(m map[string]interface{}) *Resource {
+	return NewResourceFromUnstruct(unstructured.Unstructured{Object: m})
 }
 
-// NewResource returns a new instance of Resource.
-func NewResource(m map[string]interface{}) *Resource {
-	return &Resource{
-		Unstructured: unstructured.Unstructured{Object: m},
-		b:            BehaviorUnspecified}
+// NewResourceFromUnstruct returns a new instance of Resource.
+func NewResourceFromUnstruct(u unstructured.Unstructured) *Resource {
+	return &Resource{Unstructured: u, b: BehaviorUnspecified}
 }
 
 // Behavior returns the behavior for the resource.

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestGetFieldValue(t *testing.T) {
-	res := NewResource(map[string]interface{}{
+	res := NewResourceFromMap(map[string]interface{}{
 		"Kind": "Service",
 		"metadata": map[string]interface{}{
 			"labels": map[string]string{

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -35,141 +34,129 @@ var foo = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Fo
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"old-label": "old-value",
-								},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"old-label": "old-value",
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
 				},
 			}),
 	}
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-						"labels": map[string]interface{}{
-							"label-key1": "label-value1",
-							"label-key2": "label-value2",
-						},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
 					},
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-						"labels": map[string]interface{}{
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
 							"label-key1": "label-value1",
 							"label-key2": "label-value2",
 						},
 					},
-					"spec": map[string]interface{}{
-						"selector": map[string]interface{}{
-							"matchLabels": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"old-label":  "old-value",
 								"label-key1": "label-value1",
 								"label-key2": "label-value2",
 							},
 						},
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"old-label":  "old-value",
-									"label-key1": "label-value1",
-									"label-key2": "label-value2",
-								},
-							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-						"labels": map[string]interface{}{
-							"label-key1": "label-value1",
-							"label-key2": "label-value2",
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
-						},
-						"selector": map[string]interface{}{
-							"label-key1": "label-value1",
-							"label-key2": "label-value2",
-						},
+					"selector": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
 					},
 				},
 			}),
@@ -189,212 +176,122 @@ func TestLabelsRun(t *testing.T) {
 	}
 }
 
-func makeAnnotatededConfigMap() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "ConfigMap",
-			"metadata": map[string]interface{}{
-				"name": "cm1",
-				"annotations": map[string]interface{}{
-					"anno-key1": "anno-value1",
-					"anno-key2": "anno-value2",
-				},
-			},
-		},
-	}
-}
-
-func makeAnnotatededDeployment() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"group":      "apps",
-			"apiVersion": "v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-				"annotations": map[string]interface{}{
-					"anno-key1": "anno-value1",
-					"anno-key2": "anno-value2",
-				},
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]interface{}{
-							"anno-key1": "anno-value1",
-							"anno-key2": "anno-value2",
-						},
-						"labels": map[string]interface{}{
-							"old-label": "old-value",
-						},
-					},
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:1.7.9",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func makeAnnotatededService() *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Service",
-			"metadata": map[string]interface{}{
-				"name": "svc1",
-				"annotations": map[string]interface{}{
-					"anno-key1": "anno-value1",
-					"anno-key2": "anno-value2",
-				},
-			},
-			"spec": map[string]interface{}{
-				"ports": []interface{}{
-					map[string]interface{}{
-						"name": "port1",
-						"port": "12345",
-					},
-				},
-			},
-		},
-	}
-}
-
 func TestAnnotationsRun(t *testing.T) {
 	m := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"old-label": "old-value",
-								},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"old-label": "old-value",
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
 				},
 			}),
 	}
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-						"annotations": map[string]interface{}{
-							"anno-key1": "anno-value1",
-							"anno-key2": "anno-value2",
-						},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+					"annotations": map[string]interface{}{
+						"anno-key1": "anno-value1",
+						"anno-key2": "anno-value2",
 					},
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-						"annotations": map[string]interface{}{
-							"anno-key1": "anno-value1",
-							"anno-key2": "anno-value2",
-						},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+					"annotations": map[string]interface{}{
+						"anno-key1": "anno-value1",
+						"anno-key2": "anno-value2",
 					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"annotations": map[string]interface{}{
-									"anno-key1": "anno-value1",
-									"anno-key2": "anno-value2",
-								},
-								"labels": map[string]interface{}{
-									"old-label": "old-value",
-								},
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"anno-key1": "anno-value1",
+								"anno-key2": "anno-value2",
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+							"labels": map[string]interface{}{
+								"old-label": "old-value",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-						"annotations": map[string]interface{}{
-							"anno-key1": "anno-value1",
-							"anno-key2": "anno-value2",
-						},
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+					"annotations": map[string]interface{}{
+						"anno-key1": "anno-value1",
+						"anno-key2": "anno-value2",
 					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
 				},

--- a/pkg/transformers/namehash_test.go
+++ b/pkg/transformers/namehash_test.go
@@ -22,144 +22,127 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestNameHashTransformer(t *testing.T) {
 	objs := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"old-label": "old-value",
-								},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"old-label": "old-value",
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
 				},
 			}),
-		resource.NewResId(secret, "secret1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "secret1",
-					},
+		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "secret1",
 				},
 			}),
 	}
 
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1-m462kdfb68",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1-m462kdfb68",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"labels": map[string]interface{}{
-									"old-label": "old-value",
-								},
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"old-label": "old-value",
 							},
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-									},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
 								},
 							},
 						},
 					},
 				},
 			}),
-		resource.NewResId(service, "svc1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Service",
-					"metadata": map[string]interface{}{
-						"name": "svc1",
-					},
-					"spec": map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
-								"name": "port1",
-								"port": "12345",
-							},
+		resource.NewResId(service, "svc1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "svc1",
+				},
+				"spec": map[string]interface{}{
+					"ports": []interface{}{
+						map[string]interface{}{
+							"name": "port1",
+							"port": "12345",
 						},
 					},
 				},
 			}),
-		resource.NewResId(secret, "secret1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "secret1-7kc45hd5f7",
-					},
+		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "secret1-7kc45hd5f7",
 				},
 			}),
 	}

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -22,90 +22,83 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestNameReferenceRun(t *testing.T) {
 	m := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-cm1-somehash",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm1-somehash",
 				},
 			}),
-		resource.NewResId(secret, "secret1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-secret1-somehash",
-					},
+		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-secret1-somehash",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-										"env": []interface{}{
-											map[string]interface{}{
-												"name": "CM_FOO",
-												"valueFrom": map[string]interface{}{
-													"configMapKeyRef": map[string]interface{}{
-														"name": "cm1",
-														"key":  "somekey",
-													},
-												},
-											},
-											map[string]interface{}{
-												"name": "SECRET_FOO",
-												"valueFrom": map[string]interface{}{
-													"secretKeyRef": map[string]interface{}{
-														"name": "secret1",
-														"key":  "somekey",
-													},
-												},
-											},
-										},
-										"envFrom": []interface{}{
-											map[string]interface{}{
-												"configMapRef": map[string]interface{}{
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name": "CM_FOO",
+											"valueFrom": map[string]interface{}{
+												"configMapKeyRef": map[string]interface{}{
 													"name": "cm1",
 													"key":  "somekey",
 												},
 											},
-											map[string]interface{}{
-												"secretRef": map[string]interface{}{
+										},
+										map[string]interface{}{
+											"name": "SECRET_FOO",
+											"valueFrom": map[string]interface{}{
+												"secretKeyRef": map[string]interface{}{
 													"name": "secret1",
 													"key":  "somekey",
 												},
 											},
 										},
 									},
+									"envFrom": []interface{}{
+										map[string]interface{}{
+											"configMapRef": map[string]interface{}{
+												"name": "cm1",
+												"key":  "somekey",
+											},
+										},
+										map[string]interface{}{
+											"secretRef": map[string]interface{}{
+												"name": "secret1",
+												"key":  "somekey",
+											},
+										},
+									},
 								},
-								"volumes": map[string]interface{}{
-									"configMap": map[string]interface{}{
-										"name": "cm1",
-									},
-									"secret": map[string]interface{}{
-										"secretName": "secret1",
-									},
+							},
+							"volumes": map[string]interface{}{
+								"configMap": map[string]interface{}{
+									"name": "cm1",
+								},
+								"secret": map[string]interface{}{
+									"secretName": "secret1",
 								},
 							},
 						},
@@ -115,85 +108,79 @@ func TestNameReferenceRun(t *testing.T) {
 	}
 
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-cm1-somehash",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm1-somehash",
 				},
 			}),
-		resource.NewResId(secret, "secret1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Secret",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-secret1-somehash",
-					},
+		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-secret1-somehash",
 				},
 			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"group":      "apps",
-					"apiVersion": "v1",
-					"kind":       "Deployment",
-					"metadata": map[string]interface{}{
-						"name": "deploy1",
-					},
-					"spec": map[string]interface{}{
-						"template": map[string]interface{}{
-							"spec": map[string]interface{}{
-								"containers": []interface{}{
-									map[string]interface{}{
-										"name":  "nginx",
-										"image": "nginx:1.7.9",
-										"env": []interface{}{
-											map[string]interface{}{
-												"name": "CM_FOO",
-												"valueFrom": map[string]interface{}{
-													"configMapKeyRef": map[string]interface{}{
-														"name": "someprefix-cm1-somehash",
-														"key":  "somekey",
-													},
-												},
-											},
-											map[string]interface{}{
-												"name": "SECRET_FOO",
-												"valueFrom": map[string]interface{}{
-													"secretKeyRef": map[string]interface{}{
-														"name": "someprefix-secret1-somehash",
-														"key":  "somekey",
-													},
-												},
-											},
-										},
-										"envFrom": []interface{}{
-											map[string]interface{}{
-												"configMapRef": map[string]interface{}{
+		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "deploy1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+									"env": []interface{}{
+										map[string]interface{}{
+											"name": "CM_FOO",
+											"valueFrom": map[string]interface{}{
+												"configMapKeyRef": map[string]interface{}{
 													"name": "someprefix-cm1-somehash",
 													"key":  "somekey",
 												},
 											},
-											map[string]interface{}{
-												"secretRef": map[string]interface{}{
+										},
+										map[string]interface{}{
+											"name": "SECRET_FOO",
+											"valueFrom": map[string]interface{}{
+												"secretKeyRef": map[string]interface{}{
 													"name": "someprefix-secret1-somehash",
 													"key":  "somekey",
 												},
 											},
 										},
 									},
+									"envFrom": []interface{}{
+										map[string]interface{}{
+											"configMapRef": map[string]interface{}{
+												"name": "someprefix-cm1-somehash",
+												"key":  "somekey",
+											},
+										},
+										map[string]interface{}{
+											"secretRef": map[string]interface{}{
+												"name": "someprefix-secret1-somehash",
+												"key":  "somekey",
+											},
+										},
+									},
 								},
-								"volumes": map[string]interface{}{
-									"configMap": map[string]interface{}{
-										"name": "someprefix-cm1-somehash",
-									},
-									"secret": map[string]interface{}{
-										"secretName": "someprefix-secret1-somehash",
-									},
+							},
+							"volumes": map[string]interface{}{
+								"configMap": map[string]interface{}{
+									"name": "someprefix-cm1-somehash",
+								},
+								"secret": map[string]interface{}{
+									"secretName": "someprefix-secret1-somehash",
 								},
 							},
 						},

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -22,54 +22,45 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestNamespaceRun(t *testing.T) {
 	m := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name":      "cm2",
-						"namespace": "foo",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "cm2",
+					"namespace": "foo",
 				},
 			}),
 	}
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name":      "cm1",
-						"namespace": "test",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "cm1",
+					"namespace": "test",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name":      "cm2",
-						"namespace": "test",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name":      "cm2",
+					"namespace": "test",
 				},
 			}),
 	}

--- a/pkg/transformers/prefixname_test.go
+++ b/pkg/transformers/prefixname_test.go
@@ -22,51 +22,42 @@ import (
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestPrefixNameRun(t *testing.T) {
 	m := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "cm2",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
 				},
 			}),
 	}
 	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-cm1",
-					},
+		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm1",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewBehaviorlessResource(
-			&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]interface{}{
-						"name": "someprefix-cm2",
-					},
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm2",
 				},
 			}),
 	}


### PR DESCRIPTION
A mostly mechanical change (many thanks to _go fmt_) to reduce imports of the _unstructured_ package and reduce syntax noise. 240 LOC gone.
