### PR TITLE
add secret and configmap generator plugins

### DIFF
--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
@@ -34,8 +35,8 @@ type Factory struct {
 
 // NewFactory returns a new Factory.
 func NewFactory(
-	l ifc.Loader, o *types.GeneratorOptions) *Factory {
-	return &Factory{baseFactory{ldr: l, options: o}}
+	l ifc.Loader, o *types.GeneratorOptions, reg plugin.Registry) *Factory {
+	return &Factory{baseFactory{ldr: l, options: o, reg: reg}}
 }
 
 func makeFreshConfigMap(

--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/loader"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -141,8 +142,10 @@ func TestConstructConfigMap(t *testing.T) {
 	fSys.WriteFile("/configmap/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
 	fSys.WriteFile("/configmap/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
 	fSys.WriteFile("/configmap/app.bin", []byte{0xff, 0xfd})
+	ldr := loader.NewFileLoaderAtRoot(fSys)
+	reg := plugin.NewRegistry(ldr)
 	for _, tc := range testCases {
-		f := NewFactory(loader.NewFileLoaderAtRoot(fSys), tc.options)
+		f := NewFactory(ldr, tc.options, reg)
 		cm, err := f.MakeConfigMap(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/loader"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -138,8 +139,10 @@ func TestConstructSecret(t *testing.T) {
 	fSys := fs.MakeFakeFS()
 	fSys.WriteFile("/secret/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
 	fSys.WriteFile("/secret/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
+	ldr := loader.NewFileLoaderAtRoot(fSys)
+	reg := plugin.NewRegistry(ldr)
 	for _, tc := range testCases {
-		f := NewFactory(loader.NewFileLoaderAtRoot(fSys), tc.options)
+		f := NewFactory(ldr, tc.options, reg)
 		cm, err := f.MakeSecret(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/kustomize/k8sdeps/configmapandsecret"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
@@ -81,7 +82,7 @@ func (kf *KunstructuredFactoryImpl) MakeConfigMap(
 	ldr ifc.Loader,
 	options *types.GeneratorOptions,
 	args *types.ConfigMapArgs) (ifc.Kunstructured, error) {
-	o, err := configmapandsecret.NewFactory(ldr, options).MakeConfigMap(args)
+	o, err := configmapandsecret.NewFactory(ldr, options, plugin.NewRegistry(ldr)).MakeConfigMap(args)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,7 @@ func (kf *KunstructuredFactoryImpl) MakeSecret(
 	ldr ifc.Loader,
 	options *types.GeneratorOptions,
 	args *types.SecretArgs) (ifc.Kunstructured, error) {
-	o, err := configmapandsecret.NewFactory(ldr, options).MakeSecret(args)
+	o, err := configmapandsecret.NewFactory(ldr, options, plugin.NewRegistry(ldr)).MakeSecret(args)
 	if err != nil {
 		return nil, err
 	}

--- a/k8sdeps/kv/plugin/goplugin.go
+++ b/k8sdeps/kv/plugin/goplugin.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"plugin"
+)
+
+var _ Factory = &goFactory{}
+
+const (
+	dir = "$HOME/.config/kustomize/plugins/kvsource"
+)
+
+func newGoFactory() *goFactory {
+	return &goFactory{
+		plugins: make(map[string]KVSource),
+	}
+}
+
+type goFactory struct {
+	plugins map[string]KVSource
+}
+
+func (p *goFactory) load(name string) (KVSource, error) {
+	if plug, ok := p.plugins[name]; ok {
+		return plug, nil
+	}
+
+	goPlugin, err := plugin.Open(fmt.Sprintf("%s/kustomize-%s.so", os.ExpandEnv(dir), name))
+	if err != nil {
+		return nil, err
+	}
+
+	symbol, err := goPlugin.Lookup("Plugin")
+	if err != nil {
+		return nil, err
+	}
+
+	plug, ok := symbol.(KVSource)
+	if !ok {
+		return nil, fmt.Errorf("plugin %s not found", name)
+	}
+
+	p.plugins[name] = plug
+	return plug, nil
+}

--- a/k8sdeps/kv/plugin/plugin.go
+++ b/k8sdeps/kv/plugin/plugin.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package plugin provides a plugin abstraction layer.
+package plugin
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kv"
+)
+
+// KVSource is the interface for kv source plugins.
+type KVSource interface {
+	Get(root string, args []string) ([]kv.Pair, error)
+}
+
+// Factory is the interface for new kv source plugin implementations.
+type Factory interface {
+	load(string) (KVSource, error)
+}

--- a/k8sdeps/kv/plugin/registry.go
+++ b/k8sdeps/kv/plugin/registry.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/pkg/ifc"
+)
+
+// Registry holds all the plugin factories.
+type Registry struct {
+	factories map[string]Factory
+	ldr       ifc.Loader
+}
+
+// NewRegistry returns a new Registry loaded with all the factories.
+func NewRegistry(ldr ifc.Loader) Registry {
+	return Registry{
+		ldr: ldr,
+		factories: map[string]Factory{
+			"go":       newGoFactory(),
+			"testonly": newTestonlyFactory(),
+		},
+	}
+}
+
+// Load returns a plugin by type and name,
+func (r *Registry) Load(pluginType, name string) (KVSource, error) {
+	factory, exists := r.factories[pluginType]
+	if !exists {
+		return nil, fmt.Errorf("%s is not a valid plugin type", pluginType)
+	}
+	return factory.load(name)
+}
+
+// Root returns the root of the plugins kustomization file.
+func (r *Registry) Root() string {
+	return r.ldr.Root()
+}

--- a/k8sdeps/kv/plugin/testonly.go
+++ b/k8sdeps/kv/plugin/testonly.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// testonly is temporary until we have builtin plugins to use in the tests.
+
+package plugin
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kv"
+)
+
+var _ Factory = &testonlyFactory{}
+
+func newTestonlyFactory() *testonlyFactory {
+	return &testonlyFactory{}
+}
+
+type testonlyFactory struct{}
+
+func (p testonlyFactory) Get(_ string, args []string) ([]kv.Pair, error) {
+	var kvs []kv.Pair
+	for _, arg := range args {
+		kvs = append(kvs, kv.Pair{Key: "k_" + arg, Value: "v_" + arg})
+	}
+	return kvs, nil
+}
+
+func (p *testonlyFactory) load(name string) (KVSource, error) {
+	return p, nil
+}

--- a/k8sdeps/kv/plugin/testonly.go
+++ b/k8sdeps/kv/plugin/testonly.go
@@ -38,6 +38,6 @@ func (p testonlyFactory) Get(_ string, args []string) ([]kv.Pair, error) {
 	return kvs, nil
 }
 
-func (p *testonlyFactory) load(name string) (KVSource, error) {
+func (p *testonlyFactory) load(_ string) (KVSource, error) {
 	return p, nil
 }

--- a/pkg/target/configmaps_test.go
+++ b/pkg/target/configmaps_test.go
@@ -240,3 +240,31 @@ metadata:
   name: p2-com2-c4b8md75k9
 `)
 }
+
+func TestGeneratorPlugins(t *testing.T) {
+	th := NewKustTestHarness(t, "/app")
+	th.writeK("/app", `
+secretGenerator:
+- name: bob
+  kvSources:
+  - pluginType: testonly
+    name: testonly
+    args:
+    - FRUIT
+    - VEGETABLE
+`)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  k_FRUIT: dl9GUlVJVA==
+  k_VEGETABLE: dl9WRUdFVEFCTEU=
+kind: Secret
+metadata:
+  name: bob-cb9mhbh9gg
+type: Opaque
+`)
+}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -189,6 +189,9 @@ type GeneratorArgs struct {
 
 	// DataSources for the generator.
 	DataSources `json:",inline,omitempty" yaml:",inline,omitempty"`
+
+	// KVSources for the generator.
+	KVSources []KVSource `json:",inline,omitempty" yaml:",inline,omitempty"`
 }
 
 // ConfigMapArgs contains the metadata of how to generate a configmap.
@@ -247,4 +250,11 @@ type GeneratorOptions struct {
 	// suffix to the names of generated resources that is a hash of the
 	// resource contents.
 	DisableNameSuffixHash bool `json:"disableNameSuffixHash,omitempty" yaml:"disableNameSuffixHash,omitempty"`
+}
+
+// KVSource represents a KV plugin backend.
+type KVSource struct {
+	PluginType string   `json:"pluginType,omitempty" yaml:"pluginType,omitempty"`
+	Name       string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Args       []string `json:"args,omitempty" yaml:"args,omitempty"`
 }


### PR DESCRIPTION
This is a POC of my plugin suggestion from #692

Plugins are loaded from `~/.kustomize/plugins` so there is no risk of executing malicious code from a remote base. Also plugins are built out of tree and allows people to create their own integrations.

Also to solve the distribution problem we can provide some base plugins and export them to `~/.kustomize/plugins` with a `kustomize plugin save -d ~/.kustomize/plugins` command.

Some example plugins are provided in the `plugins/` directory. They can be built with `go build -buildmode=plugin`

They can be used as follows:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

secretGenerator:
- name: env-example
  plugins:
  - name: Env
    args:
    - OTHER_PREFIX_EXAMPLE_ENV
    - MY_PREFIX_EXAMPLE_ENV
    filterPrefix: MY_PREFIX_
    stripPrefix: true
```

