### PR TITLE
Start remerging two forked sets of configmap factory code

### DIFF
--- a/pkg/commands/configmap.go
+++ b/pkg/commands/configmap.go
@@ -103,7 +103,7 @@ func addConfigMap(k *types.Kustomization, flagsAndArgs cMapFlagsAndArgs, fSys fs
 		return err
 	}
 
-	factory := configmapandsecret.NewConfigMapFactory(cmArgs, fSys)
+	factory := configmapandsecret.NewConfigMapFactory(cmArgs, fSys, nil)
 
 	// Validate by trying to create corev1.configmap.
 	_, _, err = factory.MakeUnstructAndGenerateName()

--- a/pkg/configmapandsecret/configmapfactory_test.go
+++ b/pkg/configmapandsecret/configmapfactory_test.go
@@ -136,8 +136,8 @@ func TestConstructConfigMap(t *testing.T) {
 	for _, tc := range testCases {
 		// TODO: all tests should use a FakeFs
 		fSys := fs.MakeRealFS()
-		f := NewConfigMapFactory(&tc.input, fSys)
-		cm, err := f.MakeConfigMap()
+		f := NewConfigMapFactory(&tc.input, fSys, nil)
+		cm, err := f.MakeConfigMap1()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/configmapandsecret/kv.go
+++ b/pkg/configmapandsecret/kv.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resmap
+package configmapandsecret
 
 import (
 	"bufio"
@@ -27,8 +27,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
-
-var utf8bom = []byte{0xEF, 0xBB, 0xBF}
 
 // kvPair represents a key value pair.
 type kvPair struct {

--- a/pkg/configmapandsecret/kv_test.go
+++ b/pkg/configmapandsecret/kv_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package resmap
+package configmapandsecret
 
 import (
 	"reflect"

--- a/pkg/resmap/configmap.go
+++ b/pkg/resmap/configmap.go
@@ -17,123 +17,27 @@ limitations under the License.
 package resmap
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/kubernetes-sigs/kustomize/pkg/configmapandsecret"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func newResourceFromConfigMap(l loader.Loader, cmArgs types.ConfigMapArgs) (*resource.Resource, error) {
-	cm, err := makeConfigMap(l, cmArgs)
-	if err != nil {
-		return nil, err
-	}
-	if cmArgs.Behavior == "" {
-		cmArgs.Behavior = "create"
-	}
-	return resource.NewResourceWithBehavior(cm, resource.NewGenerationBehavior(cmArgs.Behavior))
-}
-
-func makeConfigMap(l loader.Loader, cmArgs types.ConfigMapArgs) (*corev1.ConfigMap, error) {
-	var envPairs, literalPairs, filePairs []kvPair
-	var err error
-
-	cm := &corev1.ConfigMap{}
-	cm.APIVersion = "v1"
-	cm.Kind = "ConfigMap"
-	cm.Name = cmArgs.Name
-	cm.Data = map[string]string{}
-
-	if cmArgs.EnvSource != "" {
-		envPairs, err = keyValuesFromEnvFile(l, cmArgs.EnvSource)
-		if err != nil {
-			return nil, fmt.Errorf("error reading keys from env source file: %s %v", cmArgs.EnvSource, err)
-		}
-	}
-
-	literalPairs, err = keyValuesFromLiteralSources(cmArgs.LiteralSources)
-	if err != nil {
-		return nil, fmt.Errorf("error reading key values from literal sources: %v", err)
-	}
-
-	filePairs, err = keyValuesFromFileSources(l, cmArgs.FileSources)
-	if err != nil {
-		return nil, fmt.Errorf("error reading key values from file sources: %v", err)
-	}
-
-	allPairs := append(append(envPairs, literalPairs...), filePairs...)
-
-	// merge key value pairs from all the sources
-	for _, kv := range allPairs {
-		err = addKV(cm.Data, kv)
-		if err != nil {
-			return nil, fmt.Errorf("error adding key in configmap: %v", err)
-		}
-	}
-
-	return cm, nil
-}
-
-func keyValuesFromEnvFile(l loader.Loader, path string) ([]kvPair, error) {
-	content, err := l.Load(path)
-	if err != nil {
-		return nil, err
-	}
-	return keyValuesFromLines(content)
-}
-
-func keyValuesFromLiteralSources(sources []string) ([]kvPair, error) {
-	var kvs []kvPair
-	for _, s := range sources {
-		// TODO: move ParseLiteralSource in this file
-		k, v, err := configmapandsecret.ParseLiteralSource(s)
-		if err != nil {
-			return nil, err
-		}
-		kvs = append(kvs, kvPair{key: k, value: v})
-	}
-	return kvs, nil
-}
-
-func keyValuesFromFileSources(l loader.Loader, sources []string) ([]kvPair, error) {
-	var kvs []kvPair
-
-	for _, s := range sources {
-		key, path, err := configmapandsecret.ParseFileSource(s)
-		if err != nil {
-			return nil, err
-		}
-		fileContent, err := l.Load(path)
-		if err != nil {
-			return nil, err
-		}
-		kvs = append(kvs, kvPair{key: key, value: string(fileContent)})
-	}
-	return kvs, nil
-}
-
-// addKV adds key-value pair to the provided map.
-func addKV(m map[string]string, kv kvPair) error {
-	if errs := validation.IsConfigMapKey(kv.key); len(errs) != 0 {
-		return fmt.Errorf("%q is not a valid key name: %s", kv.key, strings.Join(errs, ";"))
-	}
-	if _, exists := m[kv.key]; exists {
-		return fmt.Errorf("key %s already exists: %v", kv.key, m)
-	}
-	m[kv.key] = kv.value
-	return nil
-}
-
 // NewResMapFromConfigMapArgs returns a Resource slice given a configmap metadata slice from kustomization file.
-func NewResMapFromConfigMapArgs(loader loader.Loader, cmList []types.ConfigMapArgs) (ResMap, error) {
+func NewResMapFromConfigMapArgs(
+	ldr loader.Loader, cmArgsList []types.ConfigMapArgs) (ResMap, error) {
 	var allResources []*resource.Resource
-	for _, cm := range cmList {
-		res, err := newResourceFromConfigMap(loader, cm)
+	for _, cmArgs := range cmArgsList {
+		if cmArgs.Behavior == "" {
+			cmArgs.Behavior = "create"
+		}
+		f := configmapandsecret.NewConfigMapFactory(&cmArgs, nil, ldr)
+		cm, err := f.MakeConfigMap2()
+		if err != nil {
+			return nil, err
+		}
+		res, err := resource.NewResourceWithBehavior(
+			cm, resource.NewGenerationBehavior(cmArgs.Behavior))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
No logic change here - just continuing to shave away at duplicated code.

This PR moves configmap factory code out of `resmap/configmap.go` and into `configmapfactory.go`.

Code from the former is placed next to similar code in the latter, e.g.:

- `keyValuesFromLiteralSources` is placed next to `handleConfigMapFromLiteralSources`
- `keyValuesFromEnvFile` --- `handleConfigMapFromEnvFileSource`
- `keyValuesFromFileSources` --- `handleConfigMapFromFileSources`

These very similar methods can be merged in a subsequent PR, a PR that can also figure out better names for the two public factory methods `MakeConfigMap1` and `MakeConfigMap2`. 

I don't know the origin of the copy/paste that created these two similar blobs of code, but we've got poor coverage for both.

Also the kvPair code is moved over into `configmapandsecret` package since that's the only place it is used now.

This noticed while working on #86 

