### PR TITLE
add support for transformer goplugins

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -62,7 +62,8 @@ url examples:
 func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
-	ptf transformer.Factory) *cobra.Command {
+	ptf transformer.Factory,
+	b bool) *cobra.Command {
 	var o Options
 
 	cmd := &cobra.Command{
@@ -75,7 +76,7 @@ func NewCmdBuild(
 			if err != nil {
 				return err
 			}
-			return o.RunBuild(out, fs, rf, ptf)
+			return o.RunBuild(out, fs, rf, ptf, b)
 		},
 	}
 	cmd.Flags().StringVarP(
@@ -102,13 +103,14 @@ func (o *Options) Validate(args []string) error {
 // RunBuild runs build command.
 func (o *Options) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
-	rf *resmap.Factory, ptf transformer.Factory) error {
+	rf *resmap.Factory, ptf transformer.Factory,
+	b bool) error {
 	ldr, err := loader.NewLoader(o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, rf, ptf)
+	kt, err := target.NewKustTarget(ldr, rf, ptf, b)
 	if err != nil {
 		return err
 	}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -68,7 +68,7 @@ See https://sigs.k8s.io/kustomize
 		build.NewCmdBuild(
 			stdOut, fSys,
 			resmap.NewFactory(resource.NewFactory(uf)),
-			transformer.NewFactoryImpl()),
+			transformer.NewFactoryImpl(), genMetaArgs.PluginConfig.GoEnabled),
 		edit.NewCmdEdit(fSys, validator.NewKustValidator(), uf),
 		misc.NewCmdConfig(fSys),
 		misc.NewCmdVersion(stdOut),

--- a/pkg/pgmconfig/constants.go
+++ b/pkg/pgmconfig/constants.go
@@ -28,5 +28,6 @@ var KustomizationFileNames = []string{
 }
 
 const (
-	PgmName = "kustomize"
+	PgmName    = "kustomize"
+	PluginsDir = "plugins"
 )

--- a/pkg/plugins/transformers.go
+++ b/pkg/plugins/transformers.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"path/filepath"
+	"plugin"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/pgmconfig"
+	"sigs.k8s.io/kustomize/pkg/resid"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/transformers"
+)
+
+const transformerSymbol = "Transformer"
+
+type Configurable interface {
+	Config(k ifc.Kunstructured) error
+}
+
+type transformerLoader struct {
+	pluginDir string
+	enabled   bool
+}
+
+func NewTransformerLoader(b bool) transformerLoader {
+	return transformerLoader{
+		pluginDir: filepath.Join(pgmconfig.ConfigRoot(), pgmconfig.PluginsDir),
+		enabled:   b,
+	}
+}
+
+func (l transformerLoader) Load(rm resmap.ResMap) ([]transformers.Transformer, error) {
+	if len(rm) == 0 {
+		return nil, nil
+	}
+	if !l.enabled {
+		return nil, fmt.Errorf("plugin is not enabled")
+	}
+	var result []transformers.Transformer
+	for id, res := range rm {
+		t, err := l.load(id, res)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, t)
+	}
+	return result, nil
+}
+
+func (l transformerLoader) load(id resid.ResId, res *resource.Resource) (transformers.Transformer, error) {
+	fileName := filepath.Join(l.pluginDir, id.Gvk().Kind+".so")
+	goPlugin, err := plugin.Open(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("plugin %s file not opened", fileName)
+	}
+
+	symbol, err := goPlugin.Lookup(transformerSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("plugin %s fails lookup", fileName)
+	}
+
+	c, ok := symbol.(Configurable)
+	if !ok {
+		return nil, fmt.Errorf("plugin %s not configurable", fileName)
+	}
+	err = c.Config(res)
+	if err != nil {
+		return nil, errors.Wrapf(err, "plugin %s fails configuration", fileName)
+	}
+
+	t, ok := c.(transformers.Transformer)
+	if !ok {
+		return nil, fmt.Errorf("plugin %s not a transformer", fileName)
+	}
+	return t, nil
+}

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -204,7 +204,7 @@ func TestResources(t *testing.T) {
 }
 
 func TestKustomizationNotFound(t *testing.T) {
-	_, err := NewKustTarget(loadertest.NewFakeLoader("/foo"), nil, nil)
+	_, err := NewKustTarget(loadertest.NewFakeLoader("/foo"), nil, nil, false)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}

