### PR TITLE
Update install doc to use sigs.k8s.io

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,5 +29,5 @@ To install from head with [Go] v1.10.1 or higher:
 
 <!-- @installkustomize @test -->
 ```
-go get github.com/kubernetes-sigs/kustomize
+go get sigs.k8s.io/kustomize
 ```


### PR DESCRIPTION
When using go get github.com/kubernetes-sigs/kustomize running kustomize
panics with 'log_dir redefined'.