### PR TITLE
Rename Application to KustTarget

### DIFF
--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -19,15 +19,14 @@ package commands
 import (
 	"errors"
 	"io"
+	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"log"
-	"sigs.k8s.io/kustomize/pkg/app"
 	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/target"
 	"sigs.k8s.io/kustomize/pkg/transformerconfig"
 )
 
@@ -121,13 +120,12 @@ func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
 		return err
 	}
 	defer rootLoader.Cleanup()
-
-	application, err := app.NewApplication(
+	target, err := target.NewKustTarget(
 		rootLoader, fSys, makeTransformerconfig(fSys, o.transformerconfigPaths))
 	if err != nil {
 		return err
 	}
-	allResources, err := application.MakeCustomizedResMap()
+	allResources, err := target.MakeCustomizedResMap()
 	if err != nil {
 		return err
 	}

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package app
+package target
 
 import (
 	"encoding/base64"
@@ -204,11 +204,11 @@ func TestResources1(t *testing.T) {
 	l := makeLoader1(t)
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	app, err := NewApplication(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	actual, err := app.MakeCustomizedResMap()
+	actual, err := target.MakeCustomizedResMap()
 	if err != nil {
 		t.Fatalf("Unexpected Resources error %v", err)
 	}
@@ -227,11 +227,11 @@ func TestResourceNotFound(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	app, err := NewApplication(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	_, err = app.MakeCustomizedResMap()
+	_, err = target.MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}
@@ -248,11 +248,11 @@ func TestSecretTimeout(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	app, err := NewApplication(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	_, err = app.MakeCustomizedResMap()
+	_, err = target.MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}


### PR DESCRIPTION
This fixes a TODO to remove the notion of "Application" from kustomize.
Don't want it to be confused with the https://github.com/kubernetes-sigs/application;
we'll soon be using that CRD.
