### PR TITLE
Improve test coverage.

### DIFF
--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -94,7 +94,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				Name: "envConfigMap",
 				DataSources: types.DataSources{
-					EnvSource: "configmap/app.env",
+					EnvSource: "/configmap/app.env",
 				},
 			},
 			options:  nil,
@@ -105,7 +105,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				Name: "fileConfigMap",
 				DataSources: types.DataSources{
-					FileSources: []string{"configmap/app-init.ini"},
+					FileSources: []string{"/configmap/app-init.ini"},
 				},
 			},
 			options:  nil,
@@ -129,8 +129,8 @@ func TestConstructConfigMap(t *testing.T) {
 	}
 
 	fSys := fs.MakeFakeFS()
-	fSys.WriteFile("configmap/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
-	fSys.WriteFile("configmap/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
+	fSys.WriteFile("/configmap/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
+	fSys.WriteFile("/configmap/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
 	f := NewConfigMapFactory(fSys, loader.NewFileLoader(fSys))
 	for _, tc := range testCases {
 		cm, err := f.MakeConfigMap(&tc.input, tc.options)

--- a/pkg/fs/fakefs.go
+++ b/pkg/fs/fakefs.go
@@ -21,18 +21,21 @@ import (
 	"path/filepath"
 	"sigs.k8s.io/kustomize/pkg/constants"
 	"sort"
+	"strings"
 )
 
-var _ FileSystem = &FakeFS{}
+var _ FileSystem = &fakeFs{}
 
-// FakeFS implements FileSystem using a fake in-memory filesystem.
-type FakeFS struct {
+// fakeFs implements FileSystem using a fake in-memory filesystem.
+type fakeFs struct {
 	m map[string]*FakeFile
 }
 
-// MakeFakeFS returns an instance of FakeFS with no files in it.
-func MakeFakeFS() *FakeFS {
-	return &FakeFS{m: map[string]*FakeFile{}}
+// MakeFakeFS returns an instance of fakeFs with no files in it.
+func MakeFakeFS() *fakeFs {
+	result := &fakeFs{m: map[string]*FakeFile{}}
+	result.Mkdir("/")
+	return result
 }
 
 // kustomizationContent is used in tests.
@@ -54,7 +57,7 @@ secretGenerator: []
 `
 
 // Create assures a fake file appears in the in-memory file system.
-func (fs *FakeFS) Create(name string) (File, error) {
+func (fs *fakeFs) Create(name string) (File, error) {
 	f := &FakeFile{}
 	f.open = true
 	fs.m[name] = f
@@ -62,18 +65,18 @@ func (fs *FakeFS) Create(name string) (File, error) {
 }
 
 // Mkdir assures a fake directory appears in the in-memory file system.
-func (fs *FakeFS) Mkdir(name string) error {
+func (fs *fakeFs) Mkdir(name string) error {
 	fs.m[name] = makeDir(name)
 	return nil
 }
 
 // MkdirAll delegates to Mkdir
-func (fs *FakeFS) MkdirAll(name string) error {
+func (fs *fakeFs) MkdirAll(name string) error {
 	return fs.Mkdir(name)
 }
 
 // Open returns a fake file in the open state.
-func (fs *FakeFS) Open(name string) (File, error) {
+func (fs *fakeFs) Open(name string) (File, error) {
 	if _, found := fs.m[name]; !found {
 		return nil, fmt.Errorf("file %q cannot be opened", name)
 	}
@@ -81,13 +84,13 @@ func (fs *FakeFS) Open(name string) (File, error) {
 }
 
 // Exists returns true if file is known.
-func (fs *FakeFS) Exists(name string) bool {
+func (fs *fakeFs) Exists(name string) bool {
 	_, found := fs.m[name]
 	return found
 }
 
 // Glob returns the list of matching files
-func (fs *FakeFS) Glob(pattern string) ([]string, error) {
+func (fs *fakeFs) Glob(pattern string) ([]string, error) {
 	var result []string
 	for p := range fs.m {
 		if fs.pathMatch(p, pattern) {
@@ -99,28 +102,36 @@ func (fs *FakeFS) Glob(pattern string) ([]string, error) {
 }
 
 // IsDir returns true if the file exists and is a directory.
-func (fs *FakeFS) IsDir(name string) bool {
+func (fs *fakeFs) IsDir(name string) bool {
 	f, found := fs.m[name]
-	if !found {
-		return false
+	if found && f.dir {
+		return true
 	}
-	return f.dir
+	if !strings.HasSuffix(name, "/") {
+		name = name + "/"
+	}
+	for k := range fs.m {
+		if strings.HasPrefix(k, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // ReadFile always returns an empty bytes and error depending on content of m.
-func (fs *FakeFS) ReadFile(name string) ([]byte, error) {
+func (fs *fakeFs) ReadFile(name string) ([]byte, error) {
 	if ff, found := fs.m[name]; found {
 		return ff.content, nil
 	}
 	return nil, fmt.Errorf("cannot read file %q", name)
 }
 
-func (fs *FakeFS) ReadTestKustomization() ([]byte, error) {
+func (fs *fakeFs) ReadTestKustomization() ([]byte, error) {
 	return fs.ReadFile(constants.KustomizationFileName)
 }
 
 // WriteFile always succeeds and does nothing.
-func (fs *FakeFS) WriteFile(name string, c []byte) error {
+func (fs *fakeFs) WriteFile(name string, c []byte) error {
 	ff := &FakeFile{}
 	ff.Write(c)
 	fs.m[name] = ff
@@ -128,16 +139,16 @@ func (fs *FakeFS) WriteFile(name string, c []byte) error {
 }
 
 // WriteTestKustomization writes a standard test file.
-func (fs *FakeFS) WriteTestKustomization() {
+func (fs *fakeFs) WriteTestKustomization() {
 	fs.WriteTestKustomizationWith([]byte(kustomizationContent))
 }
 
 // WriteTestKustomizationWith writes a standard test file.
-func (fs *FakeFS) WriteTestKustomizationWith(bytes []byte) {
+func (fs *fakeFs) WriteTestKustomizationWith(bytes []byte) {
 	fs.WriteFile(constants.KustomizationFileName, bytes)
 }
 
-func (fs *FakeFS) pathMatch(path, pattern string) bool {
+func (fs *fakeFs) pathMatch(path, pattern string) bool {
 	match, _ := filepath.Match(pattern, path)
 	return match
 }

--- a/pkg/fs/fakefs_test.go
+++ b/pkg/fs/fakefs_test.go
@@ -27,6 +27,10 @@ func TestExists(t *testing.T) {
 	if x.Exists("foo") {
 		t.Fatalf("expected no foo")
 	}
+	x.Mkdir("/")
+	if !x.IsDir("/") {
+		t.Fatalf("expected dir at /")
+	}
 }
 
 func TestIsDir(t *testing.T) {
@@ -41,6 +45,27 @@ func TestIsDir(t *testing.T) {
 	}
 	if !x.IsDir(expectedName) {
 		t.Fatalf(expectedName + " should be a dir")
+	}
+}
+
+func TestIsDirDeeper(t *testing.T) {
+	x := MakeFakeFS()
+	x.WriteFile("/foo/project/file.yaml", []byte("Unused"))
+	x.WriteFile("/foo/project/subdir/file.yaml", []byte("Unused"))
+	if !x.IsDir("/") {
+		t.Fatalf("/ should be a dir")
+	}
+	if !x.IsDir("/foo") {
+		t.Fatalf("/foo should be a dir")
+	}
+	if !x.IsDir("/foo/project") {
+		t.Fatalf("/foo/project should be a dir")
+	}
+	if x.IsDir("/fo") {
+		t.Fatalf("/fo should not be a dir")
+	}
+	if x.IsDir("/x") {
+		t.Fatalf("/x should not be a dir")
 	}
 }
 

--- a/pkg/loader/githubloader_test.go
+++ b/pkg/loader/githubloader_test.go
@@ -35,6 +35,10 @@ func TestIsRepoURL(t *testing.T) {
 			expected: true,
 		},
 		{
+			input:    "git::https://gitlab.com/org/repo",
+			expected: true,
+		},
+		{
 			input:    "/github.com/org/repo",
 			expected: false,
 		},
@@ -47,8 +51,16 @@ func TestIsRepoURL(t *testing.T) {
 			expected: false,
 		},
 		{
-			input:    "git::https://gitlab.com/org/repo",
-			expected: true,
+			input:    "foo",
+			expected: false,
+		},
+		{
+			input:    ".",
+			expected: false,
+		},
+		{
+			input:    "",
+			expected: false,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/transformers/config/factory_test.go
+++ b/pkg/transformers/config/factory_test.go
@@ -38,7 +38,7 @@ namePrefix:
   kind: SomeKind
 `
 	fakeFS := fs.MakeFakeFS()
-	fakeFS.WriteFile("transformerconfig/test/config.yaml", []byte(transformerConfig))
+	fakeFS.WriteFile("/transformerconfig/test/config.yaml", []byte(transformerConfig))
 	ldr := loader.NewFileLoader(fakeFS)
 	expected := &TransformerConfig{
 		NamePrefix: []FieldSpec{
@@ -53,9 +53,9 @@ namePrefix:
 
 func TestMakeTransformerConfigFromFiles(t *testing.T) {
 	ldr, expected, _ := makeFakeLoaderAndOutput()
-	tcfg, err := NewFactory(ldr).FromFiles([]string{"transformerconfig/test/config.yaml"})
+	tcfg, err := NewFactory(ldr).FromFiles([]string{"/transformerconfig/test/config.yaml"})
 	if err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if !reflect.DeepEqual(tcfg, expected) {


### PR DESCRIPTION
Looking at #366, dissatisfied with how filesystem and loader interact.
 * adding more tests before refactor.  in fileloader, add coverage for current behavior that looks bad in that
   it allows cycles.
 * make fakeFs private, and have IsDir work for implied directories, e.g. if the file /foo/bar.txt exists,
   then /foo is a directory.
 * in tests, use file rooted at / rather than depend on some vague notion of current working directory.
