### PR TITLE
Update order of resources to include psps

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -99,6 +99,7 @@ var order = []string{
 	"MutatingWebhookConfiguration",
 	"ValidatingWebhookConfiguration",
 	"ServiceAccount",
+	"PodSecurityPolicy",
 	"Role",
 	"ClusterRole",
 	"RoleBinding",


### PR DESCRIPTION
Add pod security policy to list of order after service account but before the roles that would use them