### PR TITLE
Allow all kind list types

### DIFF
--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -108,7 +108,7 @@ func (kf *KunstructuredFactoryImpl) validate(u unstructured.Unstructured) error 
 	kind := u.GetKind()
 	if kind == "" {
 		return fmt.Errorf("missing kind in object %v", u)
-	} else if kind == "List" {
+	} else if strings.HasSuffix(kind, "List") {
 		return nil
 	}
 	if u.GetName() == "" {

--- a/k8sdeps/kunstruct/factory_test.go
+++ b/k8sdeps/kunstruct/factory_test.go
@@ -42,6 +42,15 @@ func TestSliceFromBytes(t *testing.T) {
 				testConfigMap.Map(),
 			},
 		})
+	testConfigMapList := factory.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMapList",
+			"items": []interface{}{
+				testConfigMap.Map(),
+				testConfigMap.Map(),
+			},
+		})
 
 	tests := []struct {
 		name        string
@@ -149,6 +158,24 @@ items:
     name: winnie
 `),
 			expectedOut: []ifc.Kunstructured{testList},
+			expectedErr: false,
+		},
+		{
+			name: "ConfigMapList",
+			input: []byte(`
+apiVersion: v1
+kind: ConfigMapList
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: winnie
+`),
+			expectedOut: []ifc.Kunstructured{testConfigMapList},
 			expectedErr: false,
 		},
 	}

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	internal "sigs.k8s.io/kustomize/pkg/internal/error"
@@ -94,10 +95,14 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 	for len(kunStructs) > 0 {
 		u := kunStructs[0]
 		kunStructs = kunStructs[1:]
-		if u.GetKind() == "List" {
+		if strings.HasSuffix(u.GetKind(), "List") {
 			items := u.Map()["items"]
 			itemsSlice, ok := items.([]interface{})
 			if !ok {
+				if items == nil {
+					// an empty list
+					continue
+				}
 				return nil, fmt.Errorf("items in List is type %T, expected array", items)
 			}
 			for _, item := range itemsSlice {

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -94,6 +94,11 @@ apiVersion: v1
 kind: List
 items:
 `
+	patchList4 := patch.StrategicMerge("patch7.yaml")
+	patch7 := `
+apiVersion: v1
+kind: List
+`
 	testDeploymentSpec := map[string]interface{}{
 		"template": map[string]interface{}{
 			"spec": map[string]interface{}{
@@ -133,6 +138,7 @@ items:
 	l.AddFile("/"+string(patchList), []byte(patch4))
 	l.AddFile("/"+string(patchList2), []byte(patch5))
 	l.AddFile("/"+string(patchList3), []byte(patch6))
+	l.AddFile("/"+string(patchList4), []byte(patch7))
 
 	tests := []struct {
 		name        string
@@ -173,6 +179,12 @@ items:
 		{
 			name:        "listWithNoEntries",
 			input:       []patch.StrategicMerge{patchList3},
+			expectedOut: []*Resource{},
+			expectedErr: false,
+		},
+		{
+			name:        "listWithNo'items:'",
+			input:       []patch.StrategicMerge{patchList4},
 			expectedOut: []*Resource{},
 			expectedErr: false,
 		},

--- a/pkg/resource/factory_test.go
+++ b/pkg/resource/factory_test.go
@@ -68,7 +68,7 @@ items:
 	patchList2 := patch.StrategicMerge("patch5.yaml")
 	patch5 := `
 apiVersion: v1
-kind: List
+kind: DeploymentList
 items:
 - apiVersion: apps/v1
   kind: Deployment
@@ -87,6 +87,12 @@ items:
     name: deployment-b
   spec:
     <<: *hostAliases
+`
+	patchList3 := patch.StrategicMerge("patch6.yaml")
+	patch6 := `
+apiVersion: v1
+kind: List
+items:
 `
 	testDeploymentSpec := map[string]interface{}{
 		"template": map[string]interface{}{
@@ -126,6 +132,7 @@ items:
 	l.AddFile("/"+string(patchBad), []byte(patch3))
 	l.AddFile("/"+string(patchList), []byte(patch4))
 	l.AddFile("/"+string(patchList2), []byte(patch5))
+	l.AddFile("/"+string(patchList3), []byte(patch6))
 
 	tests := []struct {
 		name        string
@@ -161,6 +168,12 @@ items:
 			name:        "listWithAnchorReference",
 			input:       []patch.StrategicMerge{patchList2},
 			expectedOut: []*Resource{testDeploymentA, testDeploymentB},
+			expectedErr: false,
+		},
+		{
+			name:        "listWithNoEntries",
+			input:       []patch.StrategicMerge{patchList3},
+			expectedOut: []*Resource{},
 			expectedErr: false,
 		},
 	}


### PR DESCRIPTION
Resolves #688 by treating all kinds with suffix 'List' as lists. Also treats 'nil' lists as a noop, not an error.