### PR TITLE
POC: allow accessing labels and annotations in vars

### DIFF
--- a/k8sdeps/kunstruct/helper.go
+++ b/k8sdeps/kunstruct/helper.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kunstruct provides unstructured from api machinery and factory for creating unstructured
+package kunstruct
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseFields(path string) ([]string, error) {
+	if !strings.Contains(path, "[") {
+		return strings.Split(path, "."), nil
+	}
+
+	var fields []string
+	start := 0
+	insideParentheses := false
+	for i := range path {
+		switch path[i] {
+		case '.':
+			if !insideParentheses {
+				fields = append(fields, path[start:i])
+				start = i + 1
+			}
+		case '[':
+			if !insideParentheses {
+				if i == start {
+					start = i + 1
+				} else {
+					fields = append(fields, path[start:i])
+					start = i + 1
+				}
+				insideParentheses = true
+			} else {
+				return nil, fmt.Errorf("nested parentheses are not allowed: %s", path)
+			}
+		case ']':
+			if insideParentheses {
+				fields = append(fields, path[start:i])
+				start = i + 1
+				insideParentheses = false
+			} else {
+				return nil, fmt.Errorf("Invalid field path %s", path)
+			}
+		}
+	}
+	if start < len(path)-1 {
+		fields = append(fields, path[start:])
+	}
+	for i, f := range fields {
+		if strings.HasPrefix(f, "\"") || strings.HasPrefix(f, "'") {
+			fields[i] = strings.Trim(f, "\"'")
+		}
+	}
+	return fields, nil
+}

--- a/k8sdeps/kunstruct/kunstruct.go
+++ b/k8sdeps/kunstruct/kunstruct.go
@@ -20,7 +20,6 @@ package kunstruct
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -80,8 +79,12 @@ func (fs *UnstructAdapter) SetMap(m map[string]interface{}) {
 
 // GetFieldValue returns value at the given fieldpath.
 func (fs *UnstructAdapter) GetFieldValue(path string) (string, error) {
+	fields, err := parseFields(path)
+	if err != nil {
+		return "", err
+	}
 	s, found, err := unstructured.NestedString(
-		fs.UnstructuredContent(), strings.Split(path, ".")...)
+		fs.UnstructuredContent(), fields...)
 	if found || err != nil {
 		return s, err
 	}


### PR DESCRIPTION
Fix #526 

With this POC,
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy
spec:
  template:
    spec:
      containers:
      - name: dummy
        image: gcr.io/google_containers/pause-amd64:3.1
        env:
        - name: INSTANCE
          value: "$(INSTANCE)"
```
with kustomization.yaml as
```
nameprefix: noop-demo-
resources:
- deployment.yaml
commonLabels:
  app.kubernetes.io/instance: noop-demo
  foo: bar
vars:
- name: INSTANCE
  objRef:
    apiVersion: apps/v1
    kind: Deployment
    name: dummy
  fieldRef:
    fieldPath: metadata.labels["app.kubernetes.io/instance"]
```

will have the build output as
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: noop-demo
    foo: bar
  name: noop-demo-dummy
spec:
  selector:
    matchLabels:
      app.kubernetes.io/instance: noop-demo
      foo: bar
  template:
    metadata:
      labels:
        app.kubernetes.io/instance: noop-demo
        foo: bar
    spec:
      containers:
      - env:
        - name: INSTANCE
          value: noop-demo
        image: gcr.io/google_containers/pause-amd64:3.1
        name: dummy
```
