### PR TITLE
add support for varref in maps values

### DIFF
--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -147,5 +147,7 @@ varReference:
 
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
   kind: Deployment
+
+- path: metadata/labels
 `
 )

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -39,6 +39,17 @@ func (rv *refvarTransformer) replaceVars(in interface{}) (interface{}, error) {
 			xs = append(xs, expansion.Expand(a.(string), rv.mappingFunc))
 		}
 		return xs, nil
+	case map[string]interface{}:
+		inMap := in.(map[string]interface{})
+		xs := make(map[string]interface{}, len(inMap))
+		for k, v := range inMap {
+			s, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("%#v is expected to be %T", v, s)
+			}
+			xs[k] = expansion.Expand(s, rv.mappingFunc)
+		}
+		return xs, nil
 	case interface{}:
 		s, ok := in.(string)
 		if !ok {

--- a/pkg/transformers/refvars_test.go
+++ b/pkg/transformers/refvars_test.go
@@ -1,0 +1,91 @@
+package transformers
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/kustomize/pkg/resid"
+
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/transformers/config"
+)
+
+func TestVarRef(t *testing.T) {
+	type given struct {
+		varMap map[string]string
+		fs     []config.FieldSpec
+		res    resmap.ResMap
+	}
+	type expected struct {
+		res resmap.ResMap
+	}
+	testCases := []struct {
+		description string
+		given       given
+		expected    expected
+	}{
+		{
+			description: "var replacement in map[string]",
+			given: given{
+				varMap: map[string]string{
+					"FOO": "BAR",
+				},
+				fs: []config.FieldSpec{
+					{Gvk: cmap, Path: "data"},
+				},
+				res: resmap.ResMap{
+					resid.NewResId(cmap, "cm1"): rf.FromMap(
+						map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name": "cm1",
+							},
+							"data": map[string]interface{}{
+								"item1": "$(FOO)",
+								"item2": "bla",
+							},
+						}),
+				},
+			},
+			expected: expected{
+				res: resmap.ResMap{
+					resid.NewResId(cmap, "cm1"): rf.FromMap(
+						map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ConfigMap",
+							"metadata": map[string]interface{}{
+								"name": "cm1",
+							},
+							"data": map[string]interface{}{
+								"item1": "BAR",
+								"item2": "bla",
+							},
+						}),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// arrange
+			tr := NewRefVarTransformer(tc.given.varMap, tc.given.fs)
+
+			// act
+			err := tr.Transform(tc.given.res)
+
+			// assert
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			a, e := tc.given.res, tc.expected.res
+			if !reflect.DeepEqual(a, e) {
+				err = e.ErrorIfNotEqual(a)
+				t.Fatalf("actual doesn't match expected: \nACTUAL:\n%v\nEXPECTED:\n%v\nERR: %v", a, e, err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
# What it does

It is the second part of #682. It adds support to replace variables in `map[string]interface{}` fields. This PR adds support specifically to `metadata/labels` and `configMap/data`.
E.g. the var `$(MYVAR)` will be correctly replaced with its value.


```
apiVersion: v1
kind: Deployment
metadata:
  name: my-deployment
  labels:
    my-label: '$(MYVAR)'
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-config
data:
   - foo=$(MYVAR)
```
