### PR TITLE
Interpret projected configMap volume names

### DIFF
--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -30,6 +30,7 @@ var secret = schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
 var cmap = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 var ns = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
 var deploy = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+var statefulset = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 var foo = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
 var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 var job = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -169,148 +169,119 @@ func TestNameReferenceRun(t *testing.T) {
 			}),
 	}
 
-	expected := resmap.ResMap{
-		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
-					"name": "someprefix-cm1-somehash",
-				},
-			}),
-		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]interface{}{
-					"name": "someprefix-cm2-somehash",
-				},
-			}),
-		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Secret",
-				"metadata": map[string]interface{}{
-					"name": "someprefix-secret1-somehash",
-				},
-			}),
-		resource.NewResId(pvc, "claim1"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "PersistentVolumeClaim",
-				"metadata": map[string]interface{}{
-					"name": "someprefix-claim1",
-				},
-			}),
-		resource.NewResId(deploy, "deploy1"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"group":      "apps",
-				"apiVersion": "v1",
-				"kind":       "Deployment",
-				"metadata": map[string]interface{}{
-					"name": "deploy1",
-				},
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"spec": map[string]interface{}{
-							"containers": []interface{}{
-								map[string]interface{}{
-									"name":  "nginx",
-									"image": "nginx:1.7.9",
-									"env": []interface{}{
-										map[string]interface{}{
-											"name": "CM_FOO",
-											"valueFrom": map[string]interface{}{
-												"configMapKeyRef": map[string]interface{}{
-													"name": "someprefix-cm1-somehash",
-													"key":  "somekey",
-												},
-											},
-										},
-										map[string]interface{}{
-											"name": "SECRET_FOO",
-											"valueFrom": map[string]interface{}{
-												"secretKeyRef": map[string]interface{}{
-													"name": "someprefix-secret1-somehash",
-													"key":  "somekey",
-												},
-											},
-										},
-									},
-									"envFrom": []interface{}{
-										map[string]interface{}{
-											"configMapRef": map[string]interface{}{
+	expected := resmap.ResMap{}
+	for k, v := range m {
+		expected[k] = v
+	}
+
+	expected[resource.NewResId(deploy, "deploy1")] = resource.NewResourceFromMap(
+		map[string]interface{}{
+			"group":      "apps",
+			"apiVersion": "v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "deploy1",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx",
+								"image": "nginx:1.7.9",
+								"env": []interface{}{
+									map[string]interface{}{
+										"name": "CM_FOO",
+										"valueFrom": map[string]interface{}{
+											"configMapKeyRef": map[string]interface{}{
 												"name": "someprefix-cm1-somehash",
 												"key":  "somekey",
 											},
 										},
-										map[string]interface{}{
-											"secretRef": map[string]interface{}{
+									},
+									map[string]interface{}{
+										"name": "SECRET_FOO",
+										"valueFrom": map[string]interface{}{
+											"secretKeyRef": map[string]interface{}{
 												"name": "someprefix-secret1-somehash",
 												"key":  "somekey",
 											},
 										},
 									},
 								},
-							},
-							"imagePullSecrets": []interface{}{
-								map[string]interface{}{
-									"name": "someprefix-secret1-somehash",
-								},
-							},
-							"volumes": map[string]interface{}{
-								"configMap": map[string]interface{}{
-									"name": "someprefix-cm1-somehash",
-								},
-								"projected": map[string]interface{}{
-									"sources": map[string]interface{}{
-										"configMap": map[string]interface{}{
-											"name": "someprefix-cm2-somehash",
+								"envFrom": []interface{}{
+									map[string]interface{}{
+										"configMapRef": map[string]interface{}{
+											"name": "someprefix-cm1-somehash",
+											"key":  "somekey",
 										},
 									},
-								},
-								"secret": map[string]interface{}{
-									"secretName": "someprefix-secret1-somehash",
-								},
-								"persistentVolumeClaim": map[string]interface{}{
-									"claimName": "someprefix-claim1",
-								},
-							},
-						},
-					},
-				},
-			}),
-		resource.NewResId(statefulset, "statefulset1"): resource.NewResourceFromMap(
-			map[string]interface{}{
-				"group":      "apps",
-				"apiVersion": "v1",
-				"kind":       "StatefulSet",
-				"metadata": map[string]interface{}{
-					"name": "statefulset1",
-				},
-				"spec": map[string]interface{}{
-					"template": map[string]interface{}{
-						"spec": map[string]interface{}{
-							"containers": []interface{}{
-								map[string]interface{}{
-									"name":  "nginx",
-									"image": "nginx:1.7.9",
-								},
-							},
-							"volumes": map[string]interface{}{
-								"projected": map[string]interface{}{
-									"sources": map[string]interface{}{
-										"configMap": map[string]interface{}{
-											"name": "someprefix-cm2-somehash",
+									map[string]interface{}{
+										"secretRef": map[string]interface{}{
+											"name": "someprefix-secret1-somehash",
+											"key":  "somekey",
 										},
 									},
 								},
 							},
 						},
+						"imagePullSecrets": []interface{}{
+							map[string]interface{}{
+								"name": "someprefix-secret1-somehash",
+							},
+						},
+						"volumes": map[string]interface{}{
+							"configMap": map[string]interface{}{
+								"name": "someprefix-cm1-somehash",
+							},
+							"projected": map[string]interface{}{
+								"sources": map[string]interface{}{
+									"configMap": map[string]interface{}{
+										"name": "someprefix-cm2-somehash",
+									},
+								},
+							},
+							"secret": map[string]interface{}{
+								"secretName": "someprefix-secret1-somehash",
+							},
+							"persistentVolumeClaim": map[string]interface{}{
+								"claimName": "someprefix-claim1",
+							},
+						},
 					},
 				},
-			}),
-	}
+			},
+		})
+	expected[resource.NewResId(statefulset, "statefulset1")] = resource.NewResourceFromMap(
+		map[string]interface{}{
+			"group":      "apps",
+			"apiVersion": "v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name": "statefulset1",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "nginx",
+								"image": "nginx:1.7.9",
+							},
+						},
+						"volumes": map[string]interface{}{
+							"projected": map[string]interface{}{
+								"sources": map[string]interface{}{
+									"configMap": map[string]interface{}{
+										"name": "someprefix-cm2-somehash",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
 
 	nrt, err := NewDefaultingNameReferenceTransformer()
 	if err != nil {

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -35,6 +35,14 @@ func TestNameReferenceRun(t *testing.T) {
 					"name": "someprefix-cm1-somehash",
 				},
 			}),
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm2-somehash",
+				},
+			}),
 		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
@@ -111,11 +119,48 @@ func TestNameReferenceRun(t *testing.T) {
 								"configMap": map[string]interface{}{
 									"name": "cm1",
 								},
+								"projected": map[string]interface{}{
+									"sources": map[string]interface{}{
+										"configMap": map[string]interface{}{
+											"name": "cm2",
+										},
+									},
+								},
 								"secret": map[string]interface{}{
 									"secretName": "secret1",
 								},
 								"persistentVolumeClaim": map[string]interface{}{
 									"claimName": "claim1",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(statefulset, "statefulset1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "StatefulSet",
+				"metadata": map[string]interface{}{
+					"name": "statefulset1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
+							"volumes": map[string]interface{}{
+								"projected": map[string]interface{}{
+									"sources": map[string]interface{}{
+										"configMap": map[string]interface{}{
+											"name": "cm2",
+										},
+									},
 								},
 							},
 						},
@@ -131,6 +176,14 @@ func TestNameReferenceRun(t *testing.T) {
 				"kind":       "ConfigMap",
 				"metadata": map[string]interface{}{
 					"name": "someprefix-cm1-somehash",
+				},
+			}),
+		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "someprefix-cm2-somehash",
 				},
 			}),
 		resource.NewResId(secret, "secret1"): resource.NewResourceFromMap(
@@ -209,11 +262,48 @@ func TestNameReferenceRun(t *testing.T) {
 								"configMap": map[string]interface{}{
 									"name": "someprefix-cm1-somehash",
 								},
+								"projected": map[string]interface{}{
+									"sources": map[string]interface{}{
+										"configMap": map[string]interface{}{
+											"name": "someprefix-cm2-somehash",
+										},
+									},
+								},
 								"secret": map[string]interface{}{
 									"secretName": "someprefix-secret1-somehash",
 								},
 								"persistentVolumeClaim": map[string]interface{}{
 									"claimName": "someprefix-claim1",
+								},
+							},
+						},
+					},
+				},
+			}),
+		resource.NewResId(statefulset, "statefulset1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"group":      "apps",
+				"apiVersion": "v1",
+				"kind":       "StatefulSet",
+				"metadata": map[string]interface{}{
+					"name": "statefulset1",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name":  "nginx",
+									"image": "nginx:1.7.9",
+								},
+							},
+							"volumes": map[string]interface{}{
+								"projected": map[string]interface{}{
+									"sources": map[string]interface{}{
+										"configMap": map[string]interface{}{
+											"name": "someprefix-cm2-somehash",
+										},
+									},
 								},
 							},
 						},

