### PR TITLE
Accept a wider variety of kubernetes yaml values

### DIFF
--- a/pkg/target/nullvalues_test.go
+++ b/pkg/target/nullvalues_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target
+
+import (
+	"testing"
+)
+
+func TestNullValues(t *testing.T) {
+	th := NewKustTestHarness(t, "/app")
+	th.writeF("/app/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example
+  name: example
+spec:
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+      - args: null
+        image: image
+        name: example
+`)
+	th.writeF("/app/kustomization.yaml", `
+apiVersion: v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+
+	th.assertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: example
+  name: example
+spec:
+  selector:
+    matchLabels:
+      app: example
+  template:
+    metadata:
+      labels:
+        app: example
+    spec:
+      containers:
+      - args: null
+        image: image
+        name: example
+`)
+}

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -42,6 +42,8 @@ func (rv *refvarTransformer) replaceVars(in interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("%#v is expected to be %T", in, s)
 		}
 		return expansion.Expand(s, rv.mappingFunc), nil
+	case nil:
+		return nil, nil
 	default:
 		return "", fmt.Errorf("invalid type encountered %T", vt)
 	}


### PR DESCRIPTION
this allows kustomize to accept inputs with `args: null`, among other things.


An example input:
`deployment.yaml`
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    app: example
  name: example
spec:
  selector:
    matchLabels:
      app: example
  template:
    metadata:
      labels:
        app: example
    spec:
      containers:
      - args: null
        image: image
        name: example
```
`kustomization.yaml`
```
resources:
- deployment.yaml
apiVersion: v1beta1
kind: Kustomization
```

previous output:
`Error: invalid type encountered <nil>`

new output:
```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    app: example
  name: example
spec:
  selector:
    matchLabels:
      app: example
  template:
    metadata:
      labels:
        app: example
    spec:
      containers:
      - args: null
        image: image
        name: example
```

related to #732, replicatedhq/ship#801