### PR TITLE
Add StorageClass to the list of ordered objects

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -70,6 +70,7 @@ func (x Gvk) Equals(o Gvk) bool {
 // In some cases order just specified to provide determinism.
 var order = []string{
 	"Namespace",
+	"StorageClass",
 	"CustomResourceDefinition",
 	"ServiceAccount",
 	"Role",


### PR DESCRIPTION
StorageClasses can be configured as `default`, so that PVCs can use them without an explicit reference.
This change adds StorageClasses close to the beginning of the compiled output.