### PR TITLE
Test missing kust file message

### DIFF
--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -81,8 +81,8 @@ func (f *ConfigMapFactory) MakeConfigMap(
 	}
 	all = append(all, pairs...)
 
-	for _, kv := range all {
-		err = addKvToConfigMap(cm, kv.Key, kv.Value)
+	for _, p := range all {
+		err = addKvToConfigMap(cm, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -80,8 +80,8 @@ func (f *SecretFactory) MakeSecret(args *types.SecretArgs, options *types.Genera
 	}
 	all = append(all, pairs...)
 
-	for _, kv := range all {
-		err = addKvToSecret(s, kv.Key, kv.Value)
+	for _, p := range all {
+		err = addKvToSecret(s, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -76,6 +76,18 @@ func NewKustTarget(
 	}, nil
 }
 
+func quoted(l []string) []string {
+	r := make([]string, len(l))
+	for i, v := range l {
+		r[i] = "'" + v + "'"
+	}
+	return r
+}
+
+func commaOr(q []string) string {
+	return strings.Join(q[:len(q)-1], ", ") + " or " + q[len(q)-1]
+}
+
 func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	var content []byte
 	match := 0
@@ -88,8 +100,9 @@ func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	}
 	switch match {
 	case 0:
-		return nil, fmt.Errorf("No kustomization file found in %s. Kustomize supports the following kustomization files: %s",
-			ldr.Root(), strings.Join(constants.KustomizationFileNames, ", "))
+		return nil, fmt.Errorf(
+			"unable to find one of %v in directory '%s'",
+			commaOr(quoted(constants.KustomizationFileNames)), ldr.Root())
 	case 1:
 		return content, nil
 	default:

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/internal/loadertest"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
@@ -192,6 +194,18 @@ func TestResources1(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		err = expected.ErrorIfNotEqual(actual)
 		t.Fatalf("unexpected inequality: %v", err)
+	}
+}
+
+func TestKustomizationNotFound(t *testing.T) {
+	_, err := NewKustTarget(
+		loadertest.NewFakeLoader("/foo"), fs.MakeFakeFS(), nil, nil)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if err.Error() !=
+		`unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/foo'` {
+		t.Fatalf("unexpected error: %q", err)
 	}
 }
 


### PR DESCRIPTION
Fixing some code check nits (improper error message, var name matches package name).
Threw in test for the error message.  follow up to #771