### PR TITLE
Objectify nbrSlice code.

### DIFF
--- a/pkg/transformers/config/fieldspec.go
+++ b/pkg/transformers/config/fieldspec.go
@@ -85,3 +85,11 @@ func (fs FieldSpec) PathSlice() []string {
 	}
 	return result
 }
+
+type fsSlice []FieldSpec
+
+func (s fsSlice) Len() int      { return len(s) }
+func (s fsSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s fsSlice) Less(i, j int) bool {
+	return s[i].Gvk.IsLessThan(s[j].Gvk)
+}

--- a/pkg/transformers/config/namebackreferences_test.go
+++ b/pkg/transformers/config/namebackreferences_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestFoo(t *testing.T) {
+func TestMergeAll(t *testing.T) {
 	fsSlice1 := []FieldSpec{
 		{
 			Gvk: gvk.Gvk{
@@ -56,7 +56,7 @@ func TestFoo(t *testing.T) {
 		},
 	}
 
-	nbrsSlice1 := []NameBackReferences{
+	nbrsSlice1 := nbrSlice{
 		{
 			Gvk: gvk.Gvk{
 				Kind: "ConfigMap",
@@ -70,7 +70,7 @@ func TestFoo(t *testing.T) {
 			FieldSpecs: fsSlice2,
 		},
 	}
-	nbrsSlice2 := []NameBackReferences{
+	nbrsSlice2 := nbrSlice{
 		{
 			Gvk: gvk.Gvk{
 				Kind: "ConfigMap",
@@ -84,7 +84,7 @@ func TestFoo(t *testing.T) {
 			FieldSpecs: fsSlice2,
 		},
 	}
-	expected := []NameBackReferences{
+	expected := nbrSlice{
 		{
 			Gvk: gvk.Gvk{
 				Kind: "ConfigMap",
@@ -99,7 +99,7 @@ func TestFoo(t *testing.T) {
 			FieldSpecs: append(fsSlice2, fsSlice2...),
 		},
 	}
-	actual := mergeNameBackReferences(nbrsSlice1, nbrsSlice2)
+	actual := nbrsSlice1.mergeAll(nbrsSlice2)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expected, actual)
 	}

--- a/pkg/transformers/config/transformerconfig.go
+++ b/pkg/transformers/config/transformerconfig.go
@@ -22,22 +22,6 @@ import (
 	"sort"
 )
 
-type nbrSlice []NameBackReferences
-
-func (s nbrSlice) Len() int      { return len(s) }
-func (s nbrSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s nbrSlice) Less(i, j int) bool {
-	return s[i].Gvk.IsLessThan(s[j].Gvk)
-}
-
-type fsSlice []FieldSpec
-
-func (s fsSlice) Len() int      { return len(s) }
-func (s fsSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s fsSlice) Less(i, j int) bool {
-	return s[i].Gvk.IsLessThan(s[j].Gvk)
-}
-
 // TransformerConfig holds the data needed to perform transformations.
 type TransformerConfig struct {
 	NamePrefix        fsSlice  `json:"namePrefix,omitempty" yaml:"namePrefix,omitempty"`
@@ -75,7 +59,7 @@ func (t *TransformerConfig) AddAnnotationFieldSpec(fs FieldSpec) {
 
 // AddNamereferenceFieldSpec adds a NameBackReferences to NameReference
 func (t *TransformerConfig) AddNamereferenceFieldSpec(nbrs NameBackReferences) {
-	t.NameReference = mergeNameBackReferences(t.NameReference, []NameBackReferences{nbrs})
+	t.NameReference = t.NameReference.mergeOne(nbrs)
 }
 
 // Merge merges two TransformerConfigs objects into a new TransformerConfig object
@@ -86,7 +70,7 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) *TransformerConfig {
 	merged.CommonAnnotations = append(t.CommonAnnotations, input.CommonAnnotations...)
 	merged.CommonLabels = append(t.CommonLabels, input.CommonLabels...)
 	merged.VarReference = append(t.VarReference, input.VarReference...)
-	merged.NameReference = mergeNameBackReferences(t.NameReference, input.NameReference)
+	merged.NameReference = t.NameReference.mergeAll(input.NameReference)
 	merged.sortFields()
 	return merged
 }

--- a/pkg/transformers/config/transformerconfig_test.go
+++ b/pkg/transformers/config/transformerconfig_test.go
@@ -44,7 +44,7 @@ func TestAddNamereferenceFieldSpec(t *testing.T) {
 
 	cfg.AddNamereferenceFieldSpec(nbrs)
 	if len(cfg.NameReference) != 1 {
-		t.Fatal("failed to add namerefence FieldSpec")
+		t.Fatal("failed to add namereference FieldSpec")
 	}
 }
 


### PR DESCRIPTION
Move `nbrSlice []NameBackReferences` definition into `namebackreferences.go`;
its test is already in `namebackreferences_test.go`.
Also, express the related merge functions as object methods.

Likewise move `fsSlice []FieldSpec` definition into `fieldspec.go`
