### PR TITLE
Inject a file system object into "Application".

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/constants"
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/internal/loadertest"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
@@ -179,7 +180,7 @@ func TestResources1(t *testing.T) {
 			}),
 	}
 	l := makeLoader1(t)
-	app, err := NewApplication(l)
+	app, err := NewApplication(l, fs.MakeFakeFS())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
@@ -214,7 +215,7 @@ func TestRawResources1(t *testing.T) {
 			}),
 	}
 	l := makeLoader1(t)
-	app, err := NewApplication(l)
+	app, err := NewApplication(l, fs.MakeFakeFS())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
@@ -324,7 +325,7 @@ func TestRawResources2(t *testing.T) {
 			}),
 	}
 	l := makeLoader2(t)
-	app, err := NewApplication(l)
+	app, err := NewApplication(l, fs.MakeFakeFS())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -69,8 +69,8 @@ func (o *buildOptions) Validate(args []string) error {
 }
 
 // RunBuild runs build command.
-func (o *buildOptions) RunBuild(out io.Writer, fs fs.FileSystem) error {
-	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fs)})
+func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
+	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fSys)})
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {
@@ -82,7 +82,7 @@ func (o *buildOptions) RunBuild(out io.Writer, fs fs.FileSystem) error {
 		return err
 	}
 
-	application, err := app.NewApplication(rootLoader)
+	application, err := app.NewApplication(rootLoader, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/configmap.go
+++ b/pkg/commands/configmap.go
@@ -103,7 +103,7 @@ func addConfigMap(k *types.Kustomization, flagsAndArgs cMapFlagsAndArgs, fSys fs
 		return err
 	}
 
-	factory := configmapandsecret.NewConfigMapFactory(cmArgs, fSys, nil)
+	factory := configmapandsecret.NewConfigMapFactory(cmArgs, nil, fSys)
 
 	// Validate by trying to create corev1.configmap.
 	_, _, err = factory.MakeUnstructAndGenerateName()

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -66,9 +66,9 @@ func (o *diffOptions) Validate(args []string) error {
 }
 
 // RunDiff gets the differences between Application.MakeCustomizedResMap() and Application.MakeUncustomizedResMap().
-func (o *diffOptions) RunDiff(out, errOut io.Writer, fs fs.FileSystem) error {
+func (o *diffOptions) RunDiff(out, errOut io.Writer, fSys fs.FileSystem) error {
 
-	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fs)})
+	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fSys)})
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {
@@ -80,7 +80,7 @@ func (o *diffOptions) RunDiff(out, errOut io.Writer, fs fs.FileSystem) error {
 		return err
 	}
 
-	application, err := app.NewApplication(rootLoader)
+	application, err := app.NewApplication(rootLoader, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/configmapandsecret/configmapfactory.go
+++ b/pkg/configmapandsecret/configmapfactory.go
@@ -46,9 +46,9 @@ type ConfigMapFactory struct {
 // NewConfigMapFactory returns a new ConfigMapFactory.
 func NewConfigMapFactory(
 	args *types.ConfigMapArgs,
-	fSys fs.FileSystem,
-	l loader.Loader) *ConfigMapFactory {
-	return &ConfigMapFactory{args: args, fSys: fSys, ldr: l}
+	l loader.Loader,
+	fSys fs.FileSystem) *ConfigMapFactory {
+	return &ConfigMapFactory{args: args, ldr: l, fSys: fSys}
 }
 
 // MakeUnstructAndGenerateName returns an configmap and the name appended with a hash.

--- a/pkg/configmapandsecret/configmapfactory_test.go
+++ b/pkg/configmapandsecret/configmapfactory_test.go
@@ -136,7 +136,7 @@ func TestConstructConfigMap(t *testing.T) {
 	for _, tc := range testCases {
 		// TODO: all tests should use a FakeFs
 		fSys := fs.MakeRealFS()
-		f := NewConfigMapFactory(&tc.input, fSys, nil)
+		f := NewConfigMapFactory(&tc.input, nil, fSys)
 		cm, err := f.MakeConfigMap1()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/pkg/resmap/configmap.go
+++ b/pkg/resmap/configmap.go
@@ -18,20 +18,24 @@ package resmap
 
 import (
 	"github.com/kubernetes-sigs/kustomize/pkg/configmapandsecret"
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 )
 
-// NewResMapFromConfigMapArgs returns a Resource slice given a configmap metadata slice from kustomization file.
+// NewResMapFromConfigMapArgs returns a Resource slice given
+// a configmap metadata slice from kustomization file.
 func NewResMapFromConfigMapArgs(
-	ldr loader.Loader, cmArgsList []types.ConfigMapArgs) (ResMap, error) {
+	ldr loader.Loader,
+	fSys fs.FileSystem,
+	cmArgsList []types.ConfigMapArgs) (ResMap, error) {
 	var allResources []*resource.Resource
 	for _, cmArgs := range cmArgsList {
 		if cmArgs.Behavior == "" {
 			cmArgs.Behavior = "create"
 		}
-		f := configmapandsecret.NewConfigMapFactory(&cmArgs, nil, ldr)
+		f := configmapandsecret.NewConfigMapFactory(&cmArgs, ldr, fSys)
 		cm, err := f.MakeConfigMap2()
 		if err != nil {
 			return nil, err

--- a/pkg/resmap/configmap_test.go
+++ b/pkg/resmap/configmap_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/internal/loadertest"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
@@ -130,7 +131,7 @@ BAR=baz
 		if ferr := l.AddFile(tc.filepath, []byte(tc.content)); ferr != nil {
 			t.Fatalf("Error adding fake file: %v\n", ferr)
 		}
-		r, err := NewResMapFromConfigMapArgs(l, tc.input)
+		r, err := NewResMapFromConfigMapArgs(l, fs.MakeFakeFS(), tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
An application has a loader, presumably so it can "load itself" (from a file system, web interface, ham radio, etc.), but the reality is that an application also needs an explicit FS.  This is because even if one is loading from a ham radio signal, the generator rules for configmaps and secrets _require_ the availability of a file system (to read env files and what not).

It's true that one implementation of a loader has a file system embedded in it, but i don't want to expose that because doing so would defeat the purpose of the loader interface.  The value of the interface is questionable, but would rather tear it out cleanly than naively break it.  Hence, adding plumbing for the FS.  This is for #86.
