### PR TITLE
Move accumulator code to its own package.

### DIFF
--- a/pkg/accumulator/resaccumulator.go
+++ b/pkg/accumulator/resaccumulator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target
+package accumulator
 
 import (
 	"fmt"
@@ -30,10 +30,6 @@ import (
 
 // ResAccumulator accumulates resources and the rules
 // used to customize those resources.
-// TODO(monopole): Move to "accumulator" package and make members private.
-// This will make a better separation between KustTarget, which should
-// be mainly concerned with data loading, and this class, which could
-// become the home of all transformation data and logic.
 type ResAccumulator struct {
 	resMap  resmap.ResMap
 	tConfig *config.TransformerConfig
@@ -80,6 +76,10 @@ func (ra *ResAccumulator) MergeConfig(
 	tConfig *config.TransformerConfig) (err error) {
 	ra.tConfig, err = ra.tConfig.Merge(tConfig)
 	return err
+}
+
+func (ra *ResAccumulator) GetTransformerConfig() *config.TransformerConfig {
+	return ra.tConfig
 }
 
 func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {

--- a/pkg/accumulator/resaccumulator_test.go
+++ b/pkg/accumulator/resaccumulator_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package target_test
+package accumulator_test
 
 import (
 	"bytes"
@@ -24,11 +24,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	. "sigs.k8s.io/kustomize/pkg/accumulator"
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
-	. "sigs.k8s.io/kustomize/pkg/target"
 	"sigs.k8s.io/kustomize/pkg/transformers/config"
 	"sigs.k8s.io/kustomize/pkg/types"
 )

--- a/pkg/commands/edit/add/configmap_test.go
+++ b/pkg/commands/edit/add/configmap_test.go
@@ -65,7 +65,7 @@ func TestMakeConfigMapArgs(t *testing.T) {
 }
 
 func TestMergeFlagsIntoCmArgs_LiteralSources(t *testing.T) {
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoCmArgs(&kv, flagsAndArgs{LiteralSources: []string{"k1=v1"}})
 
@@ -81,7 +81,7 @@ func TestMergeFlagsIntoCmArgs_LiteralSources(t *testing.T) {
 }
 
 func TestMergeFlagsIntoCmArgs_FileSources(t *testing.T) {
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoCmArgs(&kv, flagsAndArgs{FileSources: []string{"file1"}})
 
@@ -99,7 +99,7 @@ func TestMergeFlagsIntoCmArgs_FileSources(t *testing.T) {
 func TestMergeFlagsIntoCmArgs_EnvSource(t *testing.T) {
 	envFileName := "env1"
 	envFileName2 := "env2"
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoCmArgs(&kv, flagsAndArgs{EnvFileSource: envFileName})
 

--- a/pkg/commands/edit/add/secret_test.go
+++ b/pkg/commands/edit/add/secret_test.go
@@ -67,7 +67,7 @@ func TestMakeSecretArgs(t *testing.T) {
 }
 
 func TestMergeFlagsIntoSecretArgs_LiteralSources(t *testing.T) {
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoSecretArgs(&kv, flagsAndArgs{LiteralSources: []string{"k1=v1"}})
 
@@ -83,7 +83,7 @@ func TestMergeFlagsIntoSecretArgs_LiteralSources(t *testing.T) {
 }
 
 func TestMergeFlagsIntoSecretArgs_FileSources(t *testing.T) {
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoSecretArgs(&kv, flagsAndArgs{FileSources: []string{"file1"}})
 
@@ -101,7 +101,7 @@ func TestMergeFlagsIntoSecretArgs_FileSources(t *testing.T) {
 func TestMergeFlagsIntoSecretArgs_EnvSource(t *testing.T) {
 	envFileName := "env1"
 	envFileName2 := "env2"
-	kv := []types.KVSource{}
+	var kv []types.KVSource
 
 	mergeFlagsIntoSecretArgs(&kv, flagsAndArgs{EnvFileSource: envFileName})
 

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/kustomize/pkg/accumulator"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/ifc/transformer"
 	interror "sigs.k8s.io/kustomize/pkg/internal/error"
@@ -151,7 +152,7 @@ func (kt *KustTarget) shouldAddHashSuffixesToGeneratedResources() bool {
 // to do so.  The name back references and vars are
 // not yet fixed.
 func (kt *KustTarget) AccumulateTarget() (
-	ra *ResAccumulator, err error) {
+	ra *accumulator.ResAccumulator, err error) {
 	// TODO(monopole): Get rid of the KustomizationErrors accumulator.
 	// It's not consistently used, and complicates tests.
 	errs := &interror.KustomizationErrors{}
@@ -205,7 +206,7 @@ func (kt *KustTarget) AccumulateTarget() (
 	if len(errs.Get()) > 0 {
 		return nil, errs
 	}
-	t, err := kt.newTransformer(patches, ra.tConfig)
+	t, err := kt.newTransformer(patches, ra.GetTransformerConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -240,9 +241,9 @@ func (kt *KustTarget) generateConfigMapsAndSecrets(
 // used to customized them from only the _bases_
 // of this KustTarget.
 func (kt *KustTarget) accumulateBases() (
-	ra *ResAccumulator, errs *interror.KustomizationErrors) {
+	ra *accumulator.ResAccumulator, errs *interror.KustomizationErrors) {
 	errs = &interror.KustomizationErrors{}
-	ra = MakeEmptyAccumulator()
+	ra = accumulator.MakeEmptyAccumulator()
 
 	for _, path := range kt.kustomization.Bases {
 		ldr, err := kt.ldr.New(path)


### PR DESCRIPTION
Close old TODO to separate the data loading code from the transformation code.