### PR TITLE
change field name: prune -> inventory

### DIFF
--- a/k8sdeps/transformer/factory.go
+++ b/k8sdeps/transformer/factory.go
@@ -19,8 +19,8 @@ package transformer
 
 import (
 	"sigs.k8s.io/kustomize/k8sdeps/transformer/hash"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer/inventory"
 	"sigs.k8s.io/kustomize/k8sdeps/transformer/patch"
-	"sigs.k8s.io/kustomize/k8sdeps/transformer/prune"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/transformers"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -44,6 +44,6 @@ func (p *FactoryImpl) MakeHashTransformer() transformers.Transformer {
 	return hash.NewNameHashTransformer()
 }
 
-func (p *FactoryImpl) MakePruneTransformer(arg *types.Prune, namespace string, append bool) transformers.Transformer {
-	return prune.NewPruneTransformer(arg, namespace, append)
+func (p *FactoryImpl) MakeInventoryTransformer(arg *types.Inventory, namespace string, append bool) transformers.Transformer {
+	return inventory.NewInventoryTransformer(arg, namespace, append)
 }

--- a/k8sdeps/transformer/inventory/inventory.go
+++ b/k8sdeps/transformer/inventory/inventory.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package prune
+package inventory
 
 import (
 	"fmt"
@@ -31,33 +31,33 @@ import (
 //const PruneAnnotation = "kustomize.k8s.io/PruneRevision"
 const PruneAnnotation = "current"
 
-// pruneTransformer compute the ConfigMap used in prune
-type pruneTransformer struct {
+// inventoryTransformer compute the ConfigMap used in prune
+type inventoryTransformer struct {
 	append      bool
 	cmName      string
 	cmNamespace string
 }
 
-var _ transformers.Transformer = &pruneTransformer{}
+var _ transformers.Transformer = &inventoryTransformer{}
 
-// NewPruneTransformer makes a pruneTransformer.
-func NewPruneTransformer(p *types.Prune, namespace string, append bool) transformers.Transformer {
+// NewInventoryTransformer makes a inventoryTransformer.
+func NewInventoryTransformer(p *types.Inventory, namespace string, append bool) transformers.Transformer {
 	if p == nil || p.Type != "ConfigMap" || p.ConfigMap.Namespace != namespace {
 		return transformers.NewNoOpTransformer()
 	}
-	return &pruneTransformer{
+	return &inventoryTransformer{
 		append:      append,
 		cmName:      p.ConfigMap.Name,
 		cmNamespace: p.ConfigMap.Namespace,
 	}
 }
 
-// Transform generates a prune ConfigMap based on the input ResMap.
+// Transform generates an inventory ConfigMap based on the input ResMap.
 // this tranformer doesn't change existing resources -
 // it just visits resources and accumulates information to make a new ConfigMap.
 // The prune ConfigMap is used to support the pruning command in the client side tool,
 // which is proposed in https://github.com/kubernetes/enhancements/pull/810
-func (o *pruneTransformer) Transform(m resmap.ResMap) error {
+func (o *inventoryTransformer) Transform(m resmap.ResMap) error {
 	var keys []string
 	for _, r := range m {
 		s := r.PruneString()

--- a/k8sdeps/transformer/inventory/inventory_test.go
+++ b/k8sdeps/transformer/inventory/inventory_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package prune
+package inventory
 
 import (
 	"reflect"
@@ -103,7 +103,7 @@ func makeResMap() resmap.ResMap {
 	return objs
 }
 
-func TestPruneTransformer(t *testing.T) {
+func TestInventoryTransformer(t *testing.T) {
 	rf := resource.NewFactory(
 		kunstruct.NewKunstructuredFactoryImpl())
 
@@ -138,7 +138,7 @@ func TestPruneTransformer(t *testing.T) {
 		resid.NewResIdWithPrefixNamespace(cmap, "pruneCM", "", "default"): pruneMap,
 	}
 
-	p := &types.Prune{
+	p := &types.Inventory{
 		Type: "ConfigMap",
 		ConfigMap: types.NameArgs{
 			Name:      "pruneCM",
@@ -148,7 +148,7 @@ func TestPruneTransformer(t *testing.T) {
 	objs := makeResMap()
 
 	// include the original resmap; only return the ConfigMap for pruning
-	tran := NewPruneTransformer(p, "default", false)
+	tran := NewInventoryTransformer(p, "default", false)
 	tran.Transform(objs)
 
 	if !reflect.DeepEqual(objs, expected) {
@@ -160,7 +160,7 @@ func TestPruneTransformer(t *testing.T) {
 	expected = objs.DeepCopy(rf)
 	expected[resid.NewResIdWithPrefixNamespace(cmap, "pruneCM", "", "default")] = pruneMap
 	// append the ConfigMap for pruning to the original resmap
-	tran = NewPruneTransformer(p, "default", true)
+	tran = NewInventoryTransformer(p, "default", true)
 	tran.Transform(objs)
 
 	if !reflect.DeepEqual(objs, expected) {

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -178,8 +178,8 @@ func NewCmdBuildPrune(
 	var o Options
 
 	cmd := &cobra.Command{
-		Use:          "alpha-prune [path]",
-		Short:        "Print configmap to prune previous applied objects",
+		Use:          "alpha-inventory [path]",
+		Short:        "Print the inventory object which contains a list of all other objects",
 		Example:      examples,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -69,7 +69,7 @@ func determineFieldOrder() []string {
 		"Configurations",
 		"Generators",
 		"Transformers",
-		"Prune",
+		"Inventory",
 	}
 
 	// Add deprecated fields here.

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -48,7 +48,7 @@ func TestFieldOrder(t *testing.T) {
 		"Configurations",
 		"Generators",
 		"Transformers",
-		"Prune",
+		"Inventory",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {

--- a/pkg/ifc/transformer/factory.go
+++ b/pkg/ifc/transformer/factory.go
@@ -27,5 +27,5 @@ import (
 type Factory interface {
 	MakePatchTransformer(slice []*resource.Resource, rf *resource.Factory) (transformers.Transformer, error)
 	MakeHashTransformer() transformers.Transformer
-	MakePruneTransformer(p *types.Prune, namespace string, append bool) transformers.Transformer
+	MakeInventoryTransformer(p *types.Inventory, namespace string, append bool) transformers.Transformer
 }

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -147,7 +147,7 @@ func (kt *KustTarget) MakeCustomizedResMap() (resmap.ResMap, error) {
 	}
 
 	rm := ra.ResMap()
-	pt := kt.tFactory.MakePruneTransformer(kt.kustomization.Prune, kt.kustomization.Namespace, true)
+	pt := kt.tFactory.MakeInventoryTransformer(kt.kustomization.Inventory, kt.kustomization.Namespace, true)
 	err = pt.Transform(rm)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (kt *KustTarget) MakePruneConfigMap() (resmap.ResMap, error) {
 	}
 
 	rm := ra.ResMap()
-	pt := kt.tFactory.MakePruneTransformer(kt.kustomization.Prune, kt.kustomization.Namespace, false)
+	pt := kt.tFactory.MakeInventoryTransformer(kt.kustomization.Inventory, kt.kustomization.Namespace, false)
 	err = pt.Transform(rm)
 	if err != nil {
 		return nil, err

--- a/pkg/target/pruneconfigmap_test.go
+++ b/pkg/target/pruneconfigmap_test.go
@@ -28,7 +28,7 @@ resources:
 - service.yaml
 - secret.yaml
 
-prune:
+inventory:
   type: ConfigMap
   configMap:
     name: haha

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -137,8 +137,9 @@ type Kustomization struct {
 	// Transformers is a list of files containing transformers
 	Transformers []string `json:"transformers,omitempty" yaml:"transformers,omitempty"`
 
-	// Name of the ConfigMap used in Prune
-	Prune *Prune `json:"prune,omitempty" yaml:"prune:omitempty"`
+	// Inventory appends an object that contains the record
+	// of all other objects, which can be used in apply, prune and delete
+	Inventory *Inventory `json:"inventory,omitempty" yaml:"inventory:omitempty"`
 }
 
 // DealWithMissingFields fills the missing fields
@@ -293,7 +294,7 @@ type KVSource struct {
 	Args       []string   `json:"args,omitempty" yaml:"args,omitempty"`
 }
 
-type Prune struct {
+type Inventory struct {
 	Type      string   `json:"type,omitempty" yaml:"type,omitempty"`
 	ConfigMap NameArgs `json:"configMap,omitempty" yaml:"configMap,omitempty"`
 }


### PR DESCRIPTION
changed `prune` to `inventory` in
- field name
- transformer names
- subcommand `alpha-prune` --> `alpha-inventory`