### PR TITLE
update transformer docs, add images tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ inspired by [DAM].
 page], or see these [install] notes. Then try one of
 the tested [examples].
 
+**Note** Kustomize is now available on kubectl v1.14 and can be used by specifying a directory containing a `kustomization.yaml`:
+```shell
+kubectl apply -k dir/
+```
+
 ## Usage
 
 

--- a/examples/remoteBuild.md
+++ b/examples/remoteBuild.md
@@ -10,7 +10,7 @@ Running `kustomize build` against the url gives the same output.
 
 <!-- @remoteBuild @test -->
 ```
-target=github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
+target=github.com/kubernetes-sigs/kustomize//examples/multibases
 test 3 == \
   $(kustomize build $target | grep cluster-a-.*-myapp-pod | wc -l); \
   echo $?

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -3,11 +3,12 @@
 Kustomize creates new resources by applying a series of transformations to an original
 set of resources. Kustomize provides the following default transformers:
 
+- annotations
+- images
+- labels
+- name reference
 - namespace
 - prefix/suffix
-- label
-- annotation
-- name reference
 - variable reference
 
 A `fieldSpec` list, in a transformer's configuration, determines which resource types and which fields
@@ -27,6 +28,31 @@ create: false
 
 If `create` is set to `true`, the transformer creates the path to the field in the resource if the path is not already found. This is most useful for label and annotation transformers, where the path for labels or annotations may not be set before the transformation.
 
+## Images transformer
+
+The default images transformer updates the list of images in relation to paths that include
+`containers` and `initcontainer` sub-paths.
+If found, the `image` key value is customized by the values set in the `newName`, `newTag`, and `digest` fields.
+You can set either the `newTag` field or the `digest` field for a given image transformation. The `name` field identifies
+the `image` key value in a resource.
+
+Example kustomization.yaml:
+
+```yaml
+images:
+  - name: postgres
+    newName: my-registry/my-postgres
+    newTag: v1
+  - name: nginx
+    newTag: 1.8.0
+  - name: my-demo-app
+    newName: my-app
+  - name: alpine
+```
+
+Image transformer configurations can be customized by creating a list of `images` containing the `path` and `kind` fields.
+The images transformation tutorial shows how to specify the default images transformer and customize the [images transformer configuration](images/README.md).
+
 ## Prefix/suffix transformer
 
 The prefix/suffix transformer adds a prefix/suffix to the `metadata/name` field for all resources. Here is the default prefix transformer configuration:
@@ -36,9 +62,24 @@ namePrefix:
 - path: metadata/name
 ```
 
-## Label transformer
+Example kustomization.yaml:
 
-The label transformer adds labels to the `metadata/labels` field for all resources. It also adds labels to the `spec/selector` field in all Service resources as well as the `spec/selector/matchLabels` field in all Deployment resources.
+```yaml
+
+namePrefix:
+  alices-
+
+nameSuffix:
+  -v2
+```
+
+All Resources with path, `metadata/name` will be updated with the prefix, `alices-`.
+
+## Labels transformer
+
+The labels transformer adds labels to the `metadata/labels` field for all resources. It also adds labels to the `spec/selector` field in all Service resources as well as the `spec/selector/matchLabels` field in all Deployment resources.
+
+Example:
 
 ```yaml
 commonLabels:
@@ -53,6 +94,29 @@ commonLabels:
 - path: spec/selector/matchLabels
   create: true
   kind: Deployment
+```
+
+Example kustomization.yaml:
+
+```yaml
+commonLabels:
+  someName: someValue
+  owner: alice
+  app: bingo
+```
+
+## Annotations transformer
+
+The annotations transformer adds annotations to the `metadata/annotations` field for all resources.
+Annotations are also added to `spec/template/metadata/annotations` for Deployment,
+ReplicaSet, DaemonSet, StatefulSet, Job, and CronJob resources, and `spec/jobTemplate/spec/template/metadata/annotations`
+for CronJob resources.
+
+Example kustomization.yaml
+
+```yaml
+commonAnnotations:
+  oncallPager: 800-555-1212
 ```
 
 ## Name reference transformer
@@ -99,7 +163,7 @@ nameReference:
 
 ## Customizing transformer configurations
 
