### PR TITLE
Disable NetworkPolicy podSelector.matchLabels CreateIfNotPresent

### DIFF
--- a/pkg/commands/testdata/testcase-base-only/expected.diff
+++ b/pkg/commands/testdata/testcase-base-only/expected.diff
@@ -32,6 +32,33 @@ diff -u -N /tmp/noop/apps_v1beta2_Deployment_nginx.yaml /tmp/transformed/apps_v1
      spec:
        containers:
        - image: nginx
+diff -u -N /tmp/noop/networking.k8s.io_v1_NetworkPolicy_nginx.yaml /tmp/transformed/networking.k8s.io_v1_NetworkPolicy_nginx.yaml
+--- /tmp/noop/networking.k8s.io_v1_NetworkPolicy_nginx.yaml	YYYY-MM-DD HH:MM:SS
++++ /tmp/transformed/networking.k8s.io_v1_NetworkPolicy_nginx.yaml	YYYY-MM-DD HH:MM:SS
+@@ -1,13 +1,21 @@
+ apiVersion: networking.k8s.io/v1
+ kind: NetworkPolicy
+ metadata:
+-  name: nginx
++  annotations:
++    note: This is a test annotation
++  labels:
++    app: mynginx
++    org: example.com
++    team: foo
++  name: team-foo-nginx
+ spec:
+   ingress:
+   - from:
+     - podSelector:
+         matchLabels:
+-          app: nginx
++          app: mynginx
++          org: example.com
++          team: foo
+   podSelector:
+     matchExpressions:
+     - key: app
 diff -u -N /tmp/noop/v1_Service_nginx.yaml /tmp/transformed/v1_Service_nginx.yaml
 --- /tmp/noop/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS
 +++ /tmp/transformed/v1_Service_nginx.yaml	YYYY-MM-DD HH:MM:SS

--- a/pkg/commands/testdata/testcase-base-only/expected.yaml
+++ b/pkg/commands/testdata/testcase-base-only/expected.yaml
@@ -44,3 +44,28 @@ spec:
       containers:
       - image: nginx
         name: nginx
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    note: This is a test annotation
+  labels:
+    app: mynginx
+    org: example.com
+    team: foo
+  name: team-foo-nginx
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: mynginx
+          org: example.com
+          team: foo
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - test

--- a/pkg/commands/testdata/testcase-base-only/in/resources/networkpolicy.yaml
+++ b/pkg/commands/testdata/testcase-base-only/in/resources/networkpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nginx
+spec:
+  podSelector:
+    matchExpressions:
+      - {key: app, operator: In, values: [test]}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: nginx

--- a/pkg/transformers/labelsandannotationsconfig.go
+++ b/pkg/transformers/labelsandannotationsconfig.go
@@ -162,7 +162,7 @@ var defaultLabelsPathConfigs = []PathConfig{
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "networking.k8s.io", Kind: "NetworkPolicy"},
 		Path:               []string{"spec", "podSelector", "matchLabels"},
-		CreateIfNotPresent: true,
+		CreateIfNotPresent: false,
 	},
 	{
 		GroupVersionKind:   &schema.GroupVersionKind{Group: "networking.k8s.io", Kind: "NetworkPolicy"},


### PR DESCRIPTION
My own PR for NetworkPolicy labels broke a use case of mine. 

I have a NetworkPolicy that uses matchExpressions in its podSelector instead of matchLabels to refer to pods outside of the kustomization, that I want to add policy rules to, so the pods from the kustomization can access them. 