### PR TITLE
[WIP] Support variable reference for ClusterRoleBinding subject namespace

### DIFF
--- a/pkg/transformers/labelsandannotations.go
+++ b/pkg/transformers/labelsandannotations.go
@@ -62,7 +62,7 @@ func (o *mapTransformer) Transform(m resmap.ResMap) error {
 			if !selectByGVK(id.Gvk(), path.GroupVersionKind) {
 				continue
 			}
-			err := mutateField(objMap, path.Path, path.CreateIfNotPresent, o.addMap)
+			err := mutateField(objMap, path.Path, path.CreateIfNotPresent, path.IgnoreIfPresent, o.addMap)
 			if err != nil {
 				return err
 			}

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -35,6 +35,8 @@ var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1bet
 var job = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 var cronjob = schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
 var pvc = schema.GroupVersionKind{Version: "v1", Kind: "PersistentVolumeClaim"}
+var clusterrolebinding = schema.GroupVersionKind{Version: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}
+var sa = schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"}
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{

--- a/pkg/transformers/namereference.go
+++ b/pkg/transformers/namereference.go
@@ -57,7 +57,7 @@ func (o *nameReferenceTransformer) Transform(m resmap.ResMap) error {
 				if !selectByGVK(id.Gvk(), path.GroupVersionKind) {
 					continue
 				}
-				err := mutateField(objMap, path.Path, path.CreateIfNotPresent,
+				err := mutateField(objMap, path.Path, path.CreateIfNotPresent, path.IgnoreIfPresent,
 					o.updateNameReference(referencePathConfig.referencedGVK, m))
 				if err != nil {
 					return err

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -51,6 +51,33 @@ func TestNamespaceRun(t *testing.T) {
 					"name": "ns1",
 				},
 			}),
+		resource.NewResId(sa, "sa1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name": "sa1",
+				},
+			}),
+		resource.NewResId(clusterrolebinding, "clusterrolebinding1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": "clusterrolebinding1",
+				},
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind": "ServiceAccount",
+						"name": "sa1",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "sa2",
+						"namespace": "foo",
+					},
+				},
+			}),
 	}
 	expected := resmap.ResMap{
 		resource.NewResId(ns, "ns1"): resource.NewResourceFromMap(
@@ -77,6 +104,35 @@ func TestNamespaceRun(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name":      "cm2",
 					"namespace": "test",
+				},
+			}),
+		resource.NewResId(sa, "sa1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name":      "sa1",
+					"namespace": "test",
+				},
+			}),
+		resource.NewResId(clusterrolebinding, "clusterrolebinding1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": "clusterrolebinding1",
+				},
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "sa1",
+						"namespace": "test",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "sa2",
+						"namespace": "foo",
+					},
 				},
 			}),
 	}

--- a/pkg/transformers/pathconfig.go
+++ b/pkg/transformers/pathconfig.go
@@ -25,6 +25,8 @@ import (
 type PathConfig struct {
 	// If true, it will create the path if it is not found.
 	CreateIfNotPresent bool
+	// If true, the path will be ignored if the path is found.
+	IgnoreIfPresent bool
 	// The gvk that this path tied to.
 	// If unset, it applied to any gvk
 	// If some fields are set, it applies to all matching gvk.

--- a/pkg/transformers/prefixname.go
+++ b/pkg/transformers/prefixname.go
@@ -84,7 +84,7 @@ func (o *namePrefixTransformer) Transform(m resmap.ResMap) error {
 			if !selectByGVK(id.Gvk(), path.GroupVersionKind) {
 				continue
 			}
-			err := mutateField(objMap, path.Path, path.CreateIfNotPresent, o.addPrefix)
+			err := mutateField(objMap, path.Path, path.CreateIfNotPresent, path.IgnoreIfPresent, o.addPrefix)
 			if err != nil {
 				return err
 			}

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -102,10 +102,6 @@ func NewRefVarTransformer(vars map[string]string) (Transformer, error) {
 				GroupVersionKind: &schema.GroupVersionKind{Kind: "Pod"},
 				Path:             []string{"spec", "containers", "env", "value"},
 			},
-			{
-				GroupVersionKind: &schema.GroupVersionKind{Kind: "ClusterRoleBinding"},
-				Path:             []string{"subjects", "namespace"},
-			},
 		},
 	}, nil
 }
@@ -126,7 +122,7 @@ func (rv *refvarTransformer) Transform(resources resmap.ResMap) error {
 			if !selectByGVK(GVKn.Gvk(), pc.GroupVersionKind) {
 				continue
 			}
-			err := mutateField(objMap, pc.Path, false, func(in interface{}) (interface{}, error) {
+			err := mutateField(objMap, pc.Path, false, false, func(in interface{}) (interface{}, error) {
 				var (
 					mappingFunc = expansion.MappingFuncFor(rv.vars)
 				)

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -102,6 +102,10 @@ func NewRefVarTransformer(vars map[string]string) (Transformer, error) {
 				GroupVersionKind: &schema.GroupVersionKind{Kind: "Pod"},
 				Path:             []string{"spec", "containers", "env", "value"},
 			},
+			{
+				GroupVersionKind: &schema.GroupVersionKind{Kind: "ClusterRoleBinding"},
+				Path:             []string{"subjects", "namespace"},
+			},
 		},
 	}, nil
 }

--- a/pkg/transformers/selectbypath.go
+++ b/pkg/transformers/selectbypath.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transformers
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// selectByPath returns true if path `p` matches any `GroupVersionKind` and `Path` in `pathConfigs`.
+func selectByPath(gvk schema.GroupVersionKind, p PathConfig, pathConfigs []PathConfig) bool {
+	// If `pathConfigs` is nil, it is considered as a wildcard; always return true.
+	if pathConfigs == nil {
+		return true
+	}
+	if len(pathConfigs) > 0 {
+		for _, pathConfig := range pathConfigs {
+			if selectByGVK(gvk, pathConfig.GroupVersionKind) {
+				// If p.Path or pathConfig.Path is nil, it is considered as a wildcard; always return true.
+				if p.Path == nil || pathConfig.Path == nil {
+					return true
+				}
+				if len(p.Path) != len(pathConfig.Path) {
+					continue
+				}
+				allSegmentsMatch := true
+				for i, segment := range p.Path {
+					if segment != pathConfig.Path[i] {
+						allSegmentsMatch = false
+						break
+					}
+				}
+				if allSegmentsMatch {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This may not be considered a direct fix for #136, but it does provide a workaround in the form of allowing the user to reference a variable from the namespace field of a ClusterRoleBinding subject.

```yaml
# kustomization.yaml
resources:
- serviceaccount.yaml
- clusterrolebinding.yaml

vars:
- name: SERVICEACCOUNT_NAMESPACE
  objref:
    kind: ServiceAccount
    name: my-crd
    apiVersion: v1
  fieldref:
    fieldpath: metadata.namespace
```

```yaml
# serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-crd
```

```yaml
# clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: my-crd
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- kind: ServiceAccount
  name: my-crd
  namespace: $(SERVICEACCOUNT_NAMESPACE)
```