### PR TITLE
Add gitHead for allowing pickup of current gitHead in repo

### DIFF
--- a/pkg/transformers/imagetag.go
+++ b/pkg/transformers/imagetag.go
@@ -82,6 +82,13 @@ func (pt *imageTagTransformer) updateContainers(obj map[string]interface{}, path
 			continue
 		}
 		for _, imagetag := range pt.imageTags {
+			if imagetag.GitHead {
+				gitTag, err := gitHead()
+				if err != nil {
+					return err
+				}
+				imagetag.NewTag = gitTag
+			}
 			if isImageMatched(image.(string), imagetag.Name) {
 				container["image"] = strings.Join([]string{imagetag.Name, imagetag.NewTag}, ":")
 				break

--- a/pkg/transformers/imagetag_test.go
+++ b/pkg/transformers/imagetag_test.go
@@ -157,6 +157,8 @@ func TestImageTagTransformer(t *testing.T) {
 	}
 
 	it, err := NewImageTagTransformer([]types.ImageTag{
+		{Name: "nginx", NewTag: "v2", GitHead: false},
+		{Name: "nginx", NewTag: "v2", GitHead: true},
 		{Name: "nginx", NewTag: "v2"},
 		{Name: "my-nginx", NewTag: "previous"},
 		{Name: "myprivaterepohostname:1234/my/image", NewTag: "v1.0.1"},

--- a/pkg/transformers/util.go
+++ b/pkg/transformers/util.go
@@ -17,7 +17,10 @@ limitations under the License.
 package transformers
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
+	"strings"
 )
 
 type mutateFunc func(interface{}) (interface{}, error)
@@ -67,4 +70,14 @@ func mutateField(m map[string]interface{}, pathToField []string, createIfNotPres
 	default:
 		return fmt.Errorf("%#v is not expected to be a primitive type", typedV)
 	}
+}
+
+// gitHead will fetch the git HEAD for a repo
+func gitHead() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", errors.New("Attempted to use 'gitHead', but no git HEAD exists in this location.")
+	}
+	output := strings.TrimSpace(string(out))
+	return output, nil
 }

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -176,4 +176,8 @@ type ImageTag struct {
 
 	// NewTag is the value to use in replacing the original tag.
 	NewTag string `json:"newTag,omitempty" yaml:"newTag,omitempty"`
+
+	// gitHead determines whether to use the git HEAD as the NewTag
+	// This will overwrite NewTag if both are used.
+	GitHead bool `json:"gitHead,omitempty" yaml:"gitHead,omitempty"`
 }


### PR DESCRIPTION
I know this is going to be a controversial commit since it's technically an eschewed feature, but let me make my case.... 

What is the best way to deploy using kustomize in a gitOps manner? Most people I know are using docker image tags that use either semantic versioning or a simpler method of simply the git commit sha. 

If one is using the latter it is impossible to put it in your kustomize template and is the one case where the kustomize rule of "everything in git" should be broken. What's the use of putting stale commits in the repo if they're just going to be overridden? I think this use case of deploying the current commit hash should be a valid paradigm for kustomize deployment.

Depending on the feedback given here I can write more comprehensive tests + documentation. Mostly hoping to get a discussion going :)