### PR TITLE
Fix typo in namereference path for cronjobs initContainers.

### DIFF
--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -114,7 +114,7 @@ nameReference:
     kind: CronJob
   - path: spec/jobTemplate/spec/template/spec/containers/envFrom/configMapRef/name
     kind: CronJob
-  - path: spec/jobTemplate/spec/template/spec/initContainers/envFrom/configmapRef/name
+  - path: spec/jobTemplate/spec/template/spec/initContainers/envFrom/configMapRef/name
     kind: CronJob
 
 - kind: Secret


### PR DESCRIPTION
Related: https://github.com/kubernetes-sigs/kustomize/pull/529

Fix namereference for CronJob path: spec/jobTemplate/spec/template/spec/initContainers/env/valueFrom/configMapKeyRef/name not working due to the lowercase m typo.