### PR TITLE
Add nil check to fix #750.

### DIFF
--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -267,7 +267,7 @@ func (l *fileLoader) errIfArgEqualOrHigher(
 // path but a different tag?
 func (l *fileLoader) errIfRepoCycle(newRepoSpec *git.RepoSpec) error {
 	// TODO(monopole): Use parsed data instead of Raw().
-	if strings.HasPrefix(l.repoSpec.Raw(), newRepoSpec.Raw()) {
+	if l.repoSpec != nil && strings.HasPrefix(l.repoSpec.Raw(), newRepoSpec.Raw()) {
 		return fmt.Errorf(
 			"cycle detected: URI '%s' referenced by previous URI '%s'",
 			newRepoSpec.Raw(), l.repoSpec.Raw())


### PR DESCRIPTION
`errIfRepoCycle` is called by `New` when the `repoSpec` is still `nil`.

This change makes a trivial case work on my machine.

`kustomization.yaml`:
```yaml
bases:
- github.com/kubernetes-sigs/kustomize//examples/helloWorld
```

Before:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xde61b0]

goroutine 1 [running]:
sigs.k8s.io/kustomize/pkg/git.(*RepoSpec).Raw(...)
	/go/src/sigs.k8s.io/kustomize/pkg/git/repospec.go:64
sigs.k8s.io/kustomize/pkg/loader.(*fileLoader).errIfRepoCycle(0xc4205b8980, 0xc4200c4b40, 0xc4200c4b40, 0x0)
	/go/src/sigs.k8s.io/kustomize/pkg/loader/fileloader.go:270 +0x30
sigs.k8s.io/kustomize/pkg/loader.(*fileLoader).New(0xc4205b8980, 0xc4203ba800, 0x39, 0xc4202799e0, 0x40fc09, 0xc420254e20, 0x20)
	/go/src/sigs.k8s.io/kustomize/pkg/loader/fileloader.go:167 +0x36d
sigs.k8s.io/kustomize/pkg/target.(*KustTarget).accumulateBases(0xc4205b8a40, 0xc420254e20, 0x40)
	/go/src/sigs.k8s.io/kustomize/pkg/target/kusttarget.go:232 +0x165
sigs.k8s.io/kustomize/pkg/target.(*KustTarget).accumulateTarget(0xc4205b8a40, 0xc420314c60, 0xc420030320, 0x427ff9)
	/go/src/sigs.k8s.io/kustomize/pkg/target/kusttarget.go:145 +0x53
sigs.k8s.io/kustomize/pkg/target.(*KustTarget).MakeCustomizedResMap(0xc4205b8a40, 0xc4205b8980, 0x10dd1e0, 0x16ef2b8)
	/go/src/sigs.k8s.io/kustomize/pkg/target/kusttarget.go:112 +0x2f
sigs.k8s.io/kustomize/pkg/commands/build.(*Options).RunBuild(0xc420254680, 0x10bc560, 0xc42000c018, 0x10dd1e0, 0x16ef2b8, 0xc42000c040, 0x10bff80, 0x16ef2b8, 0x0, 0x0)
	/go/src/sigs.k8s.io/kustomize/pkg/commands/build/build.go:115 +0x125
sigs.k8s.io/kustomize/pkg/commands/build.NewCmdBuild.func1(0xc420158c80, 0x16ef2b8, 0x0, 0x0, 0x0, 0x0)
	/go/src/sigs.k8s.io/kustomize/pkg/commands/build/build.go:78 +0x136
sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra.(*Command).execute(0xc420158c80, 0x16ef2b8, 0x0, 0x0, 0xc420158c80, 0x16ef2b8)
	/go/src/sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra/command.go:756 +0x468
sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420158780, 0xc420158f00, 0xc420217b80, 0xc42014c280)
	/go/src/sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra/command.go:846 +0x30a
sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420158780, 0xc420158780, 0xc420279f48)
	/go/src/sigs.k8s.io/kustomize/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
	/go/src/sigs.k8s.io/kustomize/kustomize.go:27 +0x157
```

After:
```
apiVersion: v1
data:
  altGreeting: Good Morning!
  enableRisky: "false"
kind: ConfigMap
metadata:
  labels:
    app: hello
  name: the-map
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: hello
  name: the-service
spec:
  ports:
  - port: 8666
    protocol: TCP
    targetPort: 8080
  selector:
    app: hello
    deployment: hello
  type: LoadBalancer
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: hello
  name: the-deployment
spec:
  replicas: 3
  selector:
    matchLabels:
      app: hello
  template:
    metadata:
      labels:
        app: hello
        deployment: hello
    spec:
      containers:
      - command:
        - /hello
        - --port=8080
        - --enableRiskyFeature=$(ENABLE_RISKY)
        env:
        - name: ALT_GREETING
          valueFrom:
            configMapKeyRef:
              key: altGreeting
              name: the-map
        - name: ENABLE_RISKY
          valueFrom:
            configMapKeyRef:
              key: enableRisky
              name: the-map
        image: monopole/hello:1
        name: the-container
        ports:
        - containerPort: 8080
```