### PR TITLE
#50 Ability to disable hash suffix for generated secrets and configmaps

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -74,12 +74,12 @@ func unmarshal(y []byte, o interface{}) error {
 
 // MakeCustomizedResMap creates a ResMap per kustomization instructions.
 // The Resources in the returned ResMap are fully customized.
-func (a *Application) MakeCustomizedResMap() (resmap.ResMap, error) {
+func (a *Application) MakeCustomizedResMap(defaultRenamingBehaviour resource.RenamingBehavior) (resmap.ResMap, error) {
 	m, err := a.loadCustomizedResMap()
 	if err != nil {
 		return nil, err
 	}
-	return a.resolveRefsToGeneratedResources(m)
+	return a.resolveRefsToGeneratedResources(defaultRenamingBehaviour, m)
 }
 
 // MakeUncustomizedResMap purports to create a ResMap without customization.
@@ -88,17 +88,17 @@ func (a *Application) MakeCustomizedResMap() (resmap.ResMap, error) {
 // and all generated secrets and configMaps.
 // Meant for use in generating a diff against customized resources.
 // TODO: See https://github.com/kubernetes-sigs/kustomize/issues/85
-func (a *Application) MakeUncustomizedResMap() (resmap.ResMap, error) {
+func (a *Application) MakeUncustomizedResMap(defaultRenamingBehaviour resource.RenamingBehavior) (resmap.ResMap, error) {
 	m, err := a.loadResMapFromBasesAndResources()
 	if err != nil {
 		return nil, err
 	}
-	return a.resolveRefsToGeneratedResources(m)
+	return a.resolveRefsToGeneratedResources(defaultRenamingBehaviour, m)
 }
 
 // resolveRefsToGeneratedResources fixes all name references.
-func (a *Application) resolveRefsToGeneratedResources(m resmap.ResMap) (resmap.ResMap, error) {
-	r := []transformers.Transformer{transformers.NewNameHashTransformer()}
+func (a *Application) resolveRefsToGeneratedResources(defaultRenamingBehavior resource.RenamingBehavior, m resmap.ResMap) (resmap.ResMap, error) {
+	r := []transformers.Transformer{transformers.NewNameHashTransformer(defaultRenamingBehavior)}
 
 	t, err := transformers.NewDefaultingNameReferenceTransformer()
 	if err != nil {

--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -184,7 +184,7 @@ func TestResources1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	actual, err := app.MakeCustomizedResMap()
+	actual, err := app.MakeCustomizedResMap(resource.RenamingBehaviorUnspecified)
 	if err != nil {
 		t.Fatalf("Unexpected Resources error %v", err)
 	}
@@ -219,7 +219,7 @@ func TestRawResources1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	actual, err := app.MakeUncustomizedResMap()
+	actual, err := app.MakeUncustomizedResMap(resource.RenamingBehaviorUnspecified)
 	if err != nil {
 		t.Fatalf("Unexpected RawResources error %v", err)
 	}
@@ -329,7 +329,7 @@ func TestRawResources2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	actual, err := app.MakeUncustomizedResMap()
+	actual, err := app.MakeUncustomizedResMap(resource.RenamingBehaviorUnspecified)
 	if err != nil {
 		t.Fatalf("Unexpected RawResources error %v", err)
 	}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -32,7 +32,7 @@ import (
 )
 
 type buildOptions struct {
-	kustomizationPath string
+	kustomizationPath       string
 	defaultRenamingBehavior string
 }
 

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -28,10 +28,12 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/constants"
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
+	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 )
 
 type buildOptions struct {
 	kustomizationPath string
+	defaultRenamingBehavior string
 }
 
 // newCmdBuild creates a new build command.
@@ -52,6 +54,13 @@ func newCmdBuild(out io.Writer, fs fs.FileSystem) *cobra.Command {
 			return o.RunBuild(out, fs)
 		},
 	}
+
+	cmd.Flags().StringVar(
+		&o.defaultRenamingBehavior,
+		"default-rename-behavior",
+		"hash",
+		"The default renaming behavior during the processing of configmaps and secrets. Can be 'none' or 'hash'.")
+
 	return cmd
 }
 
@@ -87,7 +96,7 @@ func (o *buildOptions) RunBuild(out io.Writer, fs fs.FileSystem) error {
 		return err
 	}
 
-	allResources, err := application.MakeCustomizedResMap()
+	allResources, err := application.MakeCustomizedResMap(resource.NewRenamingBehavior(o.defaultRenamingBehavior))
 
 	if err != nil {
 		return err

--- a/pkg/commands/build_test.go
+++ b/pkg/commands/build_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 type buildTestCase struct {
-	Description string   `yaml:"description"`
-	Args        []string `yaml:"args"`
-	Filename    string   `yaml:"filename"`
+	Description      string `yaml:"description"`
+	Filename         string `yaml:"filename"`
+	RenamingBehavior string `yaml:"renamingBehavior"`
 	// path to the file that contains the expected output
 	ExpectedStdout string `yaml:"expectedStdout"`
 	ExpectedError  string `yaml:"expectedError"`
@@ -122,7 +122,8 @@ func runBuildTestCase(t *testing.T, testcaseName string, updateKustomizeExpected
 	}
 
 	ops := &buildOptions{
-		kustomizationPath: testcase.Filename,
+		kustomizationPath:       testcase.Filename,
+		defaultRenamingBehavior: testcase.RenamingBehavior,
 	}
 	buf := bytes.NewBuffer([]byte{})
 	err = ops.RunBuild(buf, fs)

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -32,7 +32,7 @@ import (
 )
 
 type diffOptions struct {
-	kustomizationPath string
+	kustomizationPath       string
 	defaultRenamingBehavior string
 }
 

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -28,10 +28,12 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/diff"
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
+	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 )
 
 type diffOptions struct {
 	kustomizationPath string
+	defaultRenamingBehavior string
 }
 
 // newCmdDiff makes the diff command.
@@ -49,6 +51,13 @@ func newCmdDiff(out, errOut io.Writer, fs fs.FileSystem) *cobra.Command {
 			return o.RunDiff(out, errOut, fs)
 		},
 	}
+
+	cmd.Flags().StringVar(
+		&o.defaultRenamingBehavior,
+		"default-rename-behavior",
+		"hash",
+		"The default renaming behavior during the processing of configmaps and secrets. Can be 'none' or 'hash'.")
+
 	return cmd
 }
 
@@ -84,11 +93,11 @@ func (o *diffOptions) RunDiff(out, errOut io.Writer, fs fs.FileSystem) error {
 	if err != nil {
 		return err
 	}
-	transformedResources, err := application.MakeCustomizedResMap()
+	transformedResources, err := application.MakeCustomizedResMap(resource.NewRenamingBehavior(o.defaultRenamingBehavior))
 	if err != nil {
 		return err
 	}
-	rawResources, err := application.MakeUncustomizedResMap()
+	rawResources, err := application.MakeUncustomizedResMap(resource.NewRenamingBehavior(o.defaultRenamingBehavior))
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/diff_test.go
+++ b/pkg/commands/diff_test.go
@@ -32,9 +32,9 @@ import (
 )
 
 type DiffTestCase struct {
-	Description string   `yaml:"description"`
-	Args        []string `yaml:"args"`
-	Filename    string   `yaml:"filename"`
+	Description      string `yaml:"description"`
+	Filename         string `yaml:"filename"`
+	RenamingBehavior string `yaml:"renamingBehavior"`
 	// path to the file that contains the expected output
 	ExpectedDiff  string `yaml:"expectedDiff"`
 	ExpectedError string `yaml:"expectedError"`
@@ -94,7 +94,8 @@ func runDiffTestCase(t *testing.T, testcaseName string, updateKustomizeExpected 
 	}
 
 	diffOps := &diffOptions{
-		kustomizationPath: testcase.Filename,
+		kustomizationPath:       testcase.Filename,
+		defaultRenamingBehavior: testcase.RenamingBehavior,
 	}
 	buf := bytes.NewBuffer([]byte{})
 	err = diffOps.RunDiff(buf, os.Stderr, fs)

--- a/pkg/commands/testdata/testcase-crds/expected.diff
+++ b/pkg/commands/testdata/testcase-crds/expected.diff
@@ -14,6 +14,15 @@ diff -u -N /tmp/noop/jingfang.example.com_v1beta1_MyKind_mykind.yaml /tmp/transf
    secretRef:
 -    name: crdsecret-m5ht5thcb4
 +    name: test-crdsecret-m48btmkck5
+diff -u -N /tmp/noop/v1_Secret_crdsecret.yaml /tmp/transformed/v1_Secret_crdsecret.yaml
+--- /tmp/noop/v1_Secret_crdsecret.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_crdsecret.yaml	YYYY-MM-DD HH:MM:SS
+@@ -3,4 +3,4 @@
+   PATH: YmJiYmJiYmIK
+ kind: Secret
+ metadata:
+-  name: crdsecret-m5ht5thcb4
++  name: test-crdsecret-m48btmkck5
 diff -u -N /tmp/noop/v1beta1_Bee_bee.yaml /tmp/transformed/v1beta1_Bee_bee.yaml
 --- /tmp/noop/v1beta1_Bee_bee.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1beta1_Bee_bee.yaml	YYYY-MM-DD HH:MM:SS
@@ -25,12 +34,3 @@ diff -u -N /tmp/noop/v1beta1_Bee_bee.yaml /tmp/transformed/v1beta1_Bee_bee.yaml
 +  name: test-bee
  spec:
    action: fly
-diff -u -N /tmp/noop/v1_Secret_crdsecret.yaml /tmp/transformed/v1_Secret_crdsecret.yaml
---- /tmp/noop/v1_Secret_crdsecret.yaml	YYYY-MM-DD HH:MM:SS
-+++ /tmp/transformed/v1_Secret_crdsecret.yaml	YYYY-MM-DD HH:MM:SS
-@@ -3,4 +3,4 @@
-   PATH: YmJiYmJiYmIK
- kind: Secret
- metadata:
--  name: crdsecret-m5ht5thcb4
-+  name: test-crdsecret-m48btmkck5

--- a/pkg/commands/testdata/testcase-hash-suffix-default/expected.diff
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/expected.diff
@@ -4,18 +4,18 @@ diff -u -N /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml /tmp/transform
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_3: value_3
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
-+  name: default-with-hash-override-m46fh86fch
++  name: default-with-hash-override-k226dt925b
 diff -u -N /tmp/noop/v1_ConfigMap_default-with-none-override.yaml /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml
 --- /tmp/noop/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_2: value_2
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
@@ -26,8 +26,44 @@ diff -u -N /tmp/noop/v1_ConfigMap_default.yaml /tmp/transformed/v1_ConfigMap_def
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_1: value_1
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
-+  name: default-4dkh4mmt4m
++  name: default-98958kc77b
+diff -u -N /tmp/noop/v1_Secret_default-with-hash-override.yaml /tmp/transformed/v1_Secret_default-with-hash-override.yaml
+--- /tmp/noop/v1_Secret_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_3: dmFsdWVfMw==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default-with-hash-override-86bbmd66hf
++type: Opaque
+diff -u -N /tmp/noop/v1_Secret_default-with-none-override.yaml /tmp/transformed/v1_Secret_default-with-none-override.yaml
+--- /tmp/noop/v1_Secret_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_2: dmFsdWVfMg==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default-with-none-override
++type: Opaque
+diff -u -N /tmp/noop/v1_Secret_default.yaml /tmp/transformed/v1_Secret_default.yaml
+--- /tmp/noop/v1_Secret_default.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_1: dmFsdWVfMQ==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default-4kck9ff6g6
++type: Opaque

--- a/pkg/commands/testdata/testcase-hash-suffix-default/expected.diff
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/expected.diff
@@ -1,0 +1,33 @@
+diff -u -N /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml /tmp/transformed/v1_ConfigMap_default-with-hash-override.yaml
+--- /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default-with-hash-override-m46fh86fch
+diff -u -N /tmp/noop/v1_ConfigMap_default-with-none-override.yaml /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml
+--- /tmp/noop/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default-with-none-override
+diff -u -N /tmp/noop/v1_ConfigMap_default.yaml /tmp/transformed/v1_ConfigMap_default.yaml
+--- /tmp/noop/v1_ConfigMap_default.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default-4dkh4mmt4m

--- a/pkg/commands/testdata/testcase-hash-suffix-default/expected.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/expected.yaml
@@ -7,24 +7,58 @@ metadata:
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_1: value_1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: default-4dkh4mmt4m
+  name: default-98958kc77b
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_3: value_3
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: default-with-hash-override-m46fh86fch
+  name: default-with-hash-override-k226dt925b
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_2: value_2
 kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: default-with-none-override
+---
+apiVersion: v1
+data:
+  my-key: bXktdmFsdWUK
+kind: Secret
+metadata:
+  name: a-static-secret-b74f97t2ht
+---
+apiVersion: v1
+data:
+  VALUE_1: dmFsdWVfMQ==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default-4kck9ff6g6
+type: Opaque
+---
+apiVersion: v1
+data:
+  VALUE_3: dmFsdWVfMw==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default-with-hash-override-86bbmd66hf
+type: Opaque
+---
+apiVersion: v1
+data:
+  VALUE_2: dmFsdWVfMg==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default-with-none-override
+type: Opaque

--- a/pkg/commands/testdata/testcase-hash-suffix-default/expected.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/expected.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  my: data
+kind: ConfigMap
+metadata:
+  name: a-static-configmap-kbf5887tdm
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-4dkh4mmt4m
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-with-hash-override-m46fh86fch
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-with-none-override

--- a/pkg/commands/testdata/testcase-hash-suffix-default/in/config-map.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/in/config-map.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  my: data
+kind: ConfigMap
+metadata:
+  name: a-static-configmap

--- a/pkg/commands/testdata/testcase-hash-suffix-default/in/kustomization.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/in/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- config-map.yaml
+configMapGenerator:
+- name: default
+  literals:
+  - value_1=value_1
+- name: default-with-none-override
+  renaming: none
+  literals:
+  - value_1=value_1
+- name: default-with-hash-override
+  renaming: hash
+  literals:
+  - value_1=value_1

--- a/pkg/commands/testdata/testcase-hash-suffix-default/in/kustomization.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/in/kustomization.yaml
@@ -1,14 +1,27 @@
 resources:
 - config-map.yaml
+- secret.yaml
 configMapGenerator:
 - name: default
   literals:
-  - value_1=value_1
+  - key_1=value_1
 - name: default-with-none-override
   renaming: none
   literals:
-  - value_1=value_1
+  - key_2=value_2
 - name: default-with-hash-override
   renaming: hash
   literals:
-  - value_1=value_1
+  - key_3=value_3
+secretGenerator:
+- name: default
+  commands:
+    VALUE_1: "printf value_1"
+- name: default-with-none-override
+  renaming: none
+  commands:
+    VALUE_2: "printf value_2"
+- name: default-with-hash-override
+  renaming: hash
+  commands:
+    VALUE_3: "printf value_3"

--- a/pkg/commands/testdata/testcase-hash-suffix-default/in/secret.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/in/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: a-static-secret
+data:
+  my-key: bXktdmFsdWUK

--- a/pkg/commands/testdata/testcase-hash-suffix-default/test.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-default/test.yaml
@@ -1,0 +1,5 @@
+description: hash suffix preference
+args: []
+filename: testdata/testcase-hash-suffix-default/in
+expectedStdout: testdata/testcase-hash-suffix-default/expected.yaml
+expectedDiff: testdata/testcase-hash-suffix-default/expected.diff

--- a/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.diff
+++ b/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.diff
@@ -1,0 +1,33 @@
+diff -u -N /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml /tmp/transformed/v1_ConfigMap_default-with-hash-override.yaml
+--- /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default-with-hash-override-m46fh86fch
+diff -u -N /tmp/noop/v1_ConfigMap_default-with-none-override.yaml /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml
+--- /tmp/noop/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default-with-none-override
+diff -u -N /tmp/noop/v1_ConfigMap_default.yaml /tmp/transformed/v1_ConfigMap_default.yaml
+--- /tmp/noop/v1_ConfigMap_default.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_ConfigMap_default.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,7 @@
++apiVersion: v1
++data:
++  value_1: value_1
++kind: ConfigMap
++metadata:
++  creationTimestamp: null
++  name: default

--- a/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.diff
+++ b/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.diff
@@ -4,18 +4,18 @@ diff -u -N /tmp/noop/v1_ConfigMap_default-with-hash-override.yaml /tmp/transform
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_3: value_3
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
-+  name: default-with-hash-override-m46fh86fch
++  name: default-with-hash-override-k226dt925b
 diff -u -N /tmp/noop/v1_ConfigMap_default-with-none-override.yaml /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml
 --- /tmp/noop/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1_ConfigMap_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_2: value_2
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
@@ -26,8 +26,44 @@ diff -u -N /tmp/noop/v1_ConfigMap_default.yaml /tmp/transformed/v1_ConfigMap_def
 @@ -0,0 +1,7 @@
 +apiVersion: v1
 +data:
-+  value_1: value_1
++  key_1: value_1
 +kind: ConfigMap
 +metadata:
 +  creationTimestamp: null
 +  name: default
+diff -u -N /tmp/noop/v1_Secret_default-with-hash-override.yaml /tmp/transformed/v1_Secret_default-with-hash-override.yaml
+--- /tmp/noop/v1_Secret_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default-with-hash-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_3: dmFsdWVfMw==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default-with-hash-override-86bbmd66hf
++type: Opaque
+diff -u -N /tmp/noop/v1_Secret_default-with-none-override.yaml /tmp/transformed/v1_Secret_default-with-none-override.yaml
+--- /tmp/noop/v1_Secret_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default-with-none-override.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_2: dmFsdWVfMg==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default-with-none-override
++type: Opaque
+diff -u -N /tmp/noop/v1_Secret_default.yaml /tmp/transformed/v1_Secret_default.yaml
+--- /tmp/noop/v1_Secret_default.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/v1_Secret_default.yaml	YYYY-MM-DD HH:MM:SS
+@@ -0,0 +1,8 @@
++apiVersion: v1
++data:
++  VALUE_1: dmFsdWVfMQ==
++kind: Secret
++metadata:
++  creationTimestamp: null
++  name: default
++type: Opaque

--- a/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  my: data
+kind: ConfigMap
+metadata:
+  name: a-static-configmap
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-with-hash-override-m46fh86fch
+---
+apiVersion: v1
+data:
+  value_1: value_1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: default-with-none-override

--- a/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-disabled/expected.yaml
@@ -7,7 +7,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_1: value_1
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -15,16 +15,50 @@ metadata:
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_3: value_3
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: default-with-hash-override-m46fh86fch
+  name: default-with-hash-override-k226dt925b
 ---
 apiVersion: v1
 data:
-  value_1: value_1
+  key_2: value_2
 kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: default-with-none-override
+---
+apiVersion: v1
+data:
+  my-key: bXktdmFsdWUK
+kind: Secret
+metadata:
+  name: a-static-secret
+---
+apiVersion: v1
+data:
+  VALUE_1: dmFsdWVfMQ==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  VALUE_3: dmFsdWVfMw==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default-with-hash-override-86bbmd66hf
+type: Opaque
+---
+apiVersion: v1
+data:
+  VALUE_2: dmFsdWVfMg==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: default-with-none-override
+type: Opaque

--- a/pkg/commands/testdata/testcase-hash-suffix-disabled/test.yaml
+++ b/pkg/commands/testdata/testcase-hash-suffix-disabled/test.yaml
@@ -1,0 +1,5 @@
+description: hash suffix preference disabled
+renamingBehavior: none
+filename: testdata/testcase-hash-suffix-default/in
+expectedStdout: testdata/testcase-hash-suffix-disabled/expected.yaml
+expectedDiff: testdata/testcase-hash-suffix-disabled/expected.diff

--- a/pkg/resmap/configmap.go
+++ b/pkg/resmap/configmap.go
@@ -33,7 +33,7 @@ func newResourceFromConfigMap(l loader.Loader, cmArgs types.ConfigMapArgs) (*res
 	if err != nil {
 		return nil, err
 	}
-	return resource.NewResourceWithBehavior(cm, resource.NewGenerationBehavior(cmArgs.Behavior))
+	return resource.NewResourceWithBehavior(cm, resource.NewGenerationBehavior(cmArgs.Behavior), resource.NewRenamingBehavior(cmArgs.RenamingBehavior))
 }
 
 func makeConfigMap(l loader.Loader, cmArgs types.ConfigMapArgs) (*corev1.ConfigMap, error) {

--- a/pkg/resmap/configmap_test.go
+++ b/pkg/resmap/configmap_test.go
@@ -121,6 +121,33 @@ BAR=baz
 					}),
 			},
 		},
+		{
+			description: "config map with custom rename behavior",
+			input: []types.ConfigMapArgs{
+				{
+					Name:             "literalConfigMap",
+					RenamingBehavior: "none",
+					DataSources: types.DataSources{
+						LiteralSources: []string{"a=b"},
+					},
+				},
+			},
+			expected: ResMap{
+				resource.NewResId(cmap, "literalConfigMap"): NewResourceFromMapWithRenamingBehavior(
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ConfigMap",
+						"metadata": map[string]interface{}{
+							"name":              "literalConfigMap",
+							"creationTimestamp": nil,
+						},
+						"data": map[string]interface{}{
+							"a": "b",
+						},
+					},
+					resource.RenamingBehaviorNone),
+			},
+		},
 		// TODO: add testcase for data coming from multiple sources like
 		// files/literal/env etc.
 	}
