### PR TITLE
update PruneString for resources

### DIFF
--- a/k8sdeps/transformer/prune/prune.go
+++ b/k8sdeps/transformer/prune/prune.go
@@ -59,11 +59,12 @@ func NewPruneTransformer(p *types.Prune, namespace string, append bool) transfor
 // which is proposed in https://github.com/kubernetes/enhancements/pull/810
 func (o *pruneTransformer) Transform(m resmap.ResMap) error {
 	keys := []string{}
-	for id, r := range m {
-		s := id.PruneString()
+	for _, r := range m {
+		s := r.PruneString()
 		keys = append(keys, s)
 		for _, refid := range r.GetRefBy() {
-			keys = append(keys, s+"---"+refid.PruneString())
+			ref := m[refid]
+			keys = append(keys, s+"---"+ref.PruneString())
 		}
 	}
 	h, err := hash.SortArrayAndComputeHash(keys)

--- a/k8sdeps/transformer/prune/prune_test.go
+++ b/k8sdeps/transformer/prune/prune_test.go
@@ -54,8 +54,7 @@ func makeResMap() resmap.ResMap {
 			}),
 		resid.NewResId(deploy, "deploy1"): rf.FromMap(
 			map[string]interface{}{
-				"group":      "apps",
-				"apiVersion": "v1",
+				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
 				"metadata": map[string]interface{}{
 					"name": "deploy1",

--- a/pkg/resid/resid.go
+++ b/pkg/resid/resid.go
@@ -205,13 +205,3 @@ func (n ResId) prefixList() []string {
 func (n ResId) suffixList() []string {
 	return strings.Split(n.suffix, ":")
 }
-
-// PruneString returns a string which can be used
-// as a key in a Prune ConfigMap
-func (n ResId) PruneString() string {
-	name := n.prefix + n.name + n.suffix
-	return n.gvKind.Group +
-		"_" + n.gvKind.Kind +
-		"_" + n.namespace +
-		"_" + name
-}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -89,7 +89,11 @@ func (r *Resource) Merge(other *Resource) {
 }
 
 func (r *Resource) PruneString() string {
-	return r.Id().PruneString()
+	namespace, _ := r.GetFieldValue("metadata.namespace")
+	return r.GetGvk().Group +
+		"_" + r.GetGvk().Kind +
+		"_" + namespace +
+		"_" + r.GetName()
 }
 
 // Replace performs replace with other resource.


### PR DESCRIPTION
Previously the prunestring was get from ResId, where the namehash is not included.
As a consequence, when the configmap/secret Generator changes, the prunestring
doesn't get updated.

This change is to compute `PruneString` from a resource instead of from a id.