### PR TITLE
Add namespace for config map and secret generators

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -94,6 +94,13 @@ secretGenerator:
     tls.crt: "cat secret/tls.cert"
     tls.key: "cat secret/tls.key"
   type: "kubernetes.io/tls"
+- name: app-tls-namespaced
+  # you can define a namespace to generate secret in, defaults to: "default"
+  namspace: apps
+  commands:
+    tls.crt: "cat secret/tls.cert"
+    tls.key: "cat secret/tls.key"
+  type: "kubernetes.io/tls"
 - name: downloaded_secret
   # timeoutSeconds specifies the number of seconds to
   # wait for the commands below. It defaults to 5 seconds.

--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -49,6 +49,7 @@ func (f *ConfigMapFactory) makeFreshConfigMap(
 	cm.APIVersion = "v1"
 	cm.Kind = "ConfigMap"
 	cm.Name = args.Name
+	cm.Namespace = args.Namespace
 	cm.Data = map[string]string{}
 	return cm
 }

--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -52,6 +52,7 @@ func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
 	s.APIVersion = "v1"
 	s.Kind = "Secret"
 	s.Name = args.Name
+	s.Namespace = args.Namespace
 	s.Type = corev1.SecretType(args.Type)
 	if s.Type == "" {
 		s.Type = corev1.SecretTypeOpaque

--- a/pkg/commands/build/testdata/testcase-generators-namespace/expected.yaml
+++ b/pkg/commands/build/testdata/testcase-generators-namespace/expected.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  altGreeting: Good Morning from default namespace!
+  enableRisky: "false"
+kind: ConfigMap
+metadata:
+  name: the-map-4959m5tm6c
+---
+apiVersion: v1
+data:
+  altGreeting: Good Morning from non-default namespace!
+  enableRisky: "false"
+kind: ConfigMap
+metadata:
+  name: the-non-default-namespace-map-b6h49k7mt8
+  namespace: non-default
+---
+apiVersion: v1
+data:
+  password.txt: dmVyeSRlY3JldA==
+kind: Secret
+metadata:
+  name: the-secret-cfbmct72tb
+type: Opaque
+---
+apiVersion: v1
+data:
+  password.txt: dmVyeSRlY3JldA==
+kind: Secret
+metadata:
+  name: the-non-default-namespace-secret-255294gd9d
+  namespace: non-default
+type: Opaque

--- a/pkg/commands/build/testdata/testcase-generators-namespace/in/kustomization.yaml
+++ b/pkg/commands/build/testdata/testcase-generators-namespace/in/kustomization.yaml
@@ -1,0 +1,19 @@
+configMapGenerator:
+- name: the-non-default-namespace-map
+  namespace: non-default
+  literals:
+  - altGreeting=Good Morning from non-default namespace!
+  - enableRisky="false"
+- name: the-map
+  literals:
+  - altGreeting=Good Morning from default namespace!
+  - enableRisky="false"
+
+secretGenerator:
+- name: the-non-default-namespace-secret
+  namespace: non-default
+  commands:
+    password.txt: "cat password.txt"
+- name: the-secret
+  commands:
+    password.txt: "cat password.txt"

--- a/pkg/commands/build/testdata/testcase-generators-namespace/in/password.txt
+++ b/pkg/commands/build/testdata/testcase-generators-namespace/in/password.txt
@@ -1,0 +1,1 @@
+very$ecret

--- a/pkg/commands/build/testdata/testcase-generators-namespace/test.yaml
+++ b/pkg/commands/build/testdata/testcase-generators-namespace/test.yaml
@@ -1,0 +1,4 @@
+description: generators-namespace
+args: []
+filename: testdata/testcase-generators-namespace/in
+expectedStdout: testdata/testcase-generators-namespace/expected.yaml

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -153,6 +153,9 @@ type ConfigMapArgs struct {
 	// hash(content of configmap).
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
+	// Namespace for the configmap, optional
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+
 	// behavior of configmap, must be one of create, merge and replace
 	// 'create': create a new one;
 	// 'replace': replace the existing one;
@@ -169,6 +172,9 @@ type SecretArgs struct {
 	// The full name should be Kustomization.NamePrefix + SecretGenerator.Name +
 	// hash(content of secret).
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Namespace for the secret, optional
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	// behavior of secretGenerator, must be one of create, merge and replace
 	// 'create': create a new one;


### PR DESCRIPTION
Hi, 

This PR adds a namespace argument to secret generator and config map generator which _should_ fix https://github.com/kubernetes-sigs/kustomize/issues/595

Best regards

Łukasz Tomaszkiewicz