-Kustomize has a default set of transformer configurations. You can save the default transformer configurations to a local directory by calling `kustomize config save -d`, and modify and use these configurations. Kustomize also supports adding new transformer configurations to kustomization.yaml. This tutorial shows how to customize those configurations to:
+In addition to the default transformers, you can create custom transformer configurations. Save the default transformer configurations to a local directory by calling `kustomize config save -d`, and modify and use these configurations. This tutorial shows how to create custom transformer configurations:
 
 - [support a CRD type](crd/README.md)
 - add extra fields for variable substitution

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -47,6 +47,7 @@ images:
   - name: my-demo-app
     newName: my-app
   - name: alpine
+    digest: sha256:25a0d4
 ```
 
 Image transformer configurations can be customized by creating a list of `images` containing the `path` and `kind` fields.

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -30,11 +30,10 @@ If `create` is set to `true`, the transformer creates the path to the field in t
 
 ## Images transformer
 
-The default images transformer updates the list of images in relation to paths that include
-`containers` and `initcontainer` sub-paths.
+The default images transformer updates the specified image key values found in paths that include
+`containers` and `initcontainers` sub-paths.
 If found, the `image` key value is customized by the values set in the `newName`, `newTag`, and `digest` fields.
-You can set either the `newTag` field or the `digest` field for a given image transformation. The `name` field identifies
-the `image` key value in a resource.
+The `name` field should match the `image` key value in a resource.
 
 Example kustomization.yaml:
 
@@ -72,8 +71,6 @@ namePrefix:
 nameSuffix:
   -v2
 ```
-
-All Resources with path, `metadata/name` will be updated with the prefix, `alices-`.
 
 ## Labels transformer
 

--- a/examples/transformerconfigs/images/README.md
+++ b/examples/transformerconfigs/images/README.md
@@ -1,0 +1,112 @@
+## Images transformations
+
+This tutorial shows how to modify images in resources, and create custom images transformer configurations.
+
+Create a workspace by
+<!-- @createws @test -->
+```
+DEMO_HOME=$(mktemp -d)
+```
+
+### Adding a custom resource
+
+Consider a Custom Resource Definition(CRD) of kind `MyKind` with field
+- `.spec.runLatest.configuration.revisionTemplate.spec.container.image` referencing an image
+
+Add the following file to configure the images transformer for the CRD:
+
+<!-- @addConfig @test -->
+```
+mkdir $DEMO_HOME/kustomizeconfig
+cat > $DEMO_HOME/kustomizeconfig/mykind.yaml << EOF
+
+images:
+- path: spec/runLatest/configuration/revisionTemplate/spec/container/image
+  kind: MyKind
+EOF
+```
+
+### Apply config
+
+Create a file with some resources that includes an instance of `MyKind`:
+
+<!-- @createResource @test -->
+```
+cat > $DEMO_HOME/resources.yaml << EOF
+
+apiVersion: mykind/config/v1
+kind: MyKind
+metadata:
+  name: testSvc
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            - image: my-app
+              name: my-app-name
+  containers:
+    - image: docker
+      name: ecosystem
+    - image: my-mysql
+      name: solar
+---
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: nginx2
+        image: my-app
+      - name: init-alpine
+        image: alpine:1.8.0
+EOF
+```
+
+Create a kustomization referring to it:
+
+<!-- @createKustomization @test -->
+```
+cat > $DEMO_HOME/kustomization.yaml << EOF
+resources:
+- resources.yaml
+
+configurations:
+- mykind.yaml
+
+images:
+- name: my-app
+  newName: bear1
+  newTag: MYNEWTAG1
+- name: my-mysql
+  newName: prod-mysql
+  newTag: v3
+- name: docker
+  newName: my-docker2
+  digest: sha256:25a0d4
+EOF
+```
+
+Use the customized transformer configurations by specifying them
+in the kustomization file:
+<!-- @addTransformerConfigs @test -->
+```
+cat >> $DEMO_HOME/kustomization.yaml << EOF
+configurations:
+- kustomizeconfig/mykind.yaml
+EOF
+```
+
+Run `kustomize build` and verify that the list of images have been updated.
+
+<!-- TODO, fixme, @build @test -->
+```
+test 2 == \
+$(kustomize build $DEMO_HOME | grep -A 2 ".*image" | grep "bear1" | wc -l); \
+echo $?
+```

