### PR TITLE
Revert "Skip adding nameprefix to namespace"

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -164,12 +164,12 @@ func TestResources1(t *testing.T) {
 					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			}).SetBehavior(resource.BehaviorCreate),
-		resource.NewResIdWithPrefixNamespace(ns, "ns1", "", ""): resource.NewResourceFromMap(
+		resource.NewResIdWithPrefixNamespace(ns, "ns1", "foo-", ""): resource.NewResourceFromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
 				"metadata": map[string]interface{}{
-					"name": "ns1",
+					"name": "foo-ns1",
 					"labels": map[string]interface{}{
 						"app": "nginx",
 					},

--- a/pkg/transformers/prefixname.go
+++ b/pkg/transformers/prefixname.go
@@ -46,9 +46,6 @@ var skipNamePrefixPathConfigs = []PathConfig{
 	{
 		GroupVersionKind: &schema.GroupVersionKind{Kind: "CustomResourceDefinition"},
 	},
-	{
-		GroupVersionKind: &schema.GroupVersionKind{Kind: "Namespace"},
-	},
 }
 
 // NewDefaultingNamePrefixTransformer construct a namePrefixTransformer with defaultNamePrefixPathConfigs.


### PR DESCRIPTION
Reverts kubernetes-sigs/kustomize#239