### PR TITLE
fix the regression of building remote url

### DIFF
--- a/examples/remoteBuild.md
+++ b/examples/remoteBuild.md
@@ -10,7 +10,7 @@ Running `kustomize build` against the url gives the same output.
 
 <!-- @remoteBuild @test -->
 ```
-target=github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
+target=github.com/kubernetes-sigs/kustomize//examples/multibases
 test 3 == \
   $(kustomize build $target | grep cluster-a-.*-myapp-pod | wc -l); \
   echo $?

--- a/pkg/git/cloner.go
+++ b/pkg/git/cloner.go
@@ -68,9 +68,8 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 			"trouble adding remote %s",
 			repoSpec.CloneSpec())
 	}
-
 	if repoSpec.ref == "" {
-		return nil
+		repoSpec.ref = "master"
 	}
 	cmd = exec.Command(
 		gitProgram,


### PR DESCRIPTION
Fix #913

When the `ref` is not defined, the git cloner returned without fetching the remote.
It should treat the `ref` as `master`