### PR TITLE
kustomize build {repoUrl}

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -18,7 +18,6 @@ package commands
 
 import (
 	"io"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -75,17 +74,11 @@ func (o *buildOptions) Validate(args []string) error {
 
 // RunBuild runs build command.
 func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
-	l := loader.NewFileLoader(fSys)
-
-	absPath, err := filepath.Abs(o.kustomizationPath)
+	rootLoader, err := loader.NewLoader(o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
-
-	rootLoader, err := l.New(absPath)
-	if err != nil {
-		return err
-	}
+	defer rootLoader.Cleanup()
 
 	application, err := app.NewApplication(rootLoader, fSys)
 	if err != nil {

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -19,7 +19,6 @@ package commands
 import (
 	"errors"
 	"io"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -68,17 +67,11 @@ func (o *diffOptions) Validate(args []string) error {
 // RunDiff gets the differences between Application.MakeCustomizedResMap() and Application.MakeUncustomizedResMap().
 func (o *diffOptions) RunDiff(out, errOut io.Writer, fSys fs.FileSystem) error {
 
-	l := loader.NewFileLoader(fSys)
-
-	absPath, err := filepath.Abs(o.kustomizationPath)
+	rootLoader, err := loader.NewLoader(o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
-
-	rootLoader, err := l.New(absPath)
-	if err != nil {
-		return err
-	}
+	defer rootLoader.Cleanup()
 
 	application, err := app.NewApplication(rootLoader, fSys)
 	if err != nil {

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -63,3 +63,8 @@ func (f FakeLoader) New(newRoot string) (loader.Loader, error) {
 func (f FakeLoader) Load(location string) ([]byte, error) {
 	return f.delegate.Load(location)
 }
+
+// Cleanup does nothing
+func (f FakeLoader) Cleanup() error {
+	return nil
+}

--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
+	"github.com/kubernetes-sigs/kustomize/pkg/repourl"
 )
 
 const currentDir = "."
@@ -53,6 +54,9 @@ func (l *fileLoader) Root() string {
 // Example: "/home/seans/project" or "/home/seans/project/"
 // NOT "/home/seans/project/file.yaml".
 func (l *fileLoader) New(newRoot string) (Loader, error) {
+	if repourl.IsRepoUrl(newRoot) {
+		return newGithubLoader(newRoot, l.fSys)
+	}
 	if !l.IsAbsPath(l.root, newRoot) {
 		return nil, fmt.Errorf("Not abs path: l.root='%s', loc='%s'\n", l.root, newRoot)
 	}
@@ -108,4 +112,9 @@ func (l *fileLoader) Load(location string) ([]byte, error) {
 		return nil, err
 	}
 	return l.fSys.ReadFile(fullLocation)
+}
+
+// Cleanup does nothing
+func (l *fileLoader) Cleanup() error {
+	return nil
 }

--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/kubernetes-sigs/kustomize/pkg/fs"
+	"github.com/kubernetes-sigs/kustomize/pkg/repourl"
+)
+
+// githubLoader loads files from a checkout github repo
+type githubLoader struct {
+	repo        string
+	checkoutDir string
+	fSys        fs.FileSystem
+	loader      *fileLoader
+}
+
+// Root returns the root location for this Loader.
+func (l *githubLoader) Root() string {
+	return l.checkoutDir
+}
+
+// New delegates to fileLoader.New
+func (l *githubLoader) New(newRoot string) (Loader, error) {
+	return l.loader.New(newRoot)
+}
+
+// Load delegates to fileLoader.Load
+func (l *githubLoader) Load(location string) ([]byte, error) {
+	return l.loader.Load(location)
+}
+
+// Cleanup removes the checked out repo
+func (l *githubLoader) Cleanup() error {
+	return os.RemoveAll(l.checkoutDir)
+}
+
+// newGithubLoader returns a new fileLoader with given github Url.
+func newGithubLoader(repoUrl string, fs fs.FileSystem) (*githubLoader, error) {
+	dir, err := ioutil.TempDir("", "kustomize-repo-")
+	if err != nil {
+		return nil, err
+	}
+
+	err = repourl.Checkout(repoUrl, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	l := newFileLoaderAtRoot(dir, fs)
+	return &githubLoader{
+		repo:        repoUrl,
+		checkoutDir: dir,
+		fSys:        fs,
+		loader:      l,
+	}, nil
+}

--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -59,12 +59,11 @@ func newGithubLoader(repoUrl string, fs fs.FileSystem) (*githubLoader, error) {
 		return nil, err
 	}
 
-	err = repourl.Checkout(repoUrl, dir)
+	target, err := repourl.Checkout(repoUrl, dir)
 	if err != nil {
 		return nil, err
 	}
-
-	l := newFileLoaderAtRoot(dir, fs)
+	l := newFileLoaderAtRoot(target, fs)
 	return &githubLoader{
 		repo:        repoUrl,
 		checkoutDir: dir,

--- a/pkg/repourl/checkout.go
+++ b/pkg/repourl/checkout.go
@@ -19,32 +19,43 @@ package repourl
 import (
 	"log"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
 // Checkout clones a github repo and checkout the specified commit/tag/branch
-func Checkout(url, dir string) error {
+func Checkout(url, dir string) (string, error) {
 	repo, err := NewRepo(url)
 	if err != nil {
-		return err
+		return dir, err
 	}
 
 	cmd := exec.Command("git", "clone", repo.url, dir)
 	err = cmd.Run()
 	if err != nil {
-		return err
+		return dir, err
 	}
 
 	log.Printf("Checked out %s into %s", repo.url, dir)
 
 	if repo.ref == "" {
-		return nil
+		if repo.dir != "" {
+			return filepath.Join(dir, repo.dir), nil
+		}
+		return dir, nil
 	}
 
 	cmd = exec.Command("git", "checkout", repo.ref)
 	cmd.Dir = dir
-	return cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		return dir, err
+	}
 
+	if repo.dir != "" {
+		return filepath.Join(dir, repo.dir), nil
+	}
+	return dir, nil
 }
 
 // IsRepoUrl checks if a string is a repo Url

--- a/pkg/repourl/checkout.go
+++ b/pkg/repourl/checkout.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repourl
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// Checkout clones a github repo and checkout the specified commit/tag/branch
+func Checkout(url, dir string) error {
+	repo, err := NewRepo(url)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("git", "clone", repo.url, dir)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Checked out %s into %s", repo.url, dir)
+
+	if repo.ref == "" {
+		return nil
+	}
+
+	cmd = exec.Command("git", "checkout", repo.ref)
+	cmd.Dir = dir
+	return cmd.Run()
+
+}
+
+// IsRepoUrl checks if a string is a repo Url
+func IsRepoUrl(s string) bool {
+	return strings.Contains(s, "github.com") || strings.Contains(s, "https://") || strings.Contains(s, "git@")
+}

--- a/pkg/repourl/repourl.go
+++ b/pkg/repourl/repourl.go
@@ -23,8 +23,8 @@ import (
 )
 
 var recognizedRepos = []*regexp.Regexp{
-	regexp.MustCompile("^(git@|)([^:@]*):([^/]*)/([^.#/ ]*)(.git|)(|#([a-zA-Z0-9._-]*))$"),
-	regexp.MustCompile("^(https://|)([^/@]*)/([^/]*)/([^.#/ ]*)(.git|)(|#([a-zA-Z0-9._-]*))$"),
+	regexp.MustCompile("^(git@|)([^:@]+):([^/]+)/([^.#/ ]+)(.git|)(|/([0-9A-Za-z-_/]+))(|#([a-zA-Z0-9._-]*))$"),
+	regexp.MustCompile("^(https://|)([^/@]+)/([^/]+)/([^.#/ ]+)(.git|)(|/([0-9A-Za-z-_/]+))(|#([a-zA-Z0-9._-]*))$"),
 }
 
 // Repo defines a remote repo target
@@ -33,6 +33,7 @@ var recognizedRepos = []*regexp.Regexp{
 type Repo struct {
 	url string
 	ref string
+	dir string
 }
 
 // NewRepo create a Repo object from a repoUrl
@@ -55,7 +56,7 @@ func NewRepo(repoUrl string) (*Repo, error) {
 			continue
 		}
 		repo := fmt.Sprintf("https://%s/%s/%s.git", matches[2], matches[3], matches[4])
-		return &Repo{url: repo, ref: matches[7]}, nil
+		return &Repo{url: repo, ref: matches[9], dir: matches[7]}, nil
 	}
 	return nil, fmt.Errorf("%s is not valid github repo", repoUrl)
 }

--- a/pkg/repourl/repourl.go
+++ b/pkg/repourl/repourl.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package repourl provides functions to parse a remote repo url
+package repourl
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var recognizedRepos = []*regexp.Regexp{
+	regexp.MustCompile("^(git@|)([^:@]*):([^/]*)/([^.#/ ]*)(.git|)(|#([a-zA-Z0-9._-]*))$"),
+	regexp.MustCompile("^(https://|)([^/@]*)/([^/]*)/([^.#/ ]*)(.git|)(|#([a-zA-Z0-9._-]*))$"),
+}
+
+// Repo defines a remote repo target
+// url must be specified
+// ref is optional, could be commit, tag or branch
+type Repo struct {
+	url string
+	ref string
+}
+
+// NewRepo create a Repo object from a repoUrl
+/*
+   The accepted repoUrl has following format
+   (git@|https://|)github.com/<project>/<repository>(.git|)(#ref)
+
+   The following repoUrls are all accepted:
+   git@github.com:kubernetes-sigs/kustomize.git
+   https://github.com/kubernetes-sigs/kustomize.git
+   https://github.com/kubernetes-sigs/kustomize
+   https://github.com/kubernetes-sigs/kustomize#v1.0.6
+   github.com/kubernetes-sigs/kustomize#017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b
+   git@github.com:kubernetes-sigs/kustomize.git#test-branch
+*/
+func NewRepo(repoUrl string) (*Repo, error) {
+	for _, r := range recognizedRepos {
+		matches := r.FindStringSubmatch(repoUrl)
+		if len(matches) == 0 {
+			continue
+		}
+		repo := fmt.Sprintf("https://%s/%s/%s.git", matches[2], matches[3], matches[4])
+		return &Repo{url: repo, ref: matches[7]}, nil
+	}
+	return nil, fmt.Errorf("%s is not valid github repo", repoUrl)
+}

--- a/pkg/repourl/repourl_test.go
+++ b/pkg/repourl/repourl_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repourl
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewRepo(t *testing.T) {
+	type testcase struct {
+		repoUrl  string
+		expected Repo
+	}
+
+	testcases := []testcase{
+		{
+			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+		},
+		{
+			repoUrl:  "https://github.com/kubernetes-sigs/kustomize.git",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+		},
+		{
+			repoUrl:  "https://github.com/kubernetes-sigs/kustomize",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+		},
+		{
+			repoUrl:  "https://github.com/kubernetes-sigs/kustomize#v1.0.6",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "v1.0.6"},
+		},
+		{
+			repoUrl:  "github.com/kubernetes-sigs/kustomize#017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b"},
+		},
+		{
+			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git#test-branch",
+			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "test-branch"},
+		},
+	}
+	for _, tc := range testcases {
+		actual, err := NewRepo(tc.repoUrl)
+		if err != nil {
+			t.Fatalf("unexpected error %s", err)
+		}
+		if reflect.DeepEqual(actual, tc.expected) {
+			t.Fatalf("expected %v, but got %v", tc.expected, actual)
+		}
+	}
+}
+
+func TestNewRepoInvalid(t *testing.T) {
+	invalidUrls := []string{
+		"git@github.com/kubernetes-sigs//kustomize.git",
+		"git@github.com:kubernetes-sigs//kustomize.git#bb#aa",
+		"https://github.com//kubernetes-sigs/kustomize.git",
+		"http://github.com/kubernetes-sigs/kustomize",
+		"https://github.com/kubernetes-sigs/kustomize v1.0.6",
+		"https@somehost.com/project/repo.git",
+	}
+	for _, url := range invalidUrls {
+		_, err := NewRepo(url)
+		if err == nil {
+			t.Fatalf("Expected error happen %s", url)
+		}
+		if strings.Contains(err.Error(), "bababa") {
+			t.Fatalf("unexpected error %s", err)
+		}
+	}
+}

--- a/pkg/repourl/repourl_test.go
+++ b/pkg/repourl/repourl_test.go
@@ -25,33 +25,45 @@ import (
 func TestNewRepo(t *testing.T) {
 	type testcase struct {
 		repoUrl  string
-		expected Repo
+		expected *Repo
 	}
 
 	testcases := []testcase{
 		{
 			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "", ""},
 		},
 		{
 			repoUrl:  "https://github.com/kubernetes-sigs/kustomize.git",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "", ""},
 		},
 		{
 			repoUrl:  "https://github.com/kubernetes-sigs/kustomize",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", ""},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "", ""},
 		},
 		{
 			repoUrl:  "https://github.com/kubernetes-sigs/kustomize#v1.0.6",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "v1.0.6"},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "v1.0.6", ""},
 		},
 		{
 			repoUrl:  "github.com/kubernetes-sigs/kustomize#017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b"},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "017c4ae0aa19195db2a51ecc5aa82c56a1f1c99b", ""},
 		},
 		{
 			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git#test-branch",
-			expected: Repo{"https://github.com/kubernetes-sigs/kustomize.git", "test-branch"},
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "test-branch", ""},
+		},
+		{
+			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git/examples/helloWorld",
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "", "examples/helloWorld"},
+		},
+		{
+			repoUrl:  "git@github.com:kubernetes-sigs/kustomize.git/examples/multibases#test-branch",
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "test-branch", "examples/multibases"},
+		},
+		{
+			repoUrl:  "https://github.com/kubernetes-sigs/kustomize/examples/multibases",
+			expected: &Repo{"https://github.com/kubernetes-sigs/kustomize.git", "", "examples/multibases"},
 		},
 	}
 	for _, tc := range testcases {
@@ -59,7 +71,7 @@ func TestNewRepo(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error %s", err)
 		}
-		if reflect.DeepEqual(actual, tc.expected) {
+		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Fatalf("expected %v, but got %v", tc.expected, actual)
 		}
 	}


### PR DESCRIPTION
Fix #32 

Current implementation supports
- build a remote GitHub repo with a root level kustomization 
- build a kustomization from a subdirectory in a remote GitHub repo

The format supported is
`https://github.com/kubernetes-sigs/kustomize/<directory>#<branch/commit/tag>`
- directory is optional
- branch/commit/tag is optional

For example:
`kustomize build https://github.com/project/myrepo#v1.0.0`
will do
```
git clone https://github.com/project/myrepo   /tmp/a-tmp-dir
git checkout v1.0.0
kustomize build /tmp/a-tmp-dir
```

`kustomize build https://github.com/project/myrepo/variants/staging#v1.0.0`
will do
```
git clone https://github.com/project/myrepo   /tmp/a-tmp-dir
git checkout v1.0.0
kustomize build /tmp/a-tmp-dir/variants/staging
```





