### PR TITLE
Fix for #831 - Ignore domain when finding the image tag

### DIFF
--- a/pkg/transformers/image.go
+++ b/pkg/transformers/image.go
@@ -143,7 +143,18 @@ func isImageMatched(s, t string) bool {
 // from the image string using either colon `:` or at `@` separators.
 // Note that the returned tag keeps its separator.
 func split(imageName string) (name string, tag string) {
-	ic := strings.LastIndex(imageName, ":")
+	// check if image name contains a domain
+	// if domain is present, ignore domain and check for `:`
+	ic := -1
+	if slashIndex := strings.Index(imageName, "/"); slashIndex < 0 {
+		ic = strings.LastIndex(imageName, ":")
+	} else {
+		lastIc := strings.LastIndex(imageName[slashIndex:], ":")
+		// set ic only if `:` is present
+		if lastIc > 0 {
+			ic = slashIndex + lastIc
+		}
+	}
 	ia := strings.LastIndex(imageName, "@")
 	if ic < 0 && ia < 0 {
 		return imageName, ""

--- a/pkg/transformers/image_test.go
+++ b/pkg/transformers/image_test.go
@@ -119,6 +119,10 @@ func TestImageTransformer(t *testing.T) {
 									"image": "myprivaterepohostname:1234/my/image:latest",
 								},
 								map[string]interface{}{
+									"name":  "myimage2",
+									"image": "myprivaterepohostname:1234/my/image",
+								},
+								map[string]interface{}{
 									"name":  "my-app",
 									"image": "my-app-image:v1",
 								},
@@ -216,6 +220,10 @@ func TestImageTransformer(t *testing.T) {
 								},
 								map[string]interface{}{
 									"name":  "myimage",
+									"image": "myprivaterepohostname:1234/my/image:v1.0.1",
+								},
+								map[string]interface{}{
+									"name":  "myimage2",
 									"image": "myprivaterepohostname:1234/my/image:v1.0.1",
 								},
 								map[string]interface{}{


### PR DESCRIPTION
Fix for #831 

- Updated the split logic to ignore domain names when finding the index of `:`
- Updated the unit test