### PR TITLE
port to golangci and make travisci improvements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  deadline: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - dupl
+    - goconst
+    - gocyclo
+    - gofmt
+    - golint
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - structcheck
+    - unparam
+    - varcheck
+
+linters-settings:
+  dupl:
+    threshold: 400 
+  lll:   
+    line-length: 170
+  gocyclo:
+    min-complexity: 15
+  golint:
+    min-confidence: 0.85

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,19 @@ go:
 
 go_import_path: sigs.k8s.io/kustomize
 
+sudo: false
+
+# Only clone the most recent commit.
+git:
+  depth: 1
+
+env:
+- GOLANGCI_RELEASE="v1.10.2"
+
 before_install:
   - source ./bin/consider-early-travis-exit.sh
-  - sudo apt-get install tree
-  - go get -u github.com/golang/lint/golint
-  - go get -u golang.org/x/tools/cmd/goimports
-  - go get -u github.com/onsi/ginkgo/ginkgo
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin ${GOLANGCI_RELEASE}
   - go get -u github.com/monopole/mdrip
-  - go get -u github.com/fzipp/gocyclo
-  - go get -u gopkg.in/alecthomas/gometalinter.v2 && gometalinter.v2 --install
 
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so

--- a/bin/pre-commit.sh
+++ b/bin/pre-commit.sh
@@ -11,10 +11,6 @@ cd "$base_dir" || {
 
 rc=0
 
-function go_dirs {
-  go list -f '{{.Dir}}' ./... | tail -n +2 | tr '\n' '\0'
-}
-
 function runTest {
   local name=$1
   local result="SUCCESS"
@@ -28,40 +24,8 @@ function runTest {
   printf "============== end %s : %s code=%d\n\n\n" "$name" "$result" $code
 }
 
-function testGoFmt {
-  diff <(echo -n) <(go_dirs | xargs -0 gofmt -s -d -l)
-}
-
-
-function testGoCyclo {
-  diff <(echo -n) <(go_dirs | xargs -0 gocyclo -over 15)
-}
-
-function testGoLint {
-  diff -u <(echo -n) <(go_dirs | xargs -0 golint --min_confidence 0.85 )
-}
-
-# Not using the 'goimports' check because it reports hyphens in imported
-# package names as errors, and we vendor in packages that have
-# hyphens in their names.
-function testGoMetalinter {
-  diff -u <(echo -n) <(go_dirs | xargs -0 gometalinter.v2 --disable-all --deadline 5m \
-  --enable=misspell \
-  --enable=structcheck \
-  --enable=deadcode \
-  --enable=varcheck \
-  --enable=goconst \
-  --enable=unparam \
-  --enable=ineffassign \
-  --enable=nakedret \
-  --enable=interfacer \
-  --enable=misspell \
-  --line-length=170 --enable=lll \
-  --dupl-threshold=400 --enable=dupl)
-}
-
-function testGoVet {
-  go vet -all ./...
+function testGoLangCILint {
+  golangci-lint run ./...
 }
 
 function testGoTest {
@@ -72,11 +36,7 @@ function testExamples {
   mdrip --mode test --label test README.md ./examples
 }
 
-runTest testGoFmt
-runTest testGoMetalinter
-runTest testGoLint
-runTest testGoVet
-runTest testGoCyclo
+runTest testGoLangCILint
 runTest testGoTest
 runTest testExamples
 


### PR DESCRIPTION
This patch ports linting to [golangci-lint](https://github.com/golangci/golangci-lint) and makes a couple of small improvements to the travis file. 

Benefits:
- Improved performance. Looks like ~50s reduction in build times for PRs
- Easier to integrate additional linters
- Tooling support. VS Code, Goland, Sublime and Emacs know how to consume the yaml config

Note: this is failing tests due to the flaky crd tests. When that fix is merged in, I can rebase this or you can override.

[Sample Build ](https://travis-ci.org/kubernetes-sigs/kustomize/builds/439008366)