### PR TITLE
Fix some Go nits.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,7 +21,7 @@
 [overlays]: #overlay
 [patch]: #patch
 [patches]: #patch
-[patchJson6902]: #patchJson6902
+[patchJson6902]: #patchjson6902
 [patchesJson6902]: #patchjson6902
 [proposal]: https://github.com/kubernetes/community/pull/1629
 [rebase]: https://git-scm.com/docs/git-rebase

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -120,12 +120,12 @@ func (o *buildOptions) RunBuild(out io.Writer, fSys fs.FileSystem) error {
 		return err
 	}
 	defer rootLoader.Cleanup()
-	target, err := target.NewKustTarget(
+	kt, err := target.NewKustTarget(
 		rootLoader, fSys, makeTransformerconfig(fSys, o.transformerconfigPaths))
 	if err != nil {
 		return err
 	}
-	allResources, err := target.MakeCustomizedResMap()
+	allResources, err := kt.MakeCustomizedResMap()
 	if err != nil {
 		return err
 	}

--- a/pkg/loader/githubloader.go
+++ b/pkg/loader/githubloader.go
@@ -30,7 +30,7 @@ import (
 // githubLoader loads files from a checkout github repo
 type githubLoader struct {
 	repo string
-	// target is the directory which is to be built
+	// targetDir will hold the local repo
 	targetDir string
 	// checkoutDir is for the whole repository
 	checkoutDir string

--- a/pkg/patch/json6902.go
+++ b/pkg/patch/json6902.go
@@ -18,9 +18,9 @@ package patch
 
 import "sigs.k8s.io/kustomize/pkg/gvk"
 
-// PatchJson6902 represents a json patch for an object
+// Json6902 represents a json patch for an object
 // with format documented https://tools.ietf.org/html/rfc6902.
-type PatchJson6902 struct {
+type Json6902 struct {
 	// Target refers to a Kubernetes object that the json patch will be
 	// applied to. It must refer to a Kubernetes resource under the
 	// purview of this kustomization. Target should use the

--- a/pkg/patch/strategicmerge.go
+++ b/pkg/patch/strategicmerge.go
@@ -16,23 +16,23 @@ limitations under the License.
 
 package patch
 
-// PatchStrategicMerge represents a relative path to a
-// stategic merget patch with the format
+// StrategicMerge represents a relative path to a
+// stategic merge patch with the format
 // https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
-type PatchStrategicMerge string
+type StrategicMerge string
 
 // Append appends a slice of patch paths to a PatchStategicMerge slice
-func Append(patches []PatchStrategicMerge, paths ...string) []PatchStrategicMerge {
+func Append(patches []StrategicMerge, paths ...string) []StrategicMerge {
 	for _, p := range paths {
-		patches = append(patches, PatchStrategicMerge(p))
+		patches = append(patches, StrategicMerge(p))
 	}
 	return patches
 }
 
 // Exist determines if a patch path exists in a slice of PatchStategicMerge
-func Exist(patches []PatchStrategicMerge, path string) bool {
+func Exist(patches []StrategicMerge, path string) bool {
 	for _, p := range patches {
-		if p == PatchStrategicMerge(path) {
+		if p == StrategicMerge(path) {
 			return true
 		}
 	}

--- a/pkg/patch/transformer/factory.go
+++ b/pkg/patch/transformer/factory.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/transformers"
 )
 
-// PatchJson6902Factory makes PatchJson6902 transformers
+// PatchJson6902Factory makes Json6902 transformers
 type PatchJson6902Factory struct {
 	loader loader.Loader
 }
@@ -39,7 +39,7 @@ func NewPatchJson6902Factory(l loader.Loader) PatchJson6902Factory {
 }
 
 // MakePatchJson6902Transformer returns a transformer for applying Json6902 patch
-func (f PatchJson6902Factory) MakePatchJson6902Transformer(patches []patch.PatchJson6902) (transformers.Transformer, error) {
+func (f PatchJson6902Factory) MakePatchJson6902Transformer(patches []patch.Json6902) (transformers.Transformer, error) {
 	var ts []transformers.Transformer
 	for _, p := range patches {
 		t, err := f.makeOnePatchJson6902Transformer(p)
@@ -53,7 +53,7 @@ func (f PatchJson6902Factory) MakePatchJson6902Transformer(patches []patch.Patch
 	return transformers.NewMultiTransformerWithConflictCheck(ts), nil
 }
 
-func (f PatchJson6902Factory) makeOnePatchJson6902Transformer(p patch.PatchJson6902) (transformers.Transformer, error) {
+func (f PatchJson6902Factory) makeOnePatchJson6902Transformer(p patch.Json6902) (transformers.Transformer, error) {
 	if p.Target == nil {
 		return nil, fmt.Errorf("must specify the target field in patchesJson6902")
 	}

--- a/pkg/patch/transformer/factory_test.go
+++ b/pkg/patch/transformer/factory_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestNewPatchJson6902FactoryNoTarget(t *testing.T) {
-	p := patch.PatchJson6902{}
+	p := patch.Json6902{}
 	_, err := NewPatchJson6902Factory(nil).makeOnePatchJson6902Transformer(p)
 	if err == nil {
 		t.Fatal("expected error")
@@ -46,7 +46,7 @@ target:
   name: some-name
   kind: Deployment
 `)
-	p := patch.PatchJson6902{}
+	p := patch.Json6902{}
 	err := yaml.Unmarshal(jsonPatch, &p)
 	if err != nil {
 		t.Fatalf("expected error %v", err)
@@ -79,7 +79,7 @@ target:
   name: some-name
 path: /testpath/patch.json
 `)
-	p := patch.PatchJson6902{}
+	p := patch.Json6902{}
 	err = yaml.Unmarshal(jsonPatch, &p)
 	if err != nil {
 		t.Fatal("expected error")
@@ -117,7 +117,7 @@ target:
   kind: Deployment
 path: /testpath/patch.yaml
 `)
-	p := patch.PatchJson6902{}
+	p := patch.Json6902{}
 	err = yaml.Unmarshal(jsonPatch, &p)
 	if err != nil {
 		t.Fatalf("unexpected error : %v", err)
@@ -164,7 +164,7 @@ func TestNewPatchJson6902FactoryMulti(t *testing.T) {
     name: some-name
   path: /testpath/patch.yaml
 `)
-	var p []patch.PatchJson6902
+	var p []patch.Json6902
 	err = yaml.Unmarshal(jsonPatches, &p)
 	if err != nil {
 		t.Fatalf("unexpected error : %v", err)
@@ -278,7 +278,7 @@ func TestNewPatchJson6902FactoryMultiConflict(t *testing.T) {
     name: some-name
   path: /testpath/patch.yaml
 `)
-	var p []patch.PatchJson6902
+	var p []patch.Json6902
 	err = yaml.Unmarshal(jsonPatches, &p)
 	if err != nil {
 		t.Fatalf("unexpected error : %v", err)

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -156,7 +156,7 @@ func (m ResMap) FilterBy(inputId resource.ResId) ResMap {
 
 // NewResourceSliceFromPatches returns a slice of resources given a patch path slice from a kustomization file.
 func NewResourceSliceFromPatches(
-	loader loader.Loader, paths []patch.PatchStrategicMerge) ([]*resource.Resource, error) {
+	loader loader.Loader, paths []patch.StrategicMerge) ([]*resource.Resource, error) {
 	var result []*resource.Resource
 	for _, path := range paths {
 		content, err := loader.Load(string(path))

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -204,11 +204,11 @@ func TestResources1(t *testing.T) {
 	l := makeLoader1(t)
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	kt, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	actual, err := target.MakeCustomizedResMap()
+	actual, err := kt.MakeCustomizedResMap()
 	if err != nil {
 		t.Fatalf("Unexpected Resources error %v", err)
 	}
@@ -227,11 +227,11 @@ func TestResourceNotFound(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	kt, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	_, err = target.MakeCustomizedResMap()
+	_, err = kt.MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}
@@ -248,11 +248,11 @@ func TestSecretTimeout(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
-	target, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
+	kt, err := NewKustTarget(l, fakeFs, transformerconfig.MakeDefaultTransformerConfig())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
 	}
-	_, err = target.MakeCustomizedResMap()
+	_, err = kt.MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -61,13 +61,13 @@ type Kustomization struct {
 	// URLs and globs are not supported.
 	// The patch files should be Stategic Merge Patch, the default patching behavior for kubectl.
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/strategic-merge-patch.md
-	Patches               []string                    `json:"patches,omitempty" yaml:"patches,omitempty"`
-	PatchesStrategicMerge []patch.PatchStrategicMerge `json:"patchesStrategicMerge,omitempty" yaml:"patchesStrategicMerge,omitempty"`
+	Patches               []string               `json:"patches,omitempty" yaml:"patches,omitempty"`
+	PatchesStrategicMerge []patch.StrategicMerge `json:"patchesStrategicMerge,omitempty" yaml:"patchesStrategicMerge,omitempty"`
 
 	// JSONPatches is a list of JSONPatch for applying JSON patch.
 	// The JSON patch is documented at https://tools.ietf.org/html/rfc6902
 	// and http://jsonpatch.com/.
-	PatchesJson6902 []patch.PatchJson6902 `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
+	PatchesJson6902 []patch.Json6902 `json:"patchesJson6902,omitempty" yaml:"patchesJson6902,omitempty"`
 
 	// List of configmaps to generate from configuration sources.
 	// Base/overlay concept doesn't apply to this field.


### PR DESCRIPTION
 - broken md link
 - objects that begin with the package name (e.g. patch.PatchStrategicMerge)
 - local var that matches package name