### PR TITLE
make sure the objects loaded have name and kind

### DIFF
--- a/k8sdeps/kunstruct/factory_test.go
+++ b/k8sdeps/kunstruct/factory_test.go
@@ -100,6 +100,18 @@ WOOOOOOOOOOOOOOOOOOOOOOOOT:  woot
 			expectedOut: []ifc.Kunstructured{},
 			expectedErr: true,
 		},
+		{
+			name: "Missing .metadata.name in object",
+			input: []byte(`
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    foo: bar
+`),
+			expectedOut: nil,
+			expectedErr: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When `.metadata.name` is missing from a resource file.
kustomize build should give an error for that.