### PR TITLE
Don't crash on resource load errors

### DIFF
--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -211,10 +211,14 @@ func newResourceSliceFromBytes(in []byte) ([]*resource.Resource, error) {
 	return result, nil
 }
 
-// MergeWithoutOverride combines multiple ResMap instances, failing on key collision.
+// MergeWithoutOverride combines multiple ResMap instances, failing on key collision
+// and skipping nil maps. In case if all of the maps are nil, an empty ResMap is returned.
 func MergeWithoutOverride(maps ...ResMap) (ResMap, error) {
 	result := ResMap{}
 	for _, m := range maps {
+		if m == nil {
+			continue
+		}
 		for id, res := range m {
 			if _, found := result[id]; found {
 				return nil, fmt.Errorf("id '%q' already used", id)
@@ -226,14 +230,21 @@ func MergeWithoutOverride(maps ...ResMap) (ResMap, error) {
 }
 
 // MergeWithOverride combines multiple ResMap instances, allowing and sometimes
-// demanding certain collisions.
+// demanding certain collisions and skipping nil maps.
+// In case if all of the maps are nil, an empty ResMap is returned.
 // When looping over the instances to combine them, if a resource id for resource X
 // is found to be already in the combined map, then the behavior field for X
 // must be BehaviorMerge or BehaviorReplace.  If X is not in the map, then it's
 // behavior cannot be merge or replace.
 func MergeWithOverride(maps ...ResMap) (ResMap, error) {
 	result := maps[0]
+	if result == nil {
+		result = ResMap{}
+	}
 	for _, m := range maps[1:] {
+		if m == nil {
+			continue
+		}
 		for id, r := range m {
 			matchedId := result.FindByGVKN(id)
 			if len(matchedId) == 1 {

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -202,6 +202,22 @@ func TestMergeWithoutOverride(t *testing.T) {
 	if !reflect.DeepEqual(merged, expected) {
 		t.Fatalf("%#v doesn't equal expected %#v", merged, expected)
 	}
+	input3 := []ResMap{merged, nil}
+	merged1, err := MergeWithoutOverride(input3...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(merged1, expected) {
+		t.Fatalf("%#v doesn't equal expected %#v", merged1, expected)
+	}
+	input4 := []ResMap{nil, merged}
+	merged2, err := MergeWithoutOverride(input4...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(merged2, expected) {
+		t.Fatalf("%#v doesn't equal expected %#v", merged2, expected)
+	}
 }
 
 func TestMergeWithOverride(t *testing.T) {
@@ -261,5 +277,21 @@ func TestMergeWithOverride(t *testing.T) {
 	}
 	if !reflect.DeepEqual(merged, expected) {
 		t.Fatalf("%#v doesn't equal expected %#v", merged, expected)
+	}
+	input3 := []ResMap{merged, nil}
+	merged1, err := MergeWithOverride(input3...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(merged1, expected) {
+		t.Fatalf("%#v doesn't equal expected %#v", merged1, expected)
+	}
+	input4 := []ResMap{nil, merged}
+	merged2, err := MergeWithOverride(input4...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(merged2, expected) {
+		t.Fatalf("%#v doesn't equal expected %#v", merged2, expected)
 	}
 }


### PR DESCRIPTION
In case if a non-existent file is referenced among `resources` in `kustomization.yaml`, kustomize panics with the following stack trace:
```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/kubernetes-sigs/kustomize/pkg/resmap.MergeWithOverride(0xc4202eb438, 0x2, 0x2, 0xc420376570, 0x0, 0x0)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/resmap/resmap.go:261 +0x80a
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadCustomizedResMap(0xc42028d260, 0xc4204e4340, 0x1cb46e0, 0x2308630)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:163 +0x2d7
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadCustomizedBases(0xc42027a120, 0x1011fe9, 0xc4205030e0)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:227 +0x424
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadResMapFromBasesAndResources(0xc42027a120, 0xc4205030e0, 0xc420400200, 0x1a36c60)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:198 +0x40
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadCustomizedResMap(0xc42027a120, 0xc420502b80, 0x1cb46e0, 0x2308630)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:138 +0x60
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadCustomizedBases(0xc4204d9cb0, 0x1011fe9, 0xc420502b40)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:227 +0x424
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadResMapFromBasesAndResources(0xc4204d9cb0, 0xc420502b40, 0xc4202eba80, 0x11a00ff)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:198 +0x40
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).loadCustomizedResMap(0xc4204d9cb0, 0x1b, 0x21b, 0xc4204e2000)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:138 +0x60
github.com/kubernetes-sigs/kustomize/pkg/app.(*Application).MakeCustomizedResMap(0xc4204d9cb0, 0xc420502960, 0x1cb46e0, 0x2308630)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/app/application.go:83 +0x2b
github.com/kubernetes-sigs/kustomize/pkg/commands.(*buildOptions).RunBuild(0xc4205025a0, 0x1c96de0, 0xc42000e018, 0x1cb46e0, 0x2308630, 0x1bbdd3e, 0x4)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/commands/build.go:95 +0x10a
github.com/kubernetes-sigs/kustomize/pkg/commands.newCmdBuild.func1(0xc4200e6f00, 0x2308630, 0x0, 0x0, 0x0, 0x0)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/pkg/commands/build.go:53 +0xaf
github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra.(*Command).execute(0xc4200e6f00, 0x2308630, 0x0, 0x0, 0xc4200e6f00, 0x2308630)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra/command.go:756 +0x468
github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4200e6500, 0xc4200e7400, 0xc4200e7680, 0xc420286000)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra/command.go:846 +0x30a
github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200e6500, 0x1c34be8, 0xc4200440b8)
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
        /Users/ivan4th/work/kubernetes/src/github.com/kubernetes-sigs/kustomize/kustomize.go:30 +0x43
```

This happens because kustomize tries to proceed even after a file load error occurs, but fails to deal with nil `ResMap` properly.

Fixes #253 