### PR TITLE
remove myself from maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,5 @@
 aliases:
   kustomize-admins:
-    - grodrigues3
     - monopole
     - pwittrock
   kustomize-maintainers:


### PR DESCRIPTION
I should not be an approver for this.  And the maintainers alias is used for approvers right now.