### PR TITLE
Maintain fields of TransformerConfig in sorted order.

### DIFF
--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -52,14 +52,11 @@ func registerCRD(loader ifc.Loader, path string) (*transformerconfig.Transformer
 	var types map[string]common.OpenAPIDefinition
 	if content[0] == '{' {
 		err = json.Unmarshal(content, &types)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		err = yaml.Unmarshal(content, &types)
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	crds := getCRDs(types)

--- a/pkg/crds/crds_test.go
+++ b/pkg/crds/crds_test.go
@@ -18,7 +18,6 @@ package crds
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	"sigs.k8s.io/kustomize/pkg/gvk"
@@ -178,17 +177,7 @@ func TestRegisterCRD(t *testing.T) {
 		NameReference: refpathconfigs,
 	}
 
-	ldr := makeLoader(t)
-
-	pathconfig, _ := registerCRD(ldr, "/testpath/crd.json")
-
-	sort.Slice(expected.NameReference[:], func(i, j int) bool {
-		return expected.NameReference[i].Gvk.String() < expected.NameReference[j].Gvk.String()
-	})
-
-	sort.Slice(pathconfig.NameReference[:], func(i, j int) bool {
-		return pathconfig.NameReference[i].Gvk.String() < pathconfig.NameReference[j].Gvk.String()
-	})
+	pathconfig, _ := registerCRD(makeLoader(t), "/testpath/crd.json")
 
 	if !reflect.DeepEqual(pathconfig, expected) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expected, pathconfig)


### PR DESCRIPTION
Not needed for execution, just makes logging and tests deterministic.
Related to #428
