### PR TITLE
Fix incorrect and missing varReferences

### DIFF
--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -28,10 +28,10 @@ varReference:
 - path: spec/jobTemplate/spec/template/spec/containers/env/value
   kind: CronJob
 
-- path: spec/template/spec/containers/volumeMounts/mountPath
+- path: spec/jobTemplate/spec/template/spec/containers/volumeMounts/mountPath
   kind: CronJob
 
-- path: spec/template/spec/initContainers/volumeMounts/mountPath
+- path: spec/jobTemplate/spec/template/spec/initContainers/volumeMounts/mountPath
   kind: CronJob
 
 - path: spec/template/spec/containers/args

--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -31,6 +31,15 @@ varReference:
 - path: spec/jobTemplate/spec/template/spec/containers/volumeMounts/mountPath
   kind: CronJob
 
+- path: spec/jobTemplate/spec/template/spec/initContainers/args
+  kind: CronJob
+
+- path: spec/jobTemplate/spec/template/spec/initContainers/command
+  kind: CronJob
+
+- path: spec/jobTemplate/spec/template/spec/initContainers/env/value
+  kind: CronJob
+
 - path: spec/jobTemplate/spec/template/spec/initContainers/volumeMounts/mountPath
   kind: CronJob
 
@@ -100,6 +109,12 @@ varReference:
 - path: spec/template/spec/containers/volumeMounts/mountPath
   kind: Job
 
+- path: spec/template/spec/initContainers/args
+  kind: Job
+
+- path: spec/template/spec/initContainers/command
+  kind: Job
+
 - path: spec/template/spec/initContainers/env/value
   kind: Job
 
@@ -130,7 +145,25 @@ varReference:
 - path: spec/initContainers/volumeMounts/mountPath
   kind: Pod
 
+- path: spec/template/spec/containers/args
+  kind: ReplicaSet
+
+- path: spec/template/spec/containers/command
+  kind: ReplicaSet
+
+- path: spec/template/spec/containers/env/value
+  kind: ReplicaSet
+
 - path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: ReplicaSet
+
+- path: spec/template/spec/initContainers/args
+  kind: ReplicaSet
+
+- path: spec/template/spec/initContainers/command
+  kind: ReplicaSet
+
+- path: spec/template/spec/initContainers/env/value
   kind: ReplicaSet
 
 - path: spec/template/spec/initContainers/volumeMounts/mountPath

