### PR TITLE
Allow existing but empty resource names

### DIFF
--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -109,7 +109,9 @@ func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error 
 	} else if kind == "List" {
 		return nil
 	}
-	if u.GetName() == "" {
+
+	_, found, err := unstructured.NestedString(u.Object, "metadata", "name")
+	if !found || err != nil {
 		return fmt.Errorf("missing metadata.name in object %v", u)
 	}
 	return nil

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -101,12 +101,16 @@ func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader) {
 }
 
 // validate validates that u has kind and name
+// except for kind `List`, which doesn't require a name
 func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error {
+	kind := u.GetKind()
+	if kind == "" {
+		return fmt.Errorf("missing kind in object %v", u)
+	} else if kind == "List" {
+		return nil
+	}
 	if u.GetName() == "" {
 		return fmt.Errorf("missing metadata.name in object %v", u)
-	}
-	if u.GetKind() == "" {
-		return fmt.Errorf("missing kind in object %v", u)
 	}
 	return nil
 }

--- a/k8sdeps/kunstruct/factory_test.go
+++ b/k8sdeps/kunstruct/factory_test.go
@@ -33,6 +33,15 @@ func TestSliceFromBytes(t *testing.T) {
 				"name": "winnie",
 			},
 		})
+	testList := factory.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "List",
+			"items": []interface{}{
+				testConfigMap.Map(),
+				testConfigMap.Map(),
+			},
+		})
 
 	tests := []struct {
 		name        string
@@ -111,6 +120,24 @@ metadata:
 `),
 			expectedOut: nil,
 			expectedErr: true,
+		},
+		{
+			name: "List",
+			input: []byte(`
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+`),
+			expectedOut: []ifc.Kunstructured{testList},
+			expectedErr: false,
 		},
 	}
 


### PR DESCRIPTION
Hi,

This PR fixes #627. The validation now checks if metadata.name is available but allows empty string.

Best regards,
Florian