--- a/examples/transformerconfigs/images/README.md
+++ b/examples/transformerconfigs/images/README.md
@@ -34,7 +34,7 @@ Create a file with some resources that includes an instance of `MyKind`:
 ```
 cat > $DEMO_HOME/resources.yaml << EOF
 
-apiVersion: mykind/config/v1
+apiVersion: config/v1
 kind: MyKind
 metadata:
   name: testSvc
@@ -44,8 +44,7 @@ spec:
       revisionTemplate:
         spec:
           container:
-            - image: my-app
-              name: my-app-name
+            image: my-app
   containers:
     - image: docker
       name: ecosystem
@@ -68,16 +67,13 @@ spec:
 EOF
 ```
 
-Create a kustomization referring to it:
+Create a kustomization.yaml referring to it:
 
 <!-- @createKustomization @test -->
 ```
 cat > $DEMO_HOME/kustomization.yaml << EOF
 resources:
 - resources.yaml
-
-configurations:
-- mykind.yaml
 
 images:
 - name: my-app
@@ -102,11 +98,25 @@ configurations:
 EOF
 ```
 
-Run `kustomize build` and verify that the list of images have been updated.
+Run `kustomize build` and verify that the images have been updated.
 
-<!-- TODO, fixme, @build @test -->
+<!-- @build @test -->
 ```
-test 2 == \
+test 1 == \
 $(kustomize build $DEMO_HOME | grep -A 2 ".*image" | grep "bear1" | wc -l); \
 echo $?
 ```
+
+<!-- @build @test -->
+```
+test 2 == \
+$(kustomize build $DEMO_HOME | grep -A 2 ".*image" | grep "my-docker2@sha" | wc -l); \
+echo $?
+```
+<!-- @build @test -->
+```
+test 3 == \
+$(kustomize build $DEMO_HOME | grep -A 2 ".*image" | grep "prod-mysql:v3" | wc -l); \
+echo $?
+```
+

--- a/examples/transformerconfigs/images/kustomization.yaml
+++ b/examples/transformerconfigs/images/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- resources.yaml
+
+configurations:
+- kustomizeconfig/mykind.yaml
+
+images:
+- name: my-app
+  newName: bear1
+  newTag: MYNEWTAG1
+- name: my-mysql
+  newName: prod-mysql
+  newTag: v3
+- name: docker
+  newName: my-docker2
+  digest: sha256:25a0d4

--- a/examples/transformerconfigs/images/kustomization.yaml
+++ b/examples/transformerconfigs/images/kustomization.yaml
@@ -5,9 +5,12 @@ configurations:
 - kustomizeconfig/mykind.yaml
 
 images:
+- name: crd-image
+  newName: new-crd-image
+  newTag: new-v1-tag
 - name: my-app
-  newName: bear1
-  newTag: MYNEWTAG1
+  newName: new-app-1
+  newTag: MYNEWTAG-1
 - name: my-mysql
   newName: prod-mysql
   newTag: v3

--- a/examples/transformerconfigs/images/mykind.yaml
+++ b/examples/transformerconfigs/images/mykind.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/runLatest/configuration/revisionTemplate/spec/container/image
+  kind: MyKind

--- a/examples/transformerconfigs/images/mykind.yaml
+++ b/examples/transformerconfigs/images/mykind.yaml
@@ -1,3 +1,3 @@
 images:
-- path: spec/runLatest/configuration/revisionTemplate/spec/container/image
+- path: spec/runLatest/container/image
   kind: MyKind

--- a/examples/transformerconfigs/images/resources.yaml
+++ b/examples/transformerconfigs/images/resources.yaml
@@ -4,17 +4,13 @@ metadata:
   name: testSvc
 spec:
   runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            - image: my-app
-              name: my-app-name
+    container:
+      image: crd-image
   containers:
     - image: docker
       name: ecosystem
     - image: my-mysql
-      name: solar
+      name: testing-1
 ---
 group: apps
 apiVersion: v1

