### PR TITLE
Change the order of validate and  expandFileSource in add configmap

### DIFF
--- a/pkg/commands/configmap.go
+++ b/pkg/commands/configmap.go
@@ -45,12 +45,12 @@ func newCmdAddConfigMap(fSys fs.FileSystem) *cobra.Command {
 	kustomize edit add configmap my-configmap --from-env-file=env/path.env
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
-			err := flagsAndArgs.Validate(args)
+			err := flagsAndArgs.ExpandFileSource(fSys)
 			if err != nil {
 				return err
 			}
 
-			err = flagsAndArgs.ExpandFileSource(fSys)
+			err = flagsAndArgs.Validate(args)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
With previous order, when `ExpandFileSource` generates an empty file list, it leads to an empty configMapGenerator. So we should validate the flags after expanding the glob pattern.