### PR TITLE
if the prefix of the base is 'git::' will make the use of go-getter to download repo

### DIFF
--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -78,6 +78,9 @@ func isRepoUrl(s string) bool {
 	if strings.HasPrefix(s, "https://") {
 		return true
 	}
+	if strings.HasPrefix(s, "git::") {
+		return true
+	}
 	host := strings.SplitN(s, "/", 2)[0]
 	return strings.Contains(host, ".com") || strings.Contains(host, ".org")
 }

--- a/pkg/loader/githubloader_test.go
+++ b/pkg/loader/githubloader_test.go
@@ -46,6 +46,10 @@ func TestIsRepoURL(t *testing.T) {
 			input:    "../relative",
 			expected: false,
 		},
+		{
+			input:    "git::https://gitlab.com/org/repo",
+			expected: true,
+		},
 	}
 	for _, tc := range testcases {
 		actual := isRepoUrl(tc.input)


### PR DESCRIPTION
I don't think anyone have a folder name `git::`

This change will allow pulling from any kind of git repo, private or public

```
bases:
- some-local-dir
- github.com/kubernetes-sigs/kustomize//examples/helloWorld
- git::https://username:password@gitlab.com/org/repo.git//subfolder/sub-subfolder?ref=commit-hash
- git::git@github.com:hashicorp/go-getter.git?ref=v1.0.1&sshkey=<base64 encoded private key>
``` 