### PR TITLE
WIP: add example of writing generators for rendering helm charts

### DIFF
--- a/examples/chartInflator/base/config.yaml
+++ b/examples/chartInflator/base/config.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1
+kind: ChartInflatorExec2
+metadata:
+  name: notImportantHere

--- a/examples/chartInflator/base/kustomization.yaml
+++ b/examples/chartInflator/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - config.yaml

--- a/examples/chartInflator/chart/Chart.yaml
+++ b/examples/chartInflator/chart/Chart.yaml
@@ -1,0 +1,14 @@
+name: minecraft
+version: 0.3.2
+appVersion: 1.13.1
+home: https://minecraft.net/
+description: Minecraft server
+keywords:
+  - game
+  - server
+sources:
+  - https://hub.docker.com/r/itzg/minecraft-server/~/dockerfile/
+  - https://github.com/itzg/dockerfiles
+maintainers:
+  - name: gtaylor
+    email: gtaylor@gc-taylor.com

--- a/examples/chartInflator/chart/REAMD.md
+++ b/examples/chartInflator/chart/REAMD.md
@@ -1,0 +1,8 @@
+This chart is copied from the stable minecraft chart in
+[helm/charts](https://github.com/helm/charts), which is
+under [Apache License Version 2.0](https://github.com/helm/charts/blob/master/LICENSE).
+
+
+It is used here as an example to demonstrate how generator plugin inflate helm templates. It is not for a canonical
+chart you can rely on. Kustomize maintainers are not responsible to
+maintain and update this chart.

--- a/examples/chartInflator/chart/templates/NOTES.txt
+++ b/examples/chartInflator/chart/templates/NOTES.txt
@@ -1,0 +1,51 @@
+{{- if eq (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
+##############################################################################
+####   ERROR: You did not agree to the EULA in your 'helm install' call.  ####
+##############################################################################
+
+This deployment will be incomplete until you read the Minecraft EULA linked
+in the README.md, then:
+
+    helm upgrade {{ .Release.Name }} \
+        --set minecraftServer.eula=true stable/minecraft
+{{- else -}}
+
+Get the IP address of your Minecraft server by running these commands in the
+same shell:
+
+{{- if contains "NodePort" .Values.minecraftServer.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "minecraft.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} \
+    -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "You'll need to expose this node through your security groups/firewall"
+  echo "for it to be world-accessible."
+  echo $NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.minecraftServer.serviceType }}
+
+!! NOTE: It may take a few minutes for the LoadBalancer IP to be available. !!
+
+You can watch for EXTERNAL-IP to populate by running:
+  kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "minecraft.fullname" . }}
+
+{{- else if contains "ClusterIP" .Values.minecraftServer.serviceType }}
+  export POD_NAME=$(kubectl get pods \
+    --namespace {{ .Release.Namespace }} \
+    -l "component={{ template "minecraft.fullname" . }}" \
+    -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward $POD_NAME 25565:25565
+  echo "Point your Minecraft client at 127.0.0.1:22565"
+
+{{- end }}
+
+{{- if .Values.persistence.dataDir.enabled }}
+{{- else }}
+
+############################################################################
+###   WARNING: Persistence is disabled!!! You will lose your game state  ###
+###                when the Minecraft pod is terminated.                 ###
+###      See values.yaml's persistence.dataDir.enabled directive.        ###
+############################################################################
+{{- end }}
+{{- end }}

--- a/examples/chartInflator/chart/templates/_helpers.tpl
+++ b/examples/chartInflator/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "minecraft.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "minecraft.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/chartInflator/chart/templates/datadir-pvc.yaml
+++ b/examples/chartInflator/chart/templates/datadir-pvc.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.persistence.dataDir.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    name: {{ template "minecraft.fullname" . }}-datadir
+    labels:
+        app: {{ template "minecraft.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    annotations:
+            {{- if .Values.persistence.storageClass }}
+        volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+            {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
+spec:
+    accessModes:
+        - ReadWriteOnce
+    resources:
+        requests:
+            storage: {{ .Values.persistence.dataDir.Size | quote }}
+        {{- if .Values.persistence.storageClass }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
+    storageClassName: ""
+        {{- else }}
+    storageClassName: "{{ .Values.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+        {{- end -}}

--- a/examples/chartInflator/chart/templates/deployment.yaml
+++ b/examples/chartInflator/chart/templates/deployment.yaml
@@ -1,0 +1,160 @@
+{{- if ne (printf "%s" .Values.minecraftServer.eula) "FALSE" }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: {{ template "minecraft.fullname" . }}
+    labels:
+        app: {{ template "minecraft.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+spec:
+    template:
+        metadata:
+            labels:
+                app: {{ template "minecraft.fullname" . }}
+        spec:
+            securityContext:
+                runAsUser: {{ .Values.securityContext.runAsUser }}
+                fsGroup: {{ .Values.securityContext.fsGroup }}
+            containers:
+                - name: {{ template "minecraft.fullname" . }}
+                  image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+                  imagePullPolicy: Always
+                  resources:
+                        {{ toYaml .Values.resources | indent 10 }}
+                  env:
+                      - name: EULA
+                        value: {{ .Values.minecraftServer.eula | quote }}
+                      - name: TYPE
+                        value: {{ default "" .Values.minecraftServer.type | quote }}
+                          {{- if eq .Values.minecraftServer.type "FORGE" }}
+                          {{- if .Values.minecraftServer.forgeInstallerUrl }}
+                      - name: FORGE_INSTALLER_URL
+                        value: {{ .Values.minecraftServer.forgeInstallerUrl | quote }}
+                          {{- else }}
+                      - name: FORGEVERSION
+                        value: {{ .Values.minecraftServer.forgeVersion | quote }}
+                          {{- end }}
+                          {{- else if eq .Values.minecraftServer.type "SPIGOT" }}
+                      - name: SPIGOT_DOWNLOAD_URL
+                        value: {{ .Values.minecraftServer.spigotDownloadUrl | quote }}
+                          {{- else if eq .Values.minecraftServer.type "BUKKIT" }}
+                      - name: BUKKIT_DOWNLOAD_URL
+                        value: {{ .Values.minecraftServer.bukkitDownloadUrl | quote }}
+                          {{- else if eq .Values.minecraftServer.type "PAPER" }}
+                      - name: PAPER_DOWNLOAD_URL
+                        value: {{ .Values.minecraftServer.paperDownloadUrl | quote }}
+                          {{- else if eq .Values.minecraftServer.type "FTB" }}
+                      - name: FTB_SERVER_MOD
+                        value: {{ .Values.minecraftServer.ftbServerMod | quote }}
+                      - name: FTB_LEGACYJAVAFIXER
+                        value: {{ default false .Values.minecraftServer.ftbLegacyJavaFixer | quote }}
+                          {{- end }}
+                      - name: VERSION
+                        value: {{ .Values.minecraftServer.version | quote }}
+                      - name: DIFFICULTY
+                        value: {{ .Values.minecraftServer.difficulty | quote }}
+                      - name: WHITELIST
+                        value: {{ default "" .Values.minecraftServer.whitelist | quote }}
+                      - name: OPS
+                        value: {{ default "" .Values.minecraftServer.ops | quote }}
+                      - name: ICON
+                        value: {{ default "" .Values.minecraftServer.icon | quote }}
+                      - name: MAX_PLAYERS
+                        value: {{ .Values.minecraftServer.maxPlayers | quote }}
+                      - name: MAX_WORLD_SIZE
+                        value: {{ .Values.minecraftServer.maxWorldSize | quote }}
+                      - name: ALLOW_NETHER
+                        value: {{ .Values.minecraftServer.allowNether | quote }}
+                      - name: ANNOUNCE_PLAYER_ACHIEVEMENTS
+                        value: {{ .Values.minecraftServer.announcePlayerAchievements | quote }}
+                      - name: ENABLE_COMMAND_BLOCK
+                        value: {{ .Values.minecraftServer.enableCommandBlock | quote }}
+                      - name: FORCE_gameMode
+                        value: {{ .Values.minecraftServer.forcegameMode | quote }}
+                      - name: GENERATE_STRUCTURES
+                        value: {{ .Values.minecraftServer.generateStructures | quote }}
+                      - name: HARDCORE
+                        value: {{ .Values.minecraftServer.hardcore | quote }}
+                      - name: MAX_BUILD_HEIGHT
+                        value: {{ .Values.minecraftServer.maxBuildHeight | quote }}
+                      - name: MAX_TICK_TIME
+                        value: {{ .Values.minecraftServer.maxTickTime | quote }}
+                      - name: SPAWN_ANIMALS
+                        value: {{ .Values.minecraftServer.spawnAnimals | quote }}
+                      - name: SPAWN_MONSTERS
+                        value: {{ .Values.minecraftServer.spawnMonsters | quote }}
+                      - name: SPAWN_NPCS
+                        value: {{ .Values.minecraftServer.spawnNPCs | quote }}
+                      - name: VIEW_DISTANCE
+                        value: {{ .Values.minecraftServer.viewDistance | quote }}
+                      - name: SEED
+                        value: {{ default "" .Values.minecraftServer.levelSeed | quote }}
+                      - name: MODE
+                        value: {{ .Values.minecraftServer.gameMode | quote }}
+                      - name: MOTD
+                        value: {{ .Values.minecraftServer.motd | quote }}
+                      - name: PVP
+                        value: {{ .Values.minecraftServer.pvp | quote }}
+                      - name: LEVEL_TYPE
+                        value: {{ .Values.minecraftServer.levelType | quote }}
+                      - name: GENERATOR_SETTINGS
+                        value: {{ default "" .Values.minecraftServer.generatorSettings | quote }}
+                      - name: LEVEL
+                        value: {{ .Values.minecraftServer.worldSaveName | quote }}
+                          {{- if .Values.minecraftServer.downloadWorldUrl }}
+                      - name: WORLD
+                        value: {{ .Values.minecraftServer.downloadWorldUrl | quote }}
+                          {{- end }}
+                          {{- if .Values.minecraftServer.downloadModpackUrl }}
+                      - name: MODPACK
+                        value: {{ .Values.minecraftServer.downloadModpackUrl | quote }}
+                          {{- if .Values.minecraftServer.removeOldMods }}
+                      - name: REMOVE_OLD_MODS
+                        value: "TRUE"
+                          {{- end }}
+                          {{- end }}
+                      - name: ONLINE_MODE
+                        value: {{ .Values.minecraftServer.onlineMode | quote }}
+                      - name: JVM_OPTS
+                        value: {{ .Values.minecraftServer.jvmOpts | quote }}
+
+                          {{- if .Values.minecraftServer.rcon.enabled }}
+                      - name: ENABLE_RCON
+                        value: "true"
+                      - name: RCON_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: {{ template "minecraft.fullname" . }}
+                                key: rcon-password
+                          {{- end }}
+
+                          {{- if .Values.minecraftServer.query.enabled }}
+                      - name: ENABLE_QUERY
+                        value: "true"
+                      - name: QUERY_PORT
+                        value: {{ .Values.minecraftServer.query.port }}
+                        {{- end }}
+
+                  ports:
+                      - name: minecraft
+                        containerPort: 25565
+                        protocol: TCP
+                          {{- if .Values.minecraftServer.rcon.enabled }}
+                      - name: rcon
+                        containerPort: {{ .Values.minecraftServer.rcon.port }}
+                        protocol: TCP
+                        {{- end }}
+                  volumeMounts:
+                      - name: datadir
+                        mountPath: /data
+            volumes:
+                - name: datadir
+                        {{- if .Values.persistence.dataDir.enabled }}
+                  persistentVolumeClaim:
+                      claimName: {{ template "minecraft.fullname" . }}-datadir
+                        {{- else }}
+                  emptyDir: {}
+        {{- end }}
+        {{ end }}

--- a/examples/chartInflator/chart/templates/minecraft-svc.yaml
+++ b/examples/chartInflator/chart/templates/minecraft-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: {{ template "minecraft.fullname" . }}
+    labels:
+        app: {{ template "minecraft.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+spec:
+    type: {{ .Values.minecraftServer.serviceType }}
+    ports:
+        - name: minecraft
+          port: 25565
+          targetPort: minecraft
+          protocol: TCP
+    selector:
+        app: {{ template "minecraft.fullname" . }}

--- a/examples/chartInflator/chart/templates/rcon-svc.yaml
+++ b/examples/chartInflator/chart/templates/rcon-svc.yaml
@@ -1,0 +1,20 @@
+{{- if default "" .Values.minecraftServer.rcon.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+    name: "{{ template "minecraft.fullname" . }}-rcon"
+    labels:
+        app: {{ template "minecraft.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+spec:
+    type: {{ .Values.minecraftServer.rcon.serviceType }}
+    ports:
+        - name: rcon
+          port: {{ .Values.minecraftServer.rcon.port }}
+          targetPort: rcon
+          protocol: TCP
+    selector:
+        app: {{ template "minecraft.fullname" . }}
+        {{- end }}

--- a/examples/chartInflator/chart/templates/secrets.yaml
+++ b/examples/chartInflator/chart/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ template "minecraft.fullname" . }}
+    labels:
+        app: {{ template "minecraft.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+    rcon-password: {{ default "" .Values.minecraftServer.rcon.password | b64enc | quote }}

--- a/examples/chartInflator/chart/values.yaml
+++ b/examples/chartInflator/chart/values.yaml
@@ -1,0 +1,127 @@
+# ref: https://hub.docker.com/r/itzg/minecraft-server/
+image: itzg/minecraft-server
+imageTag: latest
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 500m
+
+securityContext:
+  # Security context settings
+  runAsUser: 1000
+  fsGroup: 2000
+# Most of these map to environment variables. See Minecraft for details:
+# https://hub.docker.com/r/itzg/minecraft-server/
+minecraftServer:
+  # This must be overridden, since we can't accept this for the user.
+  eula: "FALSE"
+  # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
+  version: "1.13.1"
+  # This can be one of empty string, "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"; empty string will produce a vanilla server
+  type: ""
+  # If type is set to FORGE, this sets the version; this is ignored if forgeInstallerUrl is set
+  forgeVersion:
+  # If type is set to SPONGEVANILLA, this sets the version
+  spongeVersion:
+  # If type is set to FORGE, this sets the URL to download the Forge installer
+  forgeInstallerUrl:
+  # If type is set to BUKKIT, this sets the URL to download the Bukkit package
+  bukkitDownloadUrl:
+  # If type is set to SPIGOT, this sets the URL to download the Spigot package
+  spigotDownloadUrl:
+  # If type is set to PAPER, this sets the URL to download the PaperSpigot package
+  paperDownloadUrl:
+  # If type is set to FTB, this sets the server mod to run
+  ftbServerMod:
+  # Set to true if running Feed The Beast and get an error like "unable to launch forgemodloader"
+  ftbLegacyJavaFixer: false
+  # One of: peaceful, easy, normal, and hard
+  difficulty: easy
+  # A comma-separated list of player names to whitelist.
+  whitelist:
+  # A comma-separated list of player names who should be admins.
+  ops:
+  # A server icon URL for server listings. Auto-scaled and transcoded.
+  icon:
+  # Max connected players.
+  maxPlayers: 20
+  # This sets the maximum possible size in blocks, expressed as a radius, that the world border can obtain.
+  maxWorldSize: 10000
+  # Allows players to travel to the Nether.
+  allowNether: true
+  # Allows server to announce when a player gets an achievement.
+  announcePlayerAchievements: true
+  # Enables command blocks.
+  enableCommandBlock: true
+  # If true, players will always join in the default gameMode even if they were previously set to something else.
+  forcegameMode: false
+  # Defines whether structures (such as villages) will be generated.
+  generateStructures: true
+  # If set to true, players will be set to spectator mode if they die.
+  hardcore: false
+  # The maximum height in which building is allowed.
+  maxBuildHeight: 256
+  # The maximum number of milliseconds a single tick may take before the server watchdog stops the server with the message. -1 disables this entirely.
+  maxTickTime: 60000
+  # Determines if animals will be able to spawn.
+  spawnAnimals: true
+  # Determines if monsters will be spawned.
+  spawnMonsters: true
+  # Determines if villagers will be spawned.
+  spawnNPCs: true
+  # Max view distance (in chunks).
+  viewDistance: 10
+  # Define this if you want a specific map generation seed.
+  levelSeed:
+  # One of: creative, survival, adventure, spectator
+  gameMode: survival
+  # Message of the Day
+  motd: "Welcome to Minecraft on Kubernetes!"
+  # If true, enable player-vs-player damage.
+  pvp: false
+  # One of: DEFAULT, FLAT, LARGEBIOMES, AMPLIFIED, CUSTOMIZED
+  levelType: DEFAULT
+  # When levelType == FLAT or CUSTOMIZED, this can be used to further customize map generation.
+  # ref: https://hub.docker.com/r/itzg/minecraft-server/
+  generatorSettings:
+  worldSaveName: world
+  # If set, this URL will be downloaded at startup and used as a starting point
+  downloadWorldUrl:
+  # If set, the modpack at this URL will be downloaded at startup
+  downloadModpackUrl:
+  # If true, old versions of downloaded mods will be replaced with new ones from downloadModpackUrl
+  removeOldMods: false
+  # Check accounts against Minecraft account service.
+  onlineMode: true
+  # If you adjust this, you may need to adjust resources.requests above to match.
+  jvmOpts: "-Xmx512M -Xms512M"
+  serviceType: LoadBalancer
+  rcon:
+    # If you enable this, make SURE to change your password below.
+    enabled: false
+    port: 25575
+    password: "CHANGEME!"
+    serviceType: LoadBalancer
+
+  query:
+    # If you enable this, your server will be "published" to Gamespy
+    enabled: false
+    port: 25565
+
+persistence:
+  ## minecraft data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  dataDir:
+    # Set this to false if you don't care to persist state between restarts.
+    enabled: true
+    Size: 1Gi

--- a/examples/chartInflator/generator/kustomization.yaml
+++ b/examples/chartInflator/generator/kustomization.yaml
@@ -1,0 +1,2 @@
+generators:
+  - ../overlay

--- a/examples/chartInflator/overlay/config.yaml
+++ b/examples/chartInflator/overlay/config.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1
+kind: ChartInflatorExec2
+metadata:
+  name: notImportantHere
+chartPath: ../chart

--- a/examples/chartInflator/overlay/kustomization.yaml
+++ b/examples/chartInflator/overlay/kustomization.yaml
@@ -1,0 +1,5 @@
+patches:
+  - config.yaml
+
+bases:
+  - ../base

--- a/pkg/plugins/execplugin.go
+++ b/pkg/plugins/execplugin.go
@@ -140,6 +140,9 @@ func (p *ExecPlugin) Generate() (resmap.ResMap, error) {
 	cmd := exec.Command(p.name, args...)
 	cmd.Env = p.getEnv()
 	cmd.Stderr = os.Stderr
+	if _, err := os.Stat(p.ldr.Root()); err == nil {
+		cmd.Dir = p.ldr.Root()
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -161,6 +164,9 @@ func (p *ExecPlugin) Transform(rm resmap.ResMap) error {
 		cmd.Env = p.getEnv()
 		cmd.Stdin = bytes.NewReader(content)
 		cmd.Stderr = os.Stderr
+		if _, err := os.Stat(p.ldr.Root()); err == nil {
+			cmd.Dir = p.ldr.Root()
+		}
 		output, err := cmd.Output()
 		if err != nil {
 			return err
@@ -191,6 +197,8 @@ func (p *ExecPlugin) getArgs() ([]string, error) {
 
 func (p *ExecPlugin) getEnv() []string {
 	env := os.Environ()
-	env = append(env, "KUSTOMIZE_PLUGIN_CONFIG_STRING="+string(p.cfg))
+	env = append(env,
+		"KUSTOMIZE_PLUGIN_CONFIG_STRING="+string(p.cfg),
+		"KUSTOMIZE_PLUGIN_CONFIG_ROOT="+p.ldr.Root())
 	return env
 }

--- a/plugins/kustomize.config.k8s.io/v1/ChartInflatorExec2
+++ b/plugins/kustomize.config.k8s.io/v1/ChartInflatorExec2
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# Helm chart inflator
+
+# Reads a file like this
+#
+#  apiVersion: kustomize.config.k8s.io/v1
+#  kind: ChartInflatorExec
+#  metadata:
+#    name: notImportantHere
+#  chartPath: path/to/a/chart
+#  values: path/to/values/file
+#  helmBin: abs/path/to/helmBin
+#
+# Example execution:
+# ./plugins/kustomize.config.k8s.io/v1/ChartInflatorExec configFile.yaml
+
+
+
+# Yaml parsing is a ridiculous thing to do in bash,
+# but let's try:
+function parseYaml {
+  local file=$1
+  while read -r line
+  do
+    local k=${line%:*}
+    local v=${line#*:}
+
+    [ "$k" == "chartPath" ] && chartPath=$v
+    [ "$k" == "values" ] && valuesFile=$v
+    [ "$k" == "helmBin" ] && helmBin=$v
+  done <"$file"
+
+  # Trim leading space
+  chartPath="${chartPath#"${chartPath%%[![:space:]]*}"}"
+  valuesFile="${valuesFile#"${valuesFile%%[![:space:]]*}"}"
+  helmBin="${helmBin#"${helmBin%%[![:space:]]*}"}"
+}
+
+parseYaml $1
+
+if [ -z "$helmBin" ]; then
+  helmBin=/usr/local/bin/helm
+fi
+
+if [ -z "$valuesFile" ]; then
+  valuesFile=$chartPath/values.yaml
+fi
+
+function doHelm {
+  $helmBin $@
+}
+
+
+doHelm template \
+    --values $valuesFile \
+    $chartPath
+


### PR DESCRIPTION
This example is based on #1011 

The example added here shows how you can customize a generator.
Here is the tree structure of this example
```
.
├── base
│   ├── config.yaml
│   └── kustomization.yaml
├── chart
│   ├── Chart.yaml
│   ├── templates
│   │   ├── datadir-pvc.yaml
│   │   ├── deployment.yaml
│   │   ├── _helpers.tpl
│   │   ├── minecraft-svc.yaml
│   │   ├── NOTES.txt
│   │   ├── rcon-svc.yaml
│   │   └── secrets.yaml
│   └── values.yaml
├── generator
│   └── kustomization.yaml
└── overlay
    ├── config.yaml
    └── kustomization.yaml
```
In base, the generator config is specified as `resources`
In an overlay, the generator config is customized by applying a `patchesStrategicMerge`.
The overlay is then passed to another `kustomization.yaml` as `generators`.
```
generators:
- ../overlay
```
TODO: add a README.md for this example.

The output of this example is
```
apiVersion: v1
data:
  rcon-password: Q0hBTkdFTUUh
kind: Secret
metadata:
  labels:
    app: RELEASE-NAME-minecraft
    chart: minecraft-0.3.2
    heritage: Tiller
    release: RELEASE-NAME
  name: RELEASE-NAME-minecraft
type: Opaque
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: RELEASE-NAME-minecraft
    chart: minecraft-0.3.2
    heritage: Tiller
    release: RELEASE-NAME
  name: RELEASE-NAME-minecraft
spec:
  ports:
  - name: minecraft
    port: 25565
    protocol: TCP
    targetPort: minecraft
  selector:
    app: RELEASE-NAME-minecraft
  type: LoadBalancer
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    volume.alpha.kubernetes.io/storage-class: default
  labels:
    app: RELEASE-NAME-minecraft
    chart: minecraft-0.3.2
    heritage: Tiller
    release: RELEASE-NAME
  name: RELEASE-NAME-minecraft-datadir
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
```