### PR TITLE
add tests for resmap

### DIFF
--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -26,8 +26,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	internal "sigs.k8s.io/kustomize/pkg/internal/error"
 	"sigs.k8s.io/kustomize/pkg/resid"
@@ -123,20 +121,6 @@ func (m ResMap) DeepCopy() ResMap {
 		mcopy[id].SetBehavior(obj.Behavior())
 	}
 	return mcopy
-}
-
-func (m ResMap) insert(newName string, obj *unstructured.Unstructured) error {
-	oldName := obj.GetName()
-	gvKind := gvk.FromSchemaGvk(obj.GroupVersionKind())
-	id := resid.NewResId(gvKind, oldName)
-
-	if _, found := m[id]; found {
-		return fmt.Errorf(
-			"the <name: %q, GroupVersionKind: %v> already exists in the map", oldName, gvKind)
-	}
-	obj.SetName(newName)
-	m[id] = resource.NewResourceFromUnstruct(*obj)
-	return nil
 }
 
 // FilterBy returns a ResMap containing ResIds with the same namespace and nameprefix

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -182,6 +182,10 @@ func TestDeepCopy(t *testing.T) {
 
 	rm2 := rm1.DeepCopy()
 
+	if &rm1 == &rm2 {
+		t.Fatalf("DeepCopy returned a reference to itself instead of a copy")
+	}
+
 	if !reflect.DeepEqual(rm1, rm2) {
 		t.Fatalf("%v doesn't equal it's deep copy %v", rm1, rm2)
 	}

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -183,7 +183,7 @@ func TestDeepCopy(t *testing.T) {
 	rm2 := rm1.DeepCopy()
 
 	if &rm1 == &rm2 {
-		t.Fatalf("DeepCopy returned a reference to itself instead of a copy")
+		t.Fatal("DeepCopy returned a reference to itself instead of a copy")
 	}
 
 	if !reflect.DeepEqual(rm1, rm2) {

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -70,6 +70,202 @@ metadata:
 	}
 }
 
+func TestDemandOneMatchForId(t *testing.T) {
+	rm1 := ResMap{
+		resid.NewResIdWithPrefixNamespace(cmap, "cm1", "prefix1", "ns1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+				},
+			}),
+		resid.NewResIdWithPrefixNamespace(cmap, "cm2", "prefix1", "ns1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
+				},
+			}),
+	}
+
+	_, ok := rm1.DemandOneMatchForId(resid.NewResIdWithPrefixNamespace(cmap, "cm2", "prefix1", "ns1"))
+	if !ok {
+		t.Fatal("Expected single map entry but got none")
+	}
+
+	// confirm that ns and prefix are not included in match
+	_, ok = rm1.DemandOneMatchForId(resid.NewResIdWithPrefixNamespace(cmap, "cm2", "prefix", "ns"))
+	if !ok {
+		t.Fatal("Expected single map entry but got none")
+	}
+
+	// confirm that name is matched correctly
+	result, ok := rm1.DemandOneMatchForId(resid.NewResIdWithPrefixNamespace(cmap, "cm3", "prefix1", "ns1"))
+	if ok {
+		t.Fatalf("Expected no map entries but got %v", result)
+	}
+
+	cmap2 := gvk.Gvk{Version: "v2", Kind: "ConfigMap"}
+
+	// confirm that gvk is matched correctly
+	result, ok = rm1.DemandOneMatchForId(resid.NewResIdWithPrefixNamespace(cmap2, "cm2", "prefix1", "ns1"))
+	if ok {
+		t.Fatalf("Expected no map entries but got %v", result)
+	}
+
+}
+
+func TestFilterBy(t *testing.T) {
+	rm := ResMap{resid.NewResIdWithPrefixNamespace(cmap, "cm1", "prefix1", "ns1"): resource.NewResourceFromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": "cm1",
+			},
+		}),
+		resid.NewResIdWithPrefixNamespace(cmap, "cm2", "prefix1", "ns1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
+				},
+			}),
+	}
+	rm1 := ResMap{
+		resid.NewResIdWithPrefixNamespace(cmap, "cm3", "prefix1", "ns2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
+				},
+			}),
+	}
+
+	for k, v := range rm {
+		rm1[k] = v
+	}
+
+	empty := rm1.FilterBy(resid.NewResIdWithPrefixNamespace(cmap, "cm4", "prefix1", "ns3"))
+	if len(empty) != 0 {
+		t.Fatalf("Expected empty filtered map but got %v", empty)
+	}
+
+	ns1map := rm1.FilterBy(resid.NewResIdWithPrefixNamespace(cmap, "cm4", "prefix1", "ns1"))
+	if !reflect.DeepEqual(rm, ns1map) {
+		t.Fatalf("Expected %v but got back %v", rm, ns1map)
+	}
+}
+func TestDeepCopy(t *testing.T) {
+	rm1 := ResMap{
+		resid.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+				},
+			}),
+		resid.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
+				},
+			}),
+	}
+
+	rm2 := rm1.DeepCopy()
+
+	if !reflect.DeepEqual(rm1, rm2) {
+		t.Fatalf("%v doesn't equal it's deep copy %v", rm1, rm2)
+	}
+}
+
+func TestErrorIfNotEqual(t *testing.T) {
+
+	rm1 := ResMap{
+		resid.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+				},
+			}),
+		resid.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm2",
+				},
+			}),
+	}
+
+	err := rm1.ErrorIfNotEqual(rm1)
+	if err != nil {
+		t.Fatalf("%v should equal itself %v", rm1, err)
+	}
+
+	rm2 := ResMap{
+		resid.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+				},
+			}),
+	}
+
+	// test the different number of keys path
+	err = rm1.ErrorIfNotEqual(rm2)
+	if err == nil {
+		t.Fatalf("%v should not equal %v %v", rm1, rm2, err)
+	}
+
+	rm3 := ResMap{
+		resid.NewResId(cmap, "cm2"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm1",
+				},
+			}),
+	}
+
+	// test the different key values path
+	err = rm2.ErrorIfNotEqual(rm3)
+	if err == nil {
+		t.Fatalf("%v should not equal %v %v", rm1, rm2, err)
+	}
+
+	rm4 := ResMap{
+		resid.NewResId(cmap, "cm1"): resource.NewResourceFromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "cm3",
+				},
+			}),
+	}
+
+	// test the deepcopy path
+	err = rm2.ErrorIfNotEqual(rm4)
+	if err == nil {
+		t.Fatalf("%v should not equal %v %v", rm1, rm2, err)
+	}
+
+}
+
 func TestNewMapFromFiles(t *testing.T) {
 
 	resourceStr := `apiVersion: apps/v1
@@ -225,7 +421,8 @@ func TestMergeWithoutOverride(t *testing.T) {
 	}
 }
 
-func TestMergeWithOverride(t *testing.T) {
+func generateMergeFixtures(b ifc.GenerationBehavior) []ResMap {
+
 	input1 := ResMap{
 		resid.NewResId(cmap, "cmap"): resource.NewResourceFromMap(
 			map[string]interface{}{
@@ -256,8 +453,11 @@ func TestMergeWithOverride(t *testing.T) {
 			}),
 	}
 	input1[resid.NewResId(cmap, "cmap")].SetBehavior(ifc.BehaviorCreate)
-	input2[resid.NewResId(cmap, "cmap")].SetBehavior(ifc.BehaviorMerge)
-	input := []ResMap{input1, input2}
+	input2[resid.NewResId(cmap, "cmap")].SetBehavior(b)
+	return []ResMap{input1, input2}
+}
+
+func TestMergeWithOverride(t *testing.T) {
 	expected := ResMap{
 		resid.NewResId(cmap, "cmap"): resource.NewResourceFromMap(
 			map[string]interface{}{
@@ -276,7 +476,7 @@ func TestMergeWithOverride(t *testing.T) {
 			}),
 	}
 	expected[resid.NewResId(cmap, "cmap")].SetBehavior(ifc.BehaviorCreate)
-	merged, err := MergeWithOverride(input...)
+	merged, err := MergeWithOverride(generateMergeFixtures(ifc.BehaviorMerge)...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -298,5 +498,20 @@ func TestMergeWithOverride(t *testing.T) {
 	}
 	if !reflect.DeepEqual(merged2, expected) {
 		t.Fatalf("%#v doesn't equal expected %#v", merged2, expected)
+	}
+
+	inputs := generateMergeFixtures(ifc.BehaviorReplace)
+	replaced, err := MergeWithOverride(inputs...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedReplaced := inputs[1]
+	if !reflect.DeepEqual(replaced, expectedReplaced) {
+		t.Fatalf("%#v doesn't equal expected %#v", replaced, expectedReplaced)
+	}
+
+	_, err = MergeWithOverride(generateMergeFixtures(ifc.BehaviorUnspecified)...)
+	if err == nil {
+		t.Fatal("Merging with GenerationBehavior BehaviorUnspecified should return an error but does not")
 	}
 }


### PR DESCRIPTION

This patch brings tests for the resmap package to 90%+

```
ok  	sigs.k8s.io/kustomize/pkg/resmap	1.071s	coverage: 90.5% of statements
```

