### PR TITLE
add fallback for GVK comparison

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -97,7 +97,9 @@ func (x Gvk) IsLessThan(o Gvk) bool {
 	indexI, foundI := typeOrders[x.Kind]
 	indexJ, foundJ := typeOrders[o.Kind]
 	if foundI && foundJ {
-		return indexI < indexJ
+		if indexI != indexJ {
+			return indexI < indexJ
+		}
 	}
 	if foundI && !foundJ {
 		return true

--- a/pkg/gvk/gvk_test.go
+++ b/pkg/gvk/gvk_test.go
@@ -48,12 +48,25 @@ var lessThanTests = []struct {
 		Gvk{Group: "a", Version: "b", Kind: "ClusterRole"}},
 	{Gvk{Group: "a", Version: "b", Kind: "a"},
 		Gvk{Group: "a", Version: "b", Kind: "b"}},
+	{Gvk{Group: "a", Version: "b", Kind: "Namespace"},
+		Gvk{Group: "a", Version: "c", Kind: "Namespace"}},
+	{Gvk{Group: "a", Version: "c", Kind: "Namespace"},
+		Gvk{Group: "b", Version: "c", Kind: "Namespace"}},
+	{Gvk{Group: "b", Version: "c", Kind: "Namespace"},
+		Gvk{Group: "a", Version: "c", Kind: "ClusterRole"}},
+	{Gvk{Group: "a", Version: "c", Kind: "Namespace"},
+		Gvk{Group: "a", Version: "b", Kind: "ClusterRole"}},
+	{Gvk{Group: "a", Version: "d", Kind: "Namespace"},
+		Gvk{Group: "b", Version: "c", Kind: "Namespace"}},
 }
 
 func TestIsLessThan1(t *testing.T) {
 	for _, hey := range lessThanTests {
 		if !hey.x1.IsLessThan(hey.x2) {
 			t.Fatalf("%v should be less than %v", hey.x1, hey.x2)
+		}
+		if hey.x2.IsLessThan(hey.x1) {
+			t.Fatalf("%v should not be less than %v", hey.x2, hey.x1)
 		}
 	}
 }


### PR DESCRIPTION
only return comparison of 'Kind' indices if they do not match
otherwise fall back to GVK string comparison
this reduces output instability

Duplicates the work of #527, but with tests and without merge conflicts.