### PR TITLE
use 'sed -i.bak' instead of 'sed -i' to make it compatible with macos…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ kustomize
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# We use sed -i.bak when doing in-line replace, because it works better cross-platform
+.bak

--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -164,7 +164,7 @@ the server will use:
 
 <!-- @changeMap @test -->
 ```
-sed -i 's/pineapple/kiwi/' $OVERLAYS/staging/map.yaml
+sed -i.bak 's/pineapple/kiwi/' $OVERLAYS/staging/map.yaml
 ```
 
 See the new greeting:

--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -108,15 +108,9 @@ label_ applied to all resources:
 
 <!-- @addLabel @test -->
 ```
-sed -i 's/app: hello/app: my-hello/' \
+sed -i.bak 's/app: hello/app: my-hello/' \
     $BASE/kustomization.yaml
 ```
-
-On a Mac, use:
-```
-sed -i '' $pattern $file
-```
-to get in-place editing.
 
 See the effect:
 <!-- @checkLabel @test -->

--- a/examples/mySql/README.md
+++ b/examples/mySql/README.md
@@ -136,7 +136,7 @@ a label, but one can always edit `kustomization.yaml` directly:
 
 <!-- @customizeLabels @test -->
 ```
-sed -i 's/app: helloworld/app: prod/' \
+sed -i.bak 's/app: helloworld/app: prod/' \
     $DEMO_HOME/kustomization.yaml
 ```
 


### PR DESCRIPTION
This is a workaround for the fact that 'sed -i' is not defined in POSIX and differs in behavior between Linux and MacOS