### PR TITLE
added ability to obtain image tag from environment variable

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -195,8 +195,10 @@ vars:
 #      image: nginx:1.7.9
 #```
 # one can change the tag of myimage to v1 and the tag of nginx to 1.8.0 with the following:
+# if variable in newTagFromEnv is empty, it will default to `newTag`
 imageTags:
   - name: mycontainerregistry/myimage
-    newTag: v1
+    newTag: dev
+    newTagFromEnv: COMMIT_SHA_FROM_CI
   - name: nginx
     newTag: 1.8.0

--- a/pkg/transformers/imagetag.go
+++ b/pkg/transformers/imagetag.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transformers
 
 import (
+	"os"
 	"strings"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
@@ -82,7 +83,11 @@ func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path
 		}
 		for _, imagetag := range pt.imageTags {
 			if isImageMatched(image.(string), imagetag.Name) {
-				container["image"] = strings.Join([]string{imagetag.Name, imagetag.NewTag}, ":")
+				newTag := os.Getenv(imagetag.NewTagFromEnv)
+				if newTag == "" {
+					newTag = imagetag.NewTag
+				}
+				container["image"] = strings.Join([]string{imagetag.Name, newTag}, ":")
 				break
 			}
 		}

--- a/pkg/transformers/imagetag_test.go
+++ b/pkg/transformers/imagetag_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transformers
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -155,10 +156,11 @@ func TestImageTagTransformer(t *testing.T) {
 				},
 			}),
 	}
-
+	os.Setenv("APPLICATION_VERSION", "v2")
+	os.Setenv("MY_NGINX_VERSION", "previous")
 	it, err := NewImageTagTransformer([]types.ImageTag{
-		{Name: "nginx", NewTag: "v2"},
-		{Name: "my-nginx", NewTag: "previous"},
+		{Name: "nginx", NewTag: "v2", NewTagFromEnv: "APPLICATION_VERSION"},
+		{Name: "my-nginx", NewTag: "previous", NewTagFromEnv: "MY_NGINX_VERSION"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -150,4 +150,7 @@ type ImageTag struct {
 
 	// NewTag is the value to use in replacing the original tag.
 	NewTag string `json:"newTag,omitempty" yaml:"newTag,omitempty"`
+
+	// NewTagFromEnv is the name of the environment variable to use to substitute the original tag. If not present will default to the `newTag` value
+	NewTagFromEnv string `json:"newTagFromEnv,omitempty" yaml:"newTag,omitempty"`
 }


### PR DESCRIPTION
In any CI/CD pipeline it's very common to have environment variables and want to deploy a specific image tag with those variables. 

I know it's also possible to do something like `kustomize edit set imagetag <image>:<new-tag-from-env> but I would rather describe in my kustomization.yaml file which variable would go toward which image in a more descriptive way. This comes helpful when the images to chance the tags are alot