### PR TITLE
Switch to black box testing of KustTarget and Resource

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -108,7 +108,7 @@ func (o *Options) RunBuild(
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, fSys, rf, ptf)
+	kt, err := target.NewKustTarget(ldr, rf, ptf)
 	if err != nil {
 		return err
 	}

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resource
+package resource_test
 
 import (
 	"reflect"
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/kustomize/pkg/internal/loadertest"
 	"sigs.k8s.io/kustomize/pkg/patch"
+	. "sigs.k8s.io/kustomize/pkg/resource"
 )
 
 func TestSliceFromPatches(t *testing.T) {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -38,7 +38,7 @@ func (r *Resource) String() string {
 	if err != nil {
 		return "<" + err.Error() + ">"
 	}
-	return strings.TrimSpace(string(bs))
+	return strings.TrimSpace(string(bs)) + r.options.String()
 }
 
 // DeepCopy returns a new copy of resource

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resource
+package resource_test
 
 import (
 	"testing"
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/resid"
+	. "sigs.k8s.io/kustomize/pkg/resource"
 )
 
 var factory = NewFactory(
@@ -37,7 +38,9 @@ var testConfigMap = factory.FromMap(
 		},
 	})
 
-const testConfigMapString = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"winnie","namespace":"hundred-acre-wood"}}`
+const genArgOptions = "{nsfx:false,beh:unspecified}"
+
+const configMapAsString = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"winnie","namespace":"hundred-acre-wood"}}`
 
 var testDeployment = factory.FromMap(
 	map[string]interface{}{
@@ -48,7 +51,7 @@ var testDeployment = factory.FromMap(
 		},
 	})
 
