### PR TITLE
Consolidate TransformerConfig creation to factory.

### DIFF
--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -24,15 +24,15 @@ import (
 	"github.com/ghodss/yaml"
 	"k8s.io/kube-openapi/pkg/common"
 	"sigs.k8s.io/kustomize/pkg/gvk"
-	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/transformerconfig"
 )
 
 // RegisterCRDs parse CRD schemas from paths and update various pathConfigs
-func RegisterCRDs(loader ifc.Loader, paths []string) (*transformerconfig.TransformerConfig, error) {
-	pathConfigs := transformerconfig.MakeEmptyTransformerConfig()
+func RegisterCRDs(
+	tf *transformerconfig.Factory, paths []string) (*transformerconfig.TransformerConfig, error) {
+	pathConfigs := tf.EmptyConfig()
 	for _, path := range paths {
-		pathConfig, err := registerCRD(loader, path)
+		pathConfig, err := registerCRD(tf, path)
 		if err != nil {
 			return nil, err
 		}
@@ -42,9 +42,9 @@ func RegisterCRDs(loader ifc.Loader, paths []string) (*transformerconfig.Transfo
 }
 
 // register CRD from one path
-func registerCRD(loader ifc.Loader, path string) (*transformerconfig.TransformerConfig, error) {
-	result := transformerconfig.MakeEmptyTransformerConfig()
-	content, err := loader.Load(path)
+func registerCRD(tf *transformerconfig.Factory, path string) (*transformerconfig.TransformerConfig, error) {
+	result := tf.EmptyConfig()
+	content, err := tf.Loader().Load(path)
 	if err != nil {
 		return result, err
 	}
@@ -61,7 +61,7 @@ func registerCRD(loader ifc.Loader, path string) (*transformerconfig.Transformer
 
 	crds := getCRDs(types)
 	for crd, k := range crds {
-		crdPathConfigs := transformerconfig.MakeEmptyTransformerConfig()
+		crdPathConfigs := tf.EmptyConfig()
 		err = getCRDPathConfig(
 			types, crd, crd, k, []string{}, crdPathConfigs)
 		if err != nil {

--- a/pkg/crds/crds_test.go
+++ b/pkg/crds/crds_test.go
@@ -177,7 +177,8 @@ func TestRegisterCRD(t *testing.T) {
 		NameReference: refpathconfigs,
 	}
 
-	pathconfig, _ := registerCRD(makeLoader(t), "/testpath/crd.json")
+	pathconfig, _ := RegisterCRDs(
+		transformerconfig.NewFactory(makeLoader(t)), []string{"/testpath/crd.json"})
 
 	if !reflect.DeepEqual(pathconfig, expected) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expected, pathconfig)

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -136,7 +136,8 @@ func (kt *KustTarget) loadCustomizedResMap() (resmap.ResMap, error) {
 	if err != nil {
 		errs.Append(errors.Wrap(err, "loadResMapFromBasesAndResources"))
 	}
-	crdPathConfigs, err := crds.RegisterCRDs(kt.ldr, kt.kustomization.Crds)
+	crdPathConfigs, err := crds.RegisterCRDs(
+		transformerconfig.NewFactory(kt.ldr), kt.kustomization.Crds)
 	kt.tcfg = kt.tcfg.Merge(crdPathConfigs)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "RegisterCRDs"))

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -91,6 +91,19 @@ metadata:
 var rf = resmap.NewFactory(resource.NewFactory(
 	k8sdeps.NewKunstructuredFactoryImpl()))
 
+func makeKustTarget(t *testing.T, l ifc.Loader) *KustTarget {
+	fakeFs := fs.MakeFakeFS()
+	fakeFs.Mkdir("/")
+	kt, err := NewKustTarget(
+		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
+		transformerconfig.NewFactory(l).DefaultConfig(),
+		k8sdeps.NewKustHash())
+	if err != nil {
+		t.Fatalf("Unexpected construction error %v", err)
+	}
+	return kt
+}
+
 func makeLoader1(t *testing.T) ifc.Loader {
 	ldr := loadertest.NewFakeLoader("/testpath")
 	err := ldr.AddFile("/testpath/"+constants.KustomizationFileName, []byte(kustomizationContent1))
@@ -206,17 +219,8 @@ func TestResources1(t *testing.T) {
 				},
 			}),
 	}
-	l := makeLoader1(t)
-	fakeFs := fs.MakeFakeFS()
-	fakeFs.Mkdir("/")
-	kt, err := NewKustTarget(
-		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
-		transformerconfig.MakeDefaultTransformerConfig(),
-		k8sdeps.NewKustHash())
-	if err != nil {
-		t.Fatalf("unexpected construction error %v", err)
-	}
-	actual, err := kt.MakeCustomizedResMap()
+	actual, err := makeKustTarget(
+		t, makeLoader1(t)).MakeCustomizedResMap()
 	if err != nil {
 		t.Fatalf("unexpected Resources error %v", err)
 	}
@@ -233,16 +237,7 @@ func TestResourceNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to setup fake ldr.")
 	}
-	fakeFs := fs.MakeFakeFS()
-	fakeFs.Mkdir("/")
-	kt, err := NewKustTarget(
-		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
-		transformerconfig.MakeDefaultTransformerConfig(),
-		k8sdeps.NewKustHash())
-	if err != nil {
-		t.Fatalf("Unexpected construction error %v", err)
-	}
-	_, err = kt.MakeCustomizedResMap()
+	_, err = makeKustTarget(t, l).MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}
@@ -257,16 +252,7 @@ func TestSecretTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to setup fake ldr.")
 	}
-	fakeFs := fs.MakeFakeFS()
-	fakeFs.Mkdir("/")
-	kt, err := NewKustTarget(
-		l, fakeFs, rf, patch.NewPatchTransformerFactory(),
-		transformerconfig.MakeDefaultTransformerConfig(),
-		k8sdeps.NewKustHash())
-	if err != nil {
-		t.Fatalf("Unexpected construction error %v", err)
-	}
-	_, err = kt.MakeCustomizedResMap()
+	_, err = makeKustTarget(t, l).MakeCustomizedResMap()
 	if err == nil {
 		t.Fatalf("Didn't get the expected error for an unknown resource")
 	}

--- a/pkg/transformerconfig/factory.go
+++ b/pkg/transformerconfig/factory.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transformerconfig
+
+import (
+	"log"
+
+	"github.com/ghodss/yaml"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/transformerconfig/defaultconfig"
+)
+
+// Factory makes instances of TransformerConfig.
+type Factory struct {
+	loader ifc.Loader
+}
+
+func NewFactory(l ifc.Loader) *Factory {
+	return &Factory{loader: l}
+}
+
+func (tf *Factory) Loader() ifc.Loader {
+	if tf.loader.(ifc.Loader) == nil {
+		log.Fatal("no loader")
+	}
+	return tf.loader
+}
+
+// FromFiles returns a TranformerConfig object from a list of files
+func (tf *Factory) FromFiles(
+	paths []string) (*TransformerConfig, error) {
+	result := &TransformerConfig{}
+	for _, path := range paths {
+		data, err := tf.Loader().Load(path)
+		if err != nil {
+			return nil, err
+		}
+		t, err := makeTransformerConfigFromBytes(data)
+		if err != nil {
+			return nil, err
+		}
+		result = result.Merge(t)
+	}
+	return result, nil
+}
+
+// makeTransformerConfigFromBytes returns a TransformerConfig object from bytes
+func makeTransformerConfigFromBytes(data []byte) (*TransformerConfig, error) {
+	var t TransformerConfig
+	err := yaml.Unmarshal(data, &t)
+	if err != nil {
+		return nil, err
+	}
+	t.sortFields()
+	return &t, nil
+}
+
+// EmptyConfig returns an empty TransformerConfig object
+func (tf *Factory) EmptyConfig() *TransformerConfig {
+	return &TransformerConfig{}
+}
+
+// DefaultConfig returns a default TransformerConfig.
+// This should never fail, hence the Fatal panic.
+func (tf *Factory) DefaultConfig() *TransformerConfig {
+	c, err := makeTransformerConfigFromBytes(
+		defaultconfig.GetDefaultPathConfigs())
+	if err != nil {
+		log.Fatalf("Unable to make default transformconfig: %v", err)
+	}
+	return c
+}

--- a/pkg/transformerconfig/factory_test.go
+++ b/pkg/transformerconfig/factory_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transformerconfig
+
+import (
+	"reflect"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/gvk"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"testing"
+)
+
+func TestMakeDefaultTransformerConfig(t *testing.T) {
+	// Confirm default can be made without fatal error inside call.
+	l, _, _ := makeFakeLoaderAndOutput()
+	_ = NewFactory(l).DefaultConfig()
+}
+
+func makeFakeLoaderAndOutput() (ifc.Loader, *TransformerConfig, *TransformerConfig) {
+	transformerConfig := `
+namePrefix:
+- path: nameprefix/path
+  kind: SomeKind
+`
+	fakeFS := fs.MakeFakeFS()
+	fakeFS.WriteFile("transformerconfig/test/config.yaml", []byte(transformerConfig))
+	ldr := loader.NewFileLoader(fakeFS)
+	expected := &TransformerConfig{
+		NamePrefix: []PathConfig{
+			{
+				Gvk:  gvk.Gvk{Kind: "SomeKind"},
+				Path: "nameprefix/path",
+			},
+		},
+	}
+	return ldr, expected, NewFactory(ldr).DefaultConfig()
+}
+
+func TestMakeTransformerConfigFromFiles(t *testing.T) {
+	ldr, expected, _ := makeFakeLoaderAndOutput()
+	tcfg, err := NewFactory(ldr).FromFiles([]string{"transformerconfig/test/config.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(tcfg, expected) {
+		t.Fatalf("expected %v\n but go6t %v\n", expected, tcfg)
+	}
+}

--- a/pkg/transformerconfig/transformerconfig.go
+++ b/pkg/transformerconfig/transformerconfig.go
@@ -19,12 +19,7 @@ limitations under the License.
 package transformerconfig
 
 import (
-	"log"
 	"sort"
-
-	"github.com/ghodss/yaml"
-	"sigs.k8s.io/kustomize/pkg/ifc"
-	"sigs.k8s.io/kustomize/pkg/transformerconfig/defaultconfig"
 )
 
 type rpcSlice []ReferencePathConfig
@@ -94,47 +89,4 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) *TransformerConfig {
 	merged.NameReference = mergeNameReferencePathConfigs(t.NameReference, input.NameReference)
 	merged.sortFields()
 	return merged
-}
-
-// MakeTransformerConfigFromFiles returns a TranformerConfig object from a list of files
-func MakeTransformerConfigFromFiles(ldr ifc.Loader, paths []string) (*TransformerConfig, error) {
-	result := &TransformerConfig{}
-	for _, path := range paths {
-		data, err := ldr.Load(path)
-		if err != nil {
-			return nil, err
-		}
-		t, err := MakeTransformerConfigFromBytes(data)
-		if err != nil {
-			return nil, err
-		}
-		result = result.Merge(t)
-	}
-	return result, nil
-}
-
-// MakeTransformerConfigFromBytes returns a TransformerConfig object from bytes
-func MakeTransformerConfigFromBytes(data []byte) (*TransformerConfig, error) {
-	var t TransformerConfig
-	err := yaml.Unmarshal(data, &t)
-	if err != nil {
-		return nil, err
-	}
-	t.sortFields()
-	return &t, nil
-}
-
-// MakeEmptyTransformerConfig returns an empty TransformerConfig object
-func MakeEmptyTransformerConfig() *TransformerConfig {
-	return &TransformerConfig{}
-}
-
-// MakeDefaultTransformerConfig returns a default TransformerConfig.
-// This should never fail, hence the Fatal panic.
-func MakeDefaultTransformerConfig() *TransformerConfig {
-	c, err := MakeTransformerConfigFromBytes(defaultconfig.GetDefaultPathConfigs())
-	if err != nil {
-		log.Fatalf("Unable to make default transformconfig: %v", err)
-	}
-	return c
 }

--- a/pkg/transformerconfig/transformerconfig_test.go
+++ b/pkg/transformerconfig/transformerconfig_test.go
@@ -17,17 +17,15 @@ limitations under the License.
 package transformerconfig
 
 import (
-	"sigs.k8s.io/kustomize/pkg/ifc"
 	"testing"
 
 	"reflect"
-	"sigs.k8s.io/kustomize/pkg/fs"
+
 	"sigs.k8s.io/kustomize/pkg/gvk"
-	"sigs.k8s.io/kustomize/pkg/loader"
 )
 
 func TestAddNameReferencePathConfigs(t *testing.T) {
-	cfg := MakeEmptyTransformerConfig()
+	cfg := &TransformerConfig{}
 
 	pathConfig := ReferencePathConfig{
 		Gvk: gvk.Gvk{
@@ -51,7 +49,7 @@ func TestAddNameReferencePathConfigs(t *testing.T) {
 }
 
 func TestAddPathConfigs(t *testing.T) {
-	cfg := MakeEmptyTransformerConfig()
+	cfg := &TransformerConfig{}
 
 	pathConfig := PathConfig{
 		Gvk:                gvk.Gvk{Group: "GroupA", Kind: "KindB"},
@@ -116,11 +114,11 @@ func TestMerge(t *testing.T) {
 			CreateIfNotPresent: true,
 		},
 	}
-	cfga := MakeEmptyTransformerConfig()
+	cfga := &TransformerConfig{}
 	cfga.AddNamereferencePathConfig(nameReference[0])
 	cfga.AddPrefixPathConfig(pathConfigs[0])
 
-	cfgb := MakeEmptyTransformerConfig()
+	cfgb := &TransformerConfig{}
 	cfgb.AddNamereferencePathConfig(nameReference[1])
 	cfgb.AddPrefixPathConfig(pathConfigs[1])
 
@@ -134,7 +132,7 @@ func TestMerge(t *testing.T) {
 		t.Fatal("merge failed for namereference pathconfig")
 	}
 
-	expected := MakeEmptyTransformerConfig()
+	expected := &TransformerConfig{}
 	expected.AddNamereferencePathConfig(nameReference[0])
 	expected.AddNamereferencePathConfig(nameReference[1])
 	expected.AddPrefixPathConfig(pathConfigs[0])
@@ -142,41 +140,5 @@ func TestMerge(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected: %v\n but got: %v\n", expected, actual)
-	}
-}
-
-func TestMakeDefaultTransformerConfig(t *testing.T) {
-	// Confirm default can be made without fatal error inside call.
-	_ = MakeDefaultTransformerConfig()
-}
-
-func makeFakeLoaderAndOutput() (ifc.Loader, *TransformerConfig, *TransformerConfig) {
-	transformerConfig := `
-namePrefix:
-- path: nameprefix/path
-  kind: SomeKind
-`
-	fakeFS := fs.MakeFakeFS()
-	fakeFS.WriteFile("transformerconfig/test/config.yaml", []byte(transformerConfig))
-	ldr := loader.NewFileLoader(fakeFS)
-	expected := &TransformerConfig{
-		NamePrefix: []PathConfig{
-			{
-				Gvk:  gvk.Gvk{Kind: "SomeKind"},
-				Path: "nameprefix/path",
-			},
-		},
-	}
-	return ldr, expected, MakeDefaultTransformerConfig()
-}
-func TestMakeTransformerConfigFromFiles(t *testing.T) {
-	ldr, expected, _ := makeFakeLoaderAndOutput()
-	tcfg, err := MakeTransformerConfigFromFiles(ldr, []string{"transformerconfig/test/config.yaml"})
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
-
-	if !reflect.DeepEqual(tcfg, expected) {
-		t.Fatalf("expected %v\n but go6t %v\n", expected, tcfg)
 	}
 }

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -41,8 +41,8 @@ var pvc = gvk.Gvk{Version: "v1", Kind: "PersistentVolumeClaim"}
 var crb = gvk.Gvk{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}
 var sa = gvk.Gvk{Version: "v1", Kind: "ServiceAccount"}
 var ingress = gvk.Gvk{Kind: "Ingress"}
-var rf = resource.NewFactory(
-	k8sdeps.NewKunstructuredFactoryImpl())
+var rf = resource.NewFactory(k8sdeps.NewKunstructuredFactoryImpl())
+var defaultTransformerConfig = transformerconfig.NewFactory(nil).DefaultConfig()
 
 func TestLabelsRun(t *testing.T) {
 	m := resmap.ResMap{
@@ -419,7 +419,7 @@ func TestLabelsRun(t *testing.T) {
 	}
 	lt, err := NewLabelsMapTransformer(
 		map[string]string{"label-key1": "label-value1", "label-key2": "label-value2"},
-		transformerconfig.MakeDefaultTransformerConfig().CommonLabels)
+		defaultTransformerConfig.CommonLabels)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -556,7 +556,7 @@ func TestAnnotationsRun(t *testing.T) {
 	}
 	at, err := NewAnnotationsMapTransformer(
 		map[string]string{"anno-key1": "anno-value1", "anno-key2": "anno-value2"},
-		transformerconfig.MakeDefaultTransformerConfig().CommonAnnotations)
+		defaultTransformerConfig.CommonAnnotations)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
-	"sigs.k8s.io/kustomize/pkg/transformerconfig"
 )
 
 func TestNameReferenceRun(t *testing.T) {
@@ -326,7 +325,7 @@ func TestNameReferenceRun(t *testing.T) {
 			},
 		},
 	)
-	nrt, err := NewNameReferenceTransformer(transformerconfig.MakeDefaultTransformerConfig().NameReference)
+	nrt, err := NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
-	"sigs.k8s.io/kustomize/pkg/transformerconfig"
 )
 
 func TestNamespaceRun(t *testing.T) {
@@ -188,7 +187,7 @@ func TestNamespaceRun(t *testing.T) {
 			}),
 	}
 
-	nst := NewNamespaceTransformer("test", transformerconfig.MakeDefaultTransformerConfig().NameSpace)
+	nst := NewNamespaceTransformer("test", defaultTransformerConfig.NameSpace)
 	err := nst.Transform(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/transformers/prefixname_test.go
+++ b/pkg/transformers/prefixname_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
-	"sigs.k8s.io/kustomize/pkg/transformerconfig"
 )
 
 func TestPrefixNameRun(t *testing.T) {
@@ -84,7 +83,7 @@ func TestPrefixNameRun(t *testing.T) {
 	}
 
 	npt, err := NewNamePrefixTransformer(
-		"someprefix-", transformerconfig.MakeDefaultTransformerConfig().NamePrefix)
+		"someprefix-", defaultTransformerConfig.NamePrefix)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
In transformerconfig package, move TransformerConfig
creation code to a factory defined in factory.go
Doing this as a prelude to adding more coverage.
Factories make fake injection easier.

