### PR TITLE
Skip empty object validation

### DIFF
--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -52,6 +52,9 @@ func (kf *KunstructuredFactoryImpl) SliceFromBytes(
 		var out unstructured.Unstructured
 		err = decoder.Decode(&out)
 		if err == nil {
+			if len(out.Object) == 0 {
+				continue
+			}
 			err = kf.validate(out)
 			if err != nil {
 				return nil, err

--- a/k8sdeps/kunstruct/factory_test.go
+++ b/k8sdeps/kunstruct/factory_test.go
@@ -110,6 +110,18 @@ WOOOOOOOOOOOOOOOOOOOOOOOOT:  woot
 			expectedErr: true,
 		},
 		{
+			name: "emptyObjects",
+			input: []byte(`
+---
+#a comment
+
+---
+
+`),
+			expectedOut: []ifc.Kunstructured{},
+			expectedErr: false,
+		},
+		{
 			name: "Missing .metadata.name in object",
 			input: []byte(`
 apiVersion: v1


### PR DESCRIPTION
When built with `k8s.io/apimachinery` at `kubernetes-1.13.1`, empty yaml objects are 'successfully' decoded without error and continue to the validate step, which they fail. (Since, being empty, they lack a 'kind' and 'name') When building with `k8s.io/apimachinery` at `master`, this does not occur - but this is not always sufficient for other projects importing kustomize.

An 'if len(out.Object) == 0' check after parsing succeeds allows the use of older apimachinery versions.