### PR TITLE
fix absolute path for temp folder in MacOs

### DIFF
--- a/pkg/fs/confirmeddir.go
+++ b/pkg/fs/confirmeddir.go
@@ -26,7 +26,7 @@ import (
 // that was confirmed to point to an existing directory.
 type ConfirmedDir string
 
-// Return a temporary dir, else error.
+// NewTmpConfirmedDir returns a temporary dir, else error.
 // The directory is cleaned, no symlinks, etc. so its
 // returned as a ConfirmedDir.
 func NewTmpConfirmedDir() (ConfirmedDir, error) {
@@ -34,7 +34,15 @@ func NewTmpConfirmedDir() (ConfirmedDir, error) {
 	if err != nil {
 		return "", err
 	}
-	return ConfirmedDir(n), nil
+
+	// In MacOs `ioutil.TempDir` creates a directory
+	// with root in the `/var` folder, which is in turn a symlinked path
+	// to `/private/var`.
+	// Function `filepath.EvalSymlinks`is used to
+	// resolve the real absolute path.
+	deLinked, err := filepath.EvalSymlinks(n)
+	return ConfirmedDir(deLinked), err
+
 }
 
 // HasPrefix returns true if the directory argument

--- a/pkg/fs/confirmeddir_test.go
+++ b/pkg/fs/confirmeddir_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fs
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -99,5 +100,20 @@ func TestHasPrefix_SlashFooBar(t *testing.T) {
 	}
 	if !d.HasPrefix("/") {
 		t.Fatalf("/foo/bar should have prefix /")
+	}
+}
+
+func TestNewTempConfirmDir(t *testing.T) {
+	tmp, err := NewTmpConfirmedDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	delinked, err := filepath.EvalSymlinks(string(tmp))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(tmp) != delinked {
+		t.Fatalf("unexpected path containing symlinks")
 	}
 }

--- a/pkg/fs/realfs_test.go
+++ b/pkg/fs/realfs_test.go
@@ -27,7 +27,11 @@ import (
 
 func makeTestDir(t *testing.T) (FileSystem, string) {
 	x := MakeRealFS()
-	testDir, err := ioutil.TempDir("", "kustomize_testing_dir")
+	td, err := ioutil.TempDir("", "kustomize_testing_dir")
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	testDir, err := filepath.EvalSymlinks(td)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}


### PR DESCRIPTION
# What it does

- Return a cleaned absolute path without symlinks when creating a new temporal dir.
- Add test
- fix macOs broken tests in `pkg/fs/realfs_test.go`
- Fix issue #810
