### PR TITLE
Add namespace transformation for subjects.namespace in ClusterRoleBinding

### DIFF
--- a/pkg/commands/testdata/testcase-multiple-patches-noconflict/in/overlay/kustomization.yaml
+++ b/pkg/commands/testdata/testcase-multiple-patches-noconflict/in/overlay/kustomization.yaml
@@ -2,7 +2,8 @@ namePrefix: staging-
 commonLabels:
   env: staging
 patches:
-  - patches/deployment-patch*.yaml
+  - patches/deployment-patch1.yaml
+  - patches/deployment-patch2.yaml
 bases:
   - ../package/
 configMapGenerator:

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -36,6 +36,8 @@ var crd = schema.GroupVersionKind{Group: "apiwctensions.k8s.io", Version: "v1bet
 var job = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 var cronjob = schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
 var pvc = schema.GroupVersionKind{Version: "v1", Kind: "PersistentVolumeClaim"}
+var crb = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}
+var sa = schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"}
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -51,6 +51,49 @@ func TestNamespaceRun(t *testing.T) {
 					"name": "ns1",
 				},
 			}),
+		resource.NewResId(sa, "default"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "system",
+				},
+			}),
+		resource.NewResId(sa, "service-account"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name":      "service-account",
+					"namespace": "system",
+				},
+			}),
+		resource.NewResId(crb, "crb"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": "manager-rolebinding",
+				},
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "default",
+						"namespace": "system",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "service-account",
+						"namespace": "system",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "another",
+						"namespace": "random",
+					},
+				},
+			}),
 	}
 	expected := resmap.ResMap{
 		resource.NewResId(ns, "ns1"): resource.NewResourceFromMap(
@@ -77,6 +120,49 @@ func TestNamespaceRun(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name":      "cm2",
 					"namespace": "test",
+				},
+			}),
+		resource.NewResId(sa, "default"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name":      "default",
+					"namespace": "test",
+				},
+			}),
+		resource.NewResId(sa, "service-account"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name":      "service-account",
+					"namespace": "test",
+				},
+			}),
+		resource.NewResId(crb, "crb"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": "manager-rolebinding",
+				},
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "default",
+						"namespace": "test",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "service-account",
+						"namespace": "test",
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      "another",
+						"namespace": "random",
+					},
 				},
 			}),
 	}


### PR DESCRIPTION
Fix #136

Add a function `updateClusterRoleBinding` as the final step of namespace transformer.
This function will 
- scan all subject items in the `subjects` list
- get the `kind` and `name` of the subject item, check if this object has been declared in current kustomization
- If found a matching object, update `namespace` in subject
- If not found a matching object, which means the subject is external to this kustomization, don't do anything

