### PR TITLE
Apply LimitRange resources before workloads

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -106,6 +106,7 @@ var order = []string{
 	"ConfigMap",
 	"Secret",
 	"Service",
+	"LimitRange",
 	"Deployment",
 	"StatefulSet",
 	"CronJob",


### PR DESCRIPTION
LimitRange resources configure the default requests and limits for all containers created in a  namespace. I've noticed that these limits are not applied to _some_ pods when applying a Kustomize overlay that contains a Namespace, a LimitRange, and a mix of workloads, and have found that applying the LimitRange before we create these workloads correctly applies the limits.

To avoid having to perform a two-pass apply to create our overlay correctly, this PR adds `LimitRange` to the list of resources with ordering considerations immediately before resources that create Pods.