@@ -138,4 +165,10 @@ BAR=baz
 			t.Fatalf("in testcase: %q got:\n%+v\n expected:\n%+v\n", tc.description, r, tc.expected)
 		}
 	}
+}
+
+func NewResourceFromMapWithRenamingBehavior(m map[string]interface{}, renamingBehavior resource.RenamingBehavior) *resource.Resource {
+	var resourceMap = resource.NewResourceFromMap(m)
+	resourceMap.SetRenamingBehavior(renamingBehavior)
+	return resourceMap
 }

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -201,11 +201,11 @@ func newResourceSliceFromBytes(in []byte) ([]*resource.Resource, error) {
 func MergeWithoutOverride(maps ...ResMap) (ResMap, error) {
 	result := ResMap{}
 	for _, m := range maps {
-		for id, resource := range m {
+		for id, res := range m {
 			if _, found := result[id]; found {
 				return nil, fmt.Errorf("id '%q' already used", id)
 			}
-			result[id] = resource
+			result[id] = res
 		}
 	}
 	return result, nil

--- a/pkg/resmap/secret.go
+++ b/pkg/resmap/secret.go
@@ -34,8 +34,7 @@ func newResourceFromSecretGenerator(p string, sArgs types.SecretArgs) (*resource
 	if err != nil {
 		return nil, errors.Wrap(err, "makeSecret")
 	}
-	return resource.NewResourceWithBehavior(
-		s, resource.NewGenerationBehavior(sArgs.Behavior))
+	return resource.NewResourceWithBehavior(s, resource.NewGenerationBehavior(sArgs.Behavior), resource.NewRenamingBehavior(sArgs.RenamingBehavior))
 }
 
 func makeSecret(p string, sArgs types.SecretArgs) (*corev1.Secret, error) {

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -66,3 +66,36 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 		t.Fatalf("%#v\ndoesn't match expected:\n%#v", actual, expected)
 	}
 }
+
+func TestNewResMapFromSecretArgsWithCustomRenamingBehavior(t *testing.T) {
+	secrets := []types.SecretArgs{
+		{
+			Name:             "my-config-map",
+			Commands:         map[string]string{},
+			RenamingBehavior: "none",
+		},
+	}
+
+	expected := ResMap{
+		resource.NewResId(secret, "my-config-map"): NewResourceFromMapWithRenamingBehavior(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name":              "my-config-map",
+					"creationTimestamp": nil,
+				},
+				"type": string(corev1.SecretTypeOpaque),
+			},
+			resource.RenamingBehaviorNone,
+		),
+	}
+
+	actual, err := NewResMapFromSecretArgs(".", secrets)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("%#v\ndoesn't match expected:\n%#v", actual, expected)
+	}
+}

