### PR TITLE
Order ValidatingWebhookConfig last.

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -92,12 +92,11 @@ func (x Gvk) Equals(o Gvk) bool {
 // a Service should come before things that refer to it.
 // Namespace should be first.
 // In some cases order just specified to provide determinism.
-var order = []string{
+var orderFirst = []string{
 	"Namespace",
 	"StorageClass",
 	"CustomResourceDefinition",
 	"MutatingWebhookConfiguration",
-	"ValidatingWebhookConfiguration",
 	"ServiceAccount",
 	"PodSecurityPolicy",
 	"Role",
@@ -113,28 +112,26 @@ var order = []string{
 	"CronJob",
 	"PodDisruptionBudget",
 }
+var orderLast = []string{
+	"ValidatingWebhookConfiguration",
+}
 var typeOrders = func() map[string]int {
 	m := map[string]int{}
-	for i, n := range order {
-		m[n] = i
+	for i, n := range orderFirst {
+		m[n] = -len(orderFirst) + i
+	}
+	for i, n := range orderLast {
+		m[n] = 1 + i
 	}
 	return m
 }()
 
 // IsLessThan returns true if self is less than the argument.
 func (x Gvk) IsLessThan(o Gvk) bool {
-	indexI, foundI := typeOrders[x.Kind]
-	indexJ, foundJ := typeOrders[o.Kind]
-	if foundI && foundJ {
-		if indexI != indexJ {
-			return indexI < indexJ
-		}
-	}
-	if foundI && !foundJ {
-		return true
-	}
-	if !foundI && foundJ {
-		return false
+	indexI := typeOrders[x.Kind]
+	indexJ := typeOrders[o.Kind]
+	if indexI != indexJ {
+		return indexI < indexJ
 	}
 	return x.String() < o.String()
 }

--- a/pkg/gvk/gvk_test.go
+++ b/pkg/gvk/gvk_test.go
@@ -58,6 +58,20 @@ var lessThanTests = []struct {
 		Gvk{Group: "a", Version: "b", Kind: "ClusterRole"}},
 	{Gvk{Group: "a", Version: "d", Kind: "Namespace"},
 		Gvk{Group: "b", Version: "c", Kind: "Namespace"}},
+	{Gvk{Group: "a", Version: "b", Kind: orderFirst[len(orderFirst)-1]},
+		Gvk{Group: "a", Version: "b", Kind: orderLast[0]}},
+	{Gvk{Group: "a", Version: "b", Kind: orderFirst[len(orderFirst)-1]},
+		Gvk{Group: "a", Version: "b", Kind: "CustomKindX"}},
+	{Gvk{Group: "a", Version: "b", Kind: "CustomKindX"},
+		Gvk{Group: "a", Version: "b", Kind: orderLast[0]}},
+	{Gvk{Group: "a", Version: "b", Kind: "CustomKindA"},
+		Gvk{Group: "a", Version: "b", Kind: "CustomKindB"}},
+	{Gvk{Group: "a", Version: "b", Kind: "CustomKindX"},
+		Gvk{Group: "a", Version: "b", Kind: "ValidatingWebhookConfiguration"}},
+	{Gvk{Group: "a", Version: "b", Kind: "APIService"},
+		Gvk{Group: "a", Version: "b", Kind: "ValidatingWebhookConfiguration"}},
+	{Gvk{Group: "a", Version: "b", Kind: "Service"},
+		Gvk{Group: "a", Version: "b", Kind: "APIService"}},
 }
 
 func TestIsLessThan1(t *testing.T) {


### PR DESCRIPTION
Fixes the cert-manager example of #821 and adds tests.

This PR makes `ValidatingWebhookConfiguration`s appear as last objects within rendered YAML - after custom resources whose insertion would fail when the webhook is not available yet

(I left the `MutatingWebhookConfiguration` order untouched because I wasn't sure about that.)