--- a/pkg/target/kusttestharness_test.go
+++ b/pkg/target/kusttestharness_test.go
@@ -40,6 +40,7 @@ type KustTestHarness struct {
 	t   *testing.T
 	rf  *resmap.Factory
 	ldr loadertest.FakeLoader
+	b   bool
 }
 
 func NewKustTestHarness(t *testing.T, path string) *KustTestHarness {
@@ -55,12 +56,13 @@ func NewKustTestHarnessWithPluginConfig(
 		rf: resmap.NewFactory(resource.NewFactory(
 			kunstruct.NewKunstructuredFactoryWithGeneratorArgs(
 				&types.GeneratorMetaArgs{PluginConfig: config}))),
-		ldr: loadertest.NewFakeLoader(path)}
+		ldr: loadertest.NewFakeLoader(path),
+		b:   config.GoEnabled}
 }
 
 func (th *KustTestHarness) makeKustTarget() *KustTarget {
 	kt, err := NewKustTarget(
-		th.ldr, th.rf, transformer.NewFactoryImpl())
+		th.ldr, th.rf, transformer.NewFactoryImpl(), th.b)
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}

--- a/pkg/target/transformerplugin_test.go
+++ b/pkg/target/transformerplugin_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package target_test
+
+import (
+	"sigs.k8s.io/kustomize/pkg/types"
+	"testing"
+)
+
+func writeDeployment(th *KustTestHarness, path string) {
+	th.writeF(path, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  template:
+    metadata:
+      labels:
+        backend: awesome
+    spec:
+      containers:
+      - name: whatever
+        image: whatever
+`)
+}
+
+func writeStringPrefixer(th *KustTestHarness, path string) {
+	th.writeF(path, `
+apiVersion: strings.microwoosh.com/v1
+kind: StringPrefixer
+metadata:
+  name: myStringPrefixer
+prefix: apple-
+`)
+}
+
+func writeDatePrefixer(th *KustTestHarness, path string) {
+	th.writeF(path, `
+apiVersion: team.dater.com/v1
+kind: DatePrefixer
+metadata:
+  name: myDatePrefixer
+`)
+}
+
+func TestOrderedTransformers(t *testing.T) {
+	th := NewKustTestHarnessWithPluginConfig(
+		t, "/app", types.PluginConfig{GoEnabled: true})
+	th.writeK("/app", `
+resources:
+- deployment.yaml
+transformers:
+- stringPrefixer.yaml
+`)
+	writeDeployment(th, "/app/deployment.yaml")
+	writeStringPrefixer(th, "/app/stringPrefixer.yaml")
+	writeDatePrefixer(th, "/app/datePrefixer.yaml")
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apple-myDeployment
+spec:
+  template:
+    metadata:
+      labels:
+        backend: awesome
+    spec:
+      containers:
+      - image: whatever
+        name: whatever
+`)
+}
+
+func xTestTransformedTransformers(t *testing.T) {
+	th := NewKustTestHarnessWithPluginConfig(
+		t, "/app/overlay", types.PluginConfig{GoEnabled: true})
+
+	th.writeK("/app/base", `
+resources:
+- stringPrefixer.yaml
+transformers:
+- datePrefixer.yaml
+`)
+	writeStringPrefixer(th, "/app/base/stringPrefixer.yaml")
+	writeDatePrefixer(th, "/app/base/datePrefixer.yaml")
+
+	th.writeK("/app/overlay", `
+resources:
+- deployment.yaml
+transformers:
+- ../base
+`)
+	writeDeployment(th, "/app/overlay/deployment.yaml")
+
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(m, `
+HEY
+`)
+}

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -17,10 +17,17 @@ limitations under the License.
 // Package transformers has implementations of resmap.ResMap transformers.
 package transformers
 
