### PR TITLE
add generated annotation

### DIFF
--- a/pkg/configmapandsecret/configmapfactory.go
+++ b/pkg/configmapandsecret/configmapfactory.go
@@ -79,6 +79,9 @@ func (f *ConfigMapFactory) makeFreshConfigMap(
 	cm.APIVersion = "v1"
 	cm.Kind = "ConfigMap"
 	cm.Name = args.Name
+	cm.ObjectMeta.Annotations = map[string]string{
+		"kustomize.sigs.k8s.io/generated": "true",
+	}
 	cm.Data = map[string]string{}
 	return cm
 }

--- a/pkg/configmapandsecret/secretfactory.go
+++ b/pkg/configmapandsecret/secretfactory.go
@@ -52,6 +52,9 @@ func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
 	s.Kind = "Secret"
 	s.Name = args.Name
 	s.Type = corev1.SecretType(args.Type)
+	s.ObjectMeta.Annotations = map[string]string{
+		"kustomize.sigs.k8s.io/generated": "true",
+	}
 	if s.Type == "" {
 		s.Type = corev1.SecretTypeOpaque
 	}


### PR DESCRIPTION
closes #353

Add a common label to generated objects, so that they may be identified as such. I don't think this requires documentation--the first place someone will probably look for this information on generated objects themselves.