### PR TITLE
Determine kustomization file by GVK

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -29,9 +29,19 @@ import (
 	"sigs.k8s.io/kustomize/pkg/target"
 )
 
-type buildOptions struct {
+type BuildOptions struct {
 	kustomizationPath string
 	outputPath        string
+	withDefaultKFile  bool
+}
+
+// NewBuildOptions creates a BuildOptions object
+func NewBuildOptions(p, o string, b bool) *BuildOptions {
+	return &BuildOptions{
+		kustomizationPath: p,
+		outputPath:        o,
+		withDefaultKFile:  b,
+	}
 }
 
 var examples = `
@@ -54,7 +64,8 @@ func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
 	ptf transformer.Factory) *cobra.Command {
-	var o buildOptions
+	var o BuildOptions
+	o.withDefaultKFile = true
 
 	cmd := &cobra.Command{
 		Use:          "build [path]",
@@ -77,7 +88,7 @@ func NewCmdBuild(
 }
 
 // Validate validates build command.
-func (o *buildOptions) Validate(args []string) error {
+func (o *BuildOptions) Validate(args []string) error {
 	if len(args) > 1 {
 		return errors.New("specify one path to " + constants.KustomizationFileName)
 	}
@@ -91,7 +102,7 @@ func (o *buildOptions) Validate(args []string) error {
 }
 
 // RunBuild runs build command.
-func (o *buildOptions) RunBuild(
+func (o *BuildOptions) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
 	rf *resmap.Factory, ptf transformer.Factory) error {
 	ldr, err := loader.NewLoader(o.kustomizationPath, fSys)
@@ -99,7 +110,7 @@ func (o *buildOptions) RunBuild(
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, fSys, rf, ptf)
+	kt, err := target.NewKustTarget(ldr, fSys, rf, ptf, o.withDefaultKFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/build/build_test.go
+++ b/pkg/commands/build/build_test.go
@@ -36,7 +36,7 @@ func TestBuildValidate(t *testing.T) {
 			"", "specify one path to " + constants.KustomizationFileName},
 	}
 	for _, mycase := range cases {
-		opts := buildOptions{}
+		opts := BuildOptions{}
 		e := opts.Validate(mycase.args)
 		if len(mycase.erMsg) > 0 {
 			if e == nil {

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -34,6 +34,8 @@ type Validator interface {
 type Loader interface {
 	// Root returns the root location for this Loader.
 	Root() string
+	// Files returns the list of file names contained in this loader.
+	Files() ([]string, error)
 	// New returns Loader located at newRoot.
 	New(newRoot string) (Loader, error)
 	// Load returns the bytes read from the location or an error.

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -69,7 +69,7 @@ func (f FakeLoader) Files() ([]string, error) {
 	var result []string
 	for _, file := range files {
 		if !f.fs.IsDir(file) {
-			result = append(result, filepath.Base(f))
+			result = append(result, filepath.Base(file))
 		}
 	}
 	return result, nil

--- a/pkg/internal/loadertest/fakeloader.go
+++ b/pkg/internal/loadertest/fakeloader.go
@@ -19,6 +19,8 @@ package loadertest
 
 import (
 	"log"
+	"path/filepath"
+
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/loader"
@@ -56,6 +58,21 @@ func (f FakeLoader) AddDirectory(fullDirPath string) error {
 // Root returns root.
 func (f FakeLoader) Root() string {
 	return f.delegate.Root()
+}
+
+// Files returns list of files
+func (f FakeLoader) Files() ([]string, error) {
+	files, err := f.fs.Glob(filepath.Join(f.Root(), "*"))
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, file := range files {
+		if !f.fs.IsDir(file) {
+			result = append(result, filepath.Base(f))
+		}
+	}
+	return result, nil
 }
 
 // New creates a new loader from a new root.

--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -103,6 +103,21 @@ func (l *fileLoader) Root() string {
 	return l.roots[len(l.roots)-1]
 }
 
+// Files returns the list of files inside the file loader
+func (l *fileLoader) Files() ([]string, error) {
+	files, err := l.fSys.Glob(filepath.Join(l.Root(), "*"))
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, f := range files {
+		if !l.fSys.IsDir(f) {
+			result = append(result, filepath.Base(f))
+		}
+	}
+	return result, nil
+}
+
 func newLoaderOrDie(fSys fs.FileSystem, path string) *fileLoader {
 	l, err := newFileLoaderAt(
 		path, fSys, []string{}, simpleGitCloner)

--- a/pkg/target/util.go
+++ b/pkg/target/util.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"sigs.k8s.io/kustomize/pkg/constants"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/types"
+)
+
+func loadKustFile(ldr ifc.Loader, withDefaultNames bool) ([]byte, error) {
+	if withDefaultNames {
+		for _, kf := range []string{
+			constants.KustomizationFileName,
+			constants.SecondaryKustomizationFileName} {
+			content, err := ldr.Load(kf)
+			if err == nil {
+				return content, nil
+			}
+			if !strings.Contains(err.Error(), "no such file or directory") {
+				return nil, err
+			}
+		}
+		return nil, fmt.Errorf("no kustomization.yaml file under %s", ldr.Root())
+	}
+	var kustFiles []string
+	files, err := ldr.Files()
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range files {
+		if IsKustomizationFile(ldr, f) {
+			kustFiles = append(kustFiles, f)
+		}
+	}
+
+	switch len(kustFiles) {
+	case 0:
+		return nil, fmt.Errorf("no kustomization.yaml file under %s", ldr.Root())
+	case 1:
+		content, err := ldr.Load(kustFiles[0])
+		if err != nil {
+			return nil, err
+		}
+		return content, nil
+	default:
+		return nil, fmt.Errorf("Found multiple files for Kustomization under %s", ldr.Root())
+	}
+}
+
+// IsKustomizationFile checks if a file
+// is a kustomization file by verifying GVK in the file
+func IsKustomizationFile(ldr ifc.Loader, filepath string) bool {
+	content, err := ldr.Load(filepath)
+	if err != nil {
+		return false
+	}
+
+	var it map[string]interface{}
+	err = yaml.Unmarshal(content, &it)
+	if err != nil {
+		return false
+	}
+	if val, ok := it["kind"]; ok {
+		if kind, ok := val.(string); ok {
+			if kind == types.KustomizationKind {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/target/util_test.go
+++ b/pkg/target/util_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"testing"
+)
+
+func writeKustomizationFiles(th *KustTestHarness) {
+	th.writeK("/app/base", `
+namePrefix: a-
+commonLabels:
+  app: myApp
+resources:
+- deployment.yaml
+- service.yaml
+kind: Kustomization
+apiVersion: v1beta1
+`)
+	th.writeF("/app/base/apply.yaml", `
+namePrefix: a-
+commonLabels:
+  app: myApp
+resources:
+- deployment.yaml
+- service.yaml
+kind: Kustomization
+apiVersion: b1
+`)
+	th.writeF("app/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+name: myService
+spec:
+selector:
+backend: bungie
+ports:
+	- port: 7002
+`)
+}
+
+func TestIsKustomizationFile(t *testing.T) {
+	th := NewKustTestHarness(t, "/app/base")
+	writeKustomizationFiles(th)
+	if !IsKustomizationFile(th.ldr, "kustomization.yaml") {
+		t.Errorf("kustomization.yaml in %s is expected to be a kustomization file", th.ldr.Root())
+	}
+	if !IsKustomizationFile(th.ldr, "apply.yaml") {
+		t.Errorf("apply.yaml in %s is expected to be a kustomization file", th.ldr.Root())
+	}
+	if IsKustomizationFile(th.ldr, "service.yaml") {
+		t.Errorf("service.yaml in %s is not kustomization file", th.ldr.Root())
+	}
+}
+
+func TestLoadKustomizationFile(t *testing.T) {
+	th := NewKustTestHarness(t, "/app/base")
+	writeKustomizationFiles(th)
+	_, err := loadKustFile(th.ldr, true)
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	_, err = loadKustFile(th.ldr, false)
+	if err == nil {
+		t.Fatalf("Expected error.")
+	}
+	if err.Error() != "Found multiple files for Kustomization under /app/base" {
+		t.Fatalf("Incorrect error.")
+	}
+}

--- a/pkg/target/utils_for_test.go
+++ b/pkg/target/utils_for_test.go
@@ -59,7 +59,7 @@ func (th *KustTestHarness) makeKustTarget() *KustTarget {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		th.ldr, fakeFs, th.rf, transformer.NewFactoryImpl())
+		th.ldr, fakeFs, th.rf, transformer.NewFactoryImpl(), true)
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}


### PR DESCRIPTION
 kubernetes/kubectl#570 documented some follow ups of the big enable kustomize in kubectl PR kubernetes/kubernetes#70875
This is to fix one of the follow up
- Make resource builder call a library that has options instead of the `builder.NewCmdBuild`

The change is to make `BuildOptions` an exported type. So in cli-runtime, we can do
```
o := NewBuildOptions(path, "", false)
o.RunBuild(...)
```