### PR TITLE
Fix loader loader when run from gopath

### DIFF
--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -75,7 +75,11 @@ func newGithubLoader(repoUrl string, fs fs.FileSystem) (*githubLoader, error) {
 
 // isRepoUrl checks if a string is a repo Url
 func isRepoUrl(s string) bool {
-	return strings.Contains(s, ".com") || strings.Contains(s, ".org") || strings.Contains(s, "https://")
+	if strings.HasPrefix(s, "https://") {
+		return true
+	}
+	host := strings.SplitN(s, "/", 2)[0]
+	return strings.Contains(host, ".com") || strings.Contains(host, ".org")
 }
 
 // Checkout clones a github repo with specified commit/tag/branch

--- a/pkg/loader/githubloader_test.go
+++ b/pkg/loader/githubloader_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"testing"
+)
+
+func TestIsRepoURL(t *testing.T) {
+
+	testcases := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "https://github.com/org/repo",
+			expected: true,
+		},
+		{
+			input:    "github.com/org/repo",
+			expected: true,
+		},
+		{
+			input:    "/github.com/org/repo",
+			expected: false,
+		},
+		{
+			input:    "/abs/path/to/file",
+			expected: false,
+		},
+		{
+			input:    "../relative",
+			expected: false,
+		},
+	}
+	for _, tc := range testcases {
+		actual := isRepoUrl(tc.input)
+		if actual != tc.expected {
+			t.Errorf("unexpected error: unexpected result %t for input %s", actual, tc.input)
+		}
+	}
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -43,7 +43,7 @@ func NewLoader(target, r string, fSys fs.FileSystem) (Loader, error) {
 		return nil, fmt.Errorf("Not valid path: root='%s', loc='%s'\n", r, target)
 	}
 
-	if isRepoUrl(target) {
+	if !isLocalTarget(target, fSys) && isRepoUrl(target) {
 		return newGithubLoader(target, fSys)
 	}
 
@@ -72,4 +72,9 @@ func isValidLoaderPath(target, root string) bool {
 
 func isRootLoaderPath(root string) bool {
 	return root == ""
+}
+
+// isLocalTarget checks if a file exists in the filesystem
+func isLocalTarget(s string, fs fs.FileSystem) bool {
+	return fs.Exists(s)
 }


### PR DESCRIPTION
`kustomize build` fails when running from a working directory within a gopath or any path with a `.org` or `.com` in for that matter.

```
base/kustomization.yaml
overlays/production/kustomization.yaml
overlays/staging/kustomization.yaml
```

```
$ kustomize build ./overlays/staging
Error: loadResMapFromBasesAndResources: couldn't make app for ../../base: open /tmp/base/kustomization.yaml: no such file or directory
```

Fixes #282 