### PR TITLE
Add --force flag to modify annotations and labels

### DIFF
--- a/pkg/commands/edit/add/addmetadata.go
+++ b/pkg/commands/edit/add/addmetadata.go
@@ -47,6 +47,7 @@ func (k kindOfAdd) String() string {
 }
 
 type addMetadataOptions struct {
+	force        bool
 	metadata     map[string]string
 	mapValidator func(map[string]string) error
 	kind         kindOfAdd
@@ -66,6 +67,9 @@ func newCmdAddAnnotation(fSys fs.FileSystem, v func(map[string]string) error) *c
 			return o.runE(args, fSys, o.addAnnotations)
 		},
 	}
+	cmd.Flags().BoolVarP(&o.force, "force", "f", false,
+		"overwrite commonAnnotation if it already exists",
+	)
 	return cmd
 }
 
@@ -83,6 +87,9 @@ func newCmdAddLabel(fSys fs.FileSystem, v func(map[string]string) error) *cobra.
 			return o.runE(args, fSys, o.addLabels)
 		},
 	}
+	cmd.Flags().BoolVarP(&o.force, "force", "f", false,
+		"overwrite commonLabel if it already exists",
+	)
 	return cmd
 }
 
@@ -163,7 +170,7 @@ func (o *addMetadataOptions) addLabels(m *types.Kustomization) error {
 
 func (o *addMetadataOptions) writeToMap(m map[string]string, kind kindOfAdd) error {
 	for k, v := range o.metadata {
-		if _, ok := m[k]; ok {
+		if _, ok := m[k]; ok && !o.force {
 			return fmt.Errorf("%s %s already in kustomization file", kind, k)
 		}
 		m[k] = v

--- a/pkg/commands/edit/add/addmetadata_test.go
+++ b/pkg/commands/edit/add/addmetadata_test.go
@@ -187,6 +187,40 @@ func TestAddAnnotationMultipleArgs(t *testing.T) {
 	}
 }
 
+func TestAddAnnotationForce(t *testing.T) {
+	fakeFS := fs.MakeFakeFS()
+	fakeFS.WriteTestKustomization()
+	v := validators.MakeHappyMapValidator(t)
+	cmd := newCmdAddAnnotation(fakeFS, v.Validator)
+	args := []string{"key:foo"}
+	err := cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err.Error())
+	}
+	// trying to add the same annotation again should not work
+	args = []string{"key:bar"}
+	v = validators.MakeHappyMapValidator(t)
+	cmd = newCmdAddAnnotation(fakeFS, v.Validator)
+	err = cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err == nil {
+		t.Errorf("expected an error")
+	}
+	if err.Error() != "annotation key already in kustomization file" {
+		t.Errorf("expected an error")
+	}
+	// but trying to add it with --force should
+	v = validators.MakeHappyMapValidator(t)
+	cmd = newCmdAddAnnotation(fakeFS, v.Validator)
+	cmd.Flag("force").Value.Set("true")
+	err = cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err.Error())
+	}
+}
+
 func TestRunAddLabel(t *testing.T) {
 	var o addMetadataOptions
 	o.metadata = map[string]string{"owls": "cute", "otters": "adorable"}
@@ -292,6 +326,40 @@ func TestAddLabelMultipleArgs(t *testing.T) {
 	}
 	if err.Error() != "labels must be comma-separated, with no spaces" {
 		t.Errorf("incorrect error: %v", err.Error())
+	}
+}
+
+func TestAddLabelForce(t *testing.T) {
+	fakeFS := fs.MakeFakeFS()
+	fakeFS.WriteTestKustomization()
+	v := validators.MakeHappyMapValidator(t)
+	cmd := newCmdAddLabel(fakeFS, v.Validator)
+	args := []string{"key:foo"}
+	err := cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err.Error())
+	}
+	// trying to add the same label again should not work
+	args = []string{"key:bar"}
+	v = validators.MakeHappyMapValidator(t)
+	cmd = newCmdAddLabel(fakeFS, v.Validator)
+	err = cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err == nil {
+		t.Errorf("expected an error")
+	}
+	if err.Error() != "label key already in kustomization file" {
+		t.Errorf("expected an error")
+	}
+	// but trying to add it with --force should
+	v = validators.MakeHappyMapValidator(t)
+	cmd = newCmdAddLabel(fakeFS, v.Validator)
+	cmd.Flag("force").Value.Set("true")
+	err = cmd.RunE(cmd, args)
+	v.VerifyCall()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err.Error())
 	}
 }
 


### PR DESCRIPTION
This change adds a new flag (`--force`) to commands `edit add annotation` and `edit add label` so that annotations and labels are modified if they already existed.

Fixes #564 