### PR TITLE
minor fix: incorrect apiVersion and add NoOpTransformer for vars

### DIFF
--- a/pkg/target/generatoroptions_test.go
+++ b/pkg/target/generatoroptions_test.go
@@ -20,7 +20,7 @@ import (
 func TestGeneratorOptionsWithBases(t *testing.T) {
 	th := NewKustTestHarness(t, "/app/overlay")
 	th.writeK("/app/base", `
-apiVersion: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 generatorOptions:
   disableNameSuffixHash: true
@@ -32,7 +32,7 @@ configMapGenerator:
   - foo=bar
 `)
 	th.writeK("/app/overlay", `
-apiVersion: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../base

--- a/pkg/target/nullvalues_test.go
+++ b/pkg/target/nullvalues_test.go
@@ -44,7 +44,7 @@ spec:
         name: example
 `)
 	th.writeF("/app/kustomization.yaml", `
-apiVersion: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -18,6 +18,9 @@ type refvarTransformer struct {
 // The fieldSpecs are the places to look for occurrences of $(VAR).
 func NewRefVarTransformer(
 	varMap map[string]string, fs []config.FieldSpec) Transformer {
+	if len(varMap) == 0 {
+		return NewNoOpTransformer()
+	}
 	return &refvarTransformer{
 		fieldSpecs:  fs,
 		mappingFunc: expansion.MappingFuncFor(varMap),


### PR DESCRIPTION
Those tests were added in different PRs. When they merged together with the changing group name PR. It caused test failure.