### PR TITLE
Add --command-timeout option for handling secrets

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -182,7 +182,7 @@ func TestResources1(t *testing.T) {
 	l := makeLoader1(t)
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	app, err := NewApplication(l, fakeFs)
+	app, err := NewApplication(l, fakeFs, 0)
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
@@ -217,7 +217,7 @@ func TestRawResources1(t *testing.T) {
 			}),
 	}
 	l := makeLoader1(t)
-	app, err := NewApplication(l, fs.MakeFakeFS())
+	app, err := NewApplication(l, fs.MakeFakeFS(), 0)
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
@@ -327,7 +327,7 @@ func TestRawResources2(t *testing.T) {
 			}),
 	}
 	l := makeLoader2(t)
-	app, err := NewApplication(l, fs.MakeFakeFS())
+	app, err := NewApplication(l, fs.MakeFakeFS(), 0)
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -19,6 +19,7 @@ package commands
 import (
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -33,6 +34,7 @@ import (
 type buildOptions struct {
 	kustomizationPath string
 	outputPath        string
+	cmdTimeout        time.Duration
 }
 
 // newCmdBuild creates a new build command.
@@ -57,6 +59,10 @@ func newCmdBuild(out io.Writer, fs fs.FileSystem) *cobra.Command {
 		&o.outputPath,
 		"output", "o", "",
 		"If specified, write the build output to this path.")
+	cmd.Flags().DurationVarP(
+		&o.cmdTimeout,
+		"command-timeout", "", 5*time.Second,
+		"Sets timeout for the shell commands invoked by kustomize")
 	return cmd
 }
 
@@ -87,7 +93,7 @@ func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
 		return err
 	}
 
-	application, err := app.NewApplication(rootLoader, fSys)
+	application, err := app.NewApplication(rootLoader, fSys, o.cmdTimeout)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/diff.go
+++ b/pkg/commands/diff.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,7 @@ import (
 
 type diffOptions struct {
 	kustomizationPath string
+	cmdTimeout        time.Duration
 }
 
 // newCmdDiff makes the diff command.
@@ -49,6 +51,10 @@ func newCmdDiff(out, errOut io.Writer, fs fs.FileSystem) *cobra.Command {
 			return o.RunDiff(out, errOut, fs)
 		},
 	}
+	cmd.Flags().DurationVarP(
+		&o.cmdTimeout,
+		"command-timeout", "", 5*time.Second,
+		"Sets timeout for the shell commands invoked by kustomize")
 	return cmd
 }
 
@@ -80,7 +86,7 @@ func (o *diffOptions) RunDiff(out, errOut io.Writer, fSys fs.FileSystem) error {
 		return err
 	}
 
-	application, err := app.NewApplication(rootLoader, fSys)
+	application, err := app.NewApplication(rootLoader, fSys, o.cmdTimeout)
 	if err != nil {
 		return err
 	}

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/configmapandsecret"
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
@@ -92,5 +93,27 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("%#v\ndoesn't match expected:\n%#v", actual, expected)
+	}
+}
+
+func TestSecretTimeout(t *testing.T) {
+	secrets := []types.SecretArgs{
+		{
+			Name: "slow",
+			CommandSources: types.CommandSources{
+				Commands: map[string]string{
+					"USER": "sleep 1",
+				},
+			},
+			Type: "Opaque",
+		},
+	}
+	fakeFs := fs.MakeFakeFS()
+	fakeFs.Mkdir(".")
+	_, err := NewResMapFromSecretArgs(
+		configmapandsecret.NewSecretFactory(fakeFs, ".", 10*time.Millisecond), secrets)
+
+	if err == nil {
+		t.Fatal("didn't get the expected timeout error", err)
 	}
 }

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -54,7 +54,7 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
 	actual, err := NewResMapFromSecretArgs(
-		configmapandsecret.NewSecretFactory(fakeFs, "."), secrets)
+		configmapandsecret.NewSecretFactory(fakeFs, ".", 0), secrets)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This PR adds `--command-timeout` option for `build` and `diff` commands.
A typical use case for it is a command in `secretGenerator` that requires the user to type a passphrase to e.g. decrypt some kind of .gpg file with secrets, which may happen when kustomize is run manually for testing as opposed to being run as part of a CI job.
Another possibility is some kind of command that may take more than 5 seconds because of network latency and so on.
I'm not quite sure this is a correct approach, and also it's a bit hard to test, so please let me know what do you think about adding this option.