### PR TITLE
Pass configs up stack.

### DIFF
--- a/pkg/target/baseandoverlaymedium_test.go
+++ b/pkg/target/baseandoverlaymedium_test.go
@@ -211,6 +211,9 @@ spec:
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
+	// TODO(#669): The name of the patched Deployment is
+	// test-infra-baseprefix-mungebot, retaining the base
+	// prefix (example of correct behavior).
 	th.assertActualEqualsExpected(m, `
 apiVersion: v1
 data:

--- a/pkg/target/baseandoverlaysmall_test.go
+++ b/pkg/target/baseandoverlaysmall_test.go
@@ -136,6 +136,9 @@ spec:
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
+	// TODO(#669): The name of the patched Deployment is
+	// b-a-myDeployment, retaining the base prefix
+	// (example of correct behavior).
 	th.assertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Service

--- a/pkg/target/crd_test.go
+++ b/pkg/target/crd_test.go
@@ -293,7 +293,7 @@ spec:
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
-	// TODO(#605): Some output here is wrong due to #605
+	// TODO(#669): Bee's name should be "prod-x-bee", not "prod-bee".
 	th.assertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -308,9 +308,9 @@ metadata:
   name: prod-x-mykind
 spec:
   beeRef:
-    name: bee
+    name: prod-bee
   secretRef:
-    name: crdsecret
+    name: prod-x-crdsecret
 ---
 apiVersion: v1beta1
 kind: Bee

--- a/pkg/target/customconfig_test.go
+++ b/pkg/target/customconfig_test.go
@@ -221,9 +221,7 @@ spec:
 `)
 }
 
-// TODO: Test demonstrates bug #605.
-// The customization supplied in a base isn't available to the overlay.
-func TestBug605(t *testing.T) {
+func TestFixedBug605_BaseCustomizationAvailableInOverlay(t *testing.T) {
 	th := NewKustTestHarness(t, "/app/overlay")
 	makeBaseReferencingCustomConfig(th)
 	th.writeDefaultConfigs("/app/base/config/defaults.yaml")
@@ -274,13 +272,8 @@ spec:
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
-	// Problems in the expected result:
-	// - The variables are not replaced in the "food" fields.
-	// - The name of the AnimalPark should be x-o-sandiego, since
-	//   AnimalPark appears in the base.
-	// - The giraffe and gorilla name are incorrect in AnimalPark;
-	//   they should be o-x-april and o-ursus respectively.  The
-	//   Gorilla ursus doesn't get an x because it's not in the base.
+	// TODO(#669): The name of AnimalPark be x-o-sandiego,
+	// not o-sandiego, since AnimalPark appears in the base.
 	th.assertActualEqualsExpected(m, `
 kind: AnimalPark
 metadata:
@@ -290,12 +283,12 @@ metadata:
   name: o-sandiego
 spec:
   food:
-  - $(APRIL_DIET)
-  - $(KOKO_DIET)
+  - mimosa
+  - bambooshoots
   giraffeRef:
-    name: april
+    name: o-x-april
   gorillaRef:
-    name: ursus
+    name: o-ursus
 ---
 kind: Giraffe
 metadata:

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -346,10 +346,11 @@ vars:
       name: heron
       apiVersion: v300
 `)
-	vars, err := th.makeKustTarget().getAllVars()
+	cr, err := th.makeKustTarget().loadResMapFromBasesAndResources()
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
+	vars := cr.varMap
 	if len(vars) != 2 {
 		t.Fatalf("unexpected size %d", len(vars))
 	}
@@ -403,10 +404,11 @@ vars:
 bases:
 - ../o1
 `)
-	vars, err := th.makeKustTarget().getAllVars()
+	cr, err := th.makeKustTarget().loadResMapFromBasesAndResources()
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
+	vars := cr.varMap
 	if len(vars) != 4 {
 		t.Fatalf("unexpected size %d", len(vars))
 	}
@@ -452,11 +454,12 @@ vars:
 bases:
 - ../o1
 `)
-	_, err := th.makeKustTarget().getAllVars()
+	_, err := th.makeKustTarget().loadResMapFromBasesAndResources()
 	if err == nil {
 		t.Fatalf("expected var collision")
 	}
-	if _, ok := err.(ErrVarCollision); !ok {
+	if !strings.Contains(err.Error(),
+		"var AWARD in /app/overlays/o1 defined in some other kustomization") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #605 

Most of my recent PR's were dedicated to increasing/improving test coverage to support this change.

There are two commits. Both pass all tests.

The first introduces the CustomizedResMap object to carry config up the stack (fixing #605).

The second is just a cleanup, to eliminate the independent recursion for Var handling, since the CustomizedResMap now provides a place to absorb Vars (just as it does with configs).