--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -19,98 +19,68 @@ package defaultconfig
 const (
 	varReferenceFieldSpecs = `
 varReference:
-- path: spec/template/spec/initContainers/command
-  kind: StatefulSet
-
-- path: spec/template/spec/containers/command
-  kind: StatefulSet
-
-- path: spec/template/spec/initContainers/command
-  kind: Deployment
-
-- path: spec/template/spec/containers/command
-  kind: Deployment
-
-- path: spec/template/spec/initContainers/command
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/command
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/command
-  kind: Job
+- path: spec/jobTemplate/spec/template/spec/containers/args
+  kind: CronJob
 
 - path: spec/jobTemplate/spec/template/spec/containers/command
   kind: CronJob
 
-- path: spec/template/spec/initContainers/args
-  kind: StatefulSet
- 
-- path: spec/template/spec/containers/args
-  kind: StatefulSet
-
-- path: spec/template/spec/initContainers/args
-  kind: Deployment
-
-- path: spec/template/spec/containers/args
-  kind: Deployment
-
-- path: spec/template/spec/initContainers/args
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/args
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/args
-  kind: Job
-
-- path: spec/jobTemplate/spec/template/spec/containers/args
-  kind: CronJob
-
-- path: spec/template/spec/initContainers/env/value
-  kind: StatefulSet
-
-- path: spec/template/spec/containers/env/value
-  kind: StatefulSet
-
-- path: spec/template/spec/initContainers/env/value
-  kind: Deployment
-
-- path: spec/template/spec/containers/env/value
-  kind: Deployment
-
-- path: spec/template/spec/initContainers/env/value
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/env/value
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/env/value
-  kind: Job
-
-- path: spec/template/spec/initContainers/env/value
-  kind: Job
-
 - path: spec/jobTemplate/spec/template/spec/containers/env/value
   kind: CronJob
 
-- path: spec/containers/command
-  kind: Pod
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: CronJob
 
-- path: spec/containers/args
-  kind: Pod
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: CronJob
 
-- path: spec/containers/env/value
-  kind: Pod
+- path: spec/template/spec/containers/args
+  kind: DaemonSet
 
-- path: spec/initContainers/command
-  kind: Pod
+- path: spec/template/spec/containers/command
+  kind: DaemonSet
 
-- path: spec/initContainers/args
-  kind: Pod
+- path: spec/template/spec/containers/env/value
+  kind: DaemonSet
 
-- path: spec/initContainers/env/value
-  kind: Pod
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/args
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/command
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/env/value
+  kind: DaemonSet
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: DaemonSet
+
+- path: spec/template/spec/containers/args
+  kind: Deployment
+
+- path: spec/template/spec/containers/command
+  kind: Deployment
+
+- path: spec/template/spec/containers/env/value
+  kind: Deployment
+
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/args
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/command
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/env/value
+  kind: Deployment
+
+- path: spec/template/spec/initContainers/volumeMounts/mountPath
+  kind: Deployment
 
 - path: spec/rules/host
   kind: Ingress
@@ -118,13 +88,43 @@ varReference:
 - path: spec/tls/hosts
   kind: Ingress
 
+- path: spec/template/spec/containers/args
+  kind: Job
+
+- path: spec/template/spec/containers/command
+  kind: Job
+
+- path: spec/template/spec/containers/env/value
+  kind: Job
+
 - path: spec/template/spec/containers/volumeMounts/mountPath
-  kind: StatefulSet
+  kind: Job
+
+- path: spec/template/spec/initContainers/env/value
+  kind: Job
 
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
-  kind: StatefulSet
+  kind: Job
+
+- path: spec/containers/args
+  kind: Pod
+
+- path: spec/containers/command
+  kind: Pod
+
+- path: spec/containers/env/value
+  kind: Pod
 
 - path: spec/containers/volumeMounts/mountPath
+  kind: Pod
+
+- path: spec/initContainers/args
+  kind: Pod
+
+- path: spec/initContainers/command
+  kind: Pod
+
+- path: spec/initContainers/env/value
   kind: Pod
 
 - path: spec/initContainers/volumeMounts/mountPath
@@ -136,29 +136,29 @@ varReference:
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
   kind: ReplicaSet
 
-- path: spec/template/spec/containers/volumeMounts/mountPath
-  kind: Job
+- path: spec/template/spec/containers/args
+  kind: StatefulSet
 
-- path: spec/template/spec/initContainers/volumeMounts/mountPath
-  kind: Job
+- path: spec/template/spec/containers/command
+  kind: StatefulSet
 
-- path: spec/template/spec/containers/volumeMounts/mountPath
-  kind: CronJob
-
-- path: spec/template/spec/initContainers/volumeMounts/mountPath
-  kind: CronJob
+- path: spec/template/spec/containers/env/value
+  kind: StatefulSet
 
 - path: spec/template/spec/containers/volumeMounts/mountPath
-  kind: DaemonSet
+  kind: StatefulSet
+
+- path: spec/template/spec/initContainers/args
+  kind: StatefulSet
+
+- path: spec/template/spec/initContainers/command
+  kind: StatefulSet
+
+- path: spec/template/spec/initContainers/env/value
+  kind: StatefulSet
 
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
-  kind: DaemonSet
-
-- path: spec/template/spec/containers/volumeMounts/mountPath
-  kind: Deployment
-
-- path: spec/template/spec/initContainers/volumeMounts/mountPath
-  kind: Deployment
+  kind: StatefulSet
 
 - path: metadata/labels
 `


### PR DESCRIPTION
The first commit here sorts the default `varReference` config by kind, then path, which made it really obvious which kinds had missing or incorrect info. The subsequent two commits contain fixes for those.

Every object that has a `Container` array (whether `containers` or `initContainers`) should now have varrefs for `args`, `command`, `env/value`, and `volumeMounts/mountPath`! :sweat_smile:

Edit: Except ye olde `ReplicationController`. Do we care about those?