### PR TITLE
Allow directory substrings in cycle check.

### DIFF
--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -191,7 +191,7 @@ func newGitLoader(
 // visited root begins with the given path.
 func (l *fileLoader) seenBefore(path string) error {
 	for _, r := range l.roots {
-		if strings.HasPrefix(r, path) {
+		if strings.HasPrefix(r, path+string(filepath.Separator)) {
 			return fmt.Errorf(
 				"cycle detected: new root '%s' contains previous root '%s'",
 				path, r)

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -243,7 +243,7 @@ func (kt *KustTarget) loadCustomizedBases() (resmap.ResMap, *interror.Kustomizat
 	for _, path := range kt.kustomization.Bases {
 		ldr, err := kt.ldr.New(path)
 		if err != nil {
-			errs.Append(errors.Wrap(err, "couldn't make ldr for "+path))
+			errs.Append(errors.Wrap(err, "couldn't make loader for "+path))
 			continue
 		}
 		target, err := NewKustTarget(


### PR DESCRIPTION
Fix #596.

The cycle check was bothered by the sibling directories aws and aws-nonprod.

The test included here reproduces the bug (fails), and the change in fileloader.go lets the test pass.
