### PR TITLE
List of strategic merge patches

### DIFF
--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -101,6 +101,7 @@ func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader) {
 }
 
 // validate validates that u has kind and name
+// except for kind `List`, which doesn't require a name
 func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error {
 	if u.GetName() == "" && u.GetKind() != "List" {
 		return fmt.Errorf("missing metadata.name in object %v", u)

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -103,11 +103,14 @@ func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader) {
 // validate validates that u has kind and name
 // except for kind `List`, which doesn't require a name
 func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error {
-	if u.GetName() == "" && u.GetKind() != "List" {
-		return fmt.Errorf("missing metadata.name in object %v", u)
-	}
-	if u.GetKind() == "" {
+	kind := u.GetKind()
+	if kind == "" {
 		return fmt.Errorf("missing kind in object %v", u)
+	} else if kind == "List" {
+		return nil
+	}
+	if u.GetName() == "" {
+		return fmt.Errorf("missing metadata.name in object %v", u)
 	}
 	return nil
 }

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -102,7 +102,7 @@ func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader) {
 
 // validate validates that u has kind and name
 func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error {
-	if u.GetName() == "" {
+	if u.GetName() == "" && u.GetKind() != "List" {
 		return fmt.Errorf("missing metadata.name in object %v", u)
 	}
 	if u.GetKind() == "" {

--- a/k8sdeps/kunstruct/factory_test.go
+++ b/k8sdeps/kunstruct/factory_test.go
@@ -33,6 +33,15 @@ func TestSliceFromBytes(t *testing.T) {
 				"name": "winnie",
 			},
 		})
+	testList := factory.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items": []interface{}{
+				testConfigMap.Map(),
+				testConfigMap.Map(),
+			},
+		})
 
 	tests := []struct {
 		name        string
@@ -111,6 +120,24 @@ metadata:
 `),
 			expectedOut: nil,
 			expectedErr: true,
+		},
+		{
+			name: "List",
+			input: []byte(`
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+`),
+			expectedOut: []ifc.Kunstructured{testList},
+			expectedErr: false,
 		},
 	}
 

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -68,31 +68,7 @@ func (rf *Factory) SliceFromPatches(
 		if err != nil {
 			return nil, internal.Handler(err, string(path))
 		}
-		for len(res) > 0 {
-			r := res[0]
-			res = res[1:]
-			if r.GetKind() == "List" {
-				items := r.Map()["items"]
-				itemsSlice, ok := items.([]interface{})
-				if !ok {
-					return nil, fmt.Errorf("items in List is type %T, expected array.", items)
-				}
-				for _, item := range itemsSlice {
-					itemJSON, err := json.Marshal(item)
-					if err != nil {
-						return nil, err
-					}
-					innerRes, err := rf.SliceFromBytes(itemJSON)
-					if err != nil {
-						return nil, err
-					}
-					// append innerRes to res so nested Lists can be handled
-					res = append(res, innerRes...)
-				}
-			} else {
-				result = append(result, r)
-			}
-		}
+		result = append(result, res...)
 	}
 	return result, nil
 }
@@ -104,8 +80,30 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 		return nil, err
 	}
 	var result []*Resource
-	for _, u := range kunStructs {
-		result = append(result, rf.FromKunstructured(u))
+	for len(kunStructs) > 0 {
+		u := kunStructs[0]
+		kunStructs = kunStructs[1:]
+		if u.GetKind() == "List" {
+			items := u.Map()["items"]
+			itemsSlice, ok := items.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("items in List is type %T, expected array.", items)
+			}
+			for _, item := range itemsSlice {
+				itemJSON, err := json.Marshal(item)
+				if err != nil {
+					return nil, err
+				}
+				innerU, err := rf.kf.SliceFromBytes(itemJSON)
+				if err != nil {
+					return nil, err
+				}
+				// append innerU to kunStructs so nested Lists can be handled
+				kunStructs = append(kunStructs, innerU...)
+			}
+		} else {
+			result = append(result, rf.FromKunstructured(u))
+		}
 	}
 	return result, nil
 }

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -64,11 +64,67 @@ items:
     name: winnie
     namespace: hundred-acre-wood
 `
+	patchList2 := patch.StrategicMerge("patch5.yaml")
+	patch5 := `
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-a
+  spec: &hostAliases
+    template:
+      spec:
+        hostAliases:
+        - hostnames:
+          - a.example.com
+          ip: 8.8.8.8
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-b
+  spec:
+    <<: *hostAliases
+`
+	testDeploymentSpec := map[string]interface{}{
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"hostAliases": []interface{}{
+					map[string]interface{}{
+						"hostnames": []interface{}{
+							"a.example.com",
+						},
+						"ip": "8.8.8.8",
+					},
+				},
+			},
+		},
+	}
+	testDeploymentA := factory.FromMap(
+		map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "deployment-a",
+			},
+			"spec": testDeploymentSpec,
+		})
+	testDeploymentB := factory.FromMap(
+		map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "deployment-b",
+			},
+			"spec": testDeploymentSpec,
+		})
 	l := loadertest.NewFakeLoader("/")
 	l.AddFile("/"+string(patchGood1), []byte(patch1))
 	l.AddFile("/"+string(patchGood2), []byte(patch2))
 	l.AddFile("/"+string(patchBad), []byte(patch3))
 	l.AddFile("/"+string(patchList), []byte(patch4))
+	l.AddFile("/"+string(patchList2), []byte(patch5))
 
 	tests := []struct {
 		name        string
@@ -98,6 +154,12 @@ items:
 			name:        "listOfPatches",
 			input:       []patch.StrategicMerge{patchList},
 			expectedOut: []*Resource{testDeployment, testConfigMap},
+			expectedErr: false,
+		},
+		{
+			name:        "listWithAnchorReference",
+			input:       []patch.StrategicMerge{patchList2},
+			expectedOut: []*Resource{testDeploymentA, testDeploymentB},
 			expectedErr: false,
 		},
 	}

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -49,10 +49,26 @@ metadata:
 	patch3 := `
 WOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOT: woot
 `
+	patchList := patch.StrategicMerge("patch4.yaml")
+	patch4 := `
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: pooh
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+    namespace: hundred-acre-wood
+`
 	l := loadertest.NewFakeLoader("/")
 	l.AddFile("/"+string(patchGood1), []byte(patch1))
 	l.AddFile("/"+string(patchGood2), []byte(patch2))
 	l.AddFile("/"+string(patchBad), []byte(patch3))
+	l.AddFile("/"+string(patchList), []byte(patch4))
 
 	tests := []struct {
 		name        string
@@ -77,6 +93,12 @@ WOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOT: woot
 			input:       []patch.StrategicMerge{patchGood1, patchBad},
 			expectedOut: []*Resource{},
 			expectedErr: true,
+		},
+		{
+			name:        "listOfPatches",
+			input:       []patch.StrategicMerge{patchList},
+			expectedOut: []*Resource{testDeployment, testConfigMap},
+			expectedErr: false,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Support multiple strategic merge patches in a `List` like [this](https://github.com/kubernetes-sigs/kustomize/issues/638#issue-391605491).

Then we can put same patch with different targets in a  `List` and reuse duplicated parts using anchor/reference of YAML.