-const testDeploymentString = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"pooh"}}`
+const deploymentAsString = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"pooh"}}`
 
 func TestResourceString(t *testing.T) {
 	tests := []struct {
@@ -57,11 +60,11 @@ func TestResourceString(t *testing.T) {
 	}{
 		{
 			in: testConfigMap,
-			s:  testConfigMapString,
+			s:  configMapAsString + genArgOptions,
 		},
 		{
 			in: testDeployment,
-			s:  testDeploymentString,
+			s:  deploymentAsString + genArgOptions,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/target/baseandoverlaymedium_test.go
+++ b/pkg/target/baseandoverlaymedium_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/baseandoverlaysmall_test.go
+++ b/pkg/target/baseandoverlaysmall_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/configmaps_test.go
+++ b/pkg/target/configmaps_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/crd_test.go
+++ b/pkg/target/crd_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/customconfig_test.go
+++ b/pkg/target/customconfig_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/generatormergeandreplace_test.go
+++ b/pkg/target/generatormergeandreplace_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/generatoroptions_test.go
+++ b/pkg/target/generatoroptions_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/kusttestharness_test.go
+++ b/pkg/target/kusttestharness_test.go
@@ -14,24 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 // A collection of utilities used in target tests.
 
 import (
 	"fmt"
 	"path/filepath"
-	"sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig"
 	"strings"
 	"testing"
 
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/pkg/constants"
-	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/internal/loadertest"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
+	. "sigs.k8s.io/kustomize/pkg/target"
+	"sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
 
@@ -50,17 +50,8 @@ func NewKustTestHarness(t *testing.T, path string) *KustTestHarness {
 }
 
 func (th *KustTestHarness) makeKustTarget() *KustTarget {
-	// Warning: the following filesystem - a fake - must be rooted at /.
-	// This fs root is used as the working directory for the shell spawned by
-	// the secretgenerator, and has nothing to do with the filesystem used
-	// to load relative paths from the fake filesystem.
-	// This trick only works for secret generator commands that don't actually
-	// try to read the file system, because these tests don't write to the
-	// real "/" directory.  See use of exec package in the secretfactory.
-	fakeFs := fs.MakeFakeFS()
-	fakeFs.Mkdir("/")
 	kt, err := NewKustTarget(
-		th.ldr, fakeFs, th.rf, transformer.NewFactoryImpl())
+		th.ldr, th.rf, transformer.NewFactoryImpl())
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}

--- a/pkg/target/multiplepatch_test.go
+++ b/pkg/target/multiplepatch_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"strings"

--- a/pkg/target/namespacedgenerators_test.go
+++ b/pkg/target/namespacedgenerators_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/nullvalues_test.go
+++ b/pkg/target/nullvalues_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/target/resaccumulator.go
+++ b/pkg/target/resaccumulator.go
@@ -55,6 +55,11 @@ func (ra *ResAccumulator) ResMap() resmap.ResMap {
 	return result
 }
 
+// Vars returns a copy of underlying vars.
+func (ra *ResAccumulator) Vars() []types.Var {
+	return ra.varSet.Set()
+}
+
 func (ra *ResAccumulator) MergeResourcesWithErrorOnIdCollision(
 	resources resmap.ResMap) (err error) {
 	ra.resMap, err = resmap.MergeWithErrorOnIdCollision(

--- a/pkg/target/resaccumulator_test.go
+++ b/pkg/target/resaccumulator_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"strings"
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
+	. "sigs.k8s.io/kustomize/pkg/target"
 	"sigs.k8s.io/kustomize/pkg/transformers/config"
 	"sigs.k8s.io/kustomize/pkg/types"
 )

--- a/pkg/target/resourceconflict_test.go
+++ b/pkg/target/resourceconflict_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"strings"

--- a/pkg/target/variableref_test.go
+++ b/pkg/target/variableref_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package target_test
 
 import (
 	"testing"

--- a/pkg/types/genargs.go
+++ b/pkg/types/genargs.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package types
 
+import (
+	"strconv"
+	"strings"
+)
+
 // GenArgs contains both generator args and options
 type GenArgs struct {
 	args *GeneratorArgs
@@ -28,6 +33,18 @@ func NewGenArgs(args *GeneratorArgs, opts *GeneratorOptions) *GenArgs {
 		args: args,
 		opts: opts,
 	}
+}
+
+func (g *GenArgs) String() string {
+	if g == nil {
+		return "{nilGenArgs}"
+	}
+	return "{" +
+		strings.Join([]string{
+			"nsfx:" + strconv.FormatBool(g.NeedsHashSuffix()),
+			"beh:" + g.Behavior().String()},
+			",") +
+		"}"
 }
 
 // NeedHashSuffix returns true if the hash suffix is needed.

--- a/pkg/types/genargs_test.go
+++ b/pkg/types/genargs_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types_test
+
+import (
+	"testing"
+
+	. "sigs.k8s.io/kustomize/pkg/types"
+)
+
+func TestGenArgs_String(t *testing.T) {
+	tests := []struct {
+		ga       *GenArgs
+		expected string
+	}{
+		{
+			ga:       nil,
+			expected: "{nilGenArgs}",
+		},
+		{
+			ga:       &GenArgs{},
+			expected: "{nsfx:false,beh:unspecified}",
+		},
+		{
+			ga: NewGenArgs(
+				&GeneratorArgs{Behavior: "merge"},
+				&GeneratorOptions{DisableNameSuffixHash: false}),
+			expected: "{nsfx:true,beh:merge}",
+		},
+	}
+	for _, test := range tests {
+		if test.ga.String() != test.expected {
+			t.Fatalf("Expected '%s', got '%s'", test.expected, test.ga.String())
+		}
+	}
+}

--- a/pkg/types/var.go
+++ b/pkg/types/var.go
@@ -75,9 +75,11 @@ type VarSet struct {
 	set []Var
 }
 
-// Set returns the var set.
+// Set returns a copy of the var set.
 func (vs *VarSet) Set() []Var {
-	return vs.set
+	s := make([]Var, len(vs.set))
+	copy(s, vs.set)
+	return s
 }
 
 // MergeSet absorbs other vars with error on name collision.


### PR DESCRIPTION
Previous test refactors of KustTarget and Resource have been building to a black box format which constrains one to using public methods only.  This PR finishes this off.

Now the target package tests will be black box, which is what we want for these relatively high level tests.

This PR also gets rid of a last vestige of the "use exec to make secrets" code path, in which we needed to pass a FileSystem into the kusttarget to provide a working directory for the child process.  That var passage is dropped here.
