### PR TITLE
hide patch transformer behind interface

### DIFF
--- a/internal/k8sdeps/patch/patch.go
+++ b/internal/k8sdeps/patch/patch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package transformers
+package patch
 
 import (
 	"encoding/json"
@@ -26,7 +26,21 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/transformers"
 )
+
+// patchTransformerFactory makes patch transformer
+type patchTransformerFactory struct{}
+
+// NewPatchTransformerFactory makes a new patchTransformerFactory
+func NewPatchTransformerFactory() *patchTransformerFactory {
+	return &patchTransformerFactory{}
+}
+
+// MakePatchTransformer makes a new patch transformer
+func (p *patchTransformerFactory) MakePatchTransformer(slice []*resource.Resource, rf *resource.Factory) (transformers.Transformer, error) {
+	return NewPatchTransformer(slice, rf)
+}
 
 // patchTransformer applies patches.
 type patchTransformer struct {
@@ -34,13 +48,13 @@ type patchTransformer struct {
 	rf      *resource.Factory
 }
 
-var _ Transformer = &patchTransformer{}
+var _ transformers.Transformer = &patchTransformer{}
 
 // NewPatchTransformer constructs a patchTransformer.
 func NewPatchTransformer(
-	slice []*resource.Resource, rf *resource.Factory) (Transformer, error) {
+	slice []*resource.Resource, rf *resource.Factory) (transformers.Transformer, error) {
 	if len(slice) == 0 {
-		return NewNoOpTransformer(), nil
+		return transformers.NewNoOpTransformer(), nil
 	}
 	return &patchTransformer{patches: slice, rf: rf}, nil
 }

--- a/internal/k8sdeps/patch/patch_test.go
+++ b/internal/k8sdeps/patch/patch_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package transformers
+package patch
 
 import (
 	"reflect"
@@ -22,14 +22,18 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/internal/k8sdeps"
+	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
 )
 
+var rf = resource.NewFactory(
+	k8sdeps.NewKustKunstructuredFactory(k8sdeps.NewKustDecoder()))
+var deploy = gvk.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"}
+var foo = gvk.Gvk{Group: "example.com", Version: "v1", Kind: "Foo"}
+
 func TestOverlayRun(t *testing.T) {
-	rf := resource.NewFactory(
-		k8sdeps.NewKustKunstructuredFactory(k8sdeps.NewKustDecoder()))
 	base := resmap.ResMap{
 		resid.NewResId(deploy, "deploy1"): rf.FromMap(
 			map[string]interface{}{

--- a/internal/k8sdeps/patch/patchconflictdetector.go
+++ b/internal/k8sdeps/patch/patchconflictdetector.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package transformers
+package patch
 
 import (
 	"encoding/json"

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/ifc/patch"
 	"sigs.k8s.io/kustomize/pkg/loader"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/target"
@@ -63,6 +64,7 @@ Use different transformer configurations by passing files to kustomize
 func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	kf ifc.KunstructuredFactory,
+	ptf patch.PatchTransformerFactory,
 	decoder ifc.Decoder, hash ifc.Hash) *cobra.Command {
 	var o buildOptions
 	var p string
@@ -77,7 +79,7 @@ func NewCmdBuild(
 			if err != nil {
 				return err
 			}
-			return o.RunBuild(out, fs, kf, decoder, hash)
+			return o.RunBuild(out, fs, kf, ptf, decoder, hash)
 		},
 	}
 	cmd.Flags().StringVarP(
@@ -123,6 +125,7 @@ func (o *buildOptions) Validate(args []string, p string, fs fs.FileSystem) error
 func (o *buildOptions) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
 	kf ifc.KunstructuredFactory,
+	ptf patch.PatchTransformerFactory,
 	decoder ifc.Decoder, hash ifc.Hash) error {
 	rootLoader, err := loader.NewLoader(o.kustomizationPath, "", fSys)
 	if err != nil {
@@ -132,6 +135,7 @@ func (o *buildOptions) RunBuild(
 	kt, err := target.NewKustTarget(
 		rootLoader, fSys,
 		resmap.NewFactory(resource.NewFactory(kf)),
+		ptf,
 		makeTransformerconfig(fSys, o.transformerconfigPaths),
 		decoder, hash)
 	if err != nil {

--- a/pkg/commands/build/build_test.go
+++ b/pkg/commands/build/build_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"sigs.k8s.io/kustomize/internal/k8sdeps"
+	"sigs.k8s.io/kustomize/internal/k8sdeps/patch"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
@@ -131,6 +132,7 @@ func runBuildTestCase(t *testing.T, testcaseName string, updateKustomizeExpected
 	err = ops.RunBuild(
 		buf, fSys,
 		k8sdeps.NewKustKunstructuredFactory(k8sdeps.NewKustDecoder()),
+		patch.NewPatchTransformerFactory(),
 		k8sdeps.NewKustDecoder(), k8sdeps.NewKustHash())
 	switch {
 	case err != nil && len(testcase.ExpectedError) == 0:

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -27,11 +27,13 @@ import (
 	"sigs.k8s.io/kustomize/pkg/commands/misc"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/ifc/patch"
 )
 
 // NewDefaultCommand returns the default (aka root) command for kustomize command.
 func NewDefaultCommand(
-	kf ifc.KunstructuredFactory, decoder ifc.Decoder,
+	kf ifc.KunstructuredFactory, ptf patch.PatchTransformerFactory,
+	decoder ifc.Decoder,
 	validator ifc.Validator, hash ifc.Hash) *cobra.Command {
 	fsys := fs.MakeRealFS()
 	stdOut := os.Stdout
@@ -48,7 +50,7 @@ See https://sigs.k8s.io/kustomize
 
 	c.AddCommand(
 		// TODO: Make consistent API for newCmd* functions.
-		build.NewCmdBuild(stdOut, fsys, kf, decoder, hash),
+		build.NewCmdBuild(stdOut, fsys, kf, ptf, decoder, hash),
 		edit.NewCmdEdit(fsys, validator),
 		misc.NewCmdConfig(fsys),
 		misc.NewCmdVersion(stdOut),

--- a/pkg/ifc/patch/patch.go
+++ b/pkg/ifc/patch/patch.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,27 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+// Package patch holds miscellaneous interfaces used by kustomize.
+package patch
 
 import (
-	"os"
-
-	"github.com/golang/glog"
-	"sigs.k8s.io/kustomize/internal/k8sdeps"
-	"sigs.k8s.io/kustomize/internal/k8sdeps/patch"
-	"sigs.k8s.io/kustomize/pkg/commands"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/transformers"
 )
 
-func main() {
-	defer glog.Flush()
-
-	if err := commands.NewDefaultCommand(
-		k8sdeps.NewKustKunstructuredFactory(k8sdeps.NewKustDecoder()),
-		patch.NewPatchTransformerFactory(),
-		k8sdeps.NewKustDecoder(),
-		k8sdeps.NewKustValidator(),
-		k8sdeps.NewKustHash()).Execute(); err != nil {
-		os.Exit(1)
-	}
-	os.Exit(0)
+// PatchTransformerFactory makes patch transformer.
+type PatchTransformerFactory interface {
+	MakePatchTransformer(slice []*resource.Resource, rf *resource.Factory) (transformers.Transformer, error)
 }

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/internal/k8sdeps"
+	"sigs.k8s.io/kustomize/internal/k8sdeps/patch"
 	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/gvk"
@@ -210,7 +211,8 @@ func TestResources1(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		l, fakeFs, rf, transformerconfig.MakeDefaultTransformerConfig(),
+		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
+		transformerconfig.MakeDefaultTransformerConfig(),
 		k8sdeps.NewKustDecoder(), k8sdeps.NewKustHash())
 	if err != nil {
 		t.Fatalf("unexpected construction error %v", err)
@@ -235,7 +237,8 @@ func TestResourceNotFound(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		l, fakeFs, rf, transformerconfig.MakeDefaultTransformerConfig(),
+		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
+		transformerconfig.MakeDefaultTransformerConfig(),
 		k8sdeps.NewKustDecoder(), k8sdeps.NewKustHash())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)
@@ -258,7 +261,8 @@ func TestSecretTimeout(t *testing.T) {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		l, fakeFs, rf, transformerconfig.MakeDefaultTransformerConfig(),
+		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
+		transformerconfig.MakeDefaultTransformerConfig(),
 		k8sdeps.NewKustDecoder(), k8sdeps.NewKustHash())
 	if err != nil {
 		t.Fatalf("Unexpected construction error %v", err)

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -34,7 +34,6 @@ var cmap = gvk.Gvk{Version: "v1", Kind: "ConfigMap"}
 var ns = gvk.Gvk{Version: "v1", Kind: "Namespace"}
 var deploy = gvk.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"}
 var statefulset = gvk.Gvk{Group: "apps", Version: "v1", Kind: "StatefulSet"}
-var foo = gvk.Gvk{Group: "example.com", Version: "v1", Kind: "Foo"}
 var crd = gvk.Gvk{Group: "apiwctensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 var job = gvk.Gvk{Group: "batch", Version: "v1", Kind: "Job"}
 var cronjob = gvk.Gvk{Group: "batch", Version: "v1beta1", Kind: "CronJob"}


### PR DESCRIPTION
I put the interface under `pkg/ifc/patch` to avoid circular dependency.