### PR TITLE
Rename kv.KVPair to kv.Pair

### DIFF
--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -55,7 +55,7 @@ func (f *ConfigMapFactory) makeFreshConfigMap(
 // MakeConfigMap returns a new ConfigMap, or nil and an error.
 func (f *ConfigMapFactory) MakeConfigMap(
 	args *types.ConfigMapArgs, options *types.GeneratorOptions) (*corev1.ConfigMap, error) {
-	var all []kv.KVPair
+	var all []kv.Pair
 	var err error
 	cm := f.makeFreshConfigMap(args)
 

--- a/k8sdeps/configmapandsecret/kv.go
+++ b/k8sdeps/configmapandsecret/kv.go
@@ -26,20 +26,20 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc"
 )
 
-func keyValuesFromLiteralSources(sources []string) ([]kv.KVPair, error) {
-	var kvs []kv.KVPair
+func keyValuesFromLiteralSources(sources []string) ([]kv.Pair, error) {
+	var kvs []kv.Pair
 	for _, s := range sources {
 		k, v, err := parseLiteralSource(s)
 		if err != nil {
 			return nil, err
 		}
-		kvs = append(kvs, kv.KVPair{Key: k, Value: v})
+		kvs = append(kvs, kv.Pair{Key: k, Value: v})
 	}
 	return kvs, nil
 }
 
-func keyValuesFromFileSources(ldr ifc.Loader, sources []string) ([]kv.KVPair, error) {
-	var kvs []kv.KVPair
+func keyValuesFromFileSources(ldr ifc.Loader, sources []string) ([]kv.Pair, error) {
+	var kvs []kv.Pair
 	for _, s := range sources {
 		k, fPath, err := parseFileSource(s)
 		if err != nil {
@@ -49,12 +49,12 @@ func keyValuesFromFileSources(ldr ifc.Loader, sources []string) ([]kv.KVPair, er
 		if err != nil {
 			return nil, err
 		}
-		kvs = append(kvs, kv.KVPair{Key: k, Value: string(content)})
+		kvs = append(kvs, kv.Pair{Key: k, Value: string(content)})
 	}
 	return kvs, nil
 }
 
-func keyValuesFromEnvFile(l ifc.Loader, path string) ([]kv.KVPair, error) {
+func keyValuesFromEnvFile(l ifc.Loader, path string) ([]kv.Pair, error) {
 	if path == "" {
 		return nil, nil
 	}

--- a/k8sdeps/configmapandsecret/kv_test.go
+++ b/k8sdeps/configmapandsecret/kv_test.go
@@ -29,12 +29,12 @@ func TestKeyValuesFromFileSources(t *testing.T) {
 	tests := []struct {
 		description string
 		sources     []string
-		expected    []kv.KVPair
+		expected    []kv.Pair
 	}{
 		{
 			description: "create kvs from file sources",
 			sources:     []string{"files/app-init.ini"},
-			expected: []kv.KVPair{
+			expected: []kv.Pair{
 				{
 					Key:   "app-init.ini",
 					Value: "FOO=bar",

--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -54,7 +54,7 @@ func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
 
 // MakeSecret returns a new secret.
 func (f *SecretFactory) MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (*corev1.Secret, error) {
-	var all []kv.KVPair
+	var all []kv.Pair
 	var err error
 	s := f.makeFreshSecret(args)
 

--- a/k8sdeps/kv/kv.go
+++ b/k8sdeps/kv/kv.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-type KVPair struct {
+type Pair struct {
 	Key   string
 	Value string
 }
@@ -36,8 +36,8 @@ type KVPair struct {
 var utf8bom = []byte{0xEF, 0xBB, 0xBF}
 
 // KeyValuesFromLines parses given content in to a list of key-value pairs.
-func KeyValuesFromLines(content []byte) ([]KVPair, error) {
-	var kvs []KVPair
+func KeyValuesFromLines(content []byte) ([]Pair, error) {
+	var kvs []Pair
 
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	currentLine := 0
@@ -63,8 +63,8 @@ func KeyValuesFromLines(content []byte) ([]KVPair, error) {
 
 // KeyValuesFromLine returns a kv with blank key if the line is empty or a comment.
 // The value will be retrieved from the environment if necessary.
-func KeyValuesFromLine(line []byte, currentLine int) (KVPair, error) {
-	kv := KVPair{}
+func KeyValuesFromLine(line []byte, currentLine int) (Pair, error) {
+	kv := Pair{}
 
 	if !utf8.Valid(line) {
 		return kv, fmt.Errorf("line %d has invalid utf8 bytes : %v", line, string(line))

--- a/k8sdeps/kv/kv_test.go
+++ b/k8sdeps/kv/kv_test.go
@@ -25,7 +25,7 @@ func TestKeyValuesFromLines(t *testing.T) {
 	tests := []struct {
 		desc          string
 		content       string
-		expectedPairs []KVPair
+		expectedPairs []Pair
 		expectedErr   bool
 	}{
 		{
@@ -34,7 +34,7 @@ func TestKeyValuesFromLines(t *testing.T) {
 		k1=v1
 		k2=v2
 		`,
-			expectedPairs: []KVPair{
+			expectedPairs: []Pair{
 				{Key: "k1", Value: "v1"},
 				{Key: "k2", Value: "v2"},
 			},
@@ -46,7 +46,7 @@ func TestKeyValuesFromLines(t *testing.T) {
 		k1=v1
 		#k2=v2
 		`,
-			expectedPairs: []KVPair{
+			expectedPairs: []Pair{
 				{Key: "k1", Value: "v1"},
 			},
 			expectedErr: false,


### PR DESCRIPTION
nit: structs in a package need not (shouldn't) start with the package name