### PR TITLE
Add Ingress spec.tls.secretName to Secret namerefs

### DIFF
--- a/pkg/transformers/namereferenceconfig.go
+++ b/pkg/transformers/namereferenceconfig.go
@@ -579,6 +579,13 @@ var defaultNameReferencePathConfigs = []referencePathConfig{
 				Path:               []string{"spec", "jobTemplate", "spec", "template", "spec", "initContainers", "envFrom", "secretRef", "name"},
 				CreateIfNotPresent: false,
 			},
+			{
+				GroupVersionKind: &schema.GroupVersionKind{
+					Kind: "Ingress",
+				},
+				Path:               []string{"spec", "tls", "secretName"},
+				CreateIfNotPresent: false,
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Enables the use of `secretGenerator` for generating Ingress TLS Secrets, [kinda like this](https://github.com/kubernetes-sigs/kustomize/blob/83b3eb9d5415663169e580982b373667762f6af8/pkg/examples/simple/instances/exampleinstance/kustomization.yaml#L18-L23) (though that example ends up using a volume).