### PR TITLE
 fix namespace transformer for cluster-scoped resources

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -158,6 +158,8 @@ var clusterLevelKinds = []string{
 	"CustomResourceDefinition",
 	"Namespace",
 	"PersistentVolume",
+	"MutatingWebhookConfiguration",
+	"ValidatingWebhookConfiguration",
 }
 
 // IsClusterKind returns true if x is a cluster-level Gvk

--- a/pkg/transformers/namespace.go
+++ b/pkg/transformers/namespace.go
@@ -48,14 +48,65 @@ func NewNamespaceTransformer(ns string, cf []config.FieldSpec) Transformer {
 
 // Transform adds the namespace.
 func (o *namespaceTransformer) Transform(m resmap.ResMap) error {
-	mf := resmap.ResMap{}
+	mf := o.filterResmap(m)
 
+	for id := range mf {
+		objMap := mf[id].Map()
+		for _, path := range o.fieldSpecsToUse {
+			switch path.Path {
+			// Special casing .metadata.namespace since it is a common metadata field across all runtime.Object
+			// We should add namespace if it's namespaced resource; otherwise, we should not.
+			case "metadata/namespace":
+				if id.Gvk().IsSelected(&path.Gvk) && !id.Gvk().IsClusterKind() {
+					if len(objMap) > 0 {
+						err := mutateField(
+							objMap, path.PathSlice(), path.CreateIfNotPresent,
+							func(_ interface{}) (interface{}, error) {
+								return o.namespace, nil
+							})
+						if err != nil {
+							return err
+						}
+					}
+				}
+			default:
+				if !id.Gvk().IsSelected(&path.Gvk) {
+					continue
+				}
+				// make sure the object is non empty
+				if len(objMap) > 0 {
+					err := mutateField(
+						objMap, path.PathSlice(), path.CreateIfNotPresent,
+						func(_ interface{}) (interface{}, error) {
+							return o.namespace, nil
+						})
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			if !id.Gvk().IsClusterKind() {
+				newid := id.CopyWithNewNamespace(o.namespace)
+				m[newid] = mf[id]
+			} else {
+				m[id] = mf[id]
+			}
+		}
+	}
+	o.updateClusterRoleBinding(m)
+	return nil
+}
+
+func (o *namespaceTransformer) filterResmap(m resmap.ResMap) resmap.ResMap {
+	mf := resmap.ResMap{}
 	for id := range m {
 		found := false
 		for _, path := range o.fieldSpecsToSkip {
 			if id.Gvk().IsSelected(&path.Gvk) {
 				found = true
-				break
+				mf[id] = m[id]
+				delete(m, id)
 			}
 		}
 		if !found {
@@ -63,31 +114,7 @@ func (o *namespaceTransformer) Transform(m resmap.ResMap) error {
 			delete(m, id)
 		}
 	}
-
-	for id := range mf {
-		objMap := mf[id].Map()
-		for _, path := range o.fieldSpecsToUse {
-			if !id.Gvk().IsSelected(&path.Gvk) {
-				continue
-			}
-			// make sure the object is non empty
-			if len(objMap) > 0 {
-				err := mutateField(
-					objMap, path.PathSlice(), path.CreateIfNotPresent,
-					func(_ interface{}) (interface{}, error) {
-						return o.namespace, nil
-					})
-				if err != nil {
-					return err
-				}
-			}
-			newid := id.CopyWithNewNamespace(o.namespace)
-			m[newid] = mf[id]
-		}
-
-	}
-	o.updateClusterRoleBinding(m)
-	return nil
+	return mf
 }
 
 func (o *namespaceTransformer) updateClusterRoleBinding(m resmap.ResMap) {


### PR DESCRIPTION
Currently kustomize doesn't support customize namespace transformer for cluster-scoped resources. It simply skip it.

With this PR, I can use the following kustomize config to add ns in CRD and admission webhook configurations.
```
namespace:
- kind: CustomResourceDefinition
  group: apiextensions.k8s.io
  path: spec/conversion/webhookClientConfig/service/namespace
  create: true
- kind: MutatingWebhookConfiguration
  group: admissionregistration.k8s.io
  path: webhooks/clientConfig/service/namespace
  create: true
- kind: ValidatingWebhookConfiguration
  group: admissionregistration.k8s.io
  path: webhooks/clientConfig/service/namespace
  create: true
```
