### PR TITLE
Introduce envs field.

### DIFF
--- a/docs/kustomization.yaml
+++ b/docs/kustomization.yaml
@@ -105,9 +105,9 @@ secretGenerator:
     - tls.key=secret/tls.key
   type: "kubernetes.io/tls"
 - name: env_file_secret
-  # env is a path to a file to read lines of key=val
-  # you can only specify one env file per secret.
-  env: env.txt
+  # paths to files with k=v pairs, one pair per line.
+  envs:
+    - env.txt
   type: Opaque
 
 # generatorOptions modify behavior of all ConfigMap and Secret generators

--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -99,7 +99,7 @@ func TestConstructConfigMap(t *testing.T) {
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "envConfigMap",
 					DataSources: types.DataSources{
-						EnvSource: "configmap/app.env",
+						EnvSources: []string{"configmap/app.env"},
 					},
 				},
 			},

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -97,7 +97,7 @@ func TestConstructSecret(t *testing.T) {
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "envSecret",
 					DataSources: types.DataSources{
-						EnvSource: "secret/app.env",
+						EnvSources: []string{"secret/app.env"},
 					},
 				},
 			},

--- a/k8sdeps/kv/plugin/registry.go
+++ b/k8sdeps/kv/plugin/registry.go
@@ -32,7 +32,6 @@ type Registry struct {
 }
 
 const (
-	PluginSymbol      = "KustomizePlugin"
 	PluginRoot        = "plugin"
 	pluginTypeGo      = types.PluginType("go")
 	pluginTypeBuiltIn = types.PluginType("builtin")

--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -159,16 +159,13 @@ func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
 	if err != nil {
 		return nil, err
 	}
-	data = types.DealWithDeprecatedFields(data)
+	data = types.FixKustomizationPreUnmarshalling(data)
 	var k types.Kustomization
 	err = yaml.Unmarshal(data, &k)
 	if err != nil {
 		return nil, err
 	}
-	msgs := k.DealWithMissingFields()
-	if len(msgs) > 0 {
-		log.Printf(strings.Join(msgs, "\n"))
-	}
+	k.FixKustomizationPostUnmarshalling()
 	err = mf.parseCommentedFields(data)
 	if err != nil {
 		return nil, err

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -81,7 +81,7 @@ func TestWriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't read kustomization file: %v\n", err)
 	}
-	kustomization.DealWithMissingFields()
+	kustomization.FixKustomizationPostUnmarshalling()
 	if !reflect.DeepEqual(kustomization, content) {
 		t.Fatal("Read kustomization is different from written kustomization")
 	}

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+const pluginSymbol = "KustomizePlugin"

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -22,7 +22,6 @@ import (
 	"plugin"
 
 	"github.com/pkg/errors"
-	kplugin "sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/resmap"
@@ -122,11 +121,11 @@ func (l *Loader) loadGoPlugin(id resid.ResId) (c Configurable, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "plugin %s fails to load", name)
 	}
-	symbol, err := p.Lookup(kplugin.PluginSymbol)
+	symbol, err := p.Lookup(pluginSymbol)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "plugin %s doesn't have symbol %s",
-			name, kplugin.PluginSymbol)
+			name, pluginSymbol)
 	}
 	c, ok = symbol.(Configurable)
 	if !ok {

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -153,7 +153,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 					GeneratorArgs: types.GeneratorArgs{
 						Name: "envConfigMap",
 						DataSources: types.DataSources{
-							EnvSource: "app.env",
+							EnvSources: []string{"app.env"},
 						},
 					},
 				},

--- a/pkg/target/generatorplugin_test.go
+++ b/pkg/target/generatorplugin_test.go
@@ -118,13 +118,14 @@ generators:
 	th.assertActualEqualsExpected(m, `
 apiVersion: v1
 data:
+  DB_PASSWORD: aWxvdmV5b3U=
   FRUIT: YXBwbGU=
   ROUTER_PASSWORD: YWRtaW4=
   VEGETABLE: Y2Fycm90
   longsecret.txt: CkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0LApjb25zZWN0ZXR1ciBhZGlwaXNjaW5nIGVsaXQsCnNlZCBkbyBlaXVzbW9kIHRlbXBvciBpbmNpZGlkdW50CnV0IGxhYm9yZSBldCBkb2xvcmUgbWFnbmEgYWxpcXVhLgo=
 kind: Secret
 metadata:
-  name: -2kt2h55789
+  name: -ktm999dkcc
 type: Opaque
 `)
 }

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -57,12 +57,13 @@ func NewKustTarget(
 	if err != nil {
 		return nil, err
 	}
-	content = types.DealWithDeprecatedFields(content)
+	content = types.FixKustomizationPreUnmarshalling(content)
 	var k types.Kustomization
 	err = unmarshal(content, &k)
 	if err != nil {
 		return nil, err
 	}
+	k.FixKustomizationPostUnmarshalling()
 	errs := k.EnforceFields()
 	if len(errs) > 0 {
 		return nil, fmt.Errorf(

--- a/plugin/builtin/SecretGenerator.go
+++ b/plugin/builtin/SecretGenerator.go
@@ -3,8 +3,6 @@
 package main
 
 import (
-	"fmt"
-
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -23,26 +21,16 @@ func (p *plugin) Config(
 	ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) error {
 	p.ldr = ldr
 	p.rf = rf
-
 	var err error
-	// TODO: Should validate this.
+	// TODO: validate behavior values.
 	p.args.Behavior, err = k.GetFieldValue("behavior")
 	if err != nil {
 		return err
 	}
-
-	envFiles, err := k.GetStringSlice("envFiles")
+	p.args.EnvSources, err = k.GetStringSlice("envFiles")
 	if err != nil {
 		return err
 	}
-	if len(envFiles) > 2 {
-		// TODO: refactor to allow this
-		return fmt.Errorf("cannot yet accept more than one envFile")
-	}
-	if len(envFiles) > 0 {
-		p.args.EnvSource = envFiles[0]
-	}
-
 	p.args.FileSources, err = k.GetStringSlice("valueFiles")
 	if err != nil {
 		return err
@@ -51,7 +39,6 @@ func (p *plugin) Config(
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
In secret / configmap generation, kustomize 2.0.3 accepts lists of k=v literals, and lists of files where the file contents is the value, but only one instance of a so called _env_ file (where the contents are k=v pairs, one per line).  This singleton is an odd special case, and makes it hard to mix k=v pairs from multiple sources, e.g. from a devops team and a UX team (one must create then merge whole ConfigMaps to accomplish it).

This PR adds the field `EnvSources` (yaml: `envs`) to kustomization.yaml, accepting a list, and deprecates the singular form `EnvSource` (yaml: `env`).  Users need do nothing, the old field is silently merged into the new.  Anyone running `kustomize fix` or `edit` will get the new field format replacing the old.

This will be new behavior in kustomize 2.1