--- a/examples/transformerconfigs/images/resources.yaml
+++ b/examples/transformerconfigs/images/resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: mykind/config/v1
+kind: MyKind
+metadata:
+  name: testSvc
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            - image: my-app
+              name: my-app-name
+  containers:
+    - image: docker
+      name: ecosystem
+    - image: my-mysql
+      name: solar
+---
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: nginx2
+        image: my-app
+      - name: init-alpine
+        image: alpine:1.8.0

--- a/examples/transformerconfigs/images/resources.yaml
+++ b/examples/transformerconfigs/images/resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: mykind/config/v1
+apiVersion: config/v1
 kind: MyKind
 metadata:
   name: testSvc

--- a/pkg/git/cloner.go
+++ b/pkg/git/cloner.go
@@ -68,9 +68,8 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 			"trouble adding remote %s",
 			repoSpec.CloneSpec())
 	}
-
 	if repoSpec.ref == "" {
-		return nil
+		repoSpec.ref = "master"
 	}
 	cmd = exec.Command(
 		gitProgram,

--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -108,6 +108,8 @@ nameReference:
     kind: Job
   - path: spec/jobTemplate/spec/template/spec/volumes/configMap/name
     kind: CronJob
+  - path: spec/jobTemplate/spec/template/spec/volumes/projected/sources/configMap/name
+    kind: CronJob
   - path: spec/jobTemplate/spec/template/spec/containers/env/valueFrom/configMapKeyRef/name
     kind: CronJob
   - path: spec/jobTemplate/spec/template/spec/initContainers/env/valueFrom/configMapKeyRef/name
@@ -203,6 +205,8 @@ nameReference:
   - path: spec/template/spec/imagePullSecrets/name
     kind: Job
   - path: spec/jobTemplate/spec/template/spec/volumes/secret/secretName
+    kind: CronJob
+  - path: spec/jobTemplate/spec/template/spec/volumes/projected/sources/secret/name
     kind: CronJob
   - path: spec/jobTemplate/spec/template/spec/containers/env/valueFrom/secretKeyRef/name
     kind: CronJob

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -241,6 +241,43 @@ func TestNameReferenceHappyRun(t *testing.T) {
 					},
 				},
 			}),
+		resid.NewResId(cronjob, "cronjob1"): rf.FromMap(
+			map[string]interface{}{
+				"apiVersion": "batch/v1beta1",
+				"kind":       "CronJob",
+				"metadata": map[string]interface{}{
+					"name": "cronjob1",
+				},
+				"spec": map[string]interface{}{
+					"schedule": "0 14 * * *",
+					"jobTemplate": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"spec": map[string]interface{}{
+									"containers": []interface{}{
+										map[string]interface{}{
+											"name":  "main",
+											"image": "myimage",
+										},
+									},
+									"volumes": map[string]interface{}{
+										"projected": map[string]interface{}{
+											"sources": map[string]interface{}{
+												"configMap": map[string]interface{}{
+													"name": "cm2",
+												},
+												"secret": map[string]interface{}{
+													"name": "secret1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 	}
 
 	expected := resmap.ResMap{}
@@ -413,6 +450,43 @@ func TestNameReferenceHappyRun(t *testing.T) {
 						"someprefix-secret1-somehash",
 						"someprefix-secret1-somehash",
 						"secret2",
+					},
+				},
+			},
+		})
+	expected[resid.NewResId(cronjob, "cronjob1")] = rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "batch/v1beta1",
+			"kind":       "CronJob",
+			"metadata": map[string]interface{}{
+				"name": "cronjob1",
+			},
+			"spec": map[string]interface{}{
+				"schedule": "0 14 * * *",
+				"jobTemplate": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "main",
+										"image": "myimage",
+									},
+								},
+								"volumes": map[string]interface{}{
+									"projected": map[string]interface{}{
+										"sources": map[string]interface{}{
+											"configMap": map[string]interface{}{
+												"name": "someprefix-cm2-somehash",
+											},
+											"secret": map[string]interface{}{
+												"name": "someprefix-secret1-somehash",
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
- See issue #909.
- The CRD part of the tutorial does not work yet. Waiting on code updates.
- Is it possible to set `newTag` and `digest` on the same image?
- Is the description, tutorial of images transformers clear or confusing? Is it needed?

