### PR TITLE
Allow directory substrings in cycle check.

### DIFF
--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -190,8 +190,9 @@ func newGitLoader(
 // seenBefore tests whether the current or any previously
 // visited root begins with the given path.
 func (l *fileLoader) seenBefore(path string) error {
+	terminated := path + string(filepath.Separator)
 	for _, r := range l.roots {
-		if strings.HasPrefix(r, path) {
+		if r == path || strings.HasPrefix(r, terminated) {
 			return fmt.Errorf(
 				"cycle detected: new root '%s' contains previous root '%s'",
 				path, r)

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -243,7 +243,7 @@ func (kt *KustTarget) loadCustomizedBases() (resmap.ResMap, *interror.Kustomizat
 	for _, path := range kt.kustomization.Bases {
 		ldr, err := kt.ldr.New(path)
 		if err != nil {
-			errs.Append(errors.Wrap(err, "couldn't make ldr for "+path))
+			errs.Append(errors.Wrap(err, "couldn't make loader for "+path))
 			continue
 		}
 		target, err := NewKustTarget(


### PR DESCRIPTION
Fix #596 

The cycle check was confused by two sibling overlay directories named `aws` and `aws-foo`.

The test in this PR reproduces the bug by failing, and the non-test code change makes the test pass.
