### PR TITLE
Update TransformerConfig.Merge function to handle nil

### DIFF
--- a/pkg/transformers/config/transformerconfig.go
+++ b/pkg/transformers/config/transformerconfig.go
@@ -64,6 +64,9 @@ func (t *TransformerConfig) AddNamereferenceFieldSpec(nbrs NameBackReferences) {
 
 // Merge merges two TransformerConfigs objects into a new TransformerConfig object
 func (t *TransformerConfig) Merge(input *TransformerConfig) *TransformerConfig {
+	if input == nil {
+		return t
+	}
 	merged := &TransformerConfig{}
 	merged.NamePrefix = append(t.NamePrefix, input.NamePrefix...)
 	merged.NameSpace = append(t.NameSpace, input.NameSpace...)

--- a/pkg/transformers/config/transformerconfig_test.go
+++ b/pkg/transformers/config/transformerconfig_test.go
@@ -141,4 +141,9 @@ func TestMerge(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected: %v\n but got: %v\n", expected, actual)
 	}
+
+	actual = cfga.Merge(nil)
+	if !reflect.DeepEqual(actual, cfga) {
+		t.Fatalf("expected: %v\n but got: %v\n", cfga, actual)
+	}
 }


### PR DESCRIPTION
When the input TransformerConfig is nil in the Merge function, it panics.