### PR TITLE
Delete some unnecessary parameter passing.

### DIFF
--- a/pkg/commands/edit/add/addbase.go
+++ b/pkg/commands/edit/add/addbase.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -70,8 +69,8 @@ func (o *addBaseOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 // RunAddBase runs addBase command (do real work).
-func (o *addBaseOptions) RunAddBase(fsys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+func (o *addBaseOptions) RunAddBase(fSys fs.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}
@@ -84,7 +83,7 @@ func (o *addBaseOptions) RunAddBase(fsys fs.FileSystem) error {
 	// split directory paths
 	paths := strings.Split(o.baseDirectoryPaths, ",")
 	for _, path := range paths {
-		if !fsys.Exists(path) {
+		if !fSys.Exists(path) {
 			return errors.New(path + " does not exist")
 		}
 		if kustfile.StringInSlice(path, m.Bases) {

--- a/pkg/commands/edit/add/addbase_test.go
+++ b/pkg/commands/edit/add/addbase_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -43,7 +42,7 @@ func TestAddBaseHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/edit/add/addmetadata.go
+++ b/pkg/commands/edit/add/addmetadata.go
@@ -92,7 +92,7 @@ func (o *addMetadataOptions) runE(
 	if err != nil {
 		return err
 	}
-	kf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fSys)
+	kf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/addmetadata_test.go
+++ b/pkg/commands/edit/add/addmetadata_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/types"
 	"sigs.k8s.io/kustomize/pkg/validators"
@@ -29,7 +28,7 @@ import (
 func makeKustomization(t *testing.T) *types.Kustomization {
 	fakeFS := fs.MakeFakeFS()
 	fakeFS.WriteTestKustomization()
-	kf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fakeFS)
+	kf, err := kustfile.NewKustomizationFile(fakeFS)
 	if err != nil {
 		t.Errorf("unexpected new error %v", err)
 	}

--- a/pkg/commands/edit/add/addpatch.go
+++ b/pkg/commands/edit/add/addpatch.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/patch"
 )
@@ -70,8 +69,8 @@ func (o *addPatchOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 // RunAddPatch runs addPatch command (do real work).
-func (o *addPatchOptions) RunAddPatch(fsys fs.FileSystem) error {
-	patches, err := globPatterns(fsys, o.patchFilePaths)
+func (o *addPatchOptions) RunAddPatch(fSys fs.FileSystem) error {
+	patches, err := globPatterns(fSys, o.patchFilePaths)
 	if err != nil {
 		return err
 	}
@@ -79,7 +78,7 @@ func (o *addPatchOptions) RunAddPatch(fsys fs.FileSystem) error {
 		return nil
 	}
 
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/addpatch_test.go
+++ b/pkg/commands/edit/add/addpatch_test.go
@@ -21,7 +21,6 @@ import (
 
 	"strings"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -45,7 +44,7 @@ func TestAddPatchHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/edit/add/addresource.go
+++ b/pkg/commands/edit/add/addresource.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -69,8 +68,8 @@ func (o *addResourceOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 // RunAddResource runs addResource command (do real work).
-func (o *addResourceOptions) RunAddResource(fsys fs.FileSystem) error {
-	resources, err := globPatterns(fsys, o.resourceFilePaths)
+func (o *addResourceOptions) RunAddResource(fSys fs.FileSystem) error {
+	resources, err := globPatterns(fSys, o.resourceFilePaths)
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func (o *addResourceOptions) RunAddResource(fsys fs.FileSystem) error {
 		return nil
 	}
 
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/addresource_test.go
+++ b/pkg/commands/edit/add/addresource_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -44,7 +43,7 @@ func TestAddResourceHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/edit/add/configmap.go
+++ b/pkg/commands/edit/add/configmap.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/loader"
@@ -57,7 +56,7 @@ func newCmdAddConfigMap(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.
 			}
 
 			// Load the kustomization file.
-			mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fSys)
+			mf, err := kustfile.NewKustomizationFile(fSys)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/edit/set/set_name_prefix.go
+++ b/pkg/commands/edit/set/set_name_prefix.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -73,8 +72,8 @@ func (o *setNamePrefixOptions) Complete(cmd *cobra.Command, args []string) error
 }
 
 // RunSetNamePrefix runs setNamePrefix command (does real work).
-func (o *setNamePrefixOptions) RunSetNamePrefix(fsys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+func (o *setNamePrefixOptions) RunSetNamePrefix(fSys fs.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/set_name_prefix_test.go
+++ b/pkg/commands/edit/set/set_name_prefix_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -38,7 +37,7 @@ func TestSetNamePrefixHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/edit/set/setimagetag.go
+++ b/pkg/commands/edit/set/setimagetag.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
@@ -99,8 +98,8 @@ func (o *setImageTagOptions) Validate(args []string) error {
 }
 
 // RunSetImageTags runs setImageTags command (does real work).
-func (o *setImageTagOptions) RunSetImageTags(fsys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+func (o *setImageTagOptions) RunSetImageTags(fSys fs.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/setimagetag_test.go
+++ b/pkg/commands/edit/set/setimagetag_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
@@ -35,7 +34,7 @@ func TestSetImageTagsHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}
@@ -70,7 +69,7 @@ func TestSetImageTagsOverride(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/edit/set/setnamespace.go
+++ b/pkg/commands/edit/set/setnamespace.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 )
@@ -72,8 +71,8 @@ func (o *setNamespaceOptions) Validate(args []string) error {
 }
 
 // RunSetNamespace runs setNamespace command (does real work).
-func (o *setNamespaceOptions) RunSetNamespace(fsys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(constants.KustomizationFileName, fsys)
+func (o *setNamespaceOptions) RunSetNamespace(fSys fs.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/setnamespace_test.go
+++ b/pkg/commands/edit/set/setnamespace_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/validators"
 )
@@ -40,7 +39,7 @@ func TestSetNamespaceHappyPath(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}
@@ -65,7 +64,7 @@ func TestSetNamespaceOverride(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := fakeFS.ReadFile(constants.KustomizationFileName)
+	content, err := fakeFS.ReadTestKustomization()
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}

--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -73,13 +73,13 @@ func squash(x [][]byte) []byte {
 
 type kustomizationFile struct {
 	path           string
-	fsys           fs.FileSystem
+	fSys           fs.FileSystem
 	originalFields []*commentedField
 }
 
 // NewKustomizationFile returns a new instance.
-func NewKustomizationFile(mPath string, fsys fs.FileSystem) (*kustomizationFile, error) { // nolint
-	mf := &kustomizationFile{path: mPath, fsys: fsys}
+func NewKustomizationFile(fSys fs.FileSystem) (*kustomizationFile, error) { // nolint
+	mf := &kustomizationFile{path: constants.KustomizationFileName, fSys: fSys}
 	err := mf.validate()
 	if err != nil {
 		return nil, err
@@ -88,12 +88,12 @@ func NewKustomizationFile(mPath string, fsys fs.FileSystem) (*kustomizationFile,
 }
 
 func (mf *kustomizationFile) validate() error {
-	if !mf.fsys.Exists(mf.path) {
+	if !mf.fSys.Exists(mf.path) {
 		return fmt.Errorf("Missing kustomization file '%s'.\n", mf.path)
 	}
-	if mf.fsys.IsDir(mf.path) {
+	if mf.fSys.IsDir(mf.path) {
 		mf.path = path.Join(mf.path, constants.KustomizationFileName)
-		if !mf.fsys.Exists(mf.path) {
+		if !mf.fSys.Exists(mf.path) {
 			return fmt.Errorf("Missing kustomization file '%s'.\n", mf.path)
 		}
 	} else {
@@ -106,7 +106,7 @@ func (mf *kustomizationFile) validate() error {
 }
 
 func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
-	data, err := mf.fsys.ReadFile(mf.path)
+	data, err := mf.fSys.ReadFile(mf.path)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (mf *kustomizationFile) Write(kustomization *types.Kustomization) error {
 	if err != nil {
 		return err
 	}
-	return mf.fsys.WriteFile(mf.path, data)
+	return mf.fSys.WriteFile(mf.path, data)
 }
 
 // StringInSlice returns true if the string is in the slice.

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
@@ -31,9 +30,9 @@ func TestWriteAndRead(t *testing.T) {
 		NamePrefix: "prefix",
 	}
 
-	fsys := fs.MakeFakeFS()
-	fsys.Create(constants.KustomizationFileName)
-	mf, err := NewKustomizationFile(constants.KustomizationFileName, fsys)
+	fSys := fs.MakeFakeFS()
+	fSys.WriteTestKustomization()
+	mf, err := NewKustomizationFile(fSys)
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
@@ -51,20 +50,9 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
-func TestEmptyFile(t *testing.T) {
-	fsys := fs.MakeFakeFS()
-	_, err := NewKustomizationFile("", fsys)
-	if err == nil {
-		t.Fatalf("Create kustomizationFile from empty filename should fail")
-	}
-}
-
 func TestNewNotExist(t *testing.T) {
-	badSuffix := "foo.bar"
 	fakeFS := fs.MakeFakeFS()
-	fakeFS.Mkdir(".")
-	fakeFS.Create(badSuffix)
-	_, err := NewKustomizationFile(constants.KustomizationFileName, fakeFS)
+	_, err := NewKustomizationFile(fakeFS)
 	if err == nil {
 		t.Fatalf("expect an error")
 	}
@@ -72,18 +60,10 @@ func TestNewNotExist(t *testing.T) {
 	if !strings.Contains(err.Error(), contained) {
 		t.Fatalf("expect an error contains %q, but got %v", contained, err)
 	}
-	_, err = NewKustomizationFile(constants.KustomizationFileName, fakeFS)
+	_, err = NewKustomizationFile(fakeFS)
 	if err == nil {
 		t.Fatalf("expect an error")
 	}
-	if !strings.Contains(err.Error(), contained) {
-		t.Fatalf("expect an error contains %q, but got %v", contained, err)
-	}
-	_, err = NewKustomizationFile(badSuffix, fakeFS)
-	if err == nil {
-		t.Fatalf("expect an error")
-	}
-	contained = "should have .yaml suffix"
 	if !strings.Contains(err.Error(), contained) {
 		t.Fatalf("expect an error contains %q, but got %v", contained, err)
 	}
@@ -113,10 +93,9 @@ patchesStrategicMerge:
 - service.yaml
 - pod.yaml
 `)
-	fsys := fs.MakeFakeFS()
-	fsys.Create(constants.KustomizationFileName)
-	fsys.WriteFile(constants.KustomizationFileName, kustomizationContentWithComments)
-	mf, err := NewKustomizationFile(constants.KustomizationFileName, fsys)
+	fSys := fs.MakeFakeFS()
+	fSys.WriteTestKustomizationWith(kustomizationContentWithComments)
+	mf, err := NewKustomizationFile(fSys)
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
@@ -127,7 +106,7 @@ patchesStrategicMerge:
 	if err = mf.Write(kustomization); err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	bytes, _ := fsys.ReadFile(mf.path)
+	bytes, _ := fSys.ReadFile(mf.path)
 
 	if !reflect.DeepEqual(kustomizationContentWithComments, bytes) {
 		t.Fatal("written kustomization with comments is not the same as original one")
@@ -204,10 +183,9 @@ patchesStrategicMerge:
 - service.yaml
 - pod.yaml
 `)
-	fsys := fs.MakeFakeFS()
-	fsys.Create(constants.KustomizationFileName)
-	fsys.WriteFile(constants.KustomizationFileName, kustomizationContentWithComments)
-	mf, err := NewKustomizationFile(constants.KustomizationFileName, fsys)
+	fSys := fs.MakeFakeFS()
+	fSys.WriteTestKustomizationWith(kustomizationContentWithComments)
+	mf, err := NewKustomizationFile(fSys)
 	if err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
@@ -219,7 +197,7 @@ patchesStrategicMerge:
 	if err = mf.Write(kustomization); err != nil {
 		t.Fatalf("Unexpected Error: %v", err)
 	}
-	bytes, _ := fsys.ReadFile(mf.path)
+	bytes, _ := fSys.ReadFile(mf.path)
 
 	if !reflect.DeepEqual(expected, bytes) {
 		t.Fatal("written kustomization with comments is not the same as original one\n", string(bytes))

--- a/pkg/fs/fakefs.go
+++ b/pkg/fs/fakefs.go
@@ -19,9 +19,8 @@ package fs
 import (
 	"fmt"
 	"path/filepath"
-	"sort"
-
 	"sigs.k8s.io/kustomize/pkg/constants"
+	"sort"
 )
 
 var _ FileSystem = &FakeFS{}
@@ -53,13 +52,6 @@ configMapGenerator: []
 # There could be secrets in Base, if just using a fork/rebase workflow
 secretGenerator: []
 `
-
-// WriteTestKustomization writes a standard test file.
-func (fs *FakeFS) WriteTestKustomization() {
-	fs.WriteFile(
-		constants.KustomizationFileName,
-		[]byte(kustomizationContent))
-}
 
 // Create assures a fake file appears in the in-memory file system.
 func (fs *FakeFS) Create(name string) (File, error) {
@@ -123,12 +115,26 @@ func (fs *FakeFS) ReadFile(name string) ([]byte, error) {
 	return nil, fmt.Errorf("cannot read file %q", name)
 }
 
+func (fs *FakeFS) ReadTestKustomization() ([]byte, error) {
+	return fs.ReadFile(constants.KustomizationFileName)
+}
+
 // WriteFile always succeeds and does nothing.
 func (fs *FakeFS) WriteFile(name string, c []byte) error {
 	ff := &FakeFile{}
 	ff.Write(c)
 	fs.m[name] = ff
 	return nil
+}
+
+// WriteTestKustomization writes a standard test file.
+func (fs *FakeFS) WriteTestKustomization() {
+	fs.WriteTestKustomizationWith([]byte(kustomizationContent))
+}
+
+// WriteTestKustomizationWith writes a standard test file.
+func (fs *FakeFS) WriteTestKustomizationWith(bytes []byte) {
+	fs.WriteFile(constants.KustomizationFileName, bytes)
 }
 
 func (fs *FakeFS) pathMatch(path, pattern string) bool {

--- a/pkg/internal/error/configmaperror_test.go
+++ b/pkg/internal/error/configmaperror_test.go
@@ -19,12 +19,9 @@ package error
 import (
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/kustomize/pkg/constants"
 )
 
 func TestConfigmapError_Error(t *testing.T) {
-	filepath := "/path/to/" + constants.KustomizationFileName
 	errorMsg := "configmap name is missing"
 	me := ConfigmapError{Path: filepath, ErrorMsg: errorMsg}
 

--- a/pkg/internal/error/kustomizationerror_test.go
+++ b/pkg/internal/error/kustomizationerror_test.go
@@ -20,12 +20,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/kustomize/pkg/constants"
 )
 
 func TestKustomizationError_Error(t *testing.T) {
-	filepath := "/path/to/" + constants.KustomizationFileName
 	errorMsg := "Kustomization not found"
 
 	me := KustomizationError{KustomizationPath: filepath, ErrorMsg: errorMsg}
@@ -39,11 +36,9 @@ func TestKustomizationError_Error(t *testing.T) {
 		t.Errorf("Incorrect KustomizationError.Error() message \n")
 		t.Errorf("Expected errorMsg %s, but unfound\n", errorMsg)
 	}
-
 }
 
 func TestKustomizationErrors_Error(t *testing.T) {
-	filepath := "/path/to/kustomize"
 	me := KustomizationError{KustomizationPath: filepath, ErrorMsg: "Kustomization not found"}
 	ce := ConfigmapError{Path: filepath, ErrorMsg: "can't find configmap name"}
 	pe := PatchError{KustomizationPath: filepath, PatchFilepath: filepath, ErrorMsg: "can't find patch file"}

--- a/pkg/internal/error/patcherror_test.go
+++ b/pkg/internal/error/patcherror_test.go
@@ -19,12 +19,9 @@ package error
 import (
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/kustomize/pkg/constants"
 )
 
 func TestPatchError_Error(t *testing.T) {
-	filepath := "/path/to/" + constants.KustomizationFileName
 	patchfilepath := "/path/to/patch/patch.yaml"
 	errorMsg := "file not found"
 	me := PatchError{KustomizationPath: filepath, PatchFilepath: patchfilepath, ErrorMsg: errorMsg}

--- a/pkg/internal/error/resourceerror_test.go
+++ b/pkg/internal/error/resourceerror_test.go
@@ -19,12 +19,9 @@ package error
 import (
 	"strings"
 	"testing"
-
-	"sigs.k8s.io/kustomize/pkg/constants"
 )
 
 func TestResourceError_Error(t *testing.T) {
-	filepath := "/path/to/" + constants.KustomizationFileName
 	resourcefilepath := "/path/to/resource/deployment.yaml"
 	errorMsg := "file not found"
 	me := ResourceError{KustomizationPath: filepath, ResourceFilepath: resourcefilepath, ErrorMsg: errorMsg}

--- a/pkg/internal/error/secreterror_test.go
+++ b/pkg/internal/error/secreterror_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestSecretError_Error(t *testing.T) {
-	filepath := "/path/to/secret.yaml"
 	errorMsg := "missing a command"
 	me := SecretError{KustomizationPath: filepath, ErrorMsg: errorMsg}
 	if !strings.Contains(me.Error(), filepath) {

--- a/pkg/internal/error/yamlformaterror_test.go
+++ b/pkg/internal/error/yamlformaterror_test.go
@@ -19,13 +19,11 @@ package error
 import (
 	"fmt"
 	"testing"
-
-	"sigs.k8s.io/kustomize/pkg/constants"
 )
 
-var (
-	filepath = "/path/to/" + constants.KustomizationFileName
-	expected = "YAML file [/path/to/kustomization.yaml] encounters a format error.\n" +
+const (
+	filepath = "/path/to/whatever"
+	expected = "YAML file [/path/to/whatever] encounters a format error.\n" +
 		"error converting YAML to JSON: yaml: line 2: found character that cannot start any token\n"
 )
 


### PR DESCRIPTION
remove some code noise.
We never use a different name for the kustomization file, so no need to pass it around.
Also, we use it in tests unnecessarily.