### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -54,7 +54,7 @@ func (r *Resource) Behavior() types.GenerationBehavior {
 	return r.options.Behavior()
 }
 
-// NeedAppendHash checks if the resource need a hash suffix
+// NeedHashSuffix checks if the resource need a hash suffix
 func (r *Resource) NeedHashSuffix() bool {
 	return r.options != nil && r.options.NeedsHashSuffix()
 }

--- a/pkg/types/genargs.go
+++ b/pkg/types/genargs.go
@@ -47,7 +47,7 @@ func (g *GenArgs) String() string {
 		"}"
 }
 
-// NeedHashSuffix returns true if the hash suffix is needed.
+// NeedsHashSuffix returns true if the hash suffix is needed.
 // It is needed when the two conditions are both met
 //  1) GenArgs is not nil
 //  2) DisableNameSuffixHash in GeneratorOptions is not set to true


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?