### PR TITLE
Secret/configmap factory cleanup.

### DIFF
--- a/k8sdeps/configmapandsecret/basefactory_test.go
+++ b/k8sdeps/configmapandsecret/basefactory_test.go
@@ -45,8 +45,9 @@ func TestKeyValuesFromFileSources(t *testing.T) {
 
 	fSys := fs.MakeFakeFS()
 	fSys.WriteFile("/files/app-init.ini", []byte("FOO=bar"))
+	bf := baseFactory{loader.NewFileLoaderAtRoot(fSys), nil}
 	for _, tc := range tests {
-		kvs, err := keyValuesFromFileSources(loader.NewFileLoaderAtRoot(fSys), tc.sources)
+		kvs, err := bf.keyValuesFromFileSources(tc.sources)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -19,29 +19,26 @@ package configmapandsecret
 
 import (
 	"fmt"
-	"strings"
 	"unicode/utf8"
 
-	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
-	"sigs.k8s.io/kustomize/k8sdeps/kv"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
 
-// ConfigMapFactory makes ConfigMaps.
-type ConfigMapFactory struct {
-	ldr ifc.Loader
+// Factory makes ConfigMaps and Secrets.
+type Factory struct {
+	baseFactory
 }
 
-// NewConfigMapFactory returns a new ConfigMapFactory.
-func NewConfigMapFactory(l ifc.Loader) *ConfigMapFactory {
-	return &ConfigMapFactory{ldr: l}
+// NewFactory returns a new Factory.
+func NewFactory(
+	l ifc.Loader, o *types.GeneratorOptions) *Factory {
+	return &Factory{baseFactory{ldr: l, options: o}}
 }
 
-func (f *ConfigMapFactory) makeFreshConfigMap(
+func makeFreshConfigMap(
 	args *types.ConfigMapArgs) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{}
 	cm.APIVersion = "v1"
@@ -53,43 +50,22 @@ func (f *ConfigMapFactory) makeFreshConfigMap(
 }
 
 // MakeConfigMap returns a new ConfigMap, or nil and an error.
-func (f *ConfigMapFactory) MakeConfigMap(
-	args *types.ConfigMapArgs, options *types.GeneratorOptions) (*corev1.ConfigMap, error) {
-	var all []kv.Pair
-	var err error
-	cm := f.makeFreshConfigMap(args)
-
-	pairs, err := keyValuesFromEnvFile(f.ldr, args.EnvSource)
+func (f *Factory) MakeConfigMap(
+	args *types.ConfigMapArgs) (*corev1.ConfigMap, error) {
+	all, err := f.loadKvPairs(args.GeneratorArgs)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"env source file: %s",
-			args.EnvSource))
+		return nil, err
 	}
-	all = append(all, pairs...)
-
-	pairs, err = keyValuesFromLiteralSources(args.LiteralSources)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"literal sources %v", args.LiteralSources))
-	}
-	all = append(all, pairs...)
-
-	pairs, err = keyValuesFromFileSources(f.ldr, args.FileSources)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"file sources: %v", args.FileSources))
-	}
-	all = append(all, pairs...)
-
+	cm := makeFreshConfigMap(args)
 	for _, p := range all {
 		err = addKvToConfigMap(cm, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if options != nil {
-		cm.SetLabels(options.Labels)
-		cm.SetAnnotations(options.Annotations)
+	if f.options != nil {
+		cm.SetLabels(f.options.Labels)
+		cm.SetAnnotations(f.options.Annotations)
 	}
 	return cm, nil
 }
@@ -97,13 +73,9 @@ func (f *ConfigMapFactory) MakeConfigMap(
 // addKvToConfigMap adds the given key and data to the given config map.
 // Error if key invalid, or already exists.
 func addKvToConfigMap(configMap *v1.ConfigMap, keyName, data string) error {
-	// Note, the rules for ConfigMap keys are the exact same as the ones for SecretKeys.
-	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
-		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))
+	if err := errIfInvalidKey(keyName); err != nil {
+		return err
 	}
-
-	keyExistsErrorMsg := "cannot add key %s, another key by that name already exists: %v"
-
 	// If the configmap data contains byte sequences that are all in the UTF-8
 	// range, we will write it to .Data
 	if utf8.Valid([]byte(data)) {
@@ -113,7 +85,6 @@ func addKvToConfigMap(configMap *v1.ConfigMap, keyName, data string) error {
 		configMap.Data[keyName] = data
 		return nil
 	}
-
 	// otherwise, it's BinaryData
 	if configMap.BinaryData == nil {
 		configMap.BinaryData = map[string][]byte{}

--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -141,9 +141,9 @@ func TestConstructConfigMap(t *testing.T) {
 	fSys.WriteFile("/configmap/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
 	fSys.WriteFile("/configmap/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
 	fSys.WriteFile("/configmap/app.bin", []byte{0xff, 0xfd})
-	f := NewConfigMapFactory(loader.NewFileLoaderAtRoot(fSys))
 	for _, tc := range testCases {
-		cm, err := f.MakeConfigMap(&tc.input, tc.options)
+		f := NewFactory(loader.NewFileLoaderAtRoot(fSys), tc.options)
+		cm, err := f.MakeConfigMap(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -18,27 +18,13 @@ package configmapandsecret
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
-	"sigs.k8s.io/kustomize/k8sdeps/kv"
-	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/types"
 )
 
-// SecretFactory makes Secrets.
-type SecretFactory struct {
-	ldr ifc.Loader
-}
-
-// NewSecretFactory returns a new SecretFactory.
-func NewSecretFactory(ldr ifc.Loader) *SecretFactory {
-	return &SecretFactory{ldr: ldr}
-}
-
-func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
+func makeFreshSecret(
+	args *types.SecretArgs) *corev1.Secret {
 	s := &corev1.Secret{}
 	s.APIVersion = "v1"
 	s.Kind = "Secret"
@@ -53,53 +39,32 @@ func (f *SecretFactory) makeFreshSecret(args *types.SecretArgs) *corev1.Secret {
 }
 
 // MakeSecret returns a new secret.
-func (f *SecretFactory) MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (*corev1.Secret, error) {
-	var all []kv.Pair
-	var err error
-	s := f.makeFreshSecret(args)
-
-	pairs, err := keyValuesFromEnvFile(f.ldr, args.EnvSource)
+func (f *Factory) MakeSecret(
+	args *types.SecretArgs) (*corev1.Secret, error) {
+	all, err := f.loadKvPairs(args.GeneratorArgs)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"env source file: %s",
-			args.EnvSource))
+		return nil, err
 	}
-	all = append(all, pairs...)
-
-	pairs, err = keyValuesFromLiteralSources(args.LiteralSources)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"literal sources %v", args.LiteralSources))
-	}
-	all = append(all, pairs...)
-
-	pairs, err = keyValuesFromFileSources(f.ldr, args.FileSources)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"file sources: %v", args.FileSources))
-	}
-	all = append(all, pairs...)
-
+	s := makeFreshSecret(args)
 	for _, p := range all {
 		err = addKvToSecret(s, p.Key, p.Value)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if options != nil {
-		s.SetLabels(options.Labels)
-		s.SetAnnotations(options.Annotations)
+	if f.options != nil {
+		s.SetLabels(f.options.Labels)
+		s.SetAnnotations(f.options.Annotations)
 	}
 	return s, nil
 }
 
 func addKvToSecret(secret *corev1.Secret, keyName, data string) error {
-	// Note, the rules for SecretKeys  keys are the exact same as the ones for ConfigMap.
-	if errs := validation.IsConfigMapKey(keyName); len(errs) != 0 {
-		return fmt.Errorf("%q is not a valid key name for a Secret: %s", keyName, strings.Join(errs, ";"))
+	if err := errIfInvalidKey(keyName); err != nil {
+		return err
 	}
 	if _, entryExists := secret.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists", keyName)
+		return fmt.Errorf(keyExistsErrorMsg, keyName, secret.Data)
 	}
 	secret.Data[keyName] = []byte(data)
 	return nil

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -138,9 +138,9 @@ func TestConstructSecret(t *testing.T) {
 	fSys := fs.MakeFakeFS()
 	fSys.WriteFile("/secret/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
 	fSys.WriteFile("/secret/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
-	f := NewSecretFactory(loader.NewFileLoaderAtRoot(fSys))
 	for _, tc := range testCases {
-		cm, err := f.MakeSecret(&tc.input, tc.options)
+		f := NewFactory(loader.NewFileLoaderAtRoot(fSys), tc.options)
+		cm, err := f.MakeSecret(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -31,8 +31,6 @@ import (
 
 // KunstructuredFactoryImpl hides construction using apimachinery types.
 type KunstructuredFactoryImpl struct {
-	cmFactory     *configmapandsecret.ConfigMapFactory
-	secretFactory *configmapandsecret.SecretFactory
 }
 
 var _ ifc.KunstructuredFactory = &KunstructuredFactoryImpl{}
@@ -79,27 +77,27 @@ func (kf *KunstructuredFactoryImpl) FromMap(
 }
 
 // MakeConfigMap returns an instance of Kunstructured for ConfigMap
-func (kf *KunstructuredFactoryImpl) MakeConfigMap(args *types.ConfigMapArgs, options *types.GeneratorOptions) (ifc.Kunstructured, error) {
-	cm, err := kf.cmFactory.MakeConfigMap(args, options)
+func (kf *KunstructuredFactoryImpl) MakeConfigMap(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	args *types.ConfigMapArgs) (ifc.Kunstructured, error) {
+	o, err := configmapandsecret.NewFactory(ldr, options).MakeConfigMap(args)
 	if err != nil {
 		return nil, err
 	}
-	return NewKunstructuredFromObject(cm)
+	return NewKunstructuredFromObject(o)
 }
 
 // MakeSecret returns an instance of Kunstructured for Secret
-func (kf *KunstructuredFactoryImpl) MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (ifc.Kunstructured, error) {
-	sec, err := kf.secretFactory.MakeSecret(args, options)
+func (kf *KunstructuredFactoryImpl) MakeSecret(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	args *types.SecretArgs) (ifc.Kunstructured, error) {
+	o, err := configmapandsecret.NewFactory(ldr, options).MakeSecret(args)
 	if err != nil {
 		return nil, err
 	}
-	return NewKunstructuredFromObject(sec)
-}
-
-// Set sets loader
-func (kf *KunstructuredFactoryImpl) Set(ldr ifc.Loader) {
-	kf.cmFactory = configmapandsecret.NewConfigMapFactory(ldr)
-	kf.secretFactory = configmapandsecret.NewSecretFactory(ldr)
+	return NewKunstructuredFromObject(o)
 }
 
 // validate validates that u has kind and name

--- a/pkg/commands/edit/add/configmap.go
+++ b/pkg/commands/edit/add/configmap.go
@@ -67,8 +67,8 @@ func newCmdAddConfigMap(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.
 			}
 
 			// Add the flagsAndArgs map to the kustomization file.
-			kf.Set(loader.NewFileLoaderAtCwd(fSys))
-			err = addConfigMap(kustomization, flags, kf)
+			err = addConfigMap(
+				loader.NewFileLoaderAtCwd(fSys), kustomization, flags, kf)
 			if err != nil {
 				return err
 			}
@@ -103,6 +103,7 @@ func newCmdAddConfigMap(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.
 // Note: error may leave kustomization file in an undefined state.
 // Suggest passing a copy of kustomization file.
 func addConfigMap(
+	ldr ifc.Loader,
 	k *types.Kustomization,
 	flags flagsAndArgs, kf ifc.KunstructuredFactory) error {
 	cmArgs := makeConfigMapArgs(k, flags.Name)
@@ -111,7 +112,7 @@ func addConfigMap(
 		return err
 	}
 	// Validate by trying to create corev1.configmap.
-	_, err = kf.MakeConfigMap(cmArgs, k.GeneratorOptions)
+	_, err = kf.MakeConfigMap(ldr, k.GeneratorOptions, cmArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/edit/add/secret.go
+++ b/pkg/commands/edit/add/secret.go
@@ -67,8 +67,8 @@ func newCmdAddSecret(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.Com
 			}
 
 			// Add the flagsAndArgs map to the kustomization file.
-			kf.Set(loader.NewFileLoaderAtCwd(fSys))
-			err = addSecret(kustomization, flags, kf)
+			err = addSecret(
+				loader.NewFileLoaderAtCwd(fSys), kustomization, flags, kf)
 			if err != nil {
 				return err
 			}
@@ -108,6 +108,7 @@ func newCmdAddSecret(fSys fs.FileSystem, kf ifc.KunstructuredFactory) *cobra.Com
 // Note: error may leave kustomization file in an undefined state.
 // Suggest passing a copy of kustomization file.
 func addSecret(
+	ldr ifc.Loader,
 	k *types.Kustomization,
 	flags flagsAndArgs, kf ifc.KunstructuredFactory) error {
 	secretArgs := makeSecretArgs(k, flags.Name, flags.Type)
@@ -116,7 +117,7 @@ func addSecret(
 		return err
 	}
 	// Validate by trying to create corev1.secret.
-	_, err = kf.MakeSecret(secretArgs, k.GeneratorOptions)
+	_, err = kf.MakeSecret(ldr, k.GeneratorOptions, secretArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -64,9 +64,14 @@ type Kunstructured interface {
 type KunstructuredFactory interface {
 	SliceFromBytes([]byte) ([]Kunstructured, error)
 	FromMap(m map[string]interface{}) Kunstructured
-	MakeConfigMap(args *types.ConfigMapArgs, options *types.GeneratorOptions) (Kunstructured, error)
-	MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (Kunstructured, error)
-	Set(ldr Loader)
+	MakeConfigMap(
+		ldr Loader,
+		options *types.GeneratorOptions,
+		args *types.ConfigMapArgs) (Kunstructured, error)
+	MakeSecret(
+		ldr Loader,
+		options *types.GeneratorOptions,
+		args *types.SecretArgs) (Kunstructured, error)
 }
 
 // See core.v1.SecretTypeOpaque

--- a/pkg/resmap/factory.go
+++ b/pkg/resmap/factory.go
@@ -79,10 +79,13 @@ func (rmF *Factory) NewResMapFromBytes(b []byte) (ResMap, error) {
 
 // NewResMapFromConfigMapArgs returns a Resource slice given
 // a configmap metadata slice from kustomization file.
-func (rmF *Factory) NewResMapFromConfigMapArgs(argList []types.ConfigMapArgs, options *types.GeneratorOptions) (ResMap, error) {
+func (rmF *Factory) NewResMapFromConfigMapArgs(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	argList []types.ConfigMapArgs) (ResMap, error) {
 	var resources []*resource.Resource
 	for _, args := range argList {
-		res, err := rmF.resF.MakeConfigMap(&args, options)
+		res, err := rmF.resF.MakeConfigMap(ldr, options, &args)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewResMapFromConfigMapArgs")
 		}
@@ -93,21 +96,19 @@ func (rmF *Factory) NewResMapFromConfigMapArgs(argList []types.ConfigMapArgs, op
 
 // NewResMapFromSecretArgs takes a SecretArgs slice, generates
 // secrets from each entry, and accumulates them in a ResMap.
-func (rmF *Factory) NewResMapFromSecretArgs(argsList []types.SecretArgs, options *types.GeneratorOptions) (ResMap, error) {
+func (rmF *Factory) NewResMapFromSecretArgs(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	argsList []types.SecretArgs) (ResMap, error) {
 	var resources []*resource.Resource
 	for _, args := range argsList {
-		res, err := rmF.resF.MakeSecret(&args, options)
+		res, err := rmF.resF.MakeSecret(ldr, options, &args)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewResMapFromSecretArgs")
 		}
 		resources = append(resources, res)
 	}
 	return newResMapFromResourceSlice(resources)
-}
-
-// Set sets the loader for the underlying factory
-func (rmF *Factory) Set(ldr ifc.Loader) {
-	rmF.resF.Set(ldr)
 }
 
 func newResMapFromResourceSlice(resources []*resource.Resource) (ResMap, error) {

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -238,12 +238,11 @@ BAR=baz
 		// TODO: add testcase for data coming from multiple sources like
 		// files/literal/env etc.
 	}
-	rmF.Set(l)
 	for _, tc := range testCases {
 		if ferr := l.AddFile(tc.filepath, []byte(tc.content)); ferr != nil {
 			t.Fatalf("Error adding fake file: %v\n", ferr)
 		}
-		r, err := rmF.NewResMapFromConfigMapArgs(tc.input, nil)
+		r, err := rmF.NewResMapFromConfigMapArgs(l, nil, tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -272,9 +271,8 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	}
 	fakeFs := fs.MakeFakeFS()
 	fakeFs.Mkdir(".")
-	rmF.Set(loader.NewFileLoaderAtRoot(fakeFs))
-	actual, err := rmF.NewResMapFromSecretArgs(secrets, nil)
-
+	actual, err := rmF.NewResMapFromSecretArgs(
+		loader.NewFileLoaderAtRoot(fakeFs), nil, secrets)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -124,25 +124,36 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 	return result, nil
 }
 
-// Set sets the loader for the underlying factory
-func (rf *Factory) Set(ldr ifc.Loader) {
-	rf.kf.Set(ldr)
-}
-
 // MakeConfigMap makes an instance of Resource for ConfigMap
-func (rf *Factory) MakeConfigMap(args *types.ConfigMapArgs, options *types.GeneratorOptions) (*Resource, error) {
-	u, err := rf.kf.MakeConfigMap(args, options)
+func (rf *Factory) MakeConfigMap(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	args *types.ConfigMapArgs) (*Resource, error) {
+	u, err := rf.kf.MakeConfigMap(ldr, options, args)
 	if err != nil {
 		return nil, err
 	}
-	return &Resource{Kunstructured: u, options: types.NewGenArgs(&types.GeneratorArgs{Behavior: args.Behavior}, options)}, nil
+	return &Resource{
+		Kunstructured: u,
+		options: types.NewGenArgs(
+			&types.GeneratorArgs{Behavior: args.Behavior},
+			options),
+	}, nil
 }
 
 // MakeSecret makes an instance of Resource for Secret
-func (rf *Factory) MakeSecret(args *types.SecretArgs, options *types.GeneratorOptions) (*Resource, error) {
-	u, err := rf.kf.MakeSecret(args, options)
+func (rf *Factory) MakeSecret(
+	ldr ifc.Loader,
+	options *types.GeneratorOptions,
+	args *types.SecretArgs) (*Resource, error) {
+	u, err := rf.kf.MakeSecret(ldr, options, args)
 	if err != nil {
 		return nil, err
 	}
-	return &Resource{Kunstructured: u, options: types.NewGenArgs(&types.GeneratorArgs{Behavior: args.Behavior}, options)}, nil
+	return &Resource{
+		Kunstructured: u,
+		options: types.NewGenArgs(
+			&types.GeneratorArgs{Behavior: args.Behavior},
+			options),
+	}, nil
 }

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -62,7 +62,9 @@ func NewKustTarget(
 	}
 	errs := k.EnforceFields()
 	if len(errs) > 0 {
-		return nil, fmt.Errorf("Failed to read kustomization file under %s:\n"+strings.Join(errs, "\n"), ldr.Root())
+		return nil, fmt.Errorf(
+			"Failed to read kustomization file under %s:\n"+
+				strings.Join(errs, "\n"), ldr.Root())
 	}
 	return &KustTarget{
 		kustomization: &k,
@@ -102,7 +104,8 @@ func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	case 1:
 		return content, nil
 	default:
-		return nil, fmt.Errorf("Found multiple kustomization files under: %s\n", ldr.Root())
+		return nil, fmt.Errorf(
+			"Found multiple kustomization files under: %s\n", ldr.Root())
 	}
 }
 
@@ -215,14 +218,17 @@ func (kt *KustTarget) AccumulateTarget() (
 
 func (kt *KustTarget) generateConfigMapsAndSecrets(
 	errs *interror.KustomizationErrors) (resmap.ResMap, error) {
-	kt.rFactory.Set(kt.ldr)
 	cms, err := kt.rFactory.NewResMapFromConfigMapArgs(
-		kt.kustomization.ConfigMapGenerator, kt.kustomization.GeneratorOptions)
+		kt.ldr,
+		kt.kustomization.GeneratorOptions,
+		kt.kustomization.ConfigMapGenerator)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromConfigMapArgs"))
 	}
 	secrets, err := kt.rFactory.NewResMapFromSecretArgs(
-		kt.kustomization.SecretGenerator, kt.kustomization.GeneratorOptions)
+		kt.ldr,
+		kt.kustomization.GeneratorOptions,
+		kt.kustomization.SecretGenerator)
 	if err != nil {
 		errs.Append(errors.Wrap(err, "NewResMapFromSecretArgs"))
 	}


### PR DESCRIPTION
This removes some duplicated code, and removes
a Set(loader) function allowed a hacky injection
of process working dir info that supported the old
"exec" code. That form of exec isn't coming back,
so getting rid of it.

Despite removing duped code, line count is a
wash, since i added LF's for readability, and
added a loader argument to the call chain
to make it's usage clear and easier to adapt
to the coming plugin code.