### PR TITLE
Revert "create namespace resource if not found"

### DIFF
--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -275,7 +275,7 @@ func (kt *KustTarget) newTransformer(patches []*resource.Resource) (transformers
 	}
 	r = append(r, t)
 	r = append(r, transformers.NewNamespaceTransformer(
-		string(kt.kustomization.Namespace), kt.tcfg.NameSpace, kt.rf.RF()))
+		string(kt.kustomization.Namespace), kt.tcfg.NameSpace))
 	t, err = transformers.NewNamePrefixTransformer(
 		string(kt.kustomization.NamePrefix), kt.tcfg.NamePrefix)
 	if err != nil {

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -47,12 +47,12 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "foo",
 				},
 			}),
-		resid.NewResId(ns, "test"): rf.FromMap(
+		resid.NewResId(ns, "ns1"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
 				"metadata": map[string]interface{}{
-					"name": "test",
+					"name": "ns1",
 				},
 			}),
 		resid.NewResId(sa, "default"): rf.FromMap(
@@ -108,12 +108,12 @@ func TestNamespaceRun(t *testing.T) {
 			}),
 	}
 	expected := resmap.ResMap{
-		resid.NewResIdWithPrefixNamespace(ns, "test", "", ""): rf.FromMap(
+		resid.NewResIdWithPrefixNamespace(ns, "ns1", "", ""): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
 				"metadata": map[string]interface{}{
-					"name": "test",
+					"name": "ns1",
 				},
 			}),
 		resid.NewResIdWithPrefixNamespace(cmap, "cm1", "", "test"): rf.FromMap(
@@ -187,7 +187,7 @@ func TestNamespaceRun(t *testing.T) {
 			}),
 	}
 
-	nst := NewNamespaceTransformer("test", defaultTransformerConfig.NameSpace, rf)
+	nst := NewNamespaceTransformer("test", defaultTransformerConfig.NameSpace)
 	err := nst.Transform(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -243,35 +243,8 @@ func TestNamespaceRunForClusterLevelKind(t *testing.T) {
 
 	expected := m.DeepCopy(rf)
 
-	nst := NewNamespaceTransformer("ns1", defaultTransformerConfig.NameSpace, rf)
+	nst := NewNamespaceTransformer("test", defaultTransformerConfig.NameSpace)
 
-	err := nst.Transform(m)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(m, expected) {
-		err = expected.ErrorIfNotEqual(m)
-		t.Fatalf("actual doesn't match expected: %v", err)
-	}
-}
-
-func TestNamespaceNotFound(t *testing.T) {
-	rf := resource.NewFactory(
-		kunstruct.NewKunstructuredFactoryImpl())
-
-	m := resmap.ResMap{}
-	expected := resmap.ResMap{
-		resid.NewResId(ns, "test"): rf.FromMap(
-			map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Namespace",
-				"metadata": map[string]interface{}{
-					"name": "test",
-				},
-			}),
-	}
-
-	nst := NewNamespaceTransformer("test", defaultTransformerConfig.NameSpace, rf)
 	err := nst.Transform(m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Reverts kubernetes-sigs/kustomize#500

This change causes problem for Kustomize users. Let's revert it.