### PR TITLE
Add Option to Override Shell

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -61,6 +61,11 @@ resources:
 - some-service.yaml
 - ../some-dir/some-deployment.yaml
 
+# It's possible to override the shell used in generator
+# commands by passing this optional parameter. Default is:
+#  ["/bin/sh", "-c"]
+generatorShell: ["/bin/bash", "-c"]
+
 # Each entry in this list results in the creation of
 # one ConfigMap resource (it's a generator of n maps).
 # The example below creates a ConfigMap with the

--- a/pkg/app/application.go
+++ b/pkg/app/application.go
@@ -59,6 +59,7 @@ func NewApplication(ldr loader.Loader, fSys fs.FileSystem) (*Application, error)
 	}
 
 	var m types.Kustomization
+	m.GeneratorShell = []string{"sh", "-c"}
 	err = unmarshal(content, &m)
 	if err != nil {
 		return nil, err
@@ -135,8 +136,10 @@ func (a *Application) loadCustomizedResMap() (resmap.ResMap, error) {
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromConfigMapArgs"))
 	}
+	shell := a.kustomization.GeneratorShell[0]
+	args := a.kustomization.GeneratorShell[1:]
 	secrets, err := resmap.NewResMapFromSecretArgs(
-		configmapandsecret.NewSecretFactory(a.fSys, a.ldr.Root()),
+		configmapandsecret.NewSecretFactory(a.fSys, a.ldr.Root(), shell, args),
 		a.kustomization.SecretGenerator)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromSecretArgs"))

--- a/pkg/commands/testdata/testcase-alt-shell/expected.yaml
+++ b/pkg/commands/testdata/testcase-alt-shell/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  test-0: L2Jpbi9iYXNoCg==
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: pipefail-secret-test-tct7hmhk56
+type: Opaque

--- a/pkg/commands/testdata/testcase-alt-shell/in/kustomization.yaml
+++ b/pkg/commands/testdata/testcase-alt-shell/in/kustomization.yaml
@@ -1,0 +1,5 @@
+generatorShell: ["/bin/bash", "-c"]
+secretGenerator:
+- name: pipefail-secret-test
+  commands:
+    test-0: echo "$0"

--- a/pkg/commands/testdata/testcase-alt-shell/test.yaml
+++ b/pkg/commands/testdata/testcase-alt-shell/test.yaml
@@ -1,0 +1,4 @@
+description: base only
+args: []
+filename: testdata/testcase-alt-shell/in
+expectedStdout: testdata/testcase-alt-shell/expected.yaml

--- a/pkg/resmap/secret_test.go
+++ b/pkg/resmap/secret_test.go
@@ -54,7 +54,7 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
 	actual, err := NewResMapFromSecretArgs(
-		configmapandsecret.NewSecretFactory(fakeFs, "."), secrets)
+		configmapandsecret.NewSecretFactory(fakeFs, ".", "/bin/sh", []string{"-c"}), secrets)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -112,7 +112,7 @@ func TestSecretTimeout(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
 	_, err := NewResMapFromSecretArgs(
-		configmapandsecret.NewSecretFactory(fakeFs, "."), secrets)
+		configmapandsecret.NewSecretFactory(fakeFs, ".", "/bin/sh", []string{"-c"}), secrets)
 
 	if err == nil {
 		t.Fatal("didn't get the expected timeout error", err)

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -69,6 +69,9 @@ type Kustomization struct {
 	// and http://jsonpatch.com/.
 	PatchesJson6902 []patch.PatchJson6902 `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
 
+	// Shell binary, arguments to use for ConfigMap and Secret generators
+	GeneratorShell []string `json:"generatorShell,omitempty" yaml:"generatorShell,omitempty"`
+
 	// List of configmaps to generate from configuration sources.
 	// Base/overlay concept doesn't apply to this field.
 	// If a configmap want to have a base and an overlay, it should go to Bases


### PR DESCRIPTION
I've added the option to override the shell in `kustomization.yaml` files through a new parameter `generateShell` which takes a list of strings. The first string is the binary to use as the alternate shell, all subsequent parameters are passed as arguments, ending with the command provided by the user in a generator.