### PR TITLE
Convert example plugins to accept bytes instead of unstruct.

### DIFF
--- a/pkg/plugins/execplugin_test.go
+++ b/pkg/plugins/execplugin_test.go
@@ -40,8 +40,8 @@ func TestExecPluginConfig(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "some-random-name",
 			},
-			ArgsOneLiner: "one two",
-			ArgsFromFile: "sed-input.txt",
+			"argsOneLiner": "one two",
+			"argsFromFile": "sed-input.txt",
 		})
 
 	ldr.AddFile("/app/sed-input.txt", []byte(`
@@ -54,7 +54,11 @@ s/$BAR/bar/g
 		plugin.DefaultPluginConfig().DirectoryPath,
 		pluginConfig.Id())
 
-	p.Config(ldr, rf, pluginConfig)
+	yaml, err := pluginConfig.AsYAML()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	p.Config(ldr, rf, yaml)
 
 	expected := "/kustomize/plugin/someteam.example.com/v1/SedTransformer"
 	if !strings.HasSuffix(p.name, expected) {

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Configurable interface {
-	Config(ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) error
+	Config(ldr ifc.Loader, rf *resmap.Factory, config []byte) error
 }
 
 type Loader struct {
@@ -114,7 +114,11 @@ func (l *Loader) loadAndConfigurePlugin(
 			return nil, err
 		}
 	}
-	err = c.Config(ldr, l.rf, res)
+	yaml, err := res.AsYAML()
+	if err != nil {
+		return nil, errors.Wrapf(err, "marshalling yaml from res %s", res.Id())
+	}
+	err = c.Config(ldr, l.rf, yaml)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "plugin %s fails configuration", res.Id())

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -18,7 +18,6 @@ package resmap_test
 
 import (
 	"encoding/base64"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -124,7 +123,6 @@ metadata:
 			}),
 	}
 	m, err := rmF.NewResMapFromBytes(encoded)
-	fmt.Printf("%v\n", m)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	"sigs.k8s.io/kustomize/pkg/types"
+	"sigs.k8s.io/yaml"
 )
 
 // Resource is map representation of a Kubernetes API resource object
@@ -54,6 +55,16 @@ func (r *Resource) DeepCopy() *Resource {
 		rc.refBy = refby
 	}
 	return rc
+}
+
+// AsYAML returns the resource in Yaml form.
+// Easier to read than JSON.
+func (r *Resource) AsYAML() ([]byte, error) {
+	json, err := r.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return yaml.JSONToYAML(json)
 }
 
 // Behavior returns the behavior for the resource.

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -54,6 +54,21 @@ var testDeployment = factory.FromMap(
 
 const deploymentAsString = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"pooh"}}`
 
+func TestAsYAML(t *testing.T) {
+	expected := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pooh
+`
+	yaml, err := testDeployment.AsYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(yaml) != expected {
+		t.Fatalf("--- expected\n%s\n--- got\n%s\n", expected, string(yaml))
+	}
+}
+
 func TestResourceString(t *testing.T) {
 	tests := []struct {
 		in *Resource

--- a/pkg/target/generatorplugin_test.go
+++ b/pkg/target/generatorplugin_test.go
@@ -31,7 +31,7 @@ apiVersion: someteam.example.com/v1
 kind: ServiceGenerator
 metadata:
   name: myServiceGenerator
-service: my-service
+name: my-service
 port: "12345"
 `)
 }
@@ -74,12 +74,13 @@ func writeSecretGeneratorConfig(th *kusttest_test.KustTestHarness, root string) 
 apiVersion: builtin
 kind: SecretGenerator
 metadata:
-  name: mySecret
+  name: mySecGen
+name: mySecret
 behavior: merge
-envFiles:
+envs:
 - a.env
 - b.env
-valueFiles:
+files:
 - longsecret.txt
 literals:
 - FRUIT=apple

--- a/plugin/builtin/ConfigMapGenerator.go
+++ b/plugin/builtin/ConfigMapGenerator.go
@@ -22,27 +22,31 @@ import (
 	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/types"
+	"sigs.k8s.io/yaml"
 )
 
 type plugin struct {
 	ldr     ifc.Loader
 	rf      *resmap.Factory
-	options types.GeneratorOptions
-	args    types.ConfigMapArgs
+	types.GeneratorOptions
+	types.ConfigMapArgs
 }
 
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) (err error) {
+	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
+	p.GeneratorOptions = types.GeneratorOptions{}
+	p.ConfigMapArgs = types.ConfigMapArgs{}
+	err = yaml.Unmarshal(config, p)
 	p.ldr = ldr
 	p.rf = rf
-	p.args.GeneratorArgs, err = resmap.GeneratorArgsFromKunstruct(k)
 	return
 }
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
 	argsList := make([]types.ConfigMapArgs, 1)
-	argsList[0] = p.args
-	return p.rf.NewResMapFromConfigMapArgs(p.ldr, &p.options, argsList)
+	argsList[0] = p.ConfigMapArgs
+	return p.rf.NewResMapFromConfigMapArgs(
+		p.ldr, &p.GeneratorOptions, argsList)
 }

--- a/plugin/builtin/ConfigMapGenerator_test.go
+++ b/plugin/builtin/ConfigMapGenerator_test.go
@@ -46,8 +46,9 @@ COLOR=red
 apiVersion: builtin
 kind: ConfigMapGenerator
 metadata:
-  name: myMap
-envFiles:
+  name: myMapGen
+name: myMap
+envs:
 - devops.env
 - uxteam.env
 literals:

--- a/plugin/builtin/SecretGenerator_test.go
+++ b/plugin/builtin/SecretGenerator_test.go
@@ -50,12 +50,14 @@ consectetur adipiscing elit.
 apiVersion: builtin
 kind: SecretGenerator
 metadata:
-  name: mySecret
+  name: exampleSecGen
+name: mySecret
+namespace: whatever
 behavior: merge
-envFiles:
+envs:
 - a.env
 - b.env
-valueFiles:
+files:
 - obscure=longsecret.txt
 literals:
 - FRUIT=apple
@@ -73,6 +75,7 @@ data:
 kind: Secret
 metadata:
   name: mySecret
+  namespace: whatever
 type: Opaque
 `)
 }

--- a/plugin/someteam.example.com/v1/DatePrefixer.go
+++ b/plugin/someteam.example.com/v1/DatePrefixer.go
@@ -30,7 +30,7 @@ type plugin struct{}
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, k ifc.Kunstructured) error {
+	ldr ifc.Loader, rf *resmap.Factory, c []byte) error {
 	return nil
 }
 


### PR DESCRIPTION
https://github.com/kubernetes-sigs/yaml looks official now, and for plugin purposes its easier to parse into a struct as a oneshot than to use unstructured field path methods.

