### PR TITLE
Jobs do not create a selector if not already present

### DIFF
--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -32,6 +32,7 @@ var ns = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
 var deploy = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
 var foo = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
 var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
+var job = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{
@@ -81,6 +82,51 @@ func TestLabelsRun(t *testing.T) {
 						map[string]interface{}{
 							"name": "port1",
 							"port": "12345",
+						},
+					},
+				},
+			}),
+		resource.NewResId(job, "job1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"name": "job1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(job, "job2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"name": "job2",
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"old-label": "old-value",
+						},
+					},
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
 						},
 					},
 				},
@@ -158,6 +204,73 @@ func TestLabelsRun(t *testing.T) {
 					"selector": map[string]interface{}{
 						"label-key1": "label-value1",
 						"label-key2": "label-value2",
+					},
+				},
+			}),
+		resource.NewResId(job, "job1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"name": "job1",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"label-key1": "label-value1",
+								"label-key2": "label-value2",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(job, "job2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"name": "job2",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"selector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"label-key1": "label-value1",
+							"label-key2": "label-value2",
+							"old-label":  "old-value",
+						},
+					},
+					"template": map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"label-key1": "label-value1",
+								"label-key2": "label-value2",
+							},
+						},
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
+						},
 					},
 				},
 			}),

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -33,6 +33,7 @@ var deploy = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deploy
 var foo = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
 var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 var job = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+var cronjob = schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{
@@ -125,6 +126,61 @@ func TestLabelsRun(t *testing.T) {
 								map[string]interface{}{
 									"name":  "nginx",
 									"image": "nginx:1.7.9",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(cronjob, "cronjob1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1beta1",
+				"kind":       "CronJob",
+				"metadata": map[string]interface{}{
+					"name": "cronjob1",
+				},
+				"spec": map[string]interface{}{
+					"schedule": "* 23 * * *",
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "nginx",
+											"image": "nginx:1.7.9",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(cronjob, "cronjob2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1beta1",
+				"kind":       "CronJob",
+				"metadata": map[string]interface{}{
+					"name": "cronjob2",
+				},
+				"spec": map[string]interface{}{
+					"schedule": "* 23 * * *",
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"selector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"old-label": "old-value",
+								},
+							},
+							"template": map[string]interface{}{
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "nginx",
+											"image": "nginx:1.7.9",
+										},
+									},
 								},
 							},
 						},
@@ -268,6 +324,83 @@ func TestLabelsRun(t *testing.T) {
 								map[string]interface{}{
 									"name":  "nginx",
 									"image": "nginx:1.7.9",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(cronjob, "cronjob1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1beta1",
+				"kind":       "CronJob",
+				"metadata": map[string]interface{}{
+					"name": "cronjob1",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"schedule": "* 23 * * *",
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"label-key1": "label-value1",
+										"label-key2": "label-value2",
+									},
+								},
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "nginx",
+											"image": "nginx:1.7.9",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(cronjob, "cronjob2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1beta1",
+				"kind":       "CronJob",
+				"metadata": map[string]interface{}{
+					"name": "cronjob2",
+					"labels": map[string]interface{}{
+						"label-key1": "label-value1",
+						"label-key2": "label-value2",
+					},
+				},
+				"spec": map[string]interface{}{
+					"schedule": "* 23 * * *",
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"selector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"old-label":  "old-value",
+									"label-key1": "label-value1",
+									"label-key2": "label-value2",
+								},
+							},
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"label-key1": "label-value1",
+										"label-key2": "label-value2",
+									},
+								},
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "nginx",
+											"image": "nginx:1.7.9",
+										},
+									},
 								},
 							},
 						},

--- a/pkg/transformers/labelsandannotationsconfig.go
+++ b/pkg/transformers/labelsandannotationsconfig.go
@@ -85,7 +85,7 @@ var defaultLabelsPathConfigs = []PathConfig{
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "batch", Kind: "Job"},
 		Path:               []string{"spec", "selector", "matchLabels"},
-		CreateIfNotPresent: true,
+		CreateIfNotPresent: false,
 	},
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "batch", Kind: "Job"},

--- a/pkg/transformers/labelsandannotationsconfig.go
+++ b/pkg/transformers/labelsandannotationsconfig.go
@@ -95,12 +95,7 @@ var defaultLabelsPathConfigs = []PathConfig{
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "batch", Kind: "CronJob"},
 		Path:               []string{"spec", "jobTemplate", "spec", "selector", "matchLabels"},
-		CreateIfNotPresent: true,
-	},
-	{
-		GroupVersionKind:   &schema.GroupVersionKind{Group: "batch", Kind: "CronJob"},
-		Path:               []string{"spec", "jobTemplate", "spec", "metadata", "labels"},
-		CreateIfNotPresent: true,
+		CreateIfNotPresent: false,
 	},
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "batch", Kind: "CronJob"},


### PR DESCRIPTION
Sets `createIfNotPresent` to `false` for Job `selector.matchLabels` and adds testing around YAML with/without `spec.selector.matchLabels` set

Fixes #118 