### PR TITLE
Reduce log noise.

### DIFF
--- a/pkg/resmap/factory.go
+++ b/pkg/resmap/factory.go
@@ -57,7 +57,7 @@ func (rmF *Factory) FromFiles(
 		}
 		result = append(result, res)
 	}
-	return MergeWithoutOverride(result...)
+	return MergeWithErrorOnIdCollision(result...)
 }
 
 // newResMapFromBytes decodes a list of objects in byte array format.

--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -410,7 +410,7 @@ func TestMergeWithoutOverride(t *testing.T) {
 				},
 			}),
 	}
-	merged, err := MergeWithoutOverride(input...)
+	merged, err := MergeWithErrorOnIdCollision(input...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestMergeWithoutOverride(t *testing.T) {
 		t.Fatalf("%#v doesn't equal expected %#v", merged, expected)
 	}
 	input3 := []ResMap{merged, nil}
-	merged1, err := MergeWithoutOverride(input3...)
+	merged1, err := MergeWithErrorOnIdCollision(input3...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestMergeWithoutOverride(t *testing.T) {
 		t.Fatalf("%#v doesn't equal expected %#v", merged1, expected)
 	}
 	input4 := []ResMap{nil, merged}
-	merged2, err := MergeWithoutOverride(input4...)
+	merged2, err := MergeWithErrorOnIdCollision(input4...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -218,7 +218,7 @@ func (kt *KustTarget) generateConfigMapsAndSecrets(
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromSecretArgs"))
 	}
-	return resmap.MergeWithoutOverride(cms, secrets)
+	return resmap.MergeWithErrorOnIdCollision(cms, secrets)
 }
 
 // Gets Bases and Resources as advertised.
@@ -232,7 +232,7 @@ func (kt *KustTarget) loadResMapFromBasesAndResources() (resmap.ResMap, error) {
 	if len(errs.Get()) > 0 {
 		return nil, errs
 	}
-	return resmap.MergeWithoutOverride(resources, bases)
+	return resmap.MergeWithErrorOnIdCollision(resources, bases)
 }
 
 // Loop through the Bases of this kustomization recursively loading resources.
@@ -261,7 +261,7 @@ func (kt *KustTarget) loadCustomizedBases() (resmap.ResMap, *interror.Kustomizat
 		ldr.Cleanup()
 		list = append(list, resMap)
 	}
-	result, err := resmap.MergeWithoutOverride(list...)
+	result, err := resmap.MergeWithErrorOnIdCollision(list...)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "Merge failed"))
 	}


### PR DESCRIPTION
Remove some log statements, 
fix some comment formatting,
and rename
> `MergeWithoutOverride`

to the slightly clearer 

> `MergeWithErrorOnIdCollision`