### PR TITLE
update goplugin for executables and add tests

### DIFF
--- a/pkg/plugins/builtin/executable.go
+++ b/pkg/plugins/builtin/executable.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"sigs.k8s.io/kustomize/pkg/ifc"
@@ -15,9 +17,11 @@ import (
 )
 
 type plugin struct {
-	name  string
-	input string
-	rf    *resmap.Factory
+	name string
+	arg  string
+	file string
+	rf   *resmap.Factory
+	ldr  ifc.Loader
 }
 
 var KustomizePlugin plugin
@@ -27,12 +31,18 @@ func (p *plugin) Config(
 	dir := filepath.Join(pgmconfig.ConfigRoot(), "plugins")
 	id := k.GetGvk()
 	p.name = filepath.Join(dir, id.Group, id.Version, id.Kind)
-	content, err := yaml.Marshal(k)
-	if err != nil {
+	p.rf = rf
+	p.ldr = ldr
+
+	var err error
+	p.arg, err = k.GetFieldValue("arg")
+	if err != nil && !strings.Contains(err.Error(), "no field named") {
 		return err
 	}
-	p.input = string(content)
-	p.rf = rf
+	p.file, err = k.GetFieldValue("file")
+	if err != nil && !strings.Contains(err.Error(), "no field named") {
+		return nil
+	}
 	return nil
 }
 
@@ -40,33 +50,57 @@ func (p *plugin) Generate() (resmap.ResMap, error) {
 	return p.run(nil)
 }
 
-func (p *plugin) Transformer(rm resmap.ResMap) error {
-	result, err := p.run(rm)
+func (p *plugin) Transform(rm resmap.ResMap) error {
+	_, err := p.run(rm)
 	if err != nil {
 		return err
-	}
-	for id := range rm {
-		delete(rm, id)
-	}
-	for id, r := range result {
-		rm[id] = r
 	}
 	return nil
 }
 
 func (p *plugin) run(rm resmap.ResMap) (resmap.ResMap, error) {
-	cmd := exec.Command(p.name, p.input)
-	cmd.Env = os.Environ()
-	if rm != nil {
-		content, err := rm.EncodeAsYaml()
+	args := strings.Split(p.arg, " ")
+	if p.file != "" {
+		content, err := p.ldr.Load(p.file)
 		if err != nil {
 			return nil, err
 		}
+		args = append(args, strings.Split(string(content), "\n")...)
+	}
+
+	// For generators
+	if rm == nil {
+		cmd := exec.Command(p.name, args...)
+		cmd.Env = os.Environ()
+		output, err := cmd.Output()
+		if err != nil {
+			return nil, err
+		}
+		return p.rf.NewResMapFromBytes(output)
+	}
+	// For transformers
+	for id, r := range rm {
+		content, err := yaml.Marshal(r.Kunstructured)
+		if err != nil {
+			return nil, err
+		}
+		cmd := exec.Command(p.name, args...)
+		cmd.Env = os.Environ()
 		cmd.Stdin = bytes.NewReader(content)
+		output, err := cmd.Output()
+		if err != nil {
+			return nil, err
+		}
+		tmpMap, err := p.rf.NewResMapFromBytes(output)
+		if err != nil {
+			return nil, err
+		}
+		if len(tmpMap) != 1 {
+			return nil, fmt.Errorf("Unable to put two resources into one")
+		}
+		for _, v := range tmpMap {
+			rm[id].Kunstructured = v.Kunstructured
+		}
 	}
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	return p.rf.NewResMapFromBytes(output)
+	return rm, nil
 }

--- a/pkg/target/generatorplugin_test.go
+++ b/pkg/target/generatorplugin_test.go
@@ -146,6 +146,7 @@ apiVersion: someteam.example.com/v1
 kind: ConfigMapGenerator
 metadata:
   name: some-random-name
+arg: "admin secret"
 `)
 	m, err := th.makeKustTarget().MakeCustomizedResMap()
 	if err != nil {

--- a/pkg/target/transformerplugin_test.go
+++ b/pkg/target/transformerplugin_test.go
@@ -140,7 +140,7 @@ data:
   FOO: foo
 kind: ConfigMap
 metadata:
-  name: test
+  name: test-k4bkhftttd
 `)
 }
 

--- a/plugins/someteam.example.com/v1/ConfigMapGenerator
+++ b/plugins/someteam.example.com/v1/ConfigMapGenerator
@@ -6,6 +6,6 @@ apiVersion: v1
 metadata:
   name: example-configmap-test
 data:
-  username: admin
-  password: secret
+  username: $1
+  password: $2
 "

--- a/plugins/someteam.example.com/v1/SedTransformer
+++ b/plugins/someteam.example.com/v1/SedTransformer
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+args=""
+
+for arg in $@; do
+  args="$args -e $arg"
+done
+cat - | sed $args
+


### PR DESCRIPTION
I realized that the executable.go was not compatible with other transformers since it has code as
```
	for id := range rm {	
		delete(rm, id)	
	}	
	for id, r := range result {	
		rm[id] = r	
	}
```
This looses all the existing IDs, the generator options and name reference relationships.
So I changed it only changing the unstructured data inside the resources.
```
rm[id].Kunstructured = v.Kunstructured
```

In the new change, the resources are applied the executable transformer one by one.


Also add `arg` and `file` fields support. `arg` is passed to `exec.Command`. `file` is loaded from loader and converted to arguments. Note that the file content is not assigned to `cmd.Stdin` since the `cmd.Stdin` is used to accept unstructured data from a resmap.
