### PR TITLE
Standalone ChartInflator plugin test.

### DIFF
--- a/bin/pre-commit.sh
+++ b/bin/pre-commit.sh
@@ -32,10 +32,13 @@ function testGoTest {
   go test -v ./...
 }
 
-# This is helm stuff.
+# These tests require the helm program, and at the moment
+# we're not asking travis to install helm.
 function testNoTravisGoTest {
   go test -v sigs.k8s.io/kustomize/pkg/target \
-      -run TestChartInflatorExecPlugin -tags=notravis
+      -run TestChartInflatorPlugin -tags=notravis
+  go test -v sigs.k8s.io/kustomize/plugin/... \
+    -run TestChartInflator -tags=notravis
   mdrip --mode test --label helmtest README.md ./examples/chart.md
 }
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -62,7 +62,7 @@ The file `chartInflator.yaml` could contain:
 
 ```
 apiVersion: someteam.example.com/v1
-kind: ChartInflatorExec
+kind: ChartInflator
 metadata:
   name: notImportantHere
 chartName: minecraft
@@ -150,7 +150,7 @@ reminder.
 
 ### Exec plugins
 
-[chartinflator]: ../plugin/someteam.example.com/v1/ChartInflatorExec
+[chartinflator]: ../plugin/someteam.example.com/v1/ChartInflator
 
 See this example [helm chart inflator][chartInflator].
 

--- a/examples/chart.md
+++ b/examples/chart.md
@@ -90,7 +90,7 @@ the arbitrarily chosen chart name _minecraft_:
 ```
 cat <<'EOF' >$DEMO_HOME/base/chartInflator.yaml
 apiVersion: someteam.example.com/v1
-kind: ChartInflatorExec
+kind: ChartInflator
 metadata:
   name: notImportantHere
 chartName: minecraft
@@ -108,7 +108,7 @@ executable:
 
 <!-- @installPlugin @helmtest -->
 ```
-plugin=plugin/someteam.example.com/v1/ChartInflatorExec
+plugin=plugin/someteam.example.com/v1/ChartInflator
 curl -s --create-dirs -o \
 "$DEMO_HOME/kustomize/$plugin" \
 "https://raw.githubusercontent.com/\
@@ -137,7 +137,7 @@ Expect something like:
 > │   └── plugin
 > │       └── someteam.example.com
 > │           └── v1
-> │               └── ChartInflatorExec
+> │               └── ChartInflator
 > └── prod
 >    └── kustomization.yaml
 > ```

--- a/pkg/target/chartinflatorplugin_test.go
+++ b/pkg/target/chartinflatorplugin_test.go
@@ -41,24 +41,24 @@ import (
 //
 // TODO: Download and inflate the chart, and check that
 // in for the test.
-func TestChartInflatorExecPlugin(t *testing.T) {
+func TestChartInflatorPlugin(t *testing.T) {
 	tc := plugintest_test.NewPluginTestEnv(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
-		"someteam.example.com", "v1", "ChartInflatorExec")
+		"someteam.example.com", "v1", "ChartInflator")
 
 	th := kusttest_test.NewKustTestHarnessWithPluginConfig(
 		t, "/app", plugin.ActivePluginConfig())
 	th.WriteK("/app", `
 generators:
-- chartInflatorExec.yaml
+- chartInflator.yaml
 namePrefix: LOOOOOOOONG-
 `)
 
-	th.WriteF("/app/chartInflatorExec.yaml", `
+	th.WriteF("/app/chartInflator.yaml", `
 apiVersion: someteam.example.com/v1
-kind: ChartInflatorExec
+kind: ChartInflator
 metadata:
   name: notImportantHere
 chartName: minecraft

--- a/plugin/someteam.example.com/v1/ChartInflator
+++ b/plugin/someteam.example.com/v1/ChartInflator
@@ -6,7 +6,7 @@ set -e
 # Reads a file like this
 #
 #  apiVersion: kustomize.config.k8s.io/v1
-#  kind: ChartInflatorExec
+#  kind: ChartInflator
 #  metadata:
 #    name: notImportantHere
 #  chartName: nameOfStableChart
@@ -21,7 +21,7 @@ set -e
 # chartDir default: $TMP_DIR/charts
 #
 # Example execution:
-# ./plugin/someteam.example.com/v1/ChartInflatorExec configFile.yaml
+# ./plugin/someteam.example.com/v1/ChartInflator configFile.yaml
 
 
 # Yaml parsing is a ridiculous thing to do in bash,

--- a/plugin/someteam.example.com/v1/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/ChartInflator_test.go
@@ -1,0 +1,103 @@
+// +build notravis
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Disabled on travis, because don't want to install helm on travis.
+
+package main_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/internal/plugintest"
+	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
+	"sigs.k8s.io/kustomize/pkg/kusttest"
+)
+
+// This test requires having the helm binary on the PATH.
+//
+// TODO: Download and inflate the chart, and check that
+// in for the test.
+func TestChartInflator(t *testing.T) {
+	tc := plugintest_test.NewPluginTestEnv(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin(
+		"someteam.example.com", "v1", "ChartInflator")
+
+	th := kusttest_test.NewKustTestHarnessWithPluginConfig(
+		t, "/app", plugin.ActivePluginConfig())
+
+	m := th.LoadAndRunGenerator(`
+apiVersion: someteam.example.com/v1
+kind: ChartInflator
+metadata:
+  name: notImportantHere
+chartName: minecraft`)
+
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  rcon-password: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: release-name-minecraft
+    chart: minecraft-0.3.2
+    heritage: Tiller
+    release: release-name
+  name: release-name-minecraft
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: release-name-minecraft
+    chart: minecraft-0.3.2
+    heritage: Tiller
+    release: release-name
+  name: release-name-minecraft
+spec:
+  ports:
+  - name: minecraft
+    port: 25565
+    protocol: TCP
+    targetPort: minecraft
+  selector:
+    app: release-name-minecraft
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: default
+  labels:
+    app: release-name-minecraft
+    chart: minecraft-0.3.2
+    heritage: Tiller
+    release: release-name
+  name: release-name-minecraft-datadir
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+`)
+}


### PR DESCRIPTION
Adds a standalone test for the chartinflator example plugin.
Removes "Exec" from the plugin name as it suggests that's necessary for exec plugins (it isn't).
