### PR TITLE
Add Service nameReference to APIService

### DIFF
--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -245,6 +245,9 @@ nameReference:
     kind: Ingress
   - path: spec/backend/serviceName
     kind: Ingress
+  - path: spec/service/name
+    kind: APIService
+    group: apiregistration.k8s.io
 
 - kind: Role
   group: rbac.authorization.k8s.io


### PR DESCRIPTION
This is a core API, so I think adding it to default config is appropriate vs. putting it in a custom config.

We probably also want to add a namespace reference for `spec/service/namespace`, but I'm not sure how to do that.