### PR TITLE
make apiVersion and kind mandatory

### DIFF
--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -156,15 +156,11 @@ func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
 	if err != nil {
 		return nil, err
 	}
-	data = types.DealWithDeprecatedFields(data)
+	data = types.DealWithDeprecatedAndMissingFields(data)
 	var k types.Kustomization
 	err = yaml.Unmarshal(data, &k)
 	if err != nil {
 		return nil, err
-	}
-	msgs := k.DealWithMissingFields()
-	if len(msgs) > 0 {
-		log.Printf(strings.Join(msgs, "\n"))
 	}
 	err = mf.parseCommentedFields(data)
 	if err != nil {

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -60,6 +60,10 @@ func TestFieldOrder(t *testing.T) {
 
 func TestWriteAndRead(t *testing.T) {
 	kustomization := &types.Kustomization{
+		TypeMeta: types.TypeMeta{
+			APIVersion: "v1beta1",
+			Kind:       "Kustomization",
+		},
 		NamePrefix: "prefix",
 	}
 
@@ -78,7 +82,6 @@ func TestWriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't read kustomization file: %v\n", err)
 	}
-	kustomization.DealWithMissingFields()
 	if !reflect.DeepEqual(kustomization, content) {
 		t.Fatal("Read kustomization is different from written kustomization")
 	}

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -58,18 +57,14 @@ func NewKustTarget(
 	if err != nil {
 		return nil, err
 	}
-	content = types.DealWithDeprecatedFields(content)
 	var k types.Kustomization
 	err = unmarshal(content, &k)
 	if err != nil {
 		return nil, err
 	}
-	msgs, errs := k.EnforceFields()
+	errs := k.EnforceFields()
 	if len(errs) > 0 {
 		return nil, fmt.Errorf(strings.Join(errs, "\n"))
-	}
-	if len(msgs) > 0 {
-		log.Printf(strings.Join(msgs, "\n"))
 	}
 	return &KustTarget{
 		kustomization: &k,


### PR DESCRIPTION
This PR depends on #735 

When `apiVersion`, `kind` are missing from `kustomization.yaml`, users will see following error messages
```
Error: apiVersion is not defined. Please add
        apiVersion: v1beta1
to kustomization.yaml or run `kustomize edit fix`
kind is not defined. Please add
        kind: Kustomization
to kustomization.yaml or run `kustomize edit fix`
```
Running `kustomize edit fix` will add the missing fields:
```

apiVersion: v1beta1

kind: Kustomization

```

discussion in #738
