### PR TITLE
skip adding namespace when the object is empty

### DIFF
--- a/pkg/transformers/namespace.go
+++ b/pkg/transformers/namespace.go
@@ -70,12 +70,16 @@ func (o *namespaceTransformer) Transform(m resmap.ResMap) error {
 			if !id.Gvk().IsSelected(&path.Gvk) {
 				continue
 			}
-
-			err := mutateField(objMap, path.PathSlice(), path.CreateIfNotPresent, func(_ interface{}) (interface{}, error) {
-				return o.namespace, nil
-			})
-			if err != nil {
-				return err
+			// make sure the object is non empty
+			if len(objMap) > 0 {
+				err := mutateField(
+					objMap, path.PathSlice(), path.CreateIfNotPresent,
+					func(_ interface{}) (interface{}, error) {
+						return o.namespace, nil
+					})
+				if err != nil {
+					return err
+				}
 			}
 			newid := id.CopyWithNewNamespace(o.namespace)
 			m[newid] = mf[id]

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -47,6 +47,9 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "foo",
 				},
 			}),
+		resid.NewResId(cmap, "cm3"): rf.FromMap(
+			map[string]interface{}{},
+		),
 		resid.NewResId(ns, "ns1"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
@@ -134,6 +137,9 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
+		resid.NewResIdWithPrefixNamespace(cmap, "cm3", "", "test"): rf.FromMap(
+			map[string]interface{}{},
+		),
 		resid.NewResIdWithPrefixNamespace(sa, "default", "", "test"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",


### PR DESCRIPTION
Fix #768
When the object is deleted by a strategic merge patch, Kustomize shouldn't add namespace to it.