### PR TITLE
(proposal) `edit` learns `--kustomization-dir`

### DIFF
--- a/pkg/commands/edit/add/addbase.go
+++ b/pkg/commands/edit/add/addbase.go
@@ -22,17 +22,19 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 type addBaseOptions struct {
+	editopts.Options
 	baseDirectoryPaths string
 }
 
 // newCmdAddBase adds the file path of the kustomize base to the kustomization file.
 func newCmdAddBase(fsys fs.FileSystem) *cobra.Command {
-	var o addBaseOptions
+	o := addBaseOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "base",
@@ -40,7 +42,7 @@ func newCmdAddBase(fsys fs.FileSystem) *cobra.Command {
 		Example: `
 		add base {filepath1},{filepath2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -55,10 +57,16 @@ func newCmdAddBase(fsys fs.FileSystem) *cobra.Command {
 }
 
 // Validate validates addBase command.
-func (o *addBaseOptions) Validate(args []string) error {
+func (o *addBaseOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("must specify a base directory")
 	}
+
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
+	}
+
 	o.baseDirectoryPaths = args[0]
 	return nil
 }
@@ -70,7 +78,7 @@ func (o *addBaseOptions) Complete(cmd *cobra.Command, args []string) error {
 
 // RunAddBase runs addBase command (do real work).
 func (o *addBaseOptions) RunAddBase(fSys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/addmetadata_test.go
+++ b/pkg/commands/edit/add/addmetadata_test.go
@@ -19,6 +19,7 @@ package add
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -28,7 +29,8 @@ import (
 func makeKustomization(t *testing.T) *types.Kustomization {
 	fakeFS := fs.MakeFakeFS()
 	fakeFS.WriteTestKustomization()
-	kf, err := kustfile.NewKustomizationFile(fakeFS)
+
+	kf, err := kustfile.NewKustomizationFile("./", fakeFS)
 	if err != nil {
 		t.Errorf("unexpected new error %v", err)
 	}

--- a/pkg/commands/edit/add/addpatch.go
+++ b/pkg/commands/edit/add/addpatch.go
@@ -21,18 +21,20 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/patch"
 )
 
 type addPatchOptions struct {
+	editopts.Options
 	patchFilePaths []string
 }
 
 // newCmdAddPatch adds the name of a file containing a patch to the kustomization file.
 func newCmdAddPatch(fsys fs.FileSystem) *cobra.Command {
-	var o addPatchOptions
+	o := addPatchOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "patch",
@@ -40,7 +42,7 @@ func newCmdAddPatch(fsys fs.FileSystem) *cobra.Command {
 		Example: `
 		add patch {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -55,9 +57,13 @@ func newCmdAddPatch(fsys fs.FileSystem) *cobra.Command {
 }
 
 // Validate validates addPatch command.
-func (o *addPatchOptions) Validate(args []string) error {
+func (o *addPatchOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return errors.New("must specify a patch file")
+	}
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 	o.patchFilePaths = args
 	return nil
@@ -78,7 +84,7 @@ func (o *addPatchOptions) RunAddPatch(fSys fs.FileSystem) error {
 		return nil
 	}
 
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/addresource.go
+++ b/pkg/commands/edit/add/addresource.go
@@ -21,17 +21,19 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 type addResourceOptions struct {
+	editopts.Options
 	resourceFilePaths []string
 }
 
 // newCmdAddResource adds the name of a file containing a resource to the kustomization file.
 func newCmdAddResource(fsys fs.FileSystem) *cobra.Command {
-	var o addResourceOptions
+	o := addResourceOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "resource",
@@ -39,7 +41,7 @@ func newCmdAddResource(fsys fs.FileSystem) *cobra.Command {
 		Example: `
 		add resource {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -54,9 +56,13 @@ func newCmdAddResource(fsys fs.FileSystem) *cobra.Command {
 }
 
 // Validate validates addResource command.
-func (o *addResourceOptions) Validate(args []string) error {
+func (o *addResourceOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return errors.New("must specify a resource file")
+	}
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 	o.resourceFilePaths = args
 	return nil
@@ -77,7 +83,7 @@ func (o *addResourceOptions) RunAddResource(fSys fs.FileSystem) error {
 		return nil
 	}
 
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/cmapflagsandargs.go
+++ b/pkg/commands/edit/add/cmapflagsandargs.go
@@ -19,11 +19,15 @@ package add
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 // cMapFlagsAndArgs encapsulates the options for add configmap commands.
 type cMapFlagsAndArgs struct {
+	editopts.Options
+
 	// Name of configMap/Secret (required)
 	Name string
 	// FileSources to derive the configMap/Secret from (optional)
@@ -36,9 +40,13 @@ type cMapFlagsAndArgs struct {
 }
 
 // Validate validates required fields are set to support structured generation.
-func (a *cMapFlagsAndArgs) Validate(args []string) error {
+func (a *cMapFlagsAndArgs) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("name must be specified once")
+	}
+	err := a.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 	a.Name = args[0]
 	if len(a.EnvFileSource) == 0 && len(a.FileSources) == 0 && len(a.LiteralSources) == 0 {

--- a/pkg/commands/edit/add/configmap.go
+++ b/pkg/commands/edit/add/configmap.go
@@ -44,19 +44,19 @@ func newCmdAddConfigMap(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.
 	# Adds a configmap from env-file
 	kustomize edit add configmap my-configmap --from-env-file=env/path.env
 `,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := flagsAndArgs.ExpandFileSource(fSys)
 			if err != nil {
 				return err
 			}
 
-			err = flagsAndArgs.Validate(args)
+			err = flagsAndArgs.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
 
 			// Load the kustomization file.
-			mf, err := kustfile.NewKustomizationFile(fSys)
+			mf, err := kustfile.NewKustomizationFile(flagsAndArgs.KustomizationDir, fSys)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/edit/all.go
+++ b/pkg/commands/edit/all.go
@@ -43,6 +43,19 @@ func NewCmdEdit(fsys fs.FileSystem, v ifc.Validator, kf ifc.KunstructuredFactory
 `,
 		Args: cobra.MinimumNArgs(1),
 	}
+
+	// This isn't accessed directly --- we will instead look it up by name in
+	// `editopts.Options.ValidateCommon()`.
+	c.PersistentFlags().StringP(
+		"kustomization-dir",
+		"d",
+		"./",
+		"The directory containing the kustomization file to act upon",
+	)
+
+	// Help tab completion hooks know how to fill out this flag
+	c.MarkPersistentFlagFilename("kustomization-dir")
+
 	c.AddCommand(
 		add.NewCmdAdd(fsys, v, kf),
 		set.NewCmdSet(fsys, v),

--- a/pkg/commands/edit/editopts/editopts.go
+++ b/pkg/commands/edit/editopts/editopts.go
@@ -1,0 +1,20 @@
+package editopts
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	KustomizationDir string
+}
+
+func (o *Options) ValidateCommon(cmd *cobra.Command, args []string) error {
+	var err error
+
+	o.KustomizationDir, err = cmd.Flags().GetString("kustomization-dir")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/commands/edit/fix/fix.go
+++ b/pkg/commands/edit/fix/fix.go
@@ -18,12 +18,19 @@ package fix
 
 import (
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
+type fixOptions struct {
+	editopts.Options
+}
+
 // NewCmdFix returns an instance of 'fix' subcommand.
 func NewCmdFix(fSys fs.FileSystem) *cobra.Command {
+	o := fixOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "fix",
 		Short: "Fix the missing fields in kustomization file",
@@ -34,14 +41,18 @@ func NewCmdFix(fSys fs.FileSystem) *cobra.Command {
 
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunFix(fSys)
+			err := o.ValidateCommon(cmd, args)
+			if err != nil {
+				return err
+			}
+			return o.RunFix(fSys)
 		},
 	}
 	return cmd
 }
 
-func RunFix(fSys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(fSys)
+func (o *fixOptions) RunFix(fSys fs.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/set_name_prefix.go
+++ b/pkg/commands/edit/set/set_name_prefix.go
@@ -20,11 +20,13 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 type setNamePrefixOptions struct {
+	editopts.Options
 	prefix string
 }
 
@@ -42,7 +44,7 @@ will add the field "namePrefix: acme-" to the kustomization file if it doesn't e
 and overwrite the value with "acme-" if the field does exist.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -57,9 +59,13 @@ and overwrite the value with "acme-" if the field does exist.
 }
 
 // Validate validates setNamePrefix command.
-func (o *setNamePrefixOptions) Validate(args []string) error {
+func (o *setNamePrefixOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("must specify exactly one prefix value")
+	}
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 	// TODO: add further validation on the value.
 	o.prefix = args[0]
@@ -73,7 +79,7 @@ func (o *setNamePrefixOptions) Complete(cmd *cobra.Command, args []string) error
 
 // RunSetNamePrefix runs setNamePrefix command (does real work).
 func (o *setNamePrefixOptions) RunSetNamePrefix(fSys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/set_name_suffix.go
+++ b/pkg/commands/edit/set/set_name_suffix.go
@@ -20,11 +20,13 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 type setNameSuffixOptions struct {
+	editopts.Options
 	suffix string
 }
 
@@ -42,7 +44,7 @@ will add the field "nameSuffix: -acme" to the kustomization file if it doesn't e
 and overwrite the value with "-acme" if the field does exist.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -57,9 +59,13 @@ and overwrite the value with "-acme" if the field does exist.
 }
 
 // Validate validates setNameSuffix command.
-func (o *setNameSuffixOptions) Validate(args []string) error {
+func (o *setNameSuffixOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("must specify exactly one suffix value")
+	}
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 	// TODO: add further validation on the value.
 	o.suffix = args[0]
@@ -73,7 +79,7 @@ func (o *setNameSuffixOptions) Complete(cmd *cobra.Command, args []string) error
 
 // RunSetNameSuffix runs setNameSuffix command (does real work).
 func (o *setNameSuffixOptions) RunSetNameSuffix(fSys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/set/setimagetag.go
+++ b/pkg/commands/edit/set/setimagetag.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/pkg/commands/edit/editopts"
 	"sigs.k8s.io/kustomize/pkg/commands/kustfile"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
 
 type setImageTagOptions struct {
+	editopts.Options
 	imageTagMap map[string]types.ImageTag
 }
 
@@ -58,7 +60,7 @@ to the kustomization file if it doesn't exist,
 and overwrite the previous ones if the image tag exists.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -69,9 +71,14 @@ and overwrite the previous ones if the image tag exists.
 }
 
 // Validate validates setImageTag command.
-func (o *setImageTagOptions) Validate(args []string) error {
+func (o *setImageTagOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return errors.New("no image specified")
+	}
+
+	err := o.ValidateCommon(cmd, args)
+	if err != nil {
+		return err
 	}
 
 	o.imageTagMap = make(map[string]types.ImageTag)
@@ -99,7 +106,7 @@ func (o *setImageTagOptions) Validate(args []string) error {
 
 // RunSetImageTags runs setImageTags command (does real work).
 func (o *setImageTagOptions) RunSetImageTags(fSys fs.FileSystem) error {
-	mf, err := kustfile.NewKustomizationFile(fSys)
+	mf, err := kustfile.NewKustomizationFile(o.KustomizationDir, fSys)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I put this together to address a small pain point I encountered while integrating kustomize into my project's build system.  I'm definitely open to different ways to achieve this, or even not using it if there's some rationale I'm missing for why `kustomize edit` doesn't have a configurable target path.

Before this change, the `kustomize edit` subcommand was restricted to
editing `kustomization.yaml` in the current directory.  Usage from
scripts required navigating to the correct directory (pushd/popd) before invoking
`kustomize`.

Since the `kustomize build` subcommand supports specifying an
arbitrary kustomization directory at the command line, it seemed
natural to add similar support to the `kustomize edit` subcommand.

Now, the `kustomize edit` subcommand takes a `--kustomization-dir`
flag (short flag `-d`) that specifies the directory containing the
`kustomization.yaml` file to edit.