### PR TITLE
add namespace to id when create resmap from files

### DIFF
--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -45,6 +45,11 @@ metadata:
 ---
 # some comment
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dply2
+  namespace: test
 ---
 `
 
@@ -68,12 +73,21 @@ metadata:
 					"name": "dply2",
 				},
 			}),
+		resid.NewResIdWithPrefixNamespace(deploy, "dply2", "", "test"): rf.FromMap(
+			map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      "dply2",
+					"namespace": "test",
+				},
+			}),
 	}
 
 	m, _ := rmF.FromFiles(
 		l, []string{"/home/seans/project/deployment.yaml"})
-	if len(m) != 2 {
-		t.Fatalf("%#v should contain 2 appResource, but got %d", m, len(m))
+	if len(m) != 3 {
+		t.Fatalf("%#v should contain 3 appResource, but got %d", m, len(m))
 	}
 
 	if err := expected.ErrorIfNotEqual(m); err != nil {

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -39,6 +39,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: winnie
+  namespace: hundred-acre-wood
 ---
 # some comment
 ---

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -58,7 +58,8 @@ func (r *Resource) IsGenerated() bool {
 
 // Id returns the ResId for the resource.
 func (r *Resource) Id() resid.ResId {
-	return resid.NewResId(r.GetGvk(), r.GetName())
+	namespace, _ := r.GetFieldValue("metadata.namespace")
+	return resid.NewResIdWithPrefixNamespace(r.GetGvk(), r.GetName(), "", namespace)
 }
 
 // Merge performs merge with other resource.


### PR DESCRIPTION
Fix #439 
When creating resmap from files, only GVK, name is captured in resid. 
If there the namespace is specified in those files, the namespace is not recorded in resid. 
This is the cause of $439
The fix is to include namespace when creating resmap from files.

Also added a unit test.