### PR TITLE
inject disableNameSuffixHash into resources

### DIFF
--- a/k8sdeps/transformer/hash/namehash.go
+++ b/k8sdeps/transformer/hash/namehash.go
@@ -35,7 +35,7 @@ func NewNameHashTransformer() transformers.Transformer {
 // Transform appends hash to generated resources.
 func (o *nameHashTransformer) Transform(m resmap.ResMap) error {
 	for _, res := range m {
-		if res.IsGenerated() {
+		if res.NeedAppendHash() {
 			h, err := NewKustHash().Hash(res.Map())
 			if err != nil {
 				return err

--- a/k8sdeps/transformer/hash/namehash_test.go
+++ b/k8sdeps/transformer/hash/namehash_test.go
@@ -88,7 +88,7 @@ func TestNameHashTransformer(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name": "secret1",
 				},
-			}).SetBehavior(ifc.BehaviorCreate),
+			}).SetBehavior(ifc.BehaviorCreate).SetAppendHash(true),
 	}
 
 	expected := resmap.ResMap{
@@ -149,7 +149,7 @@ func TestNameHashTransformer(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name": "secret1-7kc45hd5f7",
 				},
-			}).SetBehavior(ifc.BehaviorCreate),
+			}).SetBehavior(ifc.BehaviorCreate).SetAppendHash(true),
 	}
 
 	tran := NewNameHashTransformer()

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -116,6 +116,7 @@ func (m ResMap) DeepCopy(rf *resource.Factory) ResMap {
 	for id, obj := range m {
 		mcopy[id] = rf.FromKunstructured(obj.Copy())
 		mcopy[id].SetBehavior(obj.Behavior())
+		mcopy[id].SetAppendHash(obj.NeedAppendHash())
 	}
 	return mcopy
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -28,7 +28,8 @@ import (
 // paired with a GenerationBehavior.
 type Resource struct {
 	ifc.Kunstructured
-	b ifc.GenerationBehavior
+	b          ifc.GenerationBehavior
+	appendHash bool
 }
 
 // String returns resource as JSON.
@@ -51,9 +52,15 @@ func (r *Resource) SetBehavior(b ifc.GenerationBehavior) *Resource {
 	return r
 }
 
-// IsGenerated checks if the resource is generated from a generator
-func (r *Resource) IsGenerated() bool {
-	return r.b != ifc.BehaviorUnspecified
+// SetAppendHash set the appendHash bool field
+func (r *Resource) SetAppendHash(b bool) *Resource {
+	r.appendHash = b
+	return r
+}
+
+// NeedAppendHash checks if the resource need a hash suffix
+func (r *Resource) NeedAppendHash() bool {
+	return r.appendHash
 }
 
 // Id returns the ResId for the resource.

--- a/pkg/target/generatoroptions_test.go
+++ b/pkg/target/generatoroptions_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"testing"
+)
+
+func TestGeneratorOptionsWithBases(t *testing.T) {
+	th := NewKustTestHarness(t, "/app/overlay")
+	th.writeK("/app/base", `
+apiVersion: v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    foo: bar
+configMapGenerator:
+- name: shouldNotHaveHash
+  literals:
+  - foo=bar
+`)
+	th.writeK("/app/overlay", `
+apiVersion: v1beta1
+kind: Kustomization
+bases:
+- ../base
+generatorOptions:
+  disableNameSuffixHash: false
+  labels:
+    fruit: apple
+configMapGenerator:
+- name: shouldHaveHash
+  literals:
+  - fruit=apple
+`)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  fruit: apple
+kind: ConfigMap
+metadata:
+  labels:
+    fruit: apple
+  name: shouldHaveHash-2k9hc848ff
+---
+apiVersion: v1
+data:
+  foo: bar
+kind: ConfigMap
+metadata:
+  labels:
+    foo: bar
+  name: shouldNotHaveHash
+`)
+}

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -154,7 +154,7 @@ func TestResources1(t *testing.T) {
 					"DB_USERNAME": "admin",
 					"DB_PASSWORD": "somepw",
 				},
-			}).SetBehavior(ifc.BehaviorCreate),
+			}).SetBehavior(ifc.BehaviorCreate).SetAppendHash(true),
 		resid.NewResIdWithPrefixSuffixNamespace(
 			gvk.Gvk{Version: "v1", Kind: "Secret"},
 			"secret", "foo-", "-bar", "ns1"): th.fromMap(
@@ -176,7 +176,7 @@ func TestResources1(t *testing.T) {
 					"DB_USERNAME": base64.StdEncoding.EncodeToString([]byte("admin")),
 					"DB_PASSWORD": base64.StdEncoding.EncodeToString([]byte("somepw")),
 				},
-			}).SetBehavior(ifc.BehaviorCreate),
+			}).SetBehavior(ifc.BehaviorCreate).SetAppendHash(true),
 		resid.NewResIdWithPrefixSuffixNamespace(
 			gvk.Gvk{Version: "v1", Kind: "Namespace"},
 			"ns1", "foo-", "-bar", ""): th.fromMap(


### PR DESCRIPTION
Fix #597 
Change resource to
```
type Resource struct {
	ifc.Kunstructured
	b          ifc.GenerationBehavior
	appendHash bool
}
```
`appendHash` is set based on the value of `generatorOptions.DisableNameSuffixHash` when generating ConfigMaps/Secrets.