### PR TITLE
Add support for HorizontalPodAutoscaler naming

### DIFF
--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -24,6 +24,11 @@ nameReference:
   - path: spec/scaleTargetRef/name
     kind: HorizontalPodAutoscaler
 
+- kind: HorizontalPodAutoscaler
+  fieldSpecs:
+  - path: spec/scaleTargetRef/name
+    kind: Deployment
+
 - kind: ReplicationController
   fieldSpecs:
   - path: spec/scaleTargetRef/name


### PR DESCRIPTION
Currently the name of HorizontalPodAutoscaler scaleTargetRef is not being changed.

Example:
```
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: autoscaler
  namespace: default
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: app
  minReplicas: 1
  maxReplicas: 10
  targetCPUUtilizationPercentage: 75

```