### PR TITLE
Simplify plugin loader code.

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -29,9 +29,9 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc/transformer"
 	"sigs.k8s.io/kustomize/pkg/loader"
 	"sigs.k8s.io/kustomize/pkg/pgmconfig"
+	"sigs.k8s.io/kustomize/pkg/plugins"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/target"
-	"sigs.k8s.io/kustomize/pkg/types"
 )
 
 // Options contain the options for running a build
@@ -70,7 +70,7 @@ func NewCmdBuild(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
 	ptf transformer.Factory,
-	pc *types.PluginConfig) *cobra.Command {
+	pl *plugins.Loader) *cobra.Command {
 	var o Options
 
 	cmd := &cobra.Command{
@@ -83,7 +83,7 @@ func NewCmdBuild(
 			if err != nil {
 				return err
 			}
-			return o.RunBuild(out, fs, rf, ptf, pc)
+			return o.RunBuild(out, fs, rf, ptf, pl)
 		},
 	}
 	cmd.Flags().StringVarP(
@@ -92,7 +92,7 @@ func NewCmdBuild(
 		"If specified, write the build output to this path.")
 	loader.AddLoadRestrictionsFlag(cmd.Flags())
 
-	cmd.AddCommand(NewCmdBuildPrune(out, fs, rf, ptf, pc))
+	cmd.AddCommand(NewCmdBuildPrune(out, fs, rf, ptf, pl))
 	return cmd
 }
 
@@ -115,14 +115,14 @@ func (o *Options) Validate(args []string) (err error) {
 func (o *Options) RunBuild(
 	out io.Writer, fSys fs.FileSystem,
 	rf *resmap.Factory, ptf transformer.Factory,
-	pc *types.PluginConfig) error {
+	pl *plugins.Loader) error {
 	ldr, err := loader.NewLoader(
 		o.loadRestrictor, o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, rf, ptf, pc)
+	kt, err := target.NewKustTarget(ldr, rf, ptf, pl)
 	if err != nil {
 		return err
 	}
@@ -136,14 +136,14 @@ func (o *Options) RunBuild(
 func (o *Options) RunBuildPrune(
 	out io.Writer, fSys fs.FileSystem,
 	rf *resmap.Factory, ptf transformer.Factory,
-	pc *types.PluginConfig) error {
+	pl *plugins.Loader) error {
 	ldr, err := loader.NewLoader(
 		o.loadRestrictor, o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, rf, ptf, pc)
+	kt, err := target.NewKustTarget(ldr, rf, ptf, pl)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func NewCmdBuildPrune(
 	out io.Writer, fs fs.FileSystem,
 	rf *resmap.Factory,
 	ptf transformer.Factory,
-	pc *types.PluginConfig) *cobra.Command {
+	pl *plugins.Loader) *cobra.Command {
 	var o Options
 
 	cmd := &cobra.Command{
@@ -187,7 +187,7 @@ func NewCmdBuildPrune(
 			if err != nil {
 				return err
 			}
-			return o.RunBuildPrune(out, fs, rf, ptf, pc)
+			return o.RunBuildPrune(out, fs, rf, ptf, pl)
 		},
 	}
 	return cmd

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/commands/misc"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/pgmconfig"
+	"sigs.k8s.io/kustomize/pkg/plugins"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -64,12 +65,13 @@ See https://sigs.k8s.io/kustomize
 		PluginConfig: pluginConfig,
 	}
 	uf := kunstruct.NewKunstructuredFactoryWithGeneratorArgs(&genMetaArgs)
-
+	rf := resmap.NewFactory(resource.NewFactory(uf))
 	c.AddCommand(
 		build.NewCmdBuild(
 			stdOut, fSys,
-			resmap.NewFactory(resource.NewFactory(uf)),
-			transformer.NewFactoryImpl(), pluginConfig),
+			rf,
+			transformer.NewFactoryImpl(),
+			plugins.NewLoader(pluginConfig, rf)),
 		edit.NewCmdEdit(fSys, validator.NewKustValidator(), uf),
 		misc.NewCmdConfig(fSys),
 		misc.NewCmdVersion(stdOut),

--- a/pkg/plugins/compiler.go
+++ b/pkg/plugins/compiler.go
@@ -62,8 +62,7 @@ func DefaultSrcRoot() (string, error) {
 	}
 	nope = append(nope, root)
 
-	root = filepath.Join(
-		pgmconfig.ConfigRoot(), plugin.PluginRoot)
+	root = plugin.DefaultPluginConfig().DirectoryPath
 	if FileExists(root) {
 		return root, nil
 	}

--- a/pkg/plugins/execplugin.go
+++ b/pkg/plugins/execplugin.go
@@ -27,9 +27,8 @@ import (
 	"syscall"
 
 	"github.com/ghodss/yaml"
-	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/ifc"
-	"sigs.k8s.io/kustomize/pkg/pgmconfig"
+	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 )
 
@@ -59,11 +58,23 @@ type ExecPlugin struct {
 	ldr ifc.Loader
 }
 
+func NewExecPlugin(root string, id resid.ResId) *ExecPlugin {
+	return &ExecPlugin{
+		name: filepath.Join(root, pluginPath(id)),
+	}
+}
+
+// isAvailable checks to see if the plugin is available
+func (p *ExecPlugin) isAvailable() bool {
+	f, err := os.Stat(p.name)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return f.Mode()&0111 != 0000
+}
+
 func (p *ExecPlugin) Config(
 	ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) error {
-	dir := filepath.Join(pgmconfig.ConfigRoot(), plugin.PluginRoot)
-	id := k.GetGvk()
-	p.name = filepath.Join(dir, id.Group, id.Version, id.Kind)
 	p.rf = rf
 	p.ldr = ldr
 

--- a/pkg/plugins/execplugin_test.go
+++ b/pkg/plugins/execplugin_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/internal/loadertest"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
@@ -25,11 +26,11 @@ import (
 
 func TestExecPluginConfig(t *testing.T) {
 	path := "/app"
-	kFactory := kunstruct.NewKunstructuredFactoryImpl()
-	rf := resmap.NewFactory(resource.NewFactory(kFactory))
+	rf := resmap.NewFactory(
+		resource.NewFactory(
+			kunstruct.NewKunstructuredFactoryImpl()))
 	ldr := loadertest.NewFakeLoader(path)
-
-	pluginConfig := kFactory.FromMap(
+	pluginConfig := rf.RF().FromMap(
 		map[string]interface{}{
 			"apiVersion": "someteam.example.com/v1",
 			"kind":       "SedTransformer",
@@ -46,7 +47,9 @@ s/$BAR/bar/g
  \ \ \ 
 `))
 
-	p := &ExecPlugin{}
+	p := NewExecPlugin(
+		plugin.DefaultPluginConfig().DirectoryPath,
+		pluginConfig.Id())
 
 	p.Config(ldr, rf, pluginConfig)
 

--- a/pkg/plugins/generators.go
+++ b/pkg/plugins/generators.go
@@ -22,38 +22,19 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/transformers"
-	"sigs.k8s.io/kustomize/pkg/types"
 )
 
-type generatorLoader struct {
-	pc  *types.PluginConfig
-	ldr ifc.Loader
-	rf  *resmap.Factory
-}
-
-func NewGeneratorLoader(
-	pc *types.PluginConfig,
-	ldr ifc.Loader, rf *resmap.Factory) generatorLoader {
-	return generatorLoader{pc: pc, ldr: ldr, rf: rf}
-}
-
-func (l generatorLoader) Load(
-	rm resmap.ResMap) ([]transformers.Generator, error) {
-	if len(rm) == 0 {
-		return nil, nil
-	}
-	if !l.pc.GoEnabled {
-		return nil, fmt.Errorf("plugins not enabled")
-	}
+func (l *Loader) LoadGenerators(
+	ldr ifc.Loader, rm resmap.ResMap) ([]transformers.Generator, error) {
 	var result []transformers.Generator
-	for id, res := range rm {
-		c, err := loadAndConfigurePlugin(l.pc.DirectoryPath, id, l.ldr, l.rf, res)
+	for _, res := range rm {
+		c, err := l.loadAndConfigurePlugin(ldr, res)
 		if err != nil {
 			return nil, err
 		}
 		g, ok := c.(transformers.Generator)
 		if !ok {
-			return nil, fmt.Errorf("plugin %s not a generator", id.String())
+			return nil, fmt.Errorf("plugin %s not a generator", res.Id())
 		}
 		result = append(result, g)
 	}

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/internal/loadertest"
@@ -206,8 +205,7 @@ func TestResources(t *testing.T) {
 
 func TestKustomizationNotFound(t *testing.T) {
 	_, err := NewKustTarget(
-		loadertest.NewFakeLoader("/foo"),
-		nil, nil, plugin.DefaultPluginConfig())
+		loadertest.NewFakeLoader("/foo"), nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}

--- a/plugins/someteam.example.com/v1/DatePrefixer.go
+++ b/plugins/someteam.example.com/v1/DatePrefixer.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"time"
-
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/transformers"
@@ -20,9 +18,17 @@ func (p *plugin) Config(
 	return nil
 }
 
+// Returns a constant, rather than
+//   time.Now().Format("2006-01-02")
+// to make tests happy.
+// This is just an example.
+func getDate() string {
+	return "2018-05-11"
+}
+
 func (p *plugin) Transform(m resmap.ResMap) error {
 	tr, err := transformers.NewNamePrefixSuffixTransformer(
-		time.Now().Format("2006-01-02")+"-", "",
+		getDate()+"-", "",
 		config.MakeDefaultConfig().NamePrefix)
 	if err != nil {
 		return err

--- a/plugins/someteam.example.com/v1/StringPrefixer.go
+++ b/plugins/someteam.example.com/v1/StringPrefixer.go
@@ -12,6 +12,7 @@
 package main
 
 import (
+	"fmt"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/transformers"
@@ -26,11 +27,11 @@ var KustomizePlugin plugin
 
 func (p *plugin) Config(
 	ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) error {
-	var err error
-	p.prefix, err = k.GetFieldValue("prefix")
-	if err != nil {
-		return err
+	name := k.GetName()
+	if name == "" {
+		return fmt.Errorf("name cannot be empty")
 	}
+	p.prefix = name + "-"
 	return nil
 }
 


### PR DESCRIPTION
 * use one place to build plugin file names,
 * use one loader instance,
 * test for plugin enabled flag in just one place to
   avoid errors and reduce if statements,
 * don't return private objects,
 * factor goplugin loading to a method,
 * fix a related test that was commented out.