### PR TITLE
Check for config merge conflicts and duplication.

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -116,16 +116,16 @@ func (x Gvk) IsLessThan(o Gvk) bool {
 // If `selector` and `x` are the same, return true.
 // If `selector` is nil, it is considered a wildcard match, returning true.
 // If selector fields are empty, they are considered wildcards matching
-// anything in the corresponding fields, .g.
-//   selector
-//       <Group: "",           Version: "",        Kind: "Deployment">
-//   selects
-//       <Group: "extensions", Version: "v1beta1", Kind: "Deployment">.
+// anything in the corresponding fields, e.g.
 //
-//   while selector
+// this item:
+//       <Group: "extensions", Version: "v1beta1", Kind: "Deployment">
+//
+// is selected by
+//       <Group: "",           Version: "",        Kind: "Deployment">
+//
+// but rejected by
 //       <Group: "apps",       Version: "",        Kind: "Deployment">
-//   rejects
-//       <Group: "extensions", Version: "v1beta1", Kind: "Deployment">.
 //
 func (x Gvk) IsSelected(selector *Gvk) bool {
 	if selector == nil {

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -87,7 +87,7 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 			items := u.Map()["items"]
 			itemsSlice, ok := items.([]interface{})
 			if !ok {
-				return nil, fmt.Errorf("items in List is type %T, expected array.", items)
+				return nil, fmt.Errorf("items in List is type %T, expected array", items)
 			}
 			for _, item := range itemsSlice {
 				itemJSON, err := json.Marshal(item)

--- a/pkg/target/customconfig_test.go
+++ b/pkg/target/customconfig_test.go
@@ -150,9 +150,6 @@ spec:
 `)
 }
 
-// TODO: this test demonstrates #658
-// The prefix "x-" is applied twice (search for x-x-sandiego), because the
-// config from the base isn't properly merged with the config in the overlay.
 func TestCustomConfigWithDefaultOverspecification(t *testing.T) {
 	th := NewKustTestHarness(t, "/app/base")
 	makeBaseReferencingCustomConfig(th)
@@ -184,21 +181,21 @@ kind: AnimalPark
 metadata:
   labels:
     app: myApp
-  name: x-x-sandiego
+  name: x-sandiego
 spec:
   food:
   - mimosa
   - bambooshoots
   giraffeRef:
-    name: x-x-april
+    name: x-april
   gorillaRef:
-    name: x-x-koko
+    name: x-koko
 ---
 kind: Giraffe
 metadata:
   labels:
     app: myApp
-  name: x-x-april
+  name: x-april
 spec:
   diet: mimosa
   location: NE
@@ -207,7 +204,7 @@ kind: Giraffe
 metadata:
   labels:
     app: myApp
-  name: x-x-may
+  name: x-may
 spec:
   diet: acacia
   location: SE
@@ -216,7 +213,7 @@ kind: Gorilla
 metadata:
   labels:
     app: myApp
-  name: x-x-koko
+  name: x-koko
 spec:
   diet: bambooshoots
   location: SW

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -134,7 +134,7 @@ func mergeCustomConfigWithDefaults(
 	if err != nil {
 		return nil, err
 	}
-	return t1.Merge(t2), nil
+	return t1.Merge(t2)
 }
 
 // MakeCustomizedResMap creates a ResMap per kustomization instructions.
@@ -194,9 +194,12 @@ func (kt *KustTarget) loadCustomizedResMap() (resmap.ResMap, error) {
 		errs.Append(errors.Wrap(err, "loadResMapFromBasesAndResources"))
 	}
 	crdTc, err := config.NewFactory(kt.ldr).LoadCRDs(kt.kustomization.Crds)
-	kt.tConfig = kt.tConfig.Merge(crdTc)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "LoadCRDs"))
+	}
+	kt.tConfig, err = kt.tConfig.Merge(crdTc)
+	if err != nil {
+		errs.Append(errors.Wrap(err, "merge CRDs"))
 	}
 	resMap, err := kt.generateConfigMapsAndSecrets(errs)
 	if err != nil {

--- a/pkg/transformers/config/factory.go
+++ b/pkg/transformers/config/factory.go
@@ -53,7 +53,10 @@ func (tf *Factory) FromFiles(
 		if err != nil {
 			return nil, err
 		}
-		result = result.Merge(t)
+		result, err = result.Merge(t)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }

--- a/pkg/transformers/config/namebackreferences_test.go
+++ b/pkg/transformers/config/namebackreferences_test.go
@@ -89,17 +89,19 @@ func TestMergeAll(t *testing.T) {
 			Gvk: gvk.Gvk{
 				Kind: "ConfigMap",
 			},
-			// Current behavior allows repeats of FieldSpec
-			FieldSpecs: append(fsSlice1, fsSlice1...),
+			FieldSpecs: fsSlice1,
 		},
 		{
 			Gvk: gvk.Gvk{
 				Kind: "Secret",
 			},
-			FieldSpecs: append(fsSlice2, fsSlice2...),
+			FieldSpecs: fsSlice2,
 		},
 	}
-	actual := nbrsSlice1.mergeAll(nbrsSlice2)
+	actual, err := nbrsSlice1.mergeAll(nbrsSlice2)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expected, actual)
 	}

--- a/pkg/transformers/config/transformerconfig.go
+++ b/pkg/transformers/config/transformerconfig.go
@@ -44,43 +44,70 @@ func (t *TransformerConfig) sortFields() {
 }
 
 // AddPrefixFieldSpec adds a FieldSpec to NamePrefix
-func (t *TransformerConfig) AddPrefixFieldSpec(fs FieldSpec) {
-	t.NamePrefix = append(t.NamePrefix, fs)
+func (t *TransformerConfig) AddPrefixFieldSpec(fs FieldSpec) (err error) {
+	t.NamePrefix, err = t.NamePrefix.mergeOne(fs)
+	return err
 }
 
 // AddSuffixFieldSpec adds a FieldSpec to NameSuffix
-func (t *TransformerConfig) AddSuffixFieldSpec(fs FieldSpec) {
-	t.NameSuffix = append([]FieldSpec{fs}, t.NameSuffix...)
+func (t *TransformerConfig) AddSuffixFieldSpec(fs FieldSpec) (err error) {
+	t.NameSuffix, err = t.NameSuffix.mergeOne(fs)
+	return err
 }
 
 // AddLabelFieldSpec adds a FieldSpec to CommonLabels
-func (t *TransformerConfig) AddLabelFieldSpec(fs FieldSpec) {
-	t.CommonLabels = append(t.CommonLabels, fs)
+func (t *TransformerConfig) AddLabelFieldSpec(fs FieldSpec) (err error) {
+	t.CommonLabels, err = t.CommonLabels.mergeOne(fs)
+	return err
 }
 
 // AddAnnotationFieldSpec adds a FieldSpec to CommonAnnotations
-func (t *TransformerConfig) AddAnnotationFieldSpec(fs FieldSpec) {
-	t.CommonAnnotations = append(t.CommonAnnotations, fs)
+func (t *TransformerConfig) AddAnnotationFieldSpec(fs FieldSpec) (err error) {
+	t.CommonAnnotations, err = t.CommonAnnotations.mergeOne(fs)
+	return err
 }
 
 // AddNamereferenceFieldSpec adds a NameBackReferences to NameReference
-func (t *TransformerConfig) AddNamereferenceFieldSpec(nbrs NameBackReferences) {
-	t.NameReference = t.NameReference.mergeOne(nbrs)
+func (t *TransformerConfig) AddNamereferenceFieldSpec(nbrs NameBackReferences) (err error) {
+	t.NameReference, err = t.NameReference.mergeOne(nbrs)
+	return err
 }
 
 // Merge merges two TransformerConfigs objects into a new TransformerConfig object
-func (t *TransformerConfig) Merge(input *TransformerConfig) *TransformerConfig {
+func (t *TransformerConfig) Merge(input *TransformerConfig) (
+	merged *TransformerConfig, err error) {
 	if input == nil {
-		return t
+		return t, nil
 	}
-	merged := &TransformerConfig{}
-	merged.NamePrefix = append(t.NamePrefix, input.NamePrefix...)
-	merged.NameSuffix = append(input.NameSuffix, t.NameSuffix...)
-	merged.NameSpace = append(t.NameSpace, input.NameSpace...)
-	merged.CommonAnnotations = append(t.CommonAnnotations, input.CommonAnnotations...)
-	merged.CommonLabels = append(t.CommonLabels, input.CommonLabels...)
-	merged.VarReference = append(t.VarReference, input.VarReference...)
-	merged.NameReference = t.NameReference.mergeAll(input.NameReference)
+	merged = &TransformerConfig{}
+	merged.NamePrefix, err = t.NamePrefix.mergeAll(input.NamePrefix)
+	if err != nil {
+		return nil, err
+	}
+	merged.NameSuffix, err = t.NameSuffix.mergeAll(input.NameSuffix)
+	if err != nil {
+		return nil, err
+	}
+	merged.NameSpace, err = t.NameSpace.mergeAll(input.NameSpace)
+	if err != nil {
+		return nil, err
+	}
+	merged.CommonAnnotations, err = t.CommonAnnotations.mergeAll(input.CommonAnnotations)
+	if err != nil {
+		return nil, err
+	}
+	merged.CommonLabels, err = t.CommonLabels.mergeAll(input.CommonLabels)
+	if err != nil {
+		return nil, err
+	}
+	merged.VarReference, err = t.VarReference.mergeAll(input.VarReference)
+	if err != nil {
+		return nil, err
+	}
+	merged.NameReference, err = t.NameReference.mergeAll(input.NameReference)
+	if err != nil {
+		return nil, err
+	}
 	merged.sortFields()
-	return merged
+	return merged, nil
 }

--- a/pkg/transformers/config/transformerconfig_test.go
+++ b/pkg/transformers/config/transformerconfig_test.go
@@ -42,7 +42,10 @@ func TestAddNamereferenceFieldSpec(t *testing.T) {
 		},
 	}
 
-	cfg.AddNamereferenceFieldSpec(nbrs)
+	err := cfg.AddNamereferenceFieldSpec(nbrs)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if len(cfg.NameReference) != 1 {
 		t.Fatal("failed to add namereference FieldSpec")
 	}
@@ -57,19 +60,31 @@ func TestAddFieldSpecs(t *testing.T) {
 		CreateIfNotPresent: true,
 	}
 
-	cfg.AddPrefixFieldSpec(fieldSpec)
+	err := cfg.AddPrefixFieldSpec(fieldSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if len(cfg.NamePrefix) != 1 {
 		t.Fatalf("failed to add nameprefix FieldSpec")
 	}
-	cfg.AddSuffixFieldSpec(fieldSpec)
+	err = cfg.AddSuffixFieldSpec(fieldSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if len(cfg.NameSuffix) != 1 {
 		t.Fatalf("failed to add namesuffix FieldSpec")
 	}
-	cfg.AddLabelFieldSpec(fieldSpec)
+	err = cfg.AddLabelFieldSpec(fieldSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if len(cfg.CommonLabels) != 1 {
 		t.Fatalf("failed to add nameprefix FieldSpec")
 	}
-	cfg.AddAnnotationFieldSpec(fieldSpec)
+	err = cfg.AddAnnotationFieldSpec(fieldSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if len(cfg.CommonAnnotations) != 1 {
 		t.Fatalf("failed to add nameprefix FieldSpec")
 	}
@@ -128,7 +143,10 @@ func TestMerge(t *testing.T) {
 	cfgb.AddPrefixFieldSpec(fieldSpecs[1])
 	cfga.AddSuffixFieldSpec(fieldSpecs[1])
 
-	actual := cfga.Merge(cfgb)
+	actual, err := cfga.Merge(cfgb)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 
 	if len(actual.NamePrefix) != 2 {
 		t.Fatal("merge failed for namePrefix FieldSpec")
@@ -154,7 +172,10 @@ func TestMerge(t *testing.T) {
 		t.Fatalf("expected: %v\n but got: %v\n", expected, actual)
 	}
 
-	actual = cfga.Merge(nil)
+	actual, err = cfga.Merge(nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
 	if !reflect.DeepEqual(actual, cfga) {
 		t.Fatalf("expected: %v\n but got: %v\n", cfga, actual)
 	}


### PR DESCRIPTION
When loading and merging configs, ignore duplicate instructions, and return an error on conflicts.

Example conflict: two FieldSpecs with matching GVK and Path,
but different values of CreateIfNotPresent.

Fixes #658, and shores up testing for config merging up the overlay stack.

