### PR TITLE
Add timeoutSeconds to secretArgs

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -83,6 +83,9 @@ secretGenerator:
     tls.key: "cat secret/tls.key"
   type: "kubernetes.io/tls"
 - name: downloaded_secret
+  # timeoutSeconds specifies the number of seconds to
+  # wait for the commands below. It defaults to 5 seconds.
+  timeoutSeconds: 30
   commands:
     username: "curl -s https://path/to/secrets/username.yaml"
     password: "curl -s https://path/to/secrets/password.yaml"

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -94,3 +94,27 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 		t.Fatalf("%#v\ndoesn't match expected:\n%#v", actual, expected)
 	}
 }
+
+func TestSecretTimeout(t *testing.T) {
+	timeout := int64(1)
+	secrets := []types.SecretArgs{
+		{
+			Name:           "slow",
+			TimeoutSeconds: &timeout,
+			CommandSources: types.CommandSources{
+				Commands: map[string]string{
+					"USER": "sleep 2",
+				},
+			},
+			Type: "Opaque",
+		},
+	}
+	fakeFs := fs.MakeFakeFS()
+	fakeFs.Mkdir(".")
+	_, err := NewResMapFromSecretArgs(
+		configmapandsecret.NewSecretFactory(fakeFs, "."), secrets)
+
+	if err == nil {
+		t.Fatal("didn't get the expected timeout error", err)
+	}
+}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -117,6 +117,9 @@ type SecretArgs struct {
 
 	// CommandSources for secret.
 	CommandSources `json:",inline,omitempty" yaml:",inline,omitempty"`
+
+	// TimeoutSeconds specifies the timeout for commands.
+	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty" yaml:"timeoutSeconds,omitempty"`
 }
 
 // CommandSources contains some generic sources for secrets.


### PR DESCRIPTION
`timeoutSeconds` specifies timeouts for commands specified in `secretArgs`. The default value is 5 seconds (which is currently hard-wired in `kustomize`).

Fixes #252