### PR TITLE
add volumeMounts/mountPath to varreference

### DIFF
--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -105,5 +105,47 @@ varReference:
 
 - path: spec/tls/hosts
   kind: Ingress
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: StatefulSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: StatefulSet
+
+- path: spec/containers/volumeMounts/mountPath
+  kind: Pod
+
+- path: spec/initContainers/volumeMounts/mountPath
+  kind: Pod
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: ReplicaSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: ReplicaSet
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Job
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: Job
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: CronJob
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: CronJob
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: Deployment
 `
 )


### PR DESCRIPTION
# What it does

Add `volumeMounts` as *varreference*. It uses locations reported in kubernetes api reference docs for containers: [pod-v1-core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#pod-v1-core), [podtemplatespec-v1-core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core)

It addresses to some extent #682 
