### PR TITLE
remove quotes from envCommand output

### DIFF
--- a/internal/k8sdeps/configmapandsecret/kv.go
+++ b/internal/k8sdeps/configmapandsecret/kv.go
@@ -91,7 +91,7 @@ func kvFromLine(line []byte, currentLine int) (kvPair, error) {
 	}
 
 	if len(data) == 2 {
-		kv.value = data[1]
+		kv.value = stripQuotes(data[1])
 	} else {
 		// No value (no `=` in the line) is a signal to obtain the value
 		// from the environment.
@@ -99,4 +99,13 @@ func kvFromLine(line []byte, currentLine int) (kvPair, error) {
 	}
 	kv.key = key
 	return kv, nil
+}
+
+func stripQuotes(s string) string {
+	if len(s) >= 2 {
+		if s[0] == '"' && s[len(s)-1] == '"' {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/internal/k8sdeps/configmapandsecret/kv_test.go
+++ b/internal/k8sdeps/configmapandsecret/kv_test.go
@@ -65,3 +65,60 @@ func TestKeyValuesFromLines(t *testing.T) {
 
 	}
 }
+
+func TestStripQuotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"no quotes",
+			"noquotes",
+			"noquotes",
+		},
+		{
+			"empty string",
+			"",
+			"",
+		},
+		{
+			"single character",
+			"a",
+			"a",
+		},
+		{
+			"two characters",
+			"aa",
+			"aa",
+		},
+		{
+			"only left quote",
+			"\"abcd",
+			"\"abcd",
+		},
+		{
+			"only right quote",
+			"abcd\"",
+			"abcd\"",
+		},
+		{
+			"only quotes",
+			"\"\"",
+			"",
+		},
+		{
+			"quoted string",
+			"\"testing three words\"",
+			"testing three words",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripQuotes(tt.input); got != tt.expected {
+				t.Errorf("stripQuotes() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #460

Tested master and feature branch with these files:

```$ cat kustomization.yaml                                                                                                                                                                    
secretGenerator:
- name: noquotes
  envCommand: cat noquotes.txt
  type: Opaque
- name: quotes
  envCommand: cat quotes.txt
  type: Opaque

$ cat quotes.txt                                                                                                                                                                            
DB_USERNAME="admin"
DB_PASSWORD="somepw"

$ cat noquotes.txt                                                                                                                                                                          
DB_USERNAME=admin
DB_PASSWORD=somepw
```

Master branch that exhibits the bug:

```
$ kustomize build                                                                                                                                                              
apiVersion: v1
data:
  DB_PASSWORD: c29tZXB3
  DB_USERNAME: YWRtaW4=
kind: Secret
metadata:
  name: noquotes-kg2k76h6dm
type: Opaque
---
apiVersion: v1
data:
  DB_PASSWORD: InNvbWVwdyI=
  DB_USERNAME: ImFkbWluIg==
kind: Secret
metadata:
  name: quotes-744b2bg2b4
type: Opaque
```

With this patch applied:

```
$ kustomize build                                                                                                                                                              
apiVersion: v1
data:
  DB_PASSWORD: c29tZXB3
  DB_USERNAME: YWRtaW4=
kind: Secret
metadata:
  name: noquotes-kg2k76h6dm
type: Opaque
---
apiVersion: v1
data:
  DB_PASSWORD: c29tZXB3
  DB_USERNAME: YWRtaW4=
kind: Secret
metadata:
  name: quotes-ffhmmhmh64
type: Opaque
```