### PR TITLE
add namespace in ResId

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -91,7 +91,7 @@ var svc = schema.GroupVersionKind{Version: "v1", Kind: "Service"}
 
 func TestResources1(t *testing.T) {
 	expected := resmap.ResMap{
-		resource.NewResIdWithPrefix(deploy, "dply1", "foo-"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(deploy, "dply1", "foo-", "ns1"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
@@ -123,7 +123,7 @@ func TestResources1(t *testing.T) {
 					},
 				},
 			}),
-		resource.NewResIdWithPrefix(cmap, "literalConfigMap", "foo-"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(cmap, "literalConfigMap", "foo-", "ns1"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -143,7 +143,7 @@ func TestResources1(t *testing.T) {
 					"DB_PASSWORD": "somepw",
 				},
 			}).SetBehavior(resource.BehaviorCreate),
-		resource.NewResIdWithPrefix(secret, "secret", "foo-"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(secret, "secret", "foo-", "ns1"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Secret",
@@ -164,7 +164,7 @@ func TestResources1(t *testing.T) {
 					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			}).SetBehavior(resource.BehaviorCreate),
-		resource.NewResIdWithPrefix(ns, "ns1", "foo-"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(ns, "ns1", "foo-", ""): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",

--- a/pkg/resource/resid.go
+++ b/pkg/resource/resid.go
@@ -32,6 +32,15 @@ type ResId struct {
 	// an untransformed resource has no prefix, fully transformed resource has an arbitrary number of prefixes
 	// concatenated together.
 	prefix string
+	// namespace the resource belongs to
+	// an untransformed resource has no namespace, fully transformed resource has the namespace from
+	// the top most overlay
+	namespace string
+}
+
+// NewResIdWithPrefixNamespace creates new resource identifier with a prefix and a namespace
+func NewResIdWithPrefixNamespace(g schema.GroupVersionKind, n, p, ns string) ResId {
+	return ResId{gvk: g, name: n, prefix: p, namespace: ns}
 }
 
 // NewResIdWithPrefix creates new resource identifier with a prefix
@@ -46,7 +55,7 @@ func NewResId(g schema.GroupVersionKind, n string) ResId {
 
 // String of ResId based on GVK, name and prefix
 func (n ResId) String() string {
-	fields := []string{n.gvk.Group, n.gvk.Version, n.gvk.Kind, n.prefix, n.name}
+	fields := []string{n.gvk.Group, n.gvk.Version, n.gvk.Kind, n.namespace, n.prefix, n.name}
 	return strings.Join(fields, "_") + ".yaml"
 }
 
@@ -81,7 +90,17 @@ func (n ResId) Prefix() string {
 	return n.prefix
 }
 
+// Namespace returns resource namespace.
+func (n ResId) Namespace() string {
+	return n.namespace
+}
+
 // CopyWithNewPrefix make a new copy from current ResId and append a new prefix
 func (n ResId) CopyWithNewPrefix(p string) ResId {
-	return ResId{gvk: n.gvk, name: n.name, prefix: p + n.prefix}
+	return ResId{gvk: n.gvk, name: n.name, prefix: p + n.prefix, namespace: n.namespace}
+}
+
+// CopyWithNewNamespace make a new copy from current ResId and set a new namespace
+func (n ResId) CopyWithNewNamespace(ns string) ResId {
+	return ResId{gvk: n.gvk, name: n.name, prefix: n.prefix, namespace: ns}
 }

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -104,7 +104,7 @@ func TestNamespaceRun(t *testing.T) {
 			}),
 	}
 	expected := resmap.ResMap{
-		resource.NewResId(ns, "ns1"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(ns, "ns1", "", ""): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
@@ -112,7 +112,7 @@ func TestNamespaceRun(t *testing.T) {
 					"name": "ns1",
 				},
 			}),
-		resource.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(cmap, "cm1", "", "test"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -121,7 +121,7 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resource.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(cmap, "cm2", "", "test"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -130,7 +130,7 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resource.NewResId(sa, "default"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(sa, "default", "", "test"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ServiceAccount",
@@ -139,7 +139,7 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resource.NewResId(sa, "service-account"): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(sa, "service-account", "", "test"): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ServiceAccount",


### PR DESCRIPTION
Similar to `prefix`, add `namespace` to ResId. With this change, we can have objects in different namespaces with the same name.

Will add an example as a feature test.