### PR TITLE
Error out when non-existent variables dereferenced

### DIFF
--- a/examples/helloWorld/deployment.yaml
+++ b/examples/helloWorld/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         image: monopole/hello:1
         command: ["/hello",
                   "--port=8080",
-                  "--enableRiskyFeature=$(ENABLE_RISKY)"]
+                  "--enableRiskyFeature=$$(ENABLE_RISKY)"]
         ports:
         - containerPort: 8080
         env:

--- a/pkg/commands/build/testdata/testcase-variable-ref/in/package/cockroachdb-statefulset-secure.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref/in/package/cockroachdb-statefulset-secure.yaml
@@ -166,7 +166,7 @@ spec:
         command:
         - "/bin/ash"
         - "-ecx"
-        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$(hostname -f),$(hostname -f|cut -f 1-2 -d '.'),$(CDB_PUBLIC_SVC) -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$$(hostname -f),$$(hostname -f|cut -f 1-2 -d '.'),$(CDB_PUBLIC_SVC) -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         env:
         - name: POD_IP
           valueFrom:
@@ -212,7 +212,7 @@ spec:
           # The use of qualified `hostname -f` is crucial:
           # Other nodes aren't able to look up the unqualified hostname.
           # Once 2.0 is out, we should be able to switch from --host to --advertise-host to make port-forwarding work to the main port.
-          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --host $(hostname -f) --http-host 0.0.0.0 --join $(CDB_STATEFULSET_NAME)-0.$(CDB_STATEFULSET_SVC),$(CDB_STATEFULSET_NAME)-1.$(CDB_STATEFULSET_SVC),$(CDB_STATEFULSET_NAME)-2.$(CDB_STATEFULSET_SVC) --cache 25% --max-sql-memory 25%"
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --host $$(hostname -f) --http-host 0.0.0.0 --join $(CDB_STATEFULSET_NAME)-0.$(CDB_STATEFULSET_SVC),$(CDB_STATEFULSET_NAME)-1.$(CDB_STATEFULSET_SVC),$(CDB_STATEFULSET_NAME)-2.$(CDB_STATEFULSET_SVC) --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -45,7 +45,11 @@ func (rv *refvarTransformer) Transform(resources resmap.ResMap) error {
 				case []interface{}:
 					var xs []string
 					for _, a := range in.([]interface{}) {
-						xs = append(xs, expansion.Expand(a.(string), mappingFunc))
+						expanded, err := expansion.Expand(a.(string), mappingFunc)
+						if err != nil {
+							return nil, err
+						}
+						xs = append(xs, expanded)
 					}
 					return xs, nil
 				case interface{}:
@@ -53,7 +57,10 @@ func (rv *refvarTransformer) Transform(resources resmap.ResMap) error {
 					if !ok {
 						return nil, fmt.Errorf("%#v is expectd to be %T", in, s)
 					}
-					runtimeVal := expansion.Expand(s, mappingFunc)
+					runtimeVal, err := expansion.Expand(s, mappingFunc)
+					if err != nil {
+						return nil, err
+					}
 					return runtimeVal, nil
 				default:
 					return "", fmt.Errorf("invalid type encountered %T", vt)


### PR DESCRIPTION
This patch addresses #317

This PR can be considered a WIP to explore desired behavior. This has the benefit of strictness and finding issues more quickly. However, it has the drawback of requiring escaping of `$(value)` type values in input. 🤔

The general theory of operation is that kustomize will operate in a 'strict mode' wherein any un-escaped references to non-existent variables will cause builds to fail. 

This involves changing the current behavior of ignoring such references ( by returning the syntaxWrap'd value back through ). Instead, a new errortype of UnknownVarError is introduced and this return value is weaved through the return value of functions required to perform expansions. If an un known value is encountered, this error value is returned with a descriptrive string that includes the name of the non-existent variable reference.

An invocation of build that references a non-existent variable would look like the following

```
$ kustomize build examples/wordpress                                                                                                                               
Error: Invalid variable reference: $(MYSQL_SERVICE)
$ echo $?                                                                                                                                                                       
1
```