### PR TITLE
Fix typo in multibases readme

### DIFF
--- a/examples/multibases/README.md
+++ b/examples/multibases/README.md
@@ -107,7 +107,7 @@ Now the workspace has following directories
 >     └── kustomization.yaml
 > ```
 
-Confirm that the `kustomize build` output contains three pod objects from dev, staing and production variants.
+Confirm that the `kustomize build` output contains three pod objects from dev, staging and production variants.
 
 <!-- @confirmVariants @test -->
 ```


### PR DESCRIPTION
There is a little typo in multibases readme. This PR fixes #340.