### PR TITLE
Add patchesJson6902 and patchesStategicMerge to kustomization

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
@@ -61,7 +62,12 @@ func NewApplication(ldr loader.Loader, fSys fs.FileSystem) (*Application, error)
 	if err != nil {
 		return nil, err
 	}
-
+	if m.PatchesJson6902 != nil {
+		log.Printf("field patchesJson6902 ignored; no implementation yet.")
+	}
+	if m.Patches != nil {
+		log.Println("field patches will be deprecated, please change it to patchesStategicMerge")
+	}
 	return &Application{kustomization: &m, ldr: ldr, fSys: fSys}, nil
 }
 
@@ -150,7 +156,8 @@ func (a *Application) loadCustomizedResMap() (resmap.ResMap, error) {
 		return nil, err
 	}
 
-	patches, err := resmap.NewResourceSliceFromPatches(a.ldr, a.kustomization.Patches)
+	a.kustomization.PatchesStrategicMerge = append(a.kustomization.PatchesStrategicMerge, a.kustomization.Patches...)
+	patches, err := resmap.NewResourceSliceFromPatches(a.ldr, a.kustomization.PatchesStrategicMerge)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResourceSliceFromPatches"))
 	}

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	interror "github.com/kubernetes-sigs/kustomize/pkg/internal/error"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
+	"github.com/kubernetes-sigs/kustomize/pkg/patch"
 	"github.com/kubernetes-sigs/kustomize/pkg/resmap"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/kubernetes-sigs/kustomize/pkg/transformers"
@@ -64,9 +65,6 @@ func NewApplication(ldr loader.Loader, fSys fs.FileSystem) (*Application, error)
 	}
 	if m.PatchesJson6902 != nil {
 		log.Printf("field patchesJson6902 ignored; no implementation yet.")
-	}
-	if m.Patches != nil {
-		log.Println("field patches will be deprecated, please change it to patchesStategicMerge")
 	}
 	return &Application{kustomization: &m, ldr: ldr, fSys: fSys}, nil
 }
@@ -156,7 +154,7 @@ func (a *Application) loadCustomizedResMap() (resmap.ResMap, error) {
 		return nil, err
 	}
 
-	a.kustomization.PatchesStrategicMerge = append(a.kustomization.PatchesStrategicMerge, a.kustomization.Patches...)
+	a.kustomization.PatchesStrategicMerge = patch.Append(a.kustomization.PatchesStrategicMerge, a.kustomization.Patches)
 	patches, err := resmap.NewResourceSliceFromPatches(a.ldr, a.kustomization.PatchesStrategicMerge)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResourceSliceFromPatches"))

--- a/pkg/patch/jsonpatch.go
+++ b/pkg/patch/jsonpatch.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package types
+package patch
 