--- a/pkg/resource/renamingbehavior.go
+++ b/pkg/resource/renamingbehavior.go
@@ -47,7 +47,7 @@ func NewRenamingBehavior(s string) RenamingBehavior {
 	case "none":
 		return RenamingBehaviorNone
 	case "hash":
-		return RenamingBehaviorHash;
+		return RenamingBehaviorHash
 	default:
 		return RenamingBehaviorUnspecified
 	}

--- a/pkg/resource/renamingbehavior.go
+++ b/pkg/resource/renamingbehavior.go
@@ -22,6 +22,9 @@ type RenamingBehavior int
 const (
 	// RenamingBehaviorUnspecified is an Unspecified behavior; typically treated as the default.
 	RenamingBehaviorUnspecified RenamingBehavior = iota
+	// RenamingBehaviorHash is a behavior where the content is hashed and added as a suffix to the resource name
+	// Typically treated as the default.
+	RenamingBehaviorHash
 	// RenamingBehaviorNone suppresses the addition of a hash suffix on the end of the resource
 	RenamingBehaviorNone
 )
@@ -31,6 +34,8 @@ func (b RenamingBehavior) String() string {
 	switch b {
 	case RenamingBehaviorNone:
 		return "none"
+	case RenamingBehaviorHash:
+		return "hash"
 	default:
 		return "unspecified"
 	}
@@ -41,6 +46,8 @@ func NewRenamingBehavior(s string) RenamingBehavior {
 	switch s {
 	case "none":
 		return RenamingBehaviorNone
+	case "hash":
+		return RenamingBehaviorHash;
 	default:
 		return RenamingBehaviorUnspecified
 	}

--- a/pkg/resource/renamingbehavior.go
+++ b/pkg/resource/renamingbehavior.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+// RenamingBehavior specifies renaming behavior of configmaps, secrets and maybe other resources.
+type RenamingBehavior int
+
+const (
+	// RenamingBehaviorUnspecified is an Unspecified behavior; typically treated as the default.
+	RenamingBehaviorUnspecified RenamingBehavior = iota
+	// RenamingBehaviorNone suppresses the addition of a hash suffix on the end of the resource
+	RenamingBehaviorNone
+)
+
+// String converts a RenamingBehavior to a string.
+func (b RenamingBehavior) String() string {
+	switch b {
+	case RenamingBehaviorNone:
+		return "none"
+	default:
+		return "unspecified"
+	}
+}
+
+// NewRenamingBehavior converts a string to a RenamingBehavior.
+func NewRenamingBehavior(s string) RenamingBehavior {
+	switch s {
+	case "none":
+		return RenamingBehaviorNone
+	default:
+		return RenamingBehaviorUnspecified
+	}
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -32,10 +32,11 @@ import (
 type Resource struct {
 	unstructured.Unstructured
 	b GenerationBehavior
+	rb RenamingBehavior
 }
 
 // NewResourceWithBehavior returns a new instance of Resource.
-func NewResourceWithBehavior(obj runtime.Object, b GenerationBehavior) (*Resource, error) {
+func NewResourceWithBehavior(obj runtime.Object, b GenerationBehavior, rb RenamingBehavior) (*Resource, error) {
 	// Convert obj to a byte stream, then convert that to JSON (Unstructured).
 	marshaled, err := json.Marshal(obj)
 	if err != nil {
@@ -43,7 +44,7 @@ func NewResourceWithBehavior(obj runtime.Object, b GenerationBehavior) (*Resourc
 	}
 	var u unstructured.Unstructured
 	err = u.UnmarshalJSON(marshaled)
-	return &Resource{Unstructured: u, b: b}, err
+	return &Resource{Unstructured: u, b: b, rb: rb}, err
 }
 
 // NewResourceFromMap returns a new instance of Resource.
@@ -53,7 +54,7 @@ func NewResourceFromMap(m map[string]interface{}) *Resource {
 
 // NewResourceFromUnstruct returns a new instance of Resource.
 func NewResourceFromUnstruct(u unstructured.Unstructured) *Resource {
-	return &Resource{Unstructured: u, b: BehaviorUnspecified}
+	return &Resource{Unstructured: u, b: BehaviorUnspecified, rb: RenamingBehaviorUnspecified}
 }
 
 // Behavior returns the behavior for the resource.
@@ -64,6 +65,16 @@ func (r *Resource) Behavior() GenerationBehavior {
 // SetBehavior changes the resource to the new behavior
 func (r *Resource) SetBehavior(b GenerationBehavior) {
 	r.b = b
+}
+
+// RenamingBehavior returns the renamingBehavior for the resource.
+func (r *Resource) RenamingBehavior() RenamingBehavior {
+	return r.rb
+}
+
+// SetRenamingBehavior changes the resource to the new renamingBehavior
+func (r *Resource) SetRenamingBehavior(rb RenamingBehavior) {
+	r.rb = rb
 }
 
 // Id returns the ResId for the resource.

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -31,7 +31,7 @@ import (
 // paired with a GenerationBehavior.
 type Resource struct {
 	unstructured.Unstructured
-	b GenerationBehavior
+	b  GenerationBehavior
 	rb RenamingBehavior
 }
 

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -18,7 +18,32 @@ package resource
 
 import (
 	"testing"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestNewResourceFromUnstructDefaultsToRenamingUnspecified(t *testing.T) {
+	var res = NewResourceFromUnstruct(unstructured.Unstructured{})
+
+	if res.RenamingBehavior() != RenamingBehaviorUnspecified {
+		t.Fatalf("Got:%s expected:%s", res.RenamingBehavior(), RenamingBehaviorUnspecified)
+	}
+}
+
+func TestNewResourceWithBehaviorHasCorrectRenamingBehavior(t *testing.T) {
+	tests := []RenamingBehavior {
+		RenamingBehaviorHash,
+		RenamingBehaviorNone,
+		RenamingBehaviorUnspecified,
+	}
+
+	for _, test := range tests {
+		var res, _= NewResourceWithBehavior(&unstructured.Unstructured{}, BehaviorUnspecified, test)
+
+		if res.RenamingBehavior() != test {
+			t.Fatalf("Got:%s expected:%s", res.RenamingBehavior(), test)
+		}
+	}
+}
 
 func TestGetFieldValue(t *testing.T) {
 	res := NewResourceFromMap(map[string]interface{}{

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"testing"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -30,14 +31,14 @@ func TestNewResourceFromUnstructDefaultsToRenamingUnspecified(t *testing.T) {
 }
 
 func TestNewResourceWithBehaviorHasCorrectRenamingBehavior(t *testing.T) {
-	tests := []RenamingBehavior {
+	tests := []RenamingBehavior{
 		RenamingBehaviorHash,
 		RenamingBehaviorNone,
 		RenamingBehaviorUnspecified,
 	}
 
 	for _, test := range tests {
-		var res, _= NewResourceWithBehavior(&unstructured.Unstructured{}, BehaviorUnspecified, test)
+		var res, _ = NewResourceWithBehavior(&unstructured.Unstructured{}, BehaviorUnspecified, test)
 
 		if res.RenamingBehavior() != test {
 			t.Fatalf("Got:%s expected:%s", res.RenamingBehavior(), test)

--- a/pkg/transformers/namehash.go
+++ b/pkg/transformers/namehash.go
@@ -29,7 +29,7 @@ import (
 
 // nameHashTransformer contains the prefix and the path config for each field that
 // the name prefix will be applied.
-type nameHashTransformer struct{
+type nameHashTransformer struct {
 	defaultRenamingBehavior resource.RenamingBehavior
 }
 
@@ -37,7 +37,7 @@ var _ Transformer = &nameHashTransformer{}
 
 // NewNameHashTransformer construct a nameHashTransformer.
 func NewNameHashTransformer(defaultRenamingBehavior resource.RenamingBehavior) Transformer {
-	return &nameHashTransformer{ defaultRenamingBehavior: defaultRenamingBehavior }
+	return &nameHashTransformer{defaultRenamingBehavior: defaultRenamingBehavior}
 }
 
 // Transform appends hash to configmaps and secrets.

--- a/pkg/transformers/namehash.go
+++ b/pkg/transformers/namehash.go
@@ -29,18 +29,24 @@ import (
 
 // nameHashTransformer contains the prefix and the path config for each field that
 // the name prefix will be applied.
-type nameHashTransformer struct{}
+type nameHashTransformer struct{
+	defaultRenamingBehavior resource.RenamingBehavior
+}
 
 var _ Transformer = &nameHashTransformer{}
 
 // NewNameHashTransformer construct a nameHashTransformer.
-func NewNameHashTransformer() Transformer {
-	return &nameHashTransformer{}
+func NewNameHashTransformer(defaultRenamingBehavior resource.RenamingBehavior) Transformer {
+	return &nameHashTransformer{ defaultRenamingBehavior: defaultRenamingBehavior }
 }
 
 // Transform appends hash to configmaps and secrets.
 func (o *nameHashTransformer) Transform(m resmap.ResMap) error {
 	for id, res := range m {
+		if shouldNotHashName(res.RenamingBehavior(), o.defaultRenamingBehavior) {
+			continue
+		}
+
 		switch {
 		case selectByGVK(id.Gvk(), &schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}):
 			err := appendHashForConfigMap(res)
@@ -58,14 +64,16 @@ func (o *nameHashTransformer) Transform(m resmap.ResMap) error {
 	return nil
 }
 
+func shouldNotHashName(resourceBehaviour resource.RenamingBehavior, defaultBehavior resource.RenamingBehavior) bool {
+	return resourceBehaviour == resource.RenamingBehaviorNone ||
+		(resourceBehaviour == resource.RenamingBehaviorUnspecified &&
+			defaultBehavior == resource.RenamingBehaviorNone)
+}
+
 func appendHashForConfigMap(res *resource.Resource) error {
 	cm, err := unstructuredToConfigmap(res)
 	if err != nil {
 		return err
-	}
-
-	if res.RenamingBehavior() == resource.RenamingBehaviorNone {
-		return nil
 	}
 
 	h, err := hash.ConfigMapHash(cm)
@@ -92,10 +100,6 @@ func appendHashForSecret(res *resource.Resource) error {
 	secret, err := unstructuredToSecret(res)
 	if err != nil {
 		return err
-	}
-
-	if res.RenamingBehavior() == resource.RenamingBehaviorNone {
-		return nil
 	}
 
 	h, err := hash.SecretHash(secret)

--- a/pkg/transformers/namehash.go
+++ b/pkg/transformers/namehash.go
@@ -63,6 +63,11 @@ func appendHashForConfigMap(res *resource.Resource) error {
 	if err != nil {
 		return err
 	}
+
+	if res.RenamingBehavior() == resource.RenamingBehaviorNone {
+		return nil
+	}
+
 	h, err := hash.ConfigMapHash(cm)
 	if err != nil {
 		return err

--- a/pkg/transformers/namehash.go
+++ b/pkg/transformers/namehash.go
@@ -93,6 +93,11 @@ func appendHashForSecret(res *resource.Resource) error {
 	if err != nil {
 		return err
 	}
+
+	if res.RenamingBehavior() == resource.RenamingBehaviorNone {
+		return nil
+	}
+
 	h, err := hash.SecretHash(secret)
 	if err != nil {
 		return err

--- a/pkg/transformers/namehash_test.go
+++ b/pkg/transformers/namehash_test.go
@@ -147,7 +147,7 @@ func TestNameHashTransformer(t *testing.T) {
 			}),
 	}
 
-	tran := NewNameHashTransformer()
+	tran := NewNameHashTransformer(resource.RenamingBehaviorUnspecified)
 	tran.Transform(objs)
 
 	if !reflect.DeepEqual(objs, expected) {

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -85,6 +85,10 @@ type ConfigMapArgs struct {
 
 	// DataSources for configmap.
 	DataSources `json:",inline,omitempty" yaml:",inline,omitempty"`
+
+	// Naming behavior of configmap, must be one of none
+	// 'none': disable renaming behavior.
+	RenamingBehavior string `json:"renaming,omitempty" yaml:"renaming,omitempty"`
 }
 
 // SecretArgs contains the metadata of how to generate a secret.
@@ -111,6 +115,10 @@ type SecretArgs struct {
 
 	// Map of keys to commands to generate the values
 	Commands map[string]string `json:",commands,omitempty" yaml:",inline,omitempty"`
+
+	// Naming behavior of configmap, must be one of none
+	// 'none': disable renaming behavior.
+	RenamingBehavior string `json:"renaming,omitempty" yaml:"renaming,omitempty"`
 }
 
 // DataSources contains some generic sources for configmap or secret.


### PR DESCRIPTION
Users can disable hash suffix for specific resources by specifying a `renaming` policy on their configmaps or secrets:

```yaml
configMapGenerator:
- name: my-config-map
  renaming: none
  literals:
  - key=value

secretGenerator:
- name: my-secret
  renaming: none
  commands:
    key: "printf value"
```

This will not stop renaming on configmaps and secrets that are defined in K8S Yaml files.
If users need to disable generated hash suffixes on these resources then they can pass the `--default-rename-behavior` flag with a value of `none` to the build/diff commands do turn this off.
If a user chooses to do this they can regain rolling update support by adding `renaming: hash` to resources where hash-suffix support is desired:

```yaml
configMapGenerator:
- name: my-config-map
  renaming: hash
  literals:
  - key=value

secretGenerator:
- name: my-secret
  renaming: hash
  commands:
    key: "printf value"
```

I have maintained the current functionality of adding a hash to all configmaps and secrets to ensure this change is backwards compatible.

I have attempted to follow local style in the tests added but approach differs from file to file.
Feedback welcome!