### PR TITLE
Ignore empty fields targeted by transformations.

### DIFF
--- a/pkg/transformers/mutatefield.go
+++ b/pkg/transformers/mutatefield.go
@@ -18,6 +18,8 @@ package transformers
 
 import (
 	"fmt"
+	"log"
+	"strings"
 )
 
 type mutateFunc func(interface{}) (interface{}, error)
@@ -53,6 +55,11 @@ func mutateField(
 	v := m[pathToField[0]]
 	newPathToField := pathToField[1:]
 	switch typedV := v.(type) {
+	case nil:
+		log.Printf(
+			"nil value at `%s` ignored in mutation attempt",
+			strings.Join(pathToField, "."))
+		return nil
 	case map[string]interface{}:
 		return mutateField(typedV, newPathToField, createIfNotPresent, fns...)
 	case []interface{}:

--- a/pkg/transformers/mutatefield_test.go
+++ b/pkg/transformers/mutatefield_test.go
@@ -162,10 +162,7 @@ func TestWithNil(t *testing.T) {
 	m := &noopMutator{}
 	err := mutateField(
 		obj.Map(), []string{"spec", "template", "metadata", "labels", "vegetable"}, false, m.mutate)
-	if err == nil {
-		t.Fatalf("Expected error due to nil field.")
-	}
-	if err.Error() != "<nil> is not expected to be a primitive type" {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #560 

@twz123, please let me know if this doesn't address your specific issue.

With this PR, empty fields targeted by a transformation will be ignored (no error thrown).

There will be a log line to  stderr reporting last part of the field spec.  Not sure if we want that reporting - it might be noisy for those starting with a helm chart.  Easy to remove later, or suppress with a --verbosity flag, or obviously with `kustomize ... 2> /dev/null`.

