### PR TITLE
Add projected secret path to transformer config

### DIFF
--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -150,6 +150,8 @@ nameReference:
     kind: Deployment
   - path: spec/template/spec/imagePullSecrets/name
     kind: Deployment
+  - path: spec/template/spec/volumes/projected/sources/secret/name
+    kind: Deployment
   - path: spec/template/spec/volumes/secret/secretName
     kind: ReplicaSet
   - path: spec/template/spec/containers/env/valueFrom/secretKeyRef/name
@@ -185,6 +187,8 @@ nameReference:
   - path: spec/template/spec/initContainers/envFrom/secretRef/name
     kind: StatefulSet
   - path: spec/template/spec/imagePullSecrets/name
+    kind: StatefulSet
+  - path: spec/template/spec/volumes/projected/sources/secret/name
     kind: StatefulSet
   - path: spec/template/spec/volumes/secret/secretName
     kind: Job

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -148,6 +148,9 @@ func TestNameReferenceHappyRun(t *testing.T) {
 										"configMap": map[string]interface{}{
 											"name": "cm2",
 										},
+										"secret": map[string]interface{}{
+											"name": "secret1",
+										},
 									},
 								},
 								"secret": map[string]interface{}{
@@ -183,6 +186,9 @@ func TestNameReferenceHappyRun(t *testing.T) {
 									"sources": map[string]interface{}{
 										"configMap": map[string]interface{}{
 											"name": "cm2",
+										},
+										"secret": map[string]interface{}{
+											"name": "secret1",
 										},
 									},
 								},
@@ -307,6 +313,9 @@ func TestNameReferenceHappyRun(t *testing.T) {
 									"configMap": map[string]interface{}{
 										"name": "someprefix-cm2-somehash",
 									},
+									"secret": map[string]interface{}{
+										"name": "someprefix-secret1-somehash",
+									},
 								},
 							},
 							"secret": map[string]interface{}{
@@ -342,6 +351,9 @@ func TestNameReferenceHappyRun(t *testing.T) {
 								"sources": map[string]interface{}{
 									"configMap": map[string]interface{}{
 										"name": "someprefix-cm2-somehash",
+									},
+									"secret": map[string]interface{}{
+										"name": "someprefix-secret1-somehash",
 									},
 								},
 							},


### PR DESCRIPTION
The current name transformer does not detect secrets that are used in projected volumes. This makes using that feature with a kustomize created secret when name suffix hashing is enabled not viable.

This PR adds the fieldspec needed to the transformer configuration that is needed to find the secret name references in a  projected volume.

Fixes #613