### PR TITLE
Enable json patch transformers in kustomize

### DIFF
--- a/pkg/app/application_test.go
+++ b/pkg/app/application_test.go
@@ -54,6 +54,13 @@ secretGenerator:
     DB_USERNAME: "printf admin"
     DB_PASSWORD: "printf somepw"
   type: Opaque
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: dply1
+  path: /testpath/jsonpatch
 `
 	kustomizationContent2 = `
 secretGenerator:
@@ -73,6 +80,9 @@ kind: Namespace
 metadata:
   name: ns1
 `
+	jsonpatchContent = `[
+		{"op": "add", "path": "/spec/replica", "value": "3"}
+	]`
 )
 
 func makeLoader1(t *testing.T) loader.Loader {
@@ -86,6 +96,10 @@ func makeLoader1(t *testing.T) loader.Loader {
 		t.Fatalf("Failed to setup fake ldr.")
 	}
 	err = ldr.AddFile("/testpath/namespace.yaml", []byte(namespaceContent))
+	if err != nil {
+		t.Fatalf("Failed to setup fake ldr.")
+	}
+	err = ldr.AddFile("/testpath/jsonpatch", []byte(jsonpatchContent))
 	if err != nil {
 		t.Fatalf("Failed to setup fake ldr.")
 	}
@@ -114,6 +128,7 @@ func TestResources1(t *testing.T) {
 					},
 				},
 				"spec": map[string]interface{}{
+					"replica": "3",
 					"selector": map[string]interface{}{
 						"matchLabels": map[string]interface{}{
 							"app": "nginx",

--- a/pkg/commands/kustomizationfile.go
+++ b/pkg/commands/kustomizationfile.go
@@ -26,12 +26,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
-
 	"github.com/kubernetes-sigs/kustomize/pkg/constants"
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	interror "github.com/kubernetes-sigs/kustomize/pkg/internal/error"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
+	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/pkg/commands/kustomizationfile_test.go
+++ b/pkg/commands/kustomizationfile_test.go
@@ -99,13 +99,13 @@ resources:
 - service.yaml
 # something you may want to keep
 vars:
-- fieldref:
-    fieldPath: metadata.name
-  name: MY_SERVICE_NAME
+- name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
     kind: Service
     name: my-service
+  fieldref:
+    fieldPath: metadata.name
 bases:
 - ../namespaces
 # some descriptions for the patches
@@ -147,7 +147,7 @@ resources:
   # See which field this comment goes into
 - service.yaml
 
-APIVersion: v1beta1
+apiVersion: v1beta1
 kind: kustomization.yaml
 
 # something you may want to keep
@@ -160,7 +160,7 @@ vars:
     kind: Service
     name: my-service
 
-BASES:
+bases:
 - ../namespaces
 
 # some descriptions for the patches
@@ -187,13 +187,13 @@ kind: kustomization.yaml
 
 # something you may want to keep
 vars:
-- fieldref:
-    fieldPath: metadata.name
-  name: MY_SERVICE_NAME
+- name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
     kind: Service
     name: my-service
+  fieldref:
+    fieldPath: metadata.name
 
 bases:
 - ../namespaces

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -18,14 +18,25 @@ limitations under the License.
 package types
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kubernetes-sigs/kustomize/pkg/patch"
 )
 
 // Kustomization holds the information needed to generate customized k8s api resources.
 type Kustomization struct {
-	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	// Cannot be updated.
+	// In CamelCase.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	// APIVersion defines the versioned schema of this representation of an object.
+	// Servers should convert recognized schemas to the latest internal value, and
+	// may reject unrecognized values.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 
 	// NamePrefix will prefix the names of all resources mentioned in the kustomization
 	// file including generated configmaps and secrets.


### PR DESCRIPTION
Fix #169

add calling of `NewPatchJson6902Factory` and `MakePatchJson6902Transformer` in application.go

There is one important change. When parsing json patch, we use library gopkg.in/yaml.v2 since github.com/ghodss/yaml doesn't work with json patches. So I also changed to use library gopkg.in/yaml.v2 in application.go. The impact is mainly on unmarshaling kustomization.yaml. In order to keep everything work, I also changed some types in Kustomize. 
- metav1.TypeMeta  --> Kind and APIVersion
- Vars.ObjRef --> use a self defined struct Target
- Vars.FieldRef --> use a self defined struct FieldRef