--- a/pkg/transformers/namereferenceconfig.go
+++ b/pkg/transformers/namereferenceconfig.go
@@ -148,6 +148,13 @@ var defaultNameReferencePathConfigs = []ReferencePathConfig{
 			},
 			{
 				GroupVersionKind: &schema.GroupVersionKind{
+					Kind: "Deployment",
+				},
+				Path:               []string{"spec", "template", "spec", "volumes", "projected", "sources", "configMap", "name"},
+				CreateIfNotPresent: false,
+			},
+			{
+				GroupVersionKind: &schema.GroupVersionKind{
 					Kind: "ReplicaSet",
 				},
 				Path:               []string{"spec", "template", "spec", "volumes", "configMap", "name"},
@@ -249,6 +256,13 @@ var defaultNameReferencePathConfigs = []ReferencePathConfig{
 					Kind: "StatefulSet",
 				},
 				Path:               []string{"spec", "template", "spec", "initContainers", "envFrom", "configMapRef", "name"},
+				CreateIfNotPresent: false,
+			},
+			{
+				GroupVersionKind: &schema.GroupVersionKind{
+					Kind: "StatefulSet",
+				},
+				Path:               []string{"spec", "template", "spec", "volumes", "projected", "sources", "configMap", "name"},
 				CreateIfNotPresent: false,
 			},
 			{


### PR DESCRIPTION
Append hashes to configMap names under the projected configMap volume,
for Kind: Deployment and StatefulSet