### PR TITLE
Use a more deterministic sort order for ordering resources

### DIFF
--- a/pkg/resmap/idslice.go
+++ b/pkg/resmap/idslice.go
@@ -51,6 +51,9 @@ func gvkLess(i, j schema.GroupVersionKind) bool {
 	indexi, foundi := typeOrders[i.Kind]
 	indexj, foundj := typeOrders[j.Kind]
 	if foundi && foundj {
+		if indexi == indexj {
+			return i.String() < j.String()
+		}
 		return indexi < indexj
 	}
 	if foundi && !foundj {


### PR DESCRIPTION
When two resources are of the same type, compare their strings directly.