### PR TITLE
Enforce relocatable kustomizations.

### DIFF
--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -94,7 +94,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				Name: "envConfigMap",
 				DataSources: types.DataSources{
-					EnvSource: "/configmap/app.env",
+					EnvSource: "configmap/app.env",
 				},
 			},
 			options:  nil,
@@ -105,7 +105,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				Name: "fileConfigMap",
 				DataSources: types.DataSources{
-					FileSources: []string{"/configmap/app-init.ini"},
+					FileSources: []string{"configmap/app-init.ini"},
 				},
 			},
 			options:  nil,

--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -26,7 +26,10 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc"
 )
 
-const enforceRelocatable = false
+// TODO: 2018/Nov/20 remove this before next release.
+// Leave only the true path.  Retaining only for
+// quick revert.
+const enforceRelocatable = true
 
 // fileLoader loads files, returning an array of bytes.
 // It also enforces two kustomization requirements:

--- a/pkg/loader/fileloader_test.go
+++ b/pkg/loader/fileloader_test.go
@@ -31,19 +31,19 @@ type testData struct {
 
 var testCases = []testData{
 	{
-		path:            "/foo/project/fileA.yaml",
+		path:            "foo/project/fileA.yaml",
 		expectedContent: "fileA content",
 	},
 	{
-		path:            "/foo/project/subdir1/fileB.yaml",
+		path:            "foo/project/subdir1/fileB.yaml",
 		expectedContent: "fileB content",
 	},
 	{
-		path:            "/foo/project/subdir2/fileC.yaml",
+		path:            "foo/project/subdir2/fileC.yaml",
 		expectedContent: "fileC content",
 	},
 	{
-		path:            "/foo/project2/fileD.yaml",
+		path:            "foo/project/fileD.yaml",
 		expectedContent: "fileD content",
 	},
 }
@@ -51,7 +51,7 @@ var testCases = []testData{
 func MakeFakeFs(td []testData) fs.FileSystem {
 	fSys := fs.MakeFakeFS()
 	for _, x := range td {
-		fSys.WriteFile(x.path, []byte(x.expectedContent))
+		fSys.WriteFile("/"+x.path, []byte(x.expectedContent))
 	}
 	return fSys
 }
@@ -70,7 +70,7 @@ func TestLoaderLoad(t *testing.T) {
 			t.Fatalf("in load expected %s, but got %s", x.expectedContent, b)
 		}
 	}
-	l2, err := l1.New("/foo/project")
+	l2, err := l1.New("foo/project")
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
 	}
@@ -78,7 +78,7 @@ func TestLoaderLoad(t *testing.T) {
 		t.Fatalf("incorrect root: %s\n", l2.Root())
 	}
 	for _, x := range testCases {
-		b, err := l2.Load(strings.TrimPrefix(x.path, "/foo/project/"))
+		b, err := l2.Load(strings.TrimPrefix(x.path, "foo/project/"))
 		if err != nil {
 			t.Fatalf("unexpected load error %v", err)
 		}
@@ -86,7 +86,7 @@ func TestLoaderLoad(t *testing.T) {
 			t.Fatalf("in load expected %s, but got %s", x.expectedContent, b)
 		}
 	}
-	l2, err = l1.New("/foo/project/") // Assure trailing slash stripped
+	l2, err = l1.New("foo/project/") // Assure trailing slash stripped
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
 	}
@@ -96,7 +96,7 @@ func TestLoaderLoad(t *testing.T) {
 }
 
 func TestLoaderNewSubDir(t *testing.T) {
-	l1, err := NewFileLoaderAtRoot(MakeFakeFs(testCases)).New("/foo/project")
+	l1, err := NewFileLoaderAtRoot(MakeFakeFs(testCases)).New("foo/project")
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
 	}
@@ -118,7 +118,7 @@ func TestLoaderNewSubDir(t *testing.T) {
 }
 
 func TestLoaderBadRelative(t *testing.T) {
-	l1, err := NewFileLoaderAtRoot(MakeFakeFs(testCases)).New("/foo/project/subdir1")
+	l1, err := NewFileLoaderAtRoot(MakeFakeFs(testCases)).New("foo/project/subdir1")
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
 	}

--- a/pkg/patch/transformer/factory_test.go
+++ b/pkg/patch/transformer/factory_test.go
@@ -82,7 +82,7 @@ func TestNewPatchJson6902FactoryJSON(t *testing.T) {
 target:
   kind: Deployment
   name: some-name
-path: /testpath/patch.json
+path: patch.json
 `)
 	p := patch.Json6902{}
 	err = yaml.Unmarshal(jsonPatch, &p)
@@ -120,7 +120,7 @@ func TestNewPatchJson6902FactoryYAML(t *testing.T) {
 target:
   name: some-name
   kind: Deployment
-path: /testpath/patch.yaml
+path: patch.yaml
 `)
 	p := patch.Json6902{}
 	err = yaml.Unmarshal(jsonPatch, &p)
