### PR TITLE
add generators and transformers

### DIFF
--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -67,6 +67,8 @@ func determineFieldOrder() []string {
 		"Vars",
 		"Images",
 		"Configurations",
+		"Generators",
+		"Transformers",
 	}
 
 	// Add deprecated fields here.

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -46,6 +46,8 @@ func TestFieldOrder(t *testing.T) {
 		"Vars",
 		"Images",
 		"Configurations",
+		"Generators",
+		"Transformers",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {

--- a/pkg/pgmconfig/generator.go
+++ b/pkg/pgmconfig/generator.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgmconfig
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// Generator represents a Generator
+type Generator struct {
+	name  string
+	input []byte
+}
+
+// NewGenerator returns a Generator
+func NewGenerator(input []byte) (*Generator, error) {
+	dir := os.Getenv(XDG_CONFIG_HOME)
+	if len(dir) == 0 {
+		return nil, fmt.Errorf("$%s is undefined", XDG_CONFIG_HOME)
+	}
+
+	name, err := getGroup(input)
+	if err != nil {
+		return nil, err
+	}
+	executable := filepath.Join(dir, PgmName, "plugins", name)
+	return &Generator{
+		name:  executable,
+		input: input,
+	}, nil
+}
+
+func (g *Generator) Run(dir string) ([]byte, error) {
+	if !isPluginAvailable(g.name) {
+		return nil, fmt.Errorf("Executable %s not found", g.name)
+	}
+	cmd := exec.Command(g.name, "generate", string(g.input))
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	return cmd.Output()
+}
+
+// getGroup returns the Group in `groupVersion` from a generator or transformer file
+func getGroup(input []byte) (string, error) {
+	var m map[string]interface{}
+	err := yaml.Unmarshal(input, &m)
+	if err != nil {
+		return "", err
+	}
+	rawGV, ok := m["groupVersion"]
+	if !ok {
+		return "", fmt.Errorf("missing groupVersion in %s", string(input))
+	}
+	gv, ok := rawGV.(string)
+	if !ok {
+		return "", fmt.Errorf("can't convert %v to string", rawGV)
+	}
+	values := strings.Split(gv, "/")
+	return values[0], nil
+}
+
+// isPluginAvailable checks if a plugin is available from
+// $XDG_CONFIG_HOME/kustomize/plugins/
+func isPluginAvailable(name string) bool {
+	f, err := os.Stat(name)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if f.Mode()&0111 != 0000 {
+		return true
+	}
+	return false
+}

--- a/pkg/pgmconfig/generator_test.go
+++ b/pkg/pgmconfig/generator_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgmconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewGenerator(t *testing.T) {
+	testcases := []struct {
+		env    string
+		input  string
+		group  string
+		errmsg string
+	}{
+		{
+			input:  "anything",
+			errmsg: "$XDG_CONFIG_HOME is undefined",
+		},
+		{
+			env:    "test",
+			input:  "anything",
+			errmsg: "error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}",
+		},
+		{
+			env:    "test",
+			input:  "apiVersion: v1",
+			errmsg: "missing groupVersion in apiVersion: v1",
+		},
+		{
+			env:   "test",
+			input: "groupVersion: team.example.com/v1beta1",
+			group: "team.example.com",
+		},
+	}
+	for _, testcase := range testcases {
+		if testcase.env != "" {
+			os.Setenv(XDG_CONFIG_HOME, testcase.env)
+		} else {
+			os.Unsetenv(XDG_CONFIG_HOME)
+		}
+		g, err := NewGenerator([]byte(testcase.input))
+
+		if testcase.errmsg == "" {
+			if err != nil {
+				t.Errorf("unpected error %v", err)
+			}
+			expected := filepath.Join(testcase.env, "kustomize", "plugins", testcase.group)
+			if g.name != expected {
+				t.Errorf("expected executable as %s, but got %s", expected, g.name)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("expected error %s, but not happened", testcase.errmsg)
+			}
+			if err.Error() != testcase.errmsg {
+				t.Errorf("expected %s, but got %v", testcase.errmsg, err)
+			}
+		}
+	}
+}
+
+func TestGeneratorRun(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	os.Setenv(XDG_CONFIG_HOME, filepath.Join(dir, "testdata"))
+	input := []byte(`
+groupVersion: test.kustomize.k8s.io/v1beta
+kind: ConfigMapG
+generate:
+  name: test
+`)
+	g, err := NewGenerator(input)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	output, err := g.Run("./")
+	expect := `
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: example-configmap-test
+data:
+  username: admin
+  password: secret
+`
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if string(output) != expect {
+		t.Errorf("expected %s, but got %s", expect, string(output))
+	}
+}

--- a/pkg/pgmconfig/transformer.go
+++ b/pkg/pgmconfig/transformer.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgmconfig
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Transformer represents a Transformer
+type Transformer struct {
+	name  string
+	input []byte
+}
+
+// NewTransformer returns a Transformer
+// TODO: Add list of resources from ResMap as input or Run argument of the transformer
+func NewTransformer(input []byte) (*Transformer, error) {
+	name, err := getGroup(input)
+	if err != nil {
+		return nil, err
+	}
+	executable := filepath.Join(XDG_CONFIG_HOME, PgmName, "plugins", name)
+	if !isPluginAvailable(executable) {
+		return nil, fmt.Errorf("Executable %s not found", name)
+	}
+	return &Transformer{
+		name:  name,
+		input: input,
+	}, nil
+}
+
+func (g *Transformer) Run(dir string) ([]byte, error) {
+	cmd := exec.Command(g.name, "transform", string(g.input))
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	return cmd.Output()
+}

--- a/pkg/pgmconfig/transformer_test.go
+++ b/pkg/pgmconfig/transformer_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgmconfig

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -130,6 +130,12 @@ type Kustomization struct {
 
 	// Configurations is a list of transformer configuration files
 	Configurations []string `json:"configurations,omitempty" yaml:"configurations,omitempty"`
+
+	// Generators is a list of files containing custom generators
+	Generators []string `json:"generators,omitempty" yaml:"generators,omitempty"`
+
+	// Transformers is a list of files containing transformers
+	Transformers []string `json:"transformers,omitempty" yaml:"transformers,omitempty"`
 }
 
 // DealWithMissingFields fills the missing fields


### PR DESCRIPTION
implement the generators and transformers [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190318-kustomize-generators-transformers.md)

In this PR I covered:
- add fields `generators` and `transformers`
- add struct `Generators` and `Transformers`
- add Run function
- add unit tests for generators

Todo:
- add/refine Run function for Transformers
- add unit tests for transformers
- trigger generators and transformers in kusttarget