### PR TITLE
Add tests for patch/resource reading.

### DIFF
--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -157,7 +157,7 @@ func (kt *KustTarget) loadCustomizedResMap() (resmap.ResMap, error) {
 	kt.kustomization.PatchesStrategicMerge = patch.Append(
 		kt.kustomization.PatchesStrategicMerge,
 		kt.kustomization.Patches...)
-	patches, err := resmap.NewResourceSliceFromPatches(
+	patches, err := resource.NewResourceSliceFromPatches(
 		kt.ldr, kt.kustomization.PatchesStrategicMerge)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResourceSliceFromPatches"))


### PR DESCRIPTION
To support refactoring crazy.

Moves untested resource reading code from resmap package to a more appropriate home in the resource package and adds tests.
