### PR TITLE
Delete deprecated file-based build test code.

### DIFF
--- a/pkg/commands/build/build_test.go
+++ b/pkg/commands/build/build_test.go
@@ -17,28 +17,10 @@ limitations under the License.
 package build
 
 import (
-	"bytes"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
-	"sigs.k8s.io/kustomize/k8sdeps"
 	"sigs.k8s.io/kustomize/pkg/constants"
-	"sigs.k8s.io/kustomize/pkg/fs"
 )
-
-type buildTestCase struct {
-	Description string   `yaml:"description"`
-	Args        []string `yaml:"args"`
-	Filename    string   `yaml:"filename"`
-	// path to the file that contains the expected output
-	ExpectedStdout string `yaml:"expectedStdout"`
-	ExpectedError  string `yaml:"expectedError"`
-}
 
 func TestBuildValidate(t *testing.T) {
 	var cases = []struct {
@@ -73,82 +55,4 @@ func TestBuildValidate(t *testing.T) {
 			t.Errorf("%s: expected path '%s', got '%s'", mycase.name, mycase.path, opts.kustomizationPath)
 		}
 	}
-}
-
-func TestBuild(t *testing.T) {
-	const updateEnvVar = "UPDATE_KUSTOMIZE_EXPECTED_DATA"
-	updateKustomizeExpected := os.Getenv(updateEnvVar) == "true"
-	fSys := fs.MakeRealFS()
-
-	var testcases []string
-	filepath.Walk("testdata", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if path == "testdata" {
-			return nil
-		}
-		name := filepath.Base(path)
-		if info.IsDir() {
-			if strings.HasPrefix(name, "testcase-") {
-				testcases = append(testcases, strings.TrimPrefix(name, "testcase-"))
-			}
-			return filepath.SkipDir
-		}
-		return nil
-	})
-	for _, testcaseName := range testcases {
-		t.Run(testcaseName,
-			func(t *testing.T) {
-				runBuildTestCase(t, testcaseName, updateKustomizeExpected, fSys)
-			})
-	}
-}
-
-func runBuildTestCase(t *testing.T, testcaseName string, updateKustomizeExpected bool, fSys fs.FileSystem) {
-	name := testcaseName
-	testcase := buildTestCase{}
-	testcaseDir := filepath.Join("testdata", "testcase-"+name)
-	testcaseData, err := ioutil.ReadFile(filepath.Join(testcaseDir, "test.yaml"))
-	if err != nil {
-		t.Fatalf("%s: %v", name, err)
-	}
-	if err := yaml.Unmarshal(testcaseData, &testcase); err != nil {
-		t.Fatalf("%s: %v", name, err)
-	}
-
-	ops := &buildOptions{
-		kustomizationPath: testcase.Filename,
-	}
-	buf := bytes.NewBuffer([]byte{})
-	f := k8sdeps.NewFactory()
-	err = ops.RunBuild(
-		buf, fSys,
-		f.ResmapF,
-		f.TransformerF)
-	switch {
-	case err != nil && len(testcase.ExpectedError) == 0:
-		t.Errorf("unexpected error: %v", err)
-	case err != nil && len(testcase.ExpectedError) != 0:
-		if !strings.Contains(err.Error(), testcase.ExpectedError) {
-			t.Errorf("expected error to contain %q but got: %v", testcase.ExpectedError, err)
-		}
-		return
-	case err == nil && len(testcase.ExpectedError) != 0:
-		t.Errorf("unexpected no error")
-	}
-
-	actualBytes := buf.Bytes()
-	if !updateKustomizeExpected {
-		expectedBytes, err := ioutil.ReadFile(testcase.ExpectedStdout)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(actualBytes, expectedBytes) {
-			t.Errorf("\n**** Actual:\n\n%s\n\n**** doesn't equal expected:\n\n%s\n\n", actualBytes, expectedBytes)
-		}
-	} else {
-		ioutil.WriteFile(testcase.ExpectedStdout, actualBytes, 0644)
-	}
-
 }


### PR DESCRIPTION
Replaced by in-memory tests in [pkg/target](https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/target).
The new tests are easier to read and write, and failures are easier to interpret.