### PR TITLE
Delete penultimate use of Patches field.

### DIFF
--- a/pkg/commands/edit/add/addpatch.go
+++ b/pkg/commands/edit/add/addpatch.go
@@ -89,7 +89,7 @@ func (o *addPatchOptions) RunAddPatch(fSys fs.FileSystem) error {
 	}
 
 	for _, p := range patches {
-		if patch.Exist(m.PatchesStrategicMerge, p) || kustfile.StringInSlice(p, m.Patches) {
+		if patch.Exist(m.PatchesStrategicMerge, p) {
 			log.Printf("patch %s already in kustomization file", p)
 			continue
 		}

--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -110,16 +110,17 @@ func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
 	if err != nil {
 		return nil, err
 	}
-	var kustomization types.Kustomization
-	err = yaml.Unmarshal(data, &kustomization)
+	var k types.Kustomization
+	err = yaml.Unmarshal(data, &k)
 	if err != nil {
 		return nil, err
 	}
+	k.DealWithDeprecatedFields()
 	err = mf.parseCommentedFields(data)
 	if err != nil {
 		return nil, err
 	}
-	return &kustomization, err
+	return &k, err
 }
 
 func (mf *kustomizationFile) Write(kustomization *types.Kustomization) error {

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -50,6 +50,48 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+// Deprecated fields should not survive being read.
+func TestDeprecationOfPatches(t *testing.T) {
+	hasDeprecatedFields := []byte(`
+namePrefix: acme
+patches:
+- alice
+patchesStrategicMerge:
+- bob
+`)
+	fSys := fs.MakeFakeFS()
+	fSys.WriteTestKustomizationWith(hasDeprecatedFields)
+	mf, err := NewKustomizationFile(fSys)
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	k, err := mf.Read()
+	if err != nil {
+		t.Fatalf("Couldn't read kustomization file: %v\n", err)
+	}
+	if k.NamePrefix != "acme" {
+		t.Fatalf("Unexpected name prefix")
+	}
+	if len(k.Patches) > 0 {
+		t.Fatalf("Expected nothing in Patches.")
+	}
+	if len(k.PatchesStrategicMerge) != 2 {
+		t.Fatalf(
+			"Expected len(k.PatchesStrategicMerge) == 2, got %d",
+			len(k.PatchesStrategicMerge))
+	}
+	m := make(map[string]bool)
+	for _, v := range k.PatchesStrategicMerge {
+		m[string(v)] = true
+	}
+	if _, f := m["alice"]; !f {
+		t.Fatalf("Expected alice in PatchesStrategicMerge")
+	}
+	if _, f := m["bob"]; !f {
+		t.Fatalf("Expected bob in PatchesStrategicMerge")
+	}
+}
+
 func TestNewNotExist(t *testing.T) {
 	fakeFS := fs.MakeFakeFS()
 	_, err := NewKustomizationFile(fakeFS)

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -124,13 +124,16 @@ type Kustomization struct {
 // DealWithDeprecatedFields should be called immediately after
 // loading from storage.
 func (k *Kustomization) DealWithDeprecatedFields() {
-	// The Patches field, meant to hold StrategicMerge patches,
-	// is deprecated. Append anything found there to the
-	// PatchesStrategicMerge field.
-	// This happened when the PatchesJson6902 field was introduced.
-	k.PatchesStrategicMerge = patch.Append(
-		k.PatchesStrategicMerge, k.Patches...)
-	k.Patches = []string{}
+	if len(k.Patches) > 0 {
+		// The Patches field, meant to hold strategic merge
+		// patches, is deprecated. Append anything found
+		// there to the PatchesStrategicMerge field.
+		// This happened when the PatchesJson6902 field
+		// was introduced.
+		k.PatchesStrategicMerge = patch.Append(
+			k.PatchesStrategicMerge, k.Patches...)
+		k.Patches = []string{}
+	}
 }
 
 // ConfigMapArgs contains the metadata of how to generate a configmap.


### PR DESCRIPTION
Delete penultimate use of the deprecated Patches field, leaving only the check in DealWithDeprecatedFields().  Also, make sure this is called in the last remaining place we read kustomization files that doesn't already make the call.

