### PR TITLE
add options to disallow executing commands in SecretGenerators

### DIFF
--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -38,13 +38,14 @@ const (
 
 // SecretFactory makes Secrets.
 type SecretFactory struct {
-	fSys fs.FileSystem
-	wd   string
+	fSys            fs.FileSystem
+	wd              string
+	disableCommands bool
 }
 
 // NewSecretFactory returns a new SecretFactory.
-func NewSecretFactory(fSys fs.FileSystem, wd string) *SecretFactory {
-	return &SecretFactory{fSys: fSys, wd: wd}
+func NewSecretFactory(fSys fs.FileSystem, wd string, b bool) *SecretFactory {
+	return &SecretFactory{fSys: fSys, wd: wd, disableCommands: b}
 }
 
 func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
@@ -80,6 +81,9 @@ func (f *SecretFactory) MakeSecret(args *types.SecretArgs, options *types.Genera
 				args.EnvCommand))
 		}
 		all = append(all, pairs...)
+	}
+	if f.disableCommands && len(args.Commands) != 0 {
+		return nil, fmt.Errorf("Executing commands %v in SecretGenerator is not enabled.", args.Commands)
 	}
 	if len(args.Commands) != 0 {
 		pairs, err := f.keyValuesFromCommands(args.Commands, timeout, options)

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMakeSecretNoCommands(t *testing.T) {
-	factory := NewSecretFactory(fs.MakeFakeFS(), "/")
+	factory := NewSecretFactory(fs.MakeFakeFS(), "/", false)
 	args := types.SecretArgs{
 		GeneratorArgs: types.GeneratorArgs{Name: "apple"},
 		Type:          "Opaque",
@@ -45,7 +45,7 @@ func TestMakeSecretNoCommands(t *testing.T) {
 }
 
 func TestMakeSecretNoCommandsBadDir(t *testing.T) {
-	factory := NewSecretFactory(fs.MakeFakeFS(), "/does/not/exist")
+	factory := NewSecretFactory(fs.MakeFakeFS(), "/does/not/exist", false)
 	args := types.SecretArgs{
 		GeneratorArgs: types.GeneratorArgs{Name: "envConfigMap"},
 		Type:          "Opaque",
@@ -60,7 +60,7 @@ func TestMakeSecretNoCommandsBadDir(t *testing.T) {
 }
 
 func TestMakeSecretEmptyCommandMap(t *testing.T) {
-	factory := NewSecretFactory(fs.MakeFakeFS(), "/")
+	factory := NewSecretFactory(fs.MakeFakeFS(), "/", false)
 	args := types.SecretArgs{
 		GeneratorArgs: types.GeneratorArgs{Name: "envConfigMap"},
 		Type:          "Opaque",
@@ -86,7 +86,7 @@ func TestMakeSecretEmptyCommandMap(t *testing.T) {
 }
 
 func TestMakeSecretWithCommandMap(t *testing.T) {
-	factory := NewSecretFactory(fs.MakeFakeFS(), "/")
+	factory := NewSecretFactory(fs.MakeFakeFS(), "/", false)
 	args := types.SecretArgs{
 		GeneratorArgs: types.GeneratorArgs{Name: "envConfigMap"},
 		Type:          "Opaque",

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -95,9 +95,9 @@ func (kf *KunstructuredFactoryImpl) MakeSecret(args *types.SecretArgs, options *
 }
 
 // Set sets loader, filesystem and workdirectory
-func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader) {
+func (kf *KunstructuredFactoryImpl) Set(fs fs.FileSystem, ldr ifc.Loader, b bool) {
 	kf.cmFactory = configmapandsecret.NewConfigMapFactory(fs, ldr)
-	kf.secretFactory = configmapandsecret.NewSecretFactory(fs, ldr.Root())
+	kf.secretFactory = configmapandsecret.NewSecretFactory(fs, ldr.Root(), b)
 }
 
 // validate validates that u has kind and name

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -33,13 +33,15 @@ import (
 type BuildOptions struct {
 	kustomizationPath string
 	outputPath        string
+	disableCommands   bool
 }
 
 // NewBuildOptions creates a BuildOptions object
-func NewBuildOptions(p, o string) *BuildOptions {
+func NewBuildOptions(p, o string, b bool) *BuildOptions {
 	return &BuildOptions{
 		kustomizationPath: p,
 		outputPath:        o,
+		disableCommands:   b,
 	}
 }
 
@@ -95,7 +97,7 @@ func (o *BuildOptions) Validate(args []string) error {
 	} else {
 		o.kustomizationPath = args[0]
 	}
-
+	o.disableCommands = false
 	return nil
 }
 
@@ -108,7 +110,7 @@ func (o *BuildOptions) RunBuild(
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, fSys, rf, ptf)
+	kt, err := target.NewKustTarget(ldr, fSys, rf, ptf, o.disableCommands)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -29,9 +29,18 @@ import (
 	"sigs.k8s.io/kustomize/pkg/target"
 )
 
-type buildOptions struct {
+// BuildOptions contain the options for running a build
+type BuildOptions struct {
 	kustomizationPath string
 	outputPath        string
+}
+
+// NewBuildOptions creates a BuildOptions object
+func NewBuildOptions(p, o string) *BuildOptions {
+	return &BuildOptions{
+		kustomizationPath: p,
+		outputPath:        o,
+	}
 }
 
 var examples = `
@@ -54,7 +63,7 @@ func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
 	ptf transformer.Factory) *cobra.Command {
-	var o buildOptions
+	var o BuildOptions
 
 	cmd := &cobra.Command{
 		Use:          "build [path]",
@@ -77,7 +86,7 @@ func NewCmdBuild(
 }
 
 // Validate validates build command.
-func (o *buildOptions) Validate(args []string) error {
+func (o *BuildOptions) Validate(args []string) error {
 	if len(args) > 1 {
 		return errors.New("specify one path to " + constants.KustomizationFileName)
 	}
@@ -91,7 +100,7 @@ func (o *buildOptions) Validate(args []string) error {
 }
 
 // RunBuild runs build command.
-func (o *buildOptions) RunBuild(
+func (o *BuildOptions) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
 	rf *resmap.Factory, ptf transformer.Factory) error {
 	ldr, err := loader.NewLoader(o.kustomizationPath, fSys)

--- a/pkg/commands/build/build_test.go
+++ b/pkg/commands/build/build_test.go
@@ -36,7 +36,7 @@ func TestBuildValidate(t *testing.T) {
 			"", "specify one path to " + constants.KustomizationFileName},
 	}
 	for _, mycase := range cases {
-		opts := buildOptions{}
+		opts := BuildOptions{}
 		e := opts.Validate(mycase.args)
 		if len(mycase.erMsg) > 0 {
 			if e == nil {

--- a/pkg/commands/edit/add/configmap.go
+++ b/pkg/commands/edit/add/configmap.go
@@ -67,7 +67,7 @@ func newCmdAddConfigMap(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.
 			}
 
 			// Add the flagsAndArgs map to the kustomization file.
-			kf.Set(fSys, loader.NewFileLoaderAtCwd(fSys))
+			kf.Set(fSys, loader.NewFileLoaderAtCwd(fSys), false)
 			err = addConfigMap(kustomization, flagsAndArgs, kf)
 			if err != nil {
 				return err

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -67,7 +67,7 @@ type KunstructuredFactory interface {
 	FromMap(m map[string]interface{}) Kunstructured
 	MakeConfigMap(args *types.ConfigMapArgs, options *types.GeneratorOptions) (Kunstructured, error)
 	MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (Kunstructured, error)
-	Set(fs fs.FileSystem, ldr Loader)
+	Set(fs fs.FileSystem, ldr Loader, disableCommands bool)
 }
 
 // See core.v1.SecretTypeOpaque

--- a/pkg/resmap/factory.go
+++ b/pkg/resmap/factory.go
@@ -107,8 +107,8 @@ func (rmF *Factory) NewResMapFromSecretArgs(argsList []types.SecretArgs, options
 }
 
 // Set sets the filesystem and loader for the underlying factory
-func (rmF *Factory) Set(fs fs.FileSystem, ldr ifc.Loader) {
-	rmF.resF.Set(fs, ldr)
+func (rmF *Factory) Set(fs fs.FileSystem, ldr ifc.Loader, b bool) {
+	rmF.resF.Set(fs, ldr, b)
 }
 
 func newResMapFromResourceSlice(resources []*resource.Resource) (ResMap, error) {

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -231,7 +231,7 @@ BAR=baz
 		// TODO: add testcase for data coming from multiple sources like
 		// files/literal/env etc.
 	}
-	rmF.Set(fs.MakeFakeFS(), l)
+	rmF.Set(fs.MakeFakeFS(), l, false)
 	for _, tc := range testCases {
 		if ferr := l.AddFile(tc.filepath, []byte(tc.content)); ferr != nil {
 			t.Fatalf("Error adding fake file: %v\n", ferr)
@@ -270,7 +270,7 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
-	rmF.Set(fakeFs, loader.NewFileLoaderAtRoot(fakeFs))
+	rmF.Set(fakeFs, loader.NewFileLoaderAtRoot(fakeFs), false)
 	actual, err := rmF.NewResMapFromSecretArgs(secrets, nil)
 
 	if err != nil {
@@ -326,7 +326,7 @@ func TestSecretTimeout(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
-	rmF.Set(fakeFs, loader.NewFileLoaderAtRoot(fakeFs))
+	rmF.Set(fakeFs, loader.NewFileLoaderAtRoot(fakeFs), false)
 	_, err := rmF.NewResMapFromSecretArgs(secrets, nil)
 
 	if err == nil {

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -109,8 +109,8 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 }
 
 // Set sets the filesystem and loader for the underlying factory
-func (rf *Factory) Set(fs fs.FileSystem, ldr ifc.Loader) {
-	rf.kf.Set(fs, ldr)
+func (rf *Factory) Set(fs fs.FileSystem, ldr ifc.Loader, b bool) {
+	rf.kf.Set(fs, ldr, b)
 }
 
 // MakeConfigMap makes an instance of Resource for ConfigMap

--- a/pkg/target/utils_for_test.go
+++ b/pkg/target/utils_for_test.go
@@ -59,7 +59,7 @@ func (th *KustTestHarness) makeKustTarget() *KustTarget {
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		th.ldr, fakeFs, th.rf, transformer.NewFactoryImpl())
+		th.ldr, fakeFs, th.rf, transformer.NewFactoryImpl(), false)
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}


### PR DESCRIPTION
Update `BuildOptions` in customize to following struct
```
type BuildOptions struct {
	kustomizationPath string
	outputPath        string
	disableCommands   bool
}
```

With this change, kubectl can trigger `kustomize build` as follows
```
 // by default, set disableCommands to true
 o := NewBuildOptions(path, "", true)
 o.RunBuild(...)
```
As a result, the behavior of `SecretGenerator` will be different between kustomize and kubectl.
In Kustomize, the commands in SecretGenerator get executed. While in Kubectl, the commands are ignored and no Secret is generated.

If users want a consistent experience for `SecretGenerator` in Kubectl as in Kustomize, we can add a flag in Kubectl to control if those commands are allowed or disallowed.
