### PR TITLE
Improve error msg returned when no kustomization file is found

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,7 +21,7 @@ package constants
 // by Kustomize.
 // In each directory, Kustomize searches for file with the name in this list.
 // Only one match is allowed.
-var KustomizationFileNames = [3]string{
+var KustomizationFileNames = []string{
 	"kustomization.yaml",
 	"kustomization.yml",
 	"Kustomization",

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -88,11 +88,12 @@ func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	}
 	switch match {
 	case 0:
-		return nil, fmt.Errorf("no kustomization.yaml file under %s", ldr.Root())
+		return nil, fmt.Errorf("No kustomization file found in %s. Kustomize supports the following kustomization files: %s",
+			ldr.Root(), strings.Join(constants.KustomizationFileNames, ", "))
 	case 1:
 		return content, nil
 	default:
-		return nil, fmt.Errorf("Found multiple kustomization file under: %s\n", ldr.Root())
+		return nil, fmt.Errorf("Found multiple kustomization files under: %s\n", ldr.Root())
 	}
 }
 


### PR DESCRIPTION
Initial attempt at improving the error message so that the user knows which files are supported by kustomize. 

Very much open to feedback on wording, structure, etc.

Fixes #770 

