### PR TITLE
cleanup after handling remote bases

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -226,6 +226,7 @@ func (a *Application) loadCustomizedBases() (resmap.ResMap, *interror.Kustomizat
 			errs.Append(errors.Wrap(err, "SemiResources"))
 			continue
 		}
+		ldr.Cleanup()
 		list = append(list, resMap)
 	}
 	result, err := resmap.MergeWithoutOverride(list...)
@@ -322,6 +323,7 @@ func (a *Application) getAllVars() ([]types.Var, error) {
 			errs.Append(err)
 			continue
 		}
+		b.ldr.Cleanup()
 		result = append(result, vars...)
 	}
 	for _, v := range a.kustomization.Vars {

--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -369,6 +369,9 @@ func TestRawResources2(t *testing.T) {
 	if err := expected.ErrorIfNotEqual(actual); err != nil {
 		t.Fatalf("unexpected inequality: %v", err)
 	}
+	if !loadertest.CleanupCalled {
+		t.Fatalf("Cleanup should be called")
+	}
 }
 
 func TestSecretTimeout(t *testing.T) {

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -22,6 +22,9 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
 )
 
+// CleanupCalled indicates if Cleanup is called.
+var CleanupCalled = false
+
 // FakeLoader encapsulates the delegate Loader and the fake file system.
 type FakeLoader struct {
 	fs       fs.FileSystem
@@ -56,7 +59,11 @@ func (f FakeLoader) Root() string {
 
 // New creates a new loader from a new root.
 func (f FakeLoader) New(newRoot string) (loader.Loader, error) {
-	return f.delegate.New(newRoot)
+	l, err := f.delegate.New(newRoot)
+	if err != nil {
+		return nil, err
+	}
+	return FakeLoader{fs: f.fs, delegate: l}, nil
 }
 
 // Load performs load from a given location.
@@ -66,5 +73,6 @@ func (f FakeLoader) Load(location string) ([]byte, error) {
 
 // Cleanup does nothing
 func (f FakeLoader) Cleanup() error {
+	CleanupCalled = true
 	return nil
 }

--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -68,7 +68,7 @@ func newGithubLoader(repoUrl string, fs fs.FileSystem) (*githubLoader, error) {
 	l := newFileLoaderAtRoot(target, fs)
 	return &githubLoader{
 		repo:        repoUrl,
-		checkoutDir: target,
+		checkoutDir: dir,
 		loader:      l,
 	}, nil
 }


### PR DESCRIPTION
Without this cleanup, when we do `kustomize build` with remote bases like
```
bases:
- github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
```
There are some directories created for checking out the remote base but not removed.

After this fix, I think we can release a new version.