### PR TITLE
Introduce secret factory.

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -146,7 +146,8 @@ func (a *Application) loadCustomizedResMap() (resmap.ResMap, error) {
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromConfigMapArgs"))
 	}
-	secrets, err := resmap.NewResMapFromSecretArgs(a.loader.Root(), a.kustomization.SecretGenerator)
+	secrets, err := resmap.NewResMapFromSecretArgs(
+		a.loader.Root(), a.fSys, a.kustomization.SecretGenerator)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromSecretArgs"))
 	}

--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -180,7 +180,9 @@ func TestResources1(t *testing.T) {
 			}),
 	}
 	l := makeLoader1(t)
-	app, err := NewApplication(l, fs.MakeFakeFS())
+	fakeFs := fs.MakeFakeFS()
+	fakeFs.Mkdir("/")
+	app, err := NewApplication(l, fakeFs)
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}

--- a/pkg/configmapandsecret/configmapfactory.go
+++ b/pkg/configmapandsecret/configmapfactory.go
@@ -180,11 +180,11 @@ func (f *ConfigMapFactory) handleConfigMapFromLiteralSources(
 func keyValuesFromFileSources(ldr loader.Loader, sources []string) ([]kvPair, error) {
 	var kvs []kvPair
 	for _, s := range sources {
-		k, path, err := ParseFileSource(s)
+		k, fPath, err := ParseFileSource(s)
 		if err != nil {
 			return nil, err
 		}
-		content, err := ldr.Load(path)
+		content, err := ldr.Load(fPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/configmapandsecret/secretfactory.go
+++ b/pkg/configmapandsecret/secretfactory.go
@@ -1,0 +1,59 @@
+package configmapandsecret
+
+import (
+	"context"
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
+	"github.com/kubernetes-sigs/kustomize/pkg/types"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// SecretFactory makes Secrets.
+type SecretFactory struct {
+	args types.SecretArgs
+	fSys fs.FileSystem
+}
+
+// NewSecretFactory returns a new SecretFactory.
+func NewSecretFactory(args types.SecretArgs, fSys fs.FileSystem) *SecretFactory {
+	return &SecretFactory{args: args, fSys: fSys}
+}
+
+// MakeSecret returns a new secret.
+func (f *SecretFactory) MakeSecret(wd string) (*corev1.Secret, error) {
+	s := &corev1.Secret{}
+	s.APIVersion = "v1"
+	s.Kind = "Secret"
+	s.Name = f.args.Name
+	s.Type = corev1.SecretType(f.args.Type)
+	if s.Type == "" {
+		s.Type = corev1.SecretTypeOpaque
+	}
+	s.Data = map[string][]byte{}
+	for k, v := range f.args.Commands {
+		out, err := f.createSecretKey(wd, v)
+		if err != nil {
+			return nil, errors.Wrap(err, "createSecretKey")
+		}
+		s.Data[k] = out
+	}
+	return s, nil
+}
+
+// Run a command, return its output as the secret.
+func (f *SecretFactory) createSecretKey(wd string, command string) ([]byte, error) {
+	if !f.fSys.IsDir(wd) {
+		wd = filepath.Dir(wd)
+		if !f.fSys.IsDir(wd) {
+			return nil, errors.New("not a directory: " + wd)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = wd
+	return cmd.Output()
+}

--- a/pkg/resmap/secret.go
+++ b/pkg/resmap/secret.go
@@ -17,73 +17,31 @@ limitations under the License.
 package resmap
 
 import (
-	"context"
-	"os/exec"
-	"path/filepath"
-	"time"
-
-	"os"
-
+	"github.com/kubernetes-sigs/kustomize/pkg/configmapandsecret"
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 )
 
-func newResourceFromSecretGenerator(p string, sArgs types.SecretArgs) (*resource.Resource, error) {
-	s, err := makeSecret(p, sArgs)
-	if err != nil {
-		return nil, errors.Wrap(err, "makeSecret")
-	}
-	if sArgs.Behavior == "" {
-		sArgs.Behavior = "create"
-	}
-	return resource.NewResourceWithBehavior(
-		s, resource.NewGenerationBehavior(sArgs.Behavior))
-}
-
-func makeSecret(p string, sArgs types.SecretArgs) (*corev1.Secret, error) {
-	s := &corev1.Secret{}
-	s.APIVersion = "v1"
-	s.Kind = "Secret"
-	s.Name = sArgs.Name
-	s.Type = corev1.SecretType(sArgs.Type)
-	if s.Type == "" {
-		s.Type = corev1.SecretTypeOpaque
-	}
-	s.Data = map[string][]byte{}
-
-	for k, v := range sArgs.Commands {
-		out, err := createSecretKey(p, v)
-		if err != nil {
-			return nil, errors.Wrap(err, "createSecretKey")
-		}
-		s.Data[k] = out
-	}
-	return s, nil
-}
-
-// Run a command, return its output as the secret.
-func createSecretKey(wd string, command string) ([]byte, error) {
-	fi, err := os.Stat(wd)
-	if err != nil || !fi.IsDir() {
-		wd = filepath.Dir(wd)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
-	cmd.Dir = wd
-	return cmd.Output()
-}
-
-// NewResMapFromSecretArgs takes a SecretArgs slice and executes its command in directory p
-// then writes the output to a Resource slice and return it.
-func NewResMapFromSecretArgs(p string, secretList []types.SecretArgs) (ResMap, error) {
+// NewResMapFromSecretArgs takes a SecretArgs slice and executes its command in directory
+// wd then writes the output to a Resource slice and return it.
+func NewResMapFromSecretArgs(
+	wd string, fSys fs.FileSystem,
+	secretList []types.SecretArgs) (ResMap, error) {
 	var allResources []*resource.Resource
-	for _, secret := range secretList {
-		res, err := newResourceFromSecretGenerator(p, secret)
+	for _, args := range secretList {
+		s, err := configmapandsecret.NewSecretFactory(args, fSys).MakeSecret(wd)
 		if err != nil {
-			return nil, errors.Wrap(err, "newResourceFromSecretGenerator")
+			return nil, errors.Wrap(err, "makeSecret")
+		}
+		if args.Behavior == "" {
+			args.Behavior = "create"
+		}
+		res, err := resource.NewResourceWithBehavior(
+			s, resource.NewGenerationBehavior(args.Behavior))
+		if err != nil {
+			return nil, errors.Wrap(err, "NewResourceWithBehavior")
 		}
 		allResources = append(allResources, res)
 	}

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,9 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 			Type: "Opaque",
 		},
 	}
-	actual, err := NewResMapFromSecretArgs(".", secrets)
+	fakeFs := fs.MakeFakeFS()
+	fakeFs.Mkdir(".")
+	actual, err := NewResMapFromSecretArgs(".", fakeFs, secrets)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Fixes #86 (finally).

The "new" code in `secretfactory.go` is just code pulled over from `resmap/secret.go`.

The secret factory, like the configmap factory, retains a FileSystem object for doing things that requires  a local file system (reading from env, spawning a process with a particular working directory, etc.).

