### PR TITLE
update transformerconfigs/crd example

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -201,7 +201,7 @@ patchesJson6902:
   path: add_service_annotation.yaml
 
 # Each entry in this list should be a relative path to
-# a file for custom resource definition(CRD).
+# a file for custom resource definition(CRD) in openAPI definition.
 #
 # The presence of this field is to allow kustomize be
 # aware of CRDs and apply proper
@@ -211,9 +211,17 @@ patchesJson6902:
 # In kustomization, the ConfigMap object name may change by adding namePrefix, nameSuffix, or hashing
 # The name reference for this ConfigMap object in CRD object need to be
 # updated with namePrefix, nameSuffix, or hashing in the same way.
+#
+# The annotations can be put into openAPI definitions are:
+#   "x-kubernetes-annotation": ""
+#   "x-kubernetes-label-selector": ""
+#   "x-kubernetes-identity": ""
+#   "x-kubernetes-object-ref-api-version": "v1",
+#   "x-kubernetes-object-ref-kind": "Secret",
+#   "x-kubernetes-object-ref-name-key": "name",
 crds:
-- crds/typeA.yaml
-- crds/typeB.yaml
+- crds/typeA.json
+- crds/typeB.json
 
 # Vars are used to capture text from one resource's field
 # and insert that text elsewhere.

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -91,6 +91,5 @@ nameReference:
 
 Kustomize has a default set of configurations. They can be saved to local directory through `kustomize config save -d`. Kustomize allows modifying those configuration files and using them in kustomization.yaml file. This tutorial shows how to customize those configurations to
 - [support a CRD type](crd/README.md)
-- disabling adding commonLabels to fields in some kind of resources
 - add extra fields for variable substitution
 - add extra fields for name reference

--- a/examples/transformerconfigs/crd/README.md
+++ b/examples/transformerconfigs/crd/README.md
@@ -8,38 +8,6 @@ Create a workspace by
 DEMO_HOME=$(mktemp -d)
 ```
 
-### Get the native config as a starting point
-
-Get the default transformer configurations using this command:
-
-<!-- @saveConfig @test -->
-```
-kustomize config save -d $DEMO_HOME/kustomizeconfig
-```
-The default configurations are saved
-in the directory `$DEMO_HOME/kustomizeconfig` as several files
-
-> ```
-> commonannotations.yaml
-> commonlabels.yaml
-> nameprefix.yaml
-> namereference.yaml
-> namespace.yaml
-> varreference.yaml
-> ```
-
-These files contain the field specifications for native resources
-that transformation directives like `namePrefix`, `commonLabels`, etc.
-need to do their work.
-
-These default configurations already include some common
-field specifictions for all types:
-
-- nameprefix is added to `.metadata.name`
-- namespace is added to `.metadata.namespace`
-- labels is added to `.metadata.labels`
-- annotations is added to `.metadata.annotations`
-
 ### Adding a custom resource
 
 Consider a CRD of kind `MyKind` with fields
@@ -51,6 +19,7 @@ Consider a CRD of kind `MyKind` with fields
 Add the following file to configure the transformers for the above fields
 <!-- @addConfig @test -->
 ```
+mkdir $DEMO_HOME/kustomizeconfig
 cat > $DEMO_HOME/kustomizeconfig/mykind.yaml << EOF
 
 commonLabels:
@@ -148,12 +117,6 @@ in the kustomization file:
 cat >> $DEMO_HOME/kustomization.yaml << EOF
 configurations:
 - kustomizeconfig/mykind.yaml
-- kustomizeconfig/commonannotations.yaml
-- kustomizeconfig/commonlabels.yaml
-- kustomizeconfig/nameprefix.yaml
-- kustomizeconfig/namereference.yaml
-- kustomizeconfig/namespace.yaml
-- kustomizeconfig/varreference.yaml
 EOF
 ```
 


### PR DESCRIPTION
We don't need to get the default transformer configs. `Kustomize build` merges the custom config with the default ones.