@@ -162,12 +162,12 @@ func TestNewPatchJson6902FactoryMulti(t *testing.T) {
 - target:
     kind: foo
     name: some-name
-  path: /testpath/patch.json
+  path: patch.json
 
 - target:
     kind: foo
     name: some-name
-  path: /testpath/patch.yaml
+  path: patch.yaml
 `)
 	var p []patch.Json6902
 	err = yaml.Unmarshal(jsonPatches, &p)
@@ -276,12 +276,12 @@ func TestNewPatchJson6902FactoryMultiConflict(t *testing.T) {
 - target:
     kind: foo
     name: some-name
-  path: /testpath/patch.json
+  path: patch.json
 
 - target:
     kind: foo
     name: some-name
-  path: /testpath/patch.yaml
+  path: patch.yaml
 `)
 	var p []patch.Json6902
 	err = yaml.Unmarshal(jsonPatches, &p)

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -53,8 +53,8 @@ metadata:
 ---
 `
 
-	l := loadertest.NewFakeLoader("/home/seans/project")
-	if ferr := l.AddFile("/home/seans/project/deployment.yaml", []byte(resourceStr)); ferr != nil {
+	l := loadertest.NewFakeLoader("/whatever/project")
+	if ferr := l.AddFile("/whatever/project/deployment.yaml", []byte(resourceStr)); ferr != nil {
 		t.Fatalf("Error adding fake file: %v\n", ferr)
 	}
 	expected := ResMap{resid.NewResId(deploy, "dply1"): rf.FromMap(
@@ -85,7 +85,7 @@ metadata:
 	}
 
 	m, _ := rmF.FromFiles(
-		l, []string{"/home/seans/project/deployment.yaml"})
+		l, []string{"deployment.yaml"})
 	if len(m) != 3 {
 		t.Fatalf("%#v should contain 3 appResource, but got %d", m, len(m))
 	}
@@ -145,7 +145,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 		expected    ResMap
 	}
 
-	l := loadertest.NewFakeLoader("/home/seans/project/")
+	l := loadertest.NewFakeLoader("/whatever/project/")
 	testCases := []testCase{
 		{
 			description: "construct config map from env",
@@ -157,7 +157,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 					},
 				},
 			},
-			filepath: "/home/seans/project/app.env",
+			filepath: "/whatever/project/app.env",
 			content:  "DB_USERNAME=admin\nDB_PASSWORD=somepw",
 			expected: ResMap{
 				resid.NewResId(cmap, "envConfigMap"): rf.FromMap(
@@ -183,7 +183,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 				},
 			},
 			},
-			filepath: "/home/seans/project/app-init.ini",
+			filepath: "/whatever/project/app-init.ini",
 			content:  "FOO=bar\nBAR=baz\n",
 			expected: ResMap{
 				resid.NewResId(cmap, "fileConfigMap"): rf.FromMap(

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -26,14 +26,14 @@ import (
 
 func TestSliceFromPatches(t *testing.T) {
 
-	patchGood1 := patch.StrategicMerge("/foo/patch1.yaml")
+	patchGood1 := patch.StrategicMerge("patch1.yaml")
 	patch1 := `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pooh
 `
-	patchGood2 := patch.StrategicMerge("/foo/patch2.yaml")
+	patchGood2 := patch.StrategicMerge("patch2.yaml")
 	patch2 := `
 apiVersion: v1
 kind: ConfigMap
@@ -45,14 +45,14 @@ metadata:
 ---
 ---
 `
-	patchBad := patch.StrategicMerge("/foo/patch3.yaml")
+	patchBad := patch.StrategicMerge("patch3.yaml")
 	patch3 := `
 WOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOT: woot
 `
-	l := loadertest.NewFakeLoader("/foo")
-	l.AddFile(string(patchGood1), []byte(patch1))
-	l.AddFile(string(patchGood2), []byte(patch2))
-	l.AddFile(string(patchBad), []byte(patch3))
+	l := loadertest.NewFakeLoader("/")
+	l.AddFile("/"+string(patchGood1), []byte(patch1))
+	l.AddFile("/"+string(patchGood2), []byte(patch2))
+	l.AddFile("/"+string(patchBad), []byte(patch3))
 
 	tests := []struct {
 		name        string

--- a/pkg/transformers/config/factory_test.go
+++ b/pkg/transformers/config/factory_test.go
@@ -53,7 +53,7 @@ namePrefix:
 
 func TestMakeTransformerConfigFromFiles(t *testing.T) {
 	ldr, expected, _ := makeFakeLoaderAndOutput()
-	tcfg, err := NewFactory(ldr).FromFiles([]string{"/transformerconfig/test/config.yaml"})
+	tcfg, err := NewFactory(ldr).FromFiles([]string{"transformerconfig/test/config.yaml"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/transformers/config/factorycrd_test.go
+++ b/pkg/transformers/config/factorycrd_test.go
@@ -182,9 +182,11 @@ func TestLoadCRDs(t *testing.T) {
 		NameReference: nbrs,
 	}
 
-	actualTc, _ := NewFactory(makeLoader(t)).LoadCRDs(
-		[]string{"/testpath/crd.json"})
-
+	actualTc, err := NewFactory(makeLoader(t)).LoadCRDs(
+		[]string{"crd.json"})
+	if err != nil {
+		t.Fatalf("unexpected error:%v", err)
+	}
 	if !reflect.DeepEqual(actualTc, expectedTc) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expectedTc, actualTc)
 	}


### PR DESCRIPTION
This PR enforces using only relative paths in kustomization files, so that the entire directory can be relocated and still work, and so that remote git repos can be used as bases.  Allowing absolute paths (as we currently, erroneously, do) breaks this utility.

This change means we have to adjust unit tests, but none of the examples or remote repos used in the examples have to change since they already eschew absolute paths.