-import "sigs.k8s.io/kustomize/pkg/resmap"
+import (
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+)
 
 // A Transformer modifies an instance of resmap.ResMap.
 type Transformer interface {
 	// Transform modifies data in the argument, e.g. adding labels to resources that can be labelled.
 	Transform(m resmap.ResMap) error
+}
+
+type Configurable interface {
+	Config(k ifc.Kunstructured) error
 }

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -18,7 +18,6 @@ limitations under the License.
 package transformers
 
 import (
-	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 )
 
@@ -26,8 +25,4 @@ import (
 type Transformer interface {
 	// Transform modifies data in the argument, e.g. adding labels to resources that can be labelled.
 	Transform(m resmap.ResMap) error
-}
-
-type Configurable interface {
-	Config(k ifc.Kunstructured) error
 }

--- a/plugins/DatePrefixer.go
+++ b/plugins/DatePrefixer.go
@@ -1,0 +1,30 @@
+// +build plugin
+
+package main
+
+import (
+	"time"
+
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/transformers"
+	"sigs.k8s.io/kustomize/pkg/transformers/config"
+)
+
+type plugin struct{}
+
+var Transformer plugin
+
+func (p *plugin) Config(k ifc.Kunstructured) error {
+	return nil
+}
+
+func (p *plugin) Transform(m resmap.ResMap) error {
+	tr, err := transformers.NewNamePrefixSuffixTransformer(
+		time.Now().Format("2006-01-02")+"-", "",
+		config.MakeDefaultConfig().NamePrefix)
+	if err != nil {
+		return err
+	}
+	return tr.Transform(m)
+}

--- a/plugins/StringPrefixer.go
+++ b/plugins/StringPrefixer.go
@@ -1,0 +1,44 @@
+// +build plugin
+
+// Assuming GOPATH is something like
+//   ~/gopath
+// and this source file is located at
+//   $GOPATH/src/sigs.k8s.io/kustomize/plugins/StringPrefixer.go,
+// build it like this:
+//   dir=$GOPATH/src/sigs.k8s.io/kustomize/plugins
+//   go build -buildmode plugin -tags=plugin \
+//     -o $dir/StringPrefixer.so $dir/StringPrefixer.go
+
+package main
+
+import (
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/transformers"
+	"sigs.k8s.io/kustomize/pkg/transformers/config"
+)
+
+type plugin struct{
+	prefix string
+}
+
+var Transformer plugin
+
+func (p *plugin) Config(k ifc.Kunstructured) error {
+	var err error
+	p.prefix, err = k.GetFieldValue("prefix")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *plugin) Transform(m resmap.ResMap) error {
+	tr, err := transformers.NewNamePrefixSuffixTransformer(
+		p.prefix, "",
+		config.MakeDefaultConfig().NamePrefix)
+	if err != nil {
+		return err
+	}
+	return tr.Transform(m)
+}

--- a/plugins/kvMaker.go
+++ b/plugins/kvMaker.go
@@ -1,0 +1,24 @@
+// +build plugin
+
+package main
+var database = map[string]string{
+  "TREE":      "oak",
+  "ROCKET":    "Saturn V",
+  "FRUIT":     "apple",
+  "VEGETABLE": "carrot",
+  "SIMPSON":   "homer",
+}
+
+type plugin struct{}
+var KVSource plugin
+func (p plugin) Get(
+    root string, args []string) (map[string]string, error) {
+  r := make(map[string]string)
+  for _, k := range args {
+    v, ok := database[k]
+    if ok {
+      r[k] = v
+    }
+  }
+  return r, nil
+}


### PR DESCRIPTION
1. Load the file content from paths listed under `transformers` as resources.
2. Read the Kind from the resource and treat it as the goplugin name
3. The goplugin is searched under $XDG_CONFIG_HOME/kustomize/plugins, if $XDG_CONFIG_HOME is not defined, search $HOME/.config/kustomize/plugins
4. The goplugin is configued (you can also think of this as input arguments to a program) by the resource loaded in step 1.
5. Also need to run `kustomize build -enable_alpha_goplugins_accept_panic_risk` to allow goplugins