### PR TITLE
Combine loaderImpl and fileLoader.

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -70,7 +70,7 @@ func (o *buildOptions) Validate(args []string) error {
 
 // RunBuild runs build command.
 func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
-	l := loader.NewLoader(loader.NewFileLoader(fSys))
+	l := loader.NewFileLoader(fSys)
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {

--- a/pkg/commands/configmap.go
+++ b/pkg/commands/configmap.go
@@ -65,7 +65,7 @@ func newCmdAddConfigMap(fSys fs.FileSystem) *cobra.Command {
 			err = addConfigMap(
 				kustomization, flagsAndArgs,
 				configmapandsecret.NewConfigMapFactory(
-					fSys, loader.NewLoader(loader.NewFileLoader(fSys))))
+					fSys, loader.NewFileLoader(fSys)))
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -68,7 +68,7 @@ func (o *diffOptions) Validate(args []string) error {
 // RunDiff gets the differences between Application.MakeCustomizedResMap() and Application.MakeUncustomizedResMap().
 func (o *diffOptions) RunDiff(out, errOut io.Writer, fSys fs.FileSystem) error {
 
-	l := loader.NewLoader(loader.NewFileLoader(fSys))
+	l := loader.NewFileLoader(fSys)
 
 	absPath, err := filepath.Abs(o.kustomizationPath)
 	if err != nil {

--- a/pkg/configmapandsecret/configmapfactory_test.go
+++ b/pkg/configmapandsecret/configmapfactory_test.go
@@ -136,8 +136,7 @@ func TestConstructConfigMap(t *testing.T) {
 
 	// TODO: all tests should use a FakeFs
 	fSys := fs.MakeRealFS()
-	f := NewConfigMapFactory(fSys,
-		loader.NewLoader(loader.NewFileLoader(fSys)))
+	f := NewConfigMapFactory(fSys, loader.NewFileLoader(fSys))
 	for _, tc := range testCases {
 		cm, err := f.MakeConfigMap(&tc.input)
 		if err != nil {

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -34,7 +34,7 @@ type FakeLoader struct {
 func NewFakeLoader(initialDir string) FakeLoader {
 	// Create fake filesystem and inject it into initial Loader.
 	fakefs := fs.MakeFakeFS()
-	rootLoader := loader.NewLoader(loader.NewFileLoader(fakefs))
+	rootLoader := loader.NewFileLoader(fakefs)
 	ldr, _ := rootLoader.New(initialDir)
 	return FakeLoader{fs: fakefs, delegate: ldr}
 }

--- a/pkg/loader/fileloader_test.go
+++ b/pkg/loader/fileloader_test.go
@@ -24,10 +24,6 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 )
 
-func initializeRootLoader(fakefs fs.FileSystem) Loader {
-	return NewLoader(NewFileLoader(fakefs))
-}
-
 func TestLoader_Root(t *testing.T) {
 
 	// Initialize the fake file system and the root loader.
@@ -35,7 +31,7 @@ func TestLoader_Root(t *testing.T) {
 	fakefs.WriteFile("/home/seans/project/file.yaml", []byte("Unused"))
 	fakefs.WriteFile("/home/seans/project/subdir/file.yaml", []byte("Unused"))
 	fakefs.WriteFile("/home/seans/project2/file.yaml", []byte("Unused"))
-	rootLoader := initializeRootLoader(fakefs)
+	rootLoader := NewFileLoader(fakefs)
 
 	_, err := rootLoader.New("")
 	if err == nil {
@@ -89,7 +85,7 @@ func TestLoader_Load(t *testing.T) {
 	fakefs.WriteFile("/home/seans/project/file.yaml", []byte("This is a yaml file"))
 	fakefs.WriteFile("/home/seans/project/subdir/file.yaml", []byte("Subdirectory file content"))
 	fakefs.WriteFile("/home/seans/project2/file.yaml", []byte("This is another yaml file"))
-	rootLoader := initializeRootLoader(fakefs)
+	rootLoader := NewFileLoader(fakefs)
 
 	loader, err := rootLoader.New("/home/seans/project")
 	if err != nil {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -17,8 +17,6 @@ limitations under the License.
 // Package loader has a data loading interface and various implementations.
 package loader
 
-import "fmt"
-
 // Loader interface exposes methods to read bytes.
 type Loader interface {
 	// Root returns the root location for this Loader.
@@ -29,61 +27,4 @@ type Loader interface {
 	Load(location string) ([]byte, error)
 	// GlobLoad returns the bytes read from a glob path or an error.
 	GlobLoad(location string) (map[string][]byte, error)
-}
-
-// Private implementation of Loader interface.
-type loaderImpl struct {
-	root    string
-	fLoader *FileLoader
-}
-
-const emptyRoot = ""
-
-// NewLoader initializes the first loader with the supported fLoader.
-func NewLoader(fl *FileLoader) Loader {
-	return &loaderImpl{root: emptyRoot, fLoader: fl}
-}
-
-// Root returns the root location for this Loader.
-func (l *loaderImpl) Root() string {
-	return l.root
-}
-
-// Returns a new Loader rooted at newRoot. "newRoot" MUST be
-// a directory (not a file). The directory can have a trailing
-// slash or not.
-// Example: "/home/seans/project" or "/home/seans/project/"
-// NOT "/home/seans/project/file.yaml".
-func (l *loaderImpl) New(newRoot string) (Loader, error) {
-	if !l.fLoader.IsAbsPath(l.root, newRoot) {
-		return nil, fmt.Errorf("Not abs path: l.root='%s', loc='%s'\n", l.root, newRoot)
-	}
-	root, err := l.fLoader.FullLocation(l.root, newRoot)
-	if err != nil {
-		return nil, err
-	}
-	return &loaderImpl{root: root, fLoader: l.fLoader}, nil
-}
-
-// Load returns all the bytes read from location or an error.
-// "location" can be an absolute path, or if relative, full location is
-// calculated from the Root().
-func (l *loaderImpl) Load(location string) ([]byte, error) {
-	fullLocation, err := l.fLoader.FullLocation(l.root, location)
-	if err != nil {
-		fmt.Printf("Trouble in fulllocation: %v\n", err)
-		return nil, err
-	}
-	return l.fLoader.Load(fullLocation)
-}
-
-// GlobLoad returns a map from path to bytes read from the location or an error.
-// "location" can be an absolute path, or if relative, full location is
-// calculated from the Root().
-func (l *loaderImpl) GlobLoad(location string) (map[string][]byte, error) {
-	fullLocation, err := l.fLoader.FullLocation(l.root, location)
-	if err != nil {
-		return nil, err
-	}
-	return l.fLoader.GlobLoad(fullLocation)
 }


### PR DESCRIPTION
Neither class (loaderImpl or fileLoader) can be meaningfully used separately.  One could argue that loaderImpl is an adapter making the fileLoader class adapt to the Loader interface, but such an adaptation would only make sense if 1) fileLoader (as is) were somehow useful by itself, and 2) we had no access to the filerLoader source code yet we desperately wanted to use it.  Neither condition is true.  This PR drops ~30loc by collapsing them to one class - fileLoader - implementing the Loader ifc.
