### PR TITLE
Drop the notion of the SchemeLoader

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -70,7 +70,7 @@ func (o *buildOptions) Validate(args []string) error {
 
 // RunBuild runs build command.
 func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
-	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fSys)})
+	l := loader.NewLoader(loader.NewFileLoader(fSys))
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -68,7 +68,7 @@ func (o *diffOptions) Validate(args []string) error {
 // RunDiff gets the differences between Application.MakeCustomizedResMap() and Application.MakeUncustomizedResMap().
 func (o *diffOptions) RunDiff(out, errOut io.Writer, fSys fs.FileSystem) error {
 
-	l := loader.Init([]loader.SchemeLoader{loader.NewFileLoader(fSys)})
+	l := loader.NewLoader(loader.NewFileLoader(fSys))
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {

--- a/pkg/configmapandsecret/configmapfactory.go
+++ b/pkg/configmapandsecret/configmapfactory.go
@@ -137,7 +137,7 @@ func (f *ConfigMapFactory) MakeConfigMap2(
 	all = append(all, pairs...)
 
 	for _, kv := range all {
-		err = addKeyFromLiteralToConfigMap(cm, kv.key, kv.value)
+		err = AddKv(cm, kv.key, kv.value)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +166,7 @@ func (f *ConfigMapFactory) handleConfigMapFromLiteralSources(
 		if err != nil {
 			return err
 		}
-		err = addKeyFromLiteralToConfigMap(configMap, k, v)
+		err = AddKv(configMap, k, v)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func (f *ConfigMapFactory) handleConfigMapFromEnvFileSource(
 		return fmt.Errorf("env config file %s cannot be a directory", args.EnvSource)
 	}
 	return addFromEnvFile(args.EnvSource, func(key, value string) error {
-		return addKeyFromLiteralToConfigMap(configMap, key, value)
+		return AddKv(configMap, key, value)
 	})
 }
 
@@ -262,12 +262,12 @@ func addKeyFromFileToConfigMap(configMap *v1.ConfigMap, keyName, filePath string
 	if err != nil {
 		return err
 	}
-	return addKeyFromLiteralToConfigMap(configMap, keyName, string(data))
+	return AddKv(configMap, keyName, string(data))
 }
 
-// addKeyFromLiteralToConfigMap adds the given key and data to the given config map,
-// returning an error if the key is not valid or if the key already exists.
-func addKeyFromLiteralToConfigMap(configMap *v1.ConfigMap, keyName, data string) error {
+// AddKv adds the given key and data to the given config map.
+// Error if key invalid, or already exists.
+func AddKv(configMap *v1.ConfigMap, keyName, data string) error {
 	// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys.
 	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
 		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))

--- a/pkg/configmapandsecret/configmapfactory_test.go
+++ b/pkg/configmapandsecret/configmapfactory_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
+	"github.com/kubernetes-sigs/kustomize/pkg/loader"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +135,9 @@ func TestConstructConfigMap(t *testing.T) {
 	}
 
 	// TODO: all tests should use a FakeFs
-	f := NewConfigMapFactory(fs.MakeRealFS(), nil)
+	fSys := fs.MakeRealFS()
+	f := NewConfigMapFactory(fSys,
+		loader.NewLoader(loader.NewFileLoader(fSys)))
 	for _, tc := range testCases {
 		cm, err := f.MakeConfigMap1(&tc.input)
 		if err != nil {

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -34,9 +34,7 @@ type FakeLoader struct {
 func NewFakeLoader(initialDir string) FakeLoader {
 	// Create fake filesystem and inject it into initial Loader.
 	fakefs := fs.MakeFakeFS()
-	var schemes []loader.SchemeLoader
-	schemes = append(schemes, loader.NewFileLoader(fakefs))
-	rootLoader := loader.Init(schemes)
+	rootLoader := loader.NewLoader(loader.NewFileLoader(fakefs))
 	ldr, _ := rootLoader.New(initialDir)
 	return FakeLoader{fs: fakefs, delegate: ldr}
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -25,10 +25,7 @@ import (
 )
 
 func initializeRootLoader(fakefs fs.FileSystem) Loader {
-	var schemes []SchemeLoader
-	schemes = append(schemes, NewFileLoader(fakefs))
-	rootLoader := Init(schemes)
-	return rootLoader
+	return NewLoader(NewFileLoader(fakefs))
 }
 
 func TestLoader_Root(t *testing.T) {
@@ -46,7 +43,7 @@ func TestLoader_Root(t *testing.T) {
 	}
 	_, err = rootLoader.New("https://google.com/project")
 	if err == nil {
-		t.Fatalf("Expected error for unknown scheme not returned")
+		t.Fatalf("Expected error")
 	}
 
 	// Test with trailing slash in directory.


### PR DESCRIPTION
The SchemeLoader  interface :
```
// Does this location correspond to this scheme.
IsScheme(root string, location string) bool	
// Combines the root and path into a full location string.	
FullLocation(root string, path string) (string, error)	
// Load bytes at scheme-specific location or an error.	
Load(location string) ([]byte, error)	
// GlobLoad returns the bytes read from a glob path or an error.	
GlobLoad(location string) (map[string][]byte, error)
```
wraps a Loader interface
```
	// Root returns the root location for this Loader.
	Root() string
	// New returns Loader located at newRoot.
	New(newRoot string) (Loader, error)
	// Load returns the bytes read from the location or an error.
	Load(location string) ([]byte, error)
	// GlobLoad returns the bytes read from a glob path or an error.
	GlobLoad(location string) (map[string][]byte, error)
```
which doesn't make much sense in the code - the two concepts compete and are not complementary.
The comments are poor. The code seems to be in some kind of abandoned attempt to migrate from one to the other, in an attempt to abstract 'loading'  to hide where loading came from (file system, http, ham radio, etc.).  Its far from clear that this is a good foundation to build on.  loaderImpl has an array of SchemeLoader that's never used in an array context - its always a one element array, and doesn't make sense even as a single object. The unused abstraction and odd indirection is making it hard to fix bugs and remove duplicated code.  

This PR removes one layer of the abstraction - the SchemeLoader - so that the code continues to use the Loader interface, with one implementation, the FileLoader.  There's still some strangeness, but this is enough for on PR and it unblocks more deletion.