-// JSONPatch represents a json patch for an object
-type JSONPatch struct {
+// PatchJson6902 represents a json patch for an object
+// with format documented https://tools.ietf.org/html/rfc6902.
+type PatchJson6902 struct {
 	// Relative file path within the kustomization for a json patch file.
 	Path string `json:"path" yaml:"path"`
 
@@ -26,11 +27,11 @@ type JSONPatch struct {
 	// purview of this kustomization. Target should use the
 	// raw name of the object (the name specified in its YAML,
 	// before addition of a namePrefix).
-	Target PatchTarget `json:"target" yaml:"target"`
+	Target Target `json:"target" yaml:"target"`
 }
 
-// PatchTarget represents the kubernetes object that the patch is applied to
-type PatchTarget struct {
+// Target represents the kubernetes object that the patch is applied to
+type Target struct {
 	Group     string `json:"group,omitempty" yaml:"group,omitempty"`
 	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
 	Kind      string `json:"kind,omitempty" yaml:"kind,omitempty"`

--- a/pkg/patch/strategicmergepatch.go
+++ b/pkg/patch/strategicmergepatch.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+// PatchStrategicMerge represents a relative path to a
+// stategic merget patch with the format
+// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
+type PatchStrategicMerge string
+
+// Append appends a slice of patch paths to a PatchStategicMerge slice
+func Append(patches []PatchStrategicMerge, paths []string) []PatchStrategicMerge {
+	for _, p := range paths {
+		patches = append(patches, PatchStrategicMerge(p))
+	}
+	return patches
+}

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/glog"
 	internal "github.com/kubernetes-sigs/kustomize/pkg/internal/error"
 	"github.com/kubernetes-sigs/kustomize/pkg/loader"
+	"github.com/kubernetes-sigs/kustomize/pkg/patch"
 	"github.com/kubernetes-sigs/kustomize/pkg/resource"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -131,16 +132,16 @@ func (m ResMap) insert(newName string, obj *unstructured.Unstructured) error {
 
 // NewResourceSliceFromPatches returns a slice of resources given a patch path slice from a kustomization file.
 func NewResourceSliceFromPatches(
-	loader loader.Loader, paths []string) ([]*resource.Resource, error) {
+	loader loader.Loader, paths []patch.PatchStrategicMerge) ([]*resource.Resource, error) {
 	var result []*resource.Resource
 	for _, path := range paths {
-		content, err := loader.Load(path)
+		content, err := loader.Load(string(path))
 		if err != nil {
 			return nil, err
 		}
 		res, err := newResourceSliceFromBytes(content)
 		if err != nil {
-			return nil, internal.Handler(err, path)
+			return nil, internal.Handler(err, string(path))
 		}
 		result = append(result, res...)
 	}

--- a/pkg/types/jsonpatch.go
+++ b/pkg/types/jsonpatch.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+// JSONPatch represents a json patch for an object
+type JSONPatch struct {
+	// Relative file path within the kustomization for a json patch file.
+	Path string `json:"path" yaml:"path"`
+
+	// Target refers to a Kubernetes object that the json patch will be
+	// applied to. It must refer to a Kubernetes resource under the
+	// purview of this kustomization. Target should use the
+	// raw name of the object (the name specified in its YAML,
+	// before addition of a namePrefix).
+	Target PatchTarget `json:"target" yaml:"target"`
+}
+
+// PatchTarget represents the kubernetes object that the patch is applied to
+type PatchTarget struct {
+	Group     string `json:"group,omitempty" yaml:"group,omitempty"`
+	Version   string `json:"version,omitempty" yaml:"version,omitempty"`
+	Kind      string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Name      string `json:"name" yaml:"name"`
+}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -56,8 +56,15 @@ type Kustomization struct {
 
 	// An Patch entry is very similar to an Resource entry.
 	// It specifies the relative paths for patch files within the package.
-	// URLs and globs are not supported
-	Patches []string `json:"patches,omitempty" yaml:"patches,omitempty"`
+	// URLs and globs are not supported.
+	// The patch files should be Stategic Merge Patch, the default patching behavior for kubectl.
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
+	Patches               []string `json:"patches,omitempty" yaml:"patches,omitempty"`
+	PatchesStrategicMerge []string `json:"patchesSrategicMerge,omitempty" yaml:"patchesStategicMerge,omitempty"`
+
+	// JSONPatches is a list of JSONPatch for applying JSON patch.
+	// The JSON patch is documented at http://jsonpatch.com/.
+	PatchesJson6902 []JSONPatch `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
 
 	// List of configmaps to generate from configuration sources.
 	// Base/overlay concept doesn't apply to this field.

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -19,6 +19,8 @@ package types
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubernetes-sigs/kustomize/pkg/patch"
 )
 
 // Kustomization holds the information needed to generate customized k8s api resources.
@@ -59,12 +61,13 @@ type Kustomization struct {
 	// URLs and globs are not supported.
 	// The patch files should be Stategic Merge Patch, the default patching behavior for kubectl.
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
-	Patches               []string `json:"patches,omitempty" yaml:"patches,omitempty"`
-	PatchesStrategicMerge []string `json:"patchesSrategicMerge,omitempty" yaml:"patchesStategicMerge,omitempty"`
+	Patches               []string                    `json:"patches,omitempty" yaml:"patches,omitempty"`
+	PatchesStrategicMerge []patch.PatchStrategicMerge `json:"patchesSrategicMerge,omitempty" yaml:"patchesStategicMerge,omitempty"`
 
 	// JSONPatches is a list of JSONPatch for applying JSON patch.
-	// The JSON patch is documented at http://jsonpatch.com/.
-	PatchesJson6902 []JSONPatch `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
+	// The JSON patch is documented at https://tools.ietf.org/html/rfc6902
+	// and http://jsonpatch.com/.
+	PatchesJson6902 []patch.PatchJson6902 `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
 
 	// List of configmaps to generate from configuration sources.
 	// Base/overlay concept doesn't apply to this field.


### PR DESCRIPTION
This change is to add a filed in kustomization.yaml to handle JSON patch.
Let's all take a look at the change and make sure the type and fields added are meaningful, accurate and easy to use.