### PR TITLE
Skip adding nameprefix to namespace

### DIFF
--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -203,12 +203,12 @@ func TestResources1(t *testing.T) {
 					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
 			}).SetBehavior(ifc.BehaviorCreate),
-		resid.NewResIdWithPrefixNamespace(ns, "ns1", "foo-", ""): rf.RF().FromMap(
+		resid.NewResIdWithPrefixNamespace(ns, "ns1", "", ""): rf.RF().FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
 				"metadata": map[string]interface{}{
-					"name": "foo-ns1",
+					"name": "ns1",
 					"labels": map[string]interface{}{
 						"app": "nginx",
 					},

--- a/pkg/transformers/prefixname.go
+++ b/pkg/transformers/prefixname.go
@@ -19,7 +19,6 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/resmap"
@@ -40,11 +39,9 @@ var prefixFieldSpecsToSkip = []config.FieldSpec{
 	{
 		Gvk: gvk.Gvk{Kind: "CustomResourceDefinition"},
 	},
-}
-
-// deprecateNamePrefixFieldSpec will be moved into prefixFieldSpecsToSkip in next release
-var deprecateNamePrefixFieldSpec = config.FieldSpec{
-	Gvk: gvk.Gvk{Kind: "Namespace"},
+	{
+		Gvk: gvk.Gvk{Kind: "Namespace"},
+	},
 }
 
 // NewNamePrefixTransformer construct a namePrefixTransformer.
@@ -77,9 +74,6 @@ func (o *namePrefixTransformer) Transform(m resmap.ResMap) error {
 	}
 
 	for id := range mf {
-		if id.Gvk().IsSelected(&deprecateNamePrefixFieldSpec.Gvk) {
-			log.Println("Adding nameprefix to Namespace resource will be deprecated in next release.")
-		}
 		objMap := mf[id].Map()
 		for _, path := range o.fieldSpecsToUse {
 			if !id.Gvk().IsSelected(&path.Gvk) {

--- a/pkg/transformers/prefixname_test.go
+++ b/pkg/transformers/prefixname_test.go
@@ -54,6 +54,14 @@ func TestPrefixNameRun(t *testing.T) {
 					"name": "crd",
 				},
 			}),
+		resid.NewResId(ns, "ns"): rf.FromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "ns",
+				},
+			}),
 	}
 	expected := resmap.ResMap{
 		resid.NewResIdWithPrefix(cmap, "cm1", "someprefix-"): rf.FromMap(
@@ -78,6 +86,14 @@ func TestPrefixNameRun(t *testing.T) {
 				"kind":       "CustomResourceDefinition",
 				"metadata": map[string]interface{}{
 					"name": "crd",
+				},
+			}),
+		resid.NewResId(ns, "ns"): rf.FromMap(
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "ns",
 				},
 			}),
 	}


### PR DESCRIPTION
The deprecation message has been shown in versions 1.0.6, 1.0.7, 1.0.8
We can deprecate it
Fix #235