### PR TITLE
make BuildOptions exported

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -29,9 +29,18 @@ import (
 	"sigs.k8s.io/kustomize/pkg/target"
 )
 
-type buildOptions struct {
+// BuildOptions contain the options for running a build
+type BuildOptions struct {
 	kustomizationPath string
 	outputPath        string
+}
+
+// NewBuildOptions creates a BuildOptions object
+func NewBuildOptions(p, o string) *BuildOptions {
+	return &BuildOptions{
+		kustomizationPath: p,
+		outputPath:        o,
+	}
 }
 
 var examples = `
@@ -54,7 +63,7 @@ func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
 	ptf transformer.Factory) *cobra.Command {
-	var o buildOptions
+	var o BuildOptions
 
 	cmd := &cobra.Command{
 		Use:          "build [path]",
@@ -77,7 +86,7 @@ func NewCmdBuild(
 }
 
 // Validate validates build command.
-func (o *buildOptions) Validate(args []string) error {
+func (o *BuildOptions) Validate(args []string) error {
 	if len(args) > 1 {
 		return errors.New("specify one path to " + constants.KustomizationFileName)
 	}
@@ -91,7 +100,7 @@ func (o *buildOptions) Validate(args []string) error {
 }
 
 // RunBuild runs build command.
-func (o *buildOptions) RunBuild(
+func (o *BuildOptions) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
 	rf *resmap.Factory, ptf transformer.Factory) error {
 	ldr, err := loader.NewLoader(o.kustomizationPath, fSys)

--- a/pkg/commands/build/build_test.go
+++ b/pkg/commands/build/build_test.go
@@ -36,7 +36,7 @@ func TestBuildValidate(t *testing.T) {
 			"", "specify one path to " + constants.KustomizationFileName},
 	}
 	for _, mycase := range cases {
-		opts := buildOptions{}
+		opts := BuildOptions{}
 		e := opts.Validate(mycase.args)
 		if len(mycase.erMsg) > 0 {
 			if e == nil {


### PR DESCRIPTION
This is to fix one of the follow up
- Make resource builder call a library that has options instead of the builder.NewCmdBuild

The change is to make BuildOptions an exported type. So in cli-runtime, we can do
```
o := NewBuildOptions(path, "")
o.RunBuild(...)
```

currently `path` should be the directory path containing kustomization.yaml. Later we can extend it to support a file path to kustomization.yaml.