### PR TITLE
Fixed springboot example.

### DIFF
--- a/examples/springboot/base/application.properties
+++ b/examples/springboot/base/application.properties
@@ -1,0 +1,1 @@
+app.name=Kustomize Demo

--- a/examples/springboot/base/kustomization.yaml
+++ b/examples/springboot/base/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployment.yaml
+- service.yaml
+

--- a/examples/springboot/base/kustomization.yaml
+++ b/examples/springboot/base/kustomization.yaml
@@ -1,4 +1,7 @@
 resources:
 - deployment.yaml
 - service.yaml
-
+configMapGenerator:
+- files:
+    - application.properties
+  name: demo-configmap

--- a/examples/springboot/overlays/production/application-prod.properties
+++ b/examples/springboot/overlays/production/application-prod.properties
@@ -1,0 +1,2 @@
+spring.datasource.username=root
+spring.datasource.password=admin

--- a/examples/springboot/overlays/production/application.properties
+++ b/examples/springboot/overlays/production/application.properties
@@ -1,5 +1,3 @@
-app.name=Staging Kinflate Demo
+app.name=Production Kinflate Demo
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://<production_db_ip>:3306/db_example
-spring.datasource.username=root
-spring.datasource.password=admin

--- a/examples/springboot/overlays/production/kustomization.yaml
+++ b/examples/springboot/overlays/production/kustomization.yaml
@@ -1,8 +1,7 @@
 bases:
 - ../../base
-resources:
-- patch.yaml
 patchesStrategicMerge:
+- patch.yaml
 - healthcheck_patch.yaml
 - memorylimit_patch.yaml
 namePrefix: production-

--- a/examples/springboot/overlays/production/kustomization.yaml
+++ b/examples/springboot/overlays/production/kustomization.yaml
@@ -1,7 +1,8 @@
 bases:
 - ../../base
-patchesStrategicMerge:
+resources:
 - patch.yaml
+patchesStrategicMerge:
 - healthcheck_patch.yaml
 - memorylimit_patch.yaml
 namePrefix: production-

--- a/examples/springboot/overlays/production/kustomization.yaml
+++ b/examples/springboot/overlays/production/kustomization.yaml
@@ -5,3 +5,11 @@ patchesStrategicMerge:
 - healthcheck_patch.yaml
 - memorylimit_patch.yaml
 namePrefix: production-
+commonLabels:
+  env: prod
+configMapGenerator:
+- name: demo-configmap
+  behavior: merge
+  files:
+  - application.properties
+  - application-prod.properties

--- a/examples/springboot/overlays/production/patch.yaml
+++ b/examples/springboot/overlays/production/patch.yaml
@@ -1,13 +1,12 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: apps/v1beta2
+kind: Deployment
 metadata:
-  name: demo-configmap
-data:
-  application.properties: |
-    app.name=Production Kinflate Demo
-    spring.jpa.hibernate.ddl-auto=update
-    spring.datasource.url=jdbc:mysql://<production_db_ip>:3306/db_example
-    spring.datasource.username=root
-    spring.datasource.password=admin
-    server.tomcat.max-threads=20
-    server.tomcat.min-spare-threads=3
+  name: sbdemo
+spec:
+  template:
+    spec:
+      containers:
+      - name: sbdemo
+        env:
+        - name: spring.profiles.active
+          value: prod

--- a/examples/springboot/overlays/staging/kustomization.yaml
+++ b/examples/springboot/overlays/staging/kustomization.yaml
@@ -3,9 +3,9 @@ bases:
 namePrefix: staging-
 configMapGenerator:
 - name: demo-configmap
-  behavior: merge
   files:
     - application.properties
   literals:
     - foo=bar
   env: staging.env
+

--- a/examples/springboot/overlays/staging/kustomization.yaml
+++ b/examples/springboot/overlays/staging/kustomization.yaml
@@ -3,9 +3,9 @@ bases:
 namePrefix: staging-
 configMapGenerator:
 - name: demo-configmap
+  behavior: merge
   files:
     - application.properties
   literals:
     - foo=bar
   env: staging.env
-

--- a/examples/springboot/overlays/staging/staging.env
+++ b/examples/springboot/overlays/staging/staging.env
@@ -1,1 +1,1 @@
-staging
+environment=staging


### PR DESCRIPTION
Fix for https://github.com/kubernetes-sigs/kustomize/issues/792

Before this fix, the following failures were observed with the springboot example:
```bash
$ cd examples/springboot

$ kustomize build overlays/staging
Error: couldn't make target for ../../base: No kustomization file found in /Users/adeshmukh/github.com/kubernetes-sigs/kustomize/examples/springboot/base. Kustomize supports the following kustomization files: kustomization.yaml, kustomization.yml, Kustomization

$ kustomize build overlays/production
Error: couldn't make target for ../../base: No kustomization file found in /Users/adeshmukh/github.com/kubernetes-sigs/kustomize/examples/springboot/base. Kustomize supports the following kustomization files: kustomization.yaml, kustomization.yml, Kustomization
```

With this change, both `kustomize build overlays/staging` and `kustomize build overlays/production` work fine.