### PR TITLE
Extend image transformer for KNative Service

### DIFF
--- a/pkg/transformers/image.go
+++ b/pkg/transformers/image.go
@@ -74,8 +74,9 @@ func (pt *imageTransformer) findAndReplaceImage(obj map[string]interface{}) erro
 	paths := []string{"containers", "initContainers"}
 	found := false
 	for _, path := range paths {
-		containers, found := obj[path]
-		if found {
+		containers, foundHere := obj[path]
+		if foundHere {
+			found = true
 			_, err := pt.updateContainers(containers)
 			if err != nil {
 				return err
@@ -83,8 +84,9 @@ func (pt *imageTransformer) findAndReplaceImage(obj map[string]interface{}) erro
 		}
 	}
 	// Also support singleton container (as in KNative Service)
-	containers, found := obj["container"]
-	if found {
+	containers, foundHere := obj["container"]
+	if foundHere {
+		found = true
 		_, err := pt.updateContainers([]interface{}{containers})
 		if err != nil {
 			return err

--- a/pkg/transformers/image.go
+++ b/pkg/transformers/image.go
@@ -82,6 +82,15 @@ func (pt *imageTransformer) findAndReplaceImage(obj map[string]interface{}) erro
 			}
 		}
 	}
+	// Also support singleton container (as in KNative Service)
+	containers, found := obj["container"]
+	if found {
+		_, err := pt.updateContainers([]interface{}{containers})
+		if err != nil {
+			return err
+		}
+	}
+
 	if !found {
 		return pt.findContainers(obj)
 	}


### PR DESCRIPTION
The Service kind of serving.knative.dev has a singleton container
field instead of an array.  Add support for applying imageTransformer
to a singleton field called container.