### PR TITLE
ignore the empty YAML object

### DIFF
--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -78,6 +78,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dply2
+---
+# some comment
+---
+---
 `
 
 	l := loadertest.NewFakeLoader("/home/seans/project")


### PR DESCRIPTION
Fix #178 
This is a trick by checking the return error from `Decode`. 