### PR TITLE
Add support for variable subsitution in Ingress hosts

### DIFF
--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/expected.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/expected.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: nginx
+  name: kustomized-nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: nginx
+  name: kustomized-nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: nginx
+    spec:
+      containers:
+      - image: nginx:1.15.7-alpine
+        name: nginx
+        ports:
+        - containerPort: 80
+          name: http
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/component: nginx
+  name: kustomized-nginx
+spec:
+  rules:
+  - host: kustomized-nginx.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: kustomized-nginx
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - kustomized-nginx.example.com

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/deployment.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/component: nginx
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.7-alpine
+        ports:
+        - name: http
+          containerPort: 80

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/ingress.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/component: nginx
+spec:
+  rules:
+  - host: $(DEPLOYMENT_NAME).example.com
+    http:
+      paths:
+      - backend:
+          serviceName: nginx
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - $(DEPLOYMENT_NAME).example.com

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/kustomization.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+- deployment.yaml
+- ingress.yaml
+- service.yaml
+
+vars:
+- name: DEPLOYMENT_NAME
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  fieldref:
+    fieldpath: metadata.name

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/service.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/component: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/overlay/kustomization.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/in/overlay/kustomization.yaml
@@ -1,0 +1,4 @@
+nameprefix: kustomized-
+
+bases:
+- ../base

--- a/pkg/commands/build/testdata/testcase-variable-ref-ingress/test.yaml
+++ b/pkg/commands/build/testdata/testcase-variable-ref-ingress/test.yaml
@@ -1,0 +1,4 @@
+description: variable reference and substitution for ingress resources
+args: []
+filename: testdata/testcase-variable-ref-ingress/in/overlay/
+expectedStdout: testdata/testcase-variable-ref-ingress/expected.yaml

--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -81,5 +81,11 @@ varReference:
 
 - path: spec/containers/env/value
   kind: Pod
+
+- path: spec/rules/host
+  kind: Ingress
+
+- path: spec/tls/hosts
+  kind: Ingress
 `
 )


### PR DESCRIPTION
With this PR it's possible to use variables in `spec.rules.host` and `spec.tls.hosts` in Ingress resources. I didn't include an `expected.diff` file, because `diff_test.go` has been removed in PR #275.