### PR TITLE
Add doc indicating existing of 'behavior' in configMapGenerator

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -76,6 +76,9 @@ resources:
 # The example below creates two ConfigMaps. One with the
 # names and contents of the given files, the other with
 # key/value as data.
+# The configMapGenerator accepts a paramter of
+# behavior: [create|replace|merge]. This can allow 
+# an overlay to augment the configMapGenerator of the parent
 configMapGenerator:
 - name: myJavaServerProps
   files:

--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -76,9 +76,9 @@ resources:
 # The example below creates two ConfigMaps. One with the
 # names and contents of the given files, the other with
 # key/value as data.
-# The configMapGenerator accepts a paramter of
-# behavior: [create|replace|merge]. This can allow 
-# an overlay to augment the configMapGenerator of the parent
+# Each configMapGenerator item accepts a parameter of
+# behavior: [create|replace|merge]. This allows an overlay to modify or
+# replace an existing configMap from the parent.
 configMapGenerator:
 - name: myJavaServerProps
   files:


### PR DESCRIPTION
It appears from the code that configMapGenerator can take
a parameter of 'behavior' which is 'merge','create','replace'.
Add note to the 'docs/kustomization.yaml' indicating so.

Signed-off-by: Don Bowman <don@agilicus.com>