### PR TITLE
change kustomization type to use self defined types

### DIFF
--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -19,13 +19,8 @@ limitations under the License.
 package app
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
-
-	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
 
 	"github.com/kubernetes-sigs/kustomize/pkg/configmapandsecret"
 	"github.com/kubernetes-sigs/kustomize/pkg/constants"
@@ -39,6 +34,7 @@ import (
 	"github.com/kubernetes-sigs/kustomize/pkg/transformers"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 // Application implements the guts of the kustomize 'build' command.
@@ -70,14 +66,7 @@ func NewApplication(ldr loader.Loader, fSys fs.FileSystem) (*Application, error)
 }
 
 func unmarshal(y []byte, o interface{}) error {
-	j, err := yaml.YAMLToJSON(y)
-	if err != nil {
-		return err
-	}
-
-	dec := json.NewDecoder(bytes.NewReader(j))
-	dec.DisallowUnknownFields()
-	return dec.Decode(o)
+	return yaml.Unmarshal(y, o)
 }
 
 // MakeCustomizedResMap creates a ResMap per kustomization instructions.
@@ -291,7 +280,7 @@ func (a *Application) resolveRefVars(m resmap.ResMap) (map[string]string, error)
 			}
 			result[v.Name] = s
 		} else {
-			glog.Infof("couldn't resolve v: %v", v)
+			log.Printf("couldn't resolve v: %v", v)
 		}
 	}
 	return result, nil

--- a/pkg/commands/kustomizationfile.go
+++ b/pkg/commands/kustomizationfile.go
@@ -26,12 +26,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
-
 	"github.com/kubernetes-sigs/kustomize/pkg/constants"
 	"github.com/kubernetes-sigs/kustomize/pkg/fs"
 	interror "github.com/kubernetes-sigs/kustomize/pkg/internal/error"
 	"github.com/kubernetes-sigs/kustomize/pkg/types"
+	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/pkg/commands/kustomizationfile_test.go
+++ b/pkg/commands/kustomizationfile_test.go
@@ -99,13 +99,13 @@ resources:
 - service.yaml
 # something you may want to keep
 vars:
-- fieldref:
-    fieldPath: metadata.name
-  name: MY_SERVICE_NAME
+- name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
     kind: Service
     name: my-service
+  fieldref:
+    fieldPath: metadata.name
 bases:
 - ../namespaces
 # some descriptions for the patches
@@ -147,7 +147,7 @@ resources:
   # See which field this comment goes into
 - service.yaml
 
-APIVersion: v1beta1
+apiVersion: v1beta1
 kind: kustomization.yaml
 
 # something you may want to keep
@@ -160,7 +160,7 @@ vars:
     kind: Service
     name: my-service
 
-BASES:
+bases:
 - ../namespaces
 
 # some descriptions for the patches
@@ -187,13 +187,13 @@ kind: kustomization.yaml
 
 # something you may want to keep
 vars:
-- fieldref:
-    fieldPath: metadata.name
-  name: MY_SERVICE_NAME
+- name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
     kind: Service
     name: my-service
+  fieldref:
+    fieldPath: metadata.name
 
 bases:
 - ../namespaces

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -18,14 +18,25 @@ limitations under the License.
 package types
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/kubernetes-sigs/kustomize/pkg/patch"
 )
 
 // Kustomization holds the information needed to generate customized k8s api resources.
 type Kustomization struct {
-	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	// Cannot be updated.
+	// In CamelCase.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	// APIVersion defines the versioned schema of this representation of an object.
+	// Servers should convert recognized schemas to the latest internal value, and
+	// may reject unrecognized values.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 
 	// NamePrefix will prefix the names of all resources mentioned in the kustomization
 	// file including generated configmaps and secrets.


### PR DESCRIPTION
First part of #319 
- change kustomization type to use its own types
   With `metav1.TypeMeta`, when a Kustomization object is marshaled to YAML format, apiVersion and kind both show up as empty strings
- change ghodss/yaml to gopkg.in/yaml.v2
   ghodss/yaml couldn't handle the types for jsonpatch 