### PR TITLE
Improvment var and varRefs handling

### DIFF
--- a/k8sdeps/kunstruct/helper_test.go
+++ b/k8sdeps/kunstruct/helper_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kunstruct
+
+import (
+	"reflect"
+	"testing"
+)
+
+type PathSectionSlice []PathSection
+
+func buildPath(idx *int, fields ...string) PathSectionSlice {
+	return PathSectionSlice{PathSection{fields: fields, idx: idx}}
+}
+
+func (a PathSectionSlice) addSection(idx *int, fields ...string) PathSectionSlice {
+	return append(a, PathSection{fields: fields, idx: idx})
+}
+
+func TestParseField(t *testing.T) {
+	i := 1
+	var one *int = &i
+	j := 0
+	var zero *int = &j
+
+	tests := []struct {
+		name          string
+		pathToField   string
+		expectedValue []PathSection
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "oneField",
+			pathToField:   "Kind",
+			expectedValue: buildPath(nil, "Kind"),
+			errorExpected: false,
+		},
+		{
+			name:          "twoFields",
+			pathToField:   "metadata.name",
+			expectedValue: buildPath(nil, "metadata", "name"),
+			errorExpected: false,
+		},
+		{
+			name:          "threeFields",
+			pathToField:   "spec.ports.port",
+			expectedValue: buildPath(nil, "spec", "ports", "port"),
+			errorExpected: false,
+		},
+		{
+			name:          "empty",
+			pathToField:   "",
+			expectedValue: buildPath(nil, ""),
+			errorExpected: false,
+		},
+		{
+			name:          "validStringIndex",
+			pathToField:   "that[1]",
+			expectedValue: buildPath(one, "that"),
+			errorExpected: false,
+		},
+		{
+			name:          "sliceInSlice",
+			pathToField:   "that[1][0]",
+			expectedValue: buildPath(one, "that").addSection(zero),
+			errorExpected: false,
+		},
+		{
+			name:          "validStructSubField",
+			pathToField:   "those[1].field2",
+			expectedValue: buildPath(one, "those").addSection(nil, "field2"),
+			errorExpected: false,
+		},
+		{
+			name:          "validStructSubFieldIndex",
+			pathToField:   "these[1].field2[0]",
+			expectedValue: buildPath(one, "these").addSection(zero, "field2"),
+			errorExpected: false,
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].stringsubfield",
+			expectedValue: buildPath(one, "complextree").addSection(one, "field2").addSection(nil, "stringsubfield"),
+			errorExpected: false,
+		},
+		{
+			name:          "validStructSubFieldNoneIntIndex",
+			pathToField:   "complextree[thisisnotanint]",
+			errorExpected: true,
+			errorMsg:      "invalid index complextree[thisisnotanint]",
+		},
+		{
+			name:          "invalidIndexInIndex",
+			pathToField:   "complextree[1[0]]",
+			errorExpected: true,
+			errorMsg:      "nested parentheses are not allowed: complextree[1[0]]",
+		},
+		{
+			name:          "invalidClosingBrackets",
+			pathToField:   "complextree[1]]",
+			errorExpected: true,
+			errorMsg:      "invalid field path complextree[1]]",
+		},
+		{
+			name:          "validFieldsWithQuotes",
+			pathToField:   "'complextree'[1].field2[1].'stringsubfield'",
+			expectedValue: buildPath(one, "complextree").addSection(one, "field2").addSection(nil, "stringsubfield"),
+			errorExpected: false,
+		},
+	}
+
+	for _, test := range tests {
+		s, err := parseFields(test.pathToField)
+		if test.errorExpected {
+			compareExpectedParserError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedParserError(t, test.name, test.pathToField, err)
+		}
+		compareParserValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
+
+// unExpectedError function handles unexpected error
+func unExpectedParserError(t *testing.T, name string, pathToField string, err error) {
+	t.Fatalf("%q; path %q - unexpected error %v", name, pathToField, err)
+}
+
+// compareExpectedError compares the expectedError and the actualError return by parseFields
+func compareExpectedParserError(t *testing.T, name string, pathToField string, err error, errorMsg string) {
+	if err == nil {
+		t.Fatalf("%q; path %q - should return error, but no error returned",
+			name, pathToField)
+	}
+
+	if errorMsg != err.Error() {
+		t.Fatalf("%q; path %q - expected error: \"%s\", got error: \"%v\"",
+			name, pathToField, errorMsg, err.Error())
+	}
+}
+
+// compareValues compares the expectedValue and actualValue returned by parseFields
+func compareParserValues(t *testing.T, name string, pathToField string, expectedValue PathSectionSlice, actualValue []PathSection) {
+	t.Helper()
+	if len(expectedValue) != len(actualValue) {
+		t.Fatalf("%q; Path: %s Got: %v Expected: %v", name, pathToField, actualValue, expectedValue)
+	}
+
+	for idx, expected := range expectedValue {
+		if !reflect.DeepEqual(expected, actualValue[idx]) {
+			t.Fatalf("%q; Path: %s idx: %v Fields Got: %v Expected: %v", name, pathToField, idx, actualValue[idx], expected)
+		}
+	}
+}

--- a/k8sdeps/kunstruct/kunstruct_test.go
+++ b/k8sdeps/kunstruct/kunstruct_test.go
@@ -17,40 +17,139 @@ limitations under the License.
 package kunstruct
 
 import (
+	"reflect"
 	"testing"
 )
 
-func TestGetFieldValue(t *testing.T) {
-	factory := NewKunstructuredFactoryImpl()
-	kunstructured := factory.FromMap(map[string]interface{}{
-		"Kind": "Service",
-		"metadata": map[string]interface{}{
-			"labels": map[string]string{
-				"app": "application-name",
-			},
-			"name": "service-name",
+var kunstructured = NewKunstructuredFactoryImpl().FromMap(map[string]interface{}{
+	"Kind": "Service",
+	"metadata": map[string]interface{}{
+		"labels": map[string]string{
+			"app": "application-name",
 		},
-		"spec": map[string]interface{}{
-			"ports": map[string]interface{}{
-				"port": "80",
+		"name": "service-name",
+	},
+	"spec": map[string]interface{}{
+		"ports": map[string]interface{}{
+			"port": "80",
+		},
+	},
+	"this": map[string]interface{}{
+		"is": map[string]interface{}{
+			"aNumber":      int64(1000),
+			"aFloat":       float64(1.001),
+			"aNilValue":    nil,
+			"aBool":        true,
+			"anEmptyMap":   map[string]interface{}{},
+			"anEmptySlice": []interface{}{},
+			"unrecognizable": testing.InternalExample{
+				Name: "fooBar",
 			},
 		},
-		"this": map[string]interface{}{
-			"is": map[string]interface{}{
-				"aNumber":    1000,
-				"aNilValue":  nil,
-				"anEmptyMap": map[string]interface{}{},
-				"unrecognizable": testing.InternalExample{
-					Name: "fooBar",
+	},
+	"that": []interface{}{
+		"idx0",
+		"idx1",
+		"idx2",
+		"idx3",
+	},
+	"those": []interface{}{
+		map[string]interface{}{
+			"field1": "idx0foo",
+			"field2": "idx0bar",
+		},
+		map[string]interface{}{
+			"field1": "idx1foo",
+			"field2": "idx1bar",
+		},
+		map[string]interface{}{
+			"field1": "idx2foo",
+			"field2": "idx2bar",
+		},
+	},
+	"these": []interface{}{
+		map[string]interface{}{
+			"field1": []interface{}{"idx010", "idx011"},
+			"field2": []interface{}{"idx020", "idx021"},
+		},
+		map[string]interface{}{
+			"field1": []interface{}{"idx110", "idx111"},
+			"field2": []interface{}{"idx120", "idx121"},
+		},
+		map[string]interface{}{
+			"field1": []interface{}{"idx210", "idx211"},
+			"field2": []interface{}{"idx220", "idx221"},
+		},
+	},
+	"complextree": []interface{}{
+		map[string]interface{}{
+			"field1": []interface{}{
+				map[string]interface{}{
+					"stringsubfield": "idx1010",
+					"intsubfield":    int64(1010),
+					"floatsubfield":  float64(1.010),
+					"boolfield":      true,
+				},
+				map[string]interface{}{
+					"stringsubfield": "idx1011",
+					"intsubfield":    int64(1011),
+					"floatsubfield":  float64(1.011),
+					"boolfield":      false,
+				},
+			},
+			"field2": []interface{}{
+				map[string]interface{}{
+					"stringsubfield": "idx1020",
+					"intsubfield":    int64(1020),
+					"floatsubfield":  float64(1.020),
+					"boolfield":      true,
+				},
+				map[string]interface{}{
+					"stringsubfield": "idx1021",
+					"intsubfield":    int64(1021),
+					"floatsubfield":  float64(1.021),
+					"boolfield":      false,
 				},
 			},
 		},
-	})
+		map[string]interface{}{
+			"field1": []interface{}{
+				map[string]interface{}{
+					"stringsubfield": "idx1110",
+					"intsubfield":    int64(1110),
+					"floatsubfield":  float64(1.110),
+					"boolfield":      true,
+				},
+				map[string]interface{}{
+					"stringsubfield": "idx1111",
+					"intsubfield":    int64(1111),
+					"floatsubfield":  float64(1.111),
+					"boolfield":      false,
+				},
+			},
+			"field2": []interface{}{
+				map[string]interface{}{
+					"stringsubfield": "idx1120",
+					"intsubfield":    int64(1120),
+					"floatsubfield":  float64(1.1120),
+					"boolfield":      true,
+				},
+				map[string]interface{}{
+					"stringsubfield": "idx1121",
+					"intsubfield":    int64(1121),
+					"floatsubfield":  float64(1.1121),
+					"boolfield":      false,
+				},
+			},
+		},
+	},
+})
 
+func TestGetFieldValue(t *testing.T) {
 	tests := []struct {
 		name          string
 		pathToField   string
-		expectedValue string
+		expectedValue interface{}
 		errorExpected bool
 		errorMsg      string
 	}{
@@ -99,14 +198,199 @@ func TestGetFieldValue(t *testing.T) {
 		{
 			name:          "emptyMap",
 			pathToField:   "this.is.anEmptyMap",
+			errorExpected: false,
+			expectedValue: map[string]interface{}{},
+		},
+		{
+			name:          "emptySlice",
+			pathToField:   "this.is.anEmptySlice",
+			errorExpected: false,
+			expectedValue: []interface{}{},
+		},
+		{
+			name:          "numberAsValue",
+			pathToField:   "this.is.aNumber",
+			errorExpected: false,
+			expectedValue: int64(1000),
+		},
+		{
+			name:          "floatAsValue",
+			pathToField:   "this.is.aFloat",
+			errorExpected: false,
+			expectedValue: float64(1.001),
+		},
+		{
+			name:          "boolAsValue",
+			pathToField:   "this.is.aBool",
+			errorExpected: false,
+			expectedValue: true,
+		},
+		{
+			name:          "nilAsValue",
+			pathToField:   "this.is.aNilValue",
+			errorExpected: false,
+			expectedValue: nil,
+		},
+		{
+			name:          "unrecognizable",
+			pathToField:   "this.is.unrecognizable.Name",
+			errorExpected: true,
+			errorMsg:      ".this.is.unrecognizable.Name accessor error: {fooBar <nil>  false} is of the type testing.InternalExample, expected map[string]interface{}",
+		},
+		{
+			name:          "validStringIndex",
+			pathToField:   "that[2]",
+			expectedValue: "idx2",
+			errorExpected: false,
+		},
+		{
+			name:          "outOfBoundIndex",
+			pathToField:   "that[99]",
+			errorMsg:      "no field named 'that[99]'",
+			errorExpected: true,
+		},
+		{
+			name:          "unknownSlice",
+			pathToField:   "unknown[0]",
+			errorMsg:      "no field named 'unknown[0]'",
+			errorExpected: true,
+		},
+		{
+			name:          "sliceInSlice",
+			pathToField:   "that[2][0]",
+			errorExpected: true,
+			errorMsg:      "no field named 'that[2][0]'",
+		},
+		{
+			name:          "validStructIndex",
+			pathToField:   "those[1]",
+			errorExpected: false,
+			expectedValue: map[string]interface{}{"field1": "idx1foo", "field2": "idx1bar"},
+		},
+		{
+			name:          "validStructSubField",
+			pathToField:   "those[1].field2",
+			errorExpected: false,
+			expectedValue: "idx1bar",
+		},
+		{
+			name:          "validStructSubFieldIndex",
+			pathToField:   "these[1].field2[1]",
+			errorExpected: false,
+			expectedValue: "idx121",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].stringsubfield",
+			errorExpected: false,
+			expectedValue: "idx1121",
+		},
+		{
+			name:          "validStructSubFieldIndexInvalidName",
+			pathToField:   "complextree[1].field2[1].invalidsubfield",
+			errorExpected: true,
+			errorMsg:      "no field named 'complextree[1].field2[1].invalidsubfield'",
+		},
+		{
+			name:          "validStructSubFieldNoneIntIndex",
+			pathToField:   "complextree[thisisnotanint]",
+			errorExpected: true,
+			errorMsg:      "no field named 'complextree[thisisnotanint]'",
+		},
+		{
+			name:          "invalidNoneIntIndex",
+			pathToField:   "complextree[thisisnotanint]",
+			errorExpected: true,
+			errorMsg:      "no field named 'complextree[thisisnotanint]'",
+		},
+		{
+			name:          "invalidIndexInIndex",
+			pathToField:   "complextree[1[0]]",
+			errorExpected: true,
+			errorMsg:      "no field named 'complextree[1[0]]'",
+		},
+		{
+			name:          "invalidClosingBrackets",
+			pathToField:   "complextree[1]]",
+			errorExpected: true,
+			errorMsg:      "no field named 'complextree[1]]'",
+		},
+		{
+			name:          "validFieldsWithQuotes",
+			pathToField:   "'complextree'[1].field2[1].'stringsubfield'",
+			errorExpected: false,
+			expectedValue: "idx1121",
+		},
+	}
+
+	for _, test := range tests {
+		s, err := kunstructured.GetFieldValue(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+		compareValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
+
+func TestGetString(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		expectedValue string
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "oneField",
+			pathToField:   "Kind",
+			expectedValue: "Service",
+			errorExpected: false,
+		},
+		{
+			name:          "twoFields",
+			pathToField:   "metadata.name",
+			expectedValue: "service-name",
+			errorExpected: false,
+		},
+		{
+			name:          "threeFields",
+			pathToField:   "spec.ports.port",
+			expectedValue: "80",
+			errorExpected: false,
+		},
+		{
+			name:          "emptyMap",
+			pathToField:   "this.is.anEmptyMap",
 			errorExpected: true,
 			errorMsg:      ".this.is.anEmptyMap accessor error: map[] is of the type map[string]interface {}, expected string",
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "emptySlice",
+			pathToField:   "this.is.anEmptySlice",
+			errorExpected: true,
+			errorMsg:      ".this.is.anEmptySlice accessor error: [] is of the type []interface {}, expected string",
 		},
 		{
 			name:          "numberAsValue",
 			pathToField:   "this.is.aNumber",
 			errorExpected: true,
-			errorMsg:      ".this.is.aNumber accessor error: 1000 is of the type int, expected string",
+			errorMsg:      ".this.is.aNumber accessor error: 1000 is of the type int64, expected string",
 		},
 		{
 			name:          "nilAsValue",
@@ -115,34 +399,410 @@ func TestGetFieldValue(t *testing.T) {
 			errorMsg:      ".this.is.aNilValue accessor error: <nil> is of the type <nil>, expected string",
 		},
 		{
-			name:          "unrecognizable",
-			pathToField:   "this.is.unrecognizable.Name",
+			name:          "validStringIndex",
+			pathToField:   "that[2]",
+			expectedValue: "idx2",
+			errorExpected: false,
+		},
+		{
+			name:          "validStructIndex",
+			pathToField:   "those[1]",
 			errorExpected: true,
-			errorMsg:      ".this.is.unrecognizable.Name accessor error: {fooBar <nil>  false} is of the type testing.InternalExample, expected map[string]interface{}",
+			errorMsg:      ".[1] accessor error: map[field1:idx1foo field2:idx1bar] is of the type map[string]interface {}, expected string",
+		},
+		{
+			name:          "validStructSubField",
+			pathToField:   "those[1].field2",
+			errorExpected: false,
+			expectedValue: "idx1bar",
+		},
+		{
+			name:          "validStructSubFieldIndex",
+			pathToField:   "these[1].field2[1]",
+			errorExpected: false,
+			expectedValue: "idx121",
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].stringsubfield",
+			errorExpected: false,
+			expectedValue: "idx1121",
+		},
+		{
+			name:          "invalidIndexInMap",
+			pathToField:   "this.is[1]",
+			errorExpected: true,
+			errorMsg:      "no field named 'this.is[1]'",
+		},
+		{
+			name:          "anotherInvalidIndexInMap",
+			pathToField:   "this.is[1].aString",
+			errorExpected: true,
+			errorMsg:      "no field named 'this.is[1].aString'",
 		},
 	}
 
 	for _, test := range tests {
-		s, err := kunstructured.GetFieldValue(test.pathToField)
+		s, err := kunstructured.GetString(test.pathToField)
 		if test.errorExpected {
-			if err == nil {
-				t.Fatalf("%q; path %q - should return error, but no error returned",
-					test.name, test.pathToField)
-			}
-			if test.errorMsg != err.Error() {
-				t.Fatalf("%q; path %q - expected error: \"%s\", got error: \"%v\"",
-					test.name, test.pathToField, test.errorMsg, err.Error())
-			}
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
 			continue
 		}
 		if err != nil {
-			t.Fatalf("%q; path %q - unexpected error %v",
-				test.name, test.pathToField, err)
+			unExpectedError(t, test.name, test.pathToField, err)
 		}
-		if test.expectedValue != s {
-			t.Fatalf("%q; Got: %s expected: %s",
-				test.name, s, test.expectedValue)
-		}
+		compareValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
 
+func TestGetInt64(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		expectedValue int64
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "numberAsValue",
+			pathToField:   "this.is.aNumber",
+			errorExpected: false,
+			expectedValue: int64(1000),
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].intsubfield",
+			errorExpected: false,
+			expectedValue: int64(1121),
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		s, err := kunstructured.GetInt64(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+		compareValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
+
+func TestGetFloat64(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		expectedValue float64
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "floatAsValue",
+			pathToField:   "this.is.aFloat",
+			errorExpected: false,
+			expectedValue: float64(1.001),
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].floatsubfield",
+			errorExpected: false,
+			expectedValue: float64(1.1121),
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "index 99 is out of bounds",
+		},
+	}
+
+	for _, test := range tests {
+		s, err := kunstructured.GetFloat64(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+		compareValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		expectedValue bool
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "boolAsValue",
+			pathToField:   "this.is.aBool",
+			errorExpected: false,
+			expectedValue: true,
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1].boolfield",
+			errorExpected: false,
+			expectedValue: false,
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		s, err := kunstructured.GetBool(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+		compareValues(t, test.name, test.pathToField, test.expectedValue, s)
+	}
+}
+
+func TestGetStringMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "validStringMap",
+			pathToField:   "those[2]",
+			errorExpected: false,
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := kunstructured.GetStringMap(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+	}
+}
+
+func TestGetMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "validMap",
+			pathToField:   "those[2]",
+			errorExpected: false,
+		},
+		{
+			name:          "validStructSubFieldIndexSubfield",
+			pathToField:   "complextree[1].field2[1]",
+			errorExpected: false,
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := kunstructured.GetMap(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+	}
+}
+
+func TestGetStringSlice(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "validStringSlice",
+			pathToField:   "that",
+			errorExpected: false,
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := kunstructured.GetStringSlice(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+	}
+}
+
+func TestGetSlice(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathToField   string
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name:          "validSlice1",
+			pathToField:   "that",
+			errorExpected: false,
+		},
+		{
+			name:          "validSlice2",
+			pathToField:   "those",
+			errorExpected: false,
+		},
+		{
+			name:          "validSlice3",
+			pathToField:   "these",
+			errorExpected: false,
+		},
+		{
+			name:          "validSlice4",
+			pathToField:   "complextree",
+			errorExpected: false,
+		},
+		{
+			name:          "twoFieldsOneMissing",
+			pathToField:   "metadata.banana",
+			errorExpected: true,
+			errorMsg:      "no field named 'metadata.banana'",
+		},
+		{
+			name:          "validStructSubFieldOutOfBoundIndex",
+			pathToField:   "these[1].field2[99]",
+			errorExpected: true,
+			errorMsg:      "no field named 'these[1].field2[99]'",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := kunstructured.GetSlice(test.pathToField)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, test.pathToField, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, test.pathToField, err)
+		}
+	}
+}
+
+// unExpectedError function handles unexpected error
+func unExpectedError(t *testing.T, name string, pathToField string, err error) {
+	t.Fatalf("%q; path %q - unexpected error %v", name, pathToField, err)
+}
+
+// compareExpectedError compares the expectedError and the actualError return by GetFieldValue
+func compareExpectedError(t *testing.T, name string, pathToField string, err error, errorMsg string) {
+	if err == nil {
+		t.Fatalf("%q; path %q - should return error, but no error returned",
+			name, pathToField)
+	}
+
+	if errorMsg != err.Error() {
+		t.Fatalf("%q; path %q - expected error: \"%s\", got error: \"%v\"",
+			name, pathToField, errorMsg, err.Error())
+	}
+}
+
+// compareValues compares the expectedValue and actualValue returned by GetFieldValue
+func compareValues(t *testing.T, name string, pathToField string, expectedValue interface{}, actualValue interface{}) {
+	t.Helper()
+	switch typedV := expectedValue.(type) {
+	case nil, string, bool, float64, int, int64:
+		if expectedValue != actualValue {
+			t.Fatalf("%q; Got: %v Expected: %v", name, actualValue, expectedValue)
+		}
+	case map[string]interface{}:
+		if !reflect.DeepEqual(expectedValue, actualValue) {
+			t.Fatalf("%q; Got: %v Expected: %v", name, actualValue, expectedValue)
+		}
+	case []interface{}:
+		if !reflect.DeepEqual(expectedValue, actualValue) {
+			t.Fatalf("%q; Got: %v Expected: %v", name, actualValue, expectedValue)
+		}
+	default:
+		t.Logf("%T value at `%s`", typedV, pathToField)
 	}
 }

--- a/pkg/accumulator/resaccumulator.go
+++ b/pkg/accumulator/resaccumulator.go
@@ -91,7 +91,7 @@ func (ra *ResAccumulator) MergeAccumulator(other *ResAccumulator) (err error) {
 	return ra.varSet.MergeSet(other.varSet)
 }
 
-func (ra *ResAccumulator) findValueFromResources(v types.Var) (string, error) {
+func (ra *ResAccumulator) findVarValueFromResources(v types.Var) (interface{}, error) {
 	for _, res := range ra.resMap.Resources() {
 		for _, varName := range res.GetRefVarNames() {
 			if varName == v.Name {
@@ -115,10 +115,10 @@ func (ra *ResAccumulator) findValueFromResources(v types.Var) (string, error) {
 // makeVarReplacementMap returns a map of Var names to
 // their final values. The values are strings intended
 // for substitution wherever the $(var.Name) occurs.
-func (ra *ResAccumulator) makeVarReplacementMap() (map[string]string, error) {
-	result := map[string]string{}
+func (ra *ResAccumulator) makeVarReplacementMap() (map[string]interface{}, error) {
+	result := map[string]interface{}{}
 	for _, v := range ra.Vars() {
-		s, err := ra.findValueFromResources(v)
+		s, err := ra.findVarValueFromResources(v)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/accumulator/resaccumulator_test.go
+++ b/pkg/accumulator/resaccumulator_test.go
@@ -326,5 +326,11 @@ func getCommand(r *resource.Resource) string {
 	m, _ = m["spec"].(map[string]interface{})
 	c, _ = m["containers"].([]interface{})
 	m, _ = c[0].(map[string]interface{})
-	return strings.Join(m["command"].([]string), " ")
+
+	cmd, _ := m["command"].([]interface{})
+	n := make([]string, len(cmd))
+	for i, v := range cmd {
+		n[i] = v.(string)
+	}
+	return strings.Join(n, " ")
 }

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -40,8 +40,15 @@ type Kunstructured interface {
 	Map() map[string]interface{}
 	SetMap(map[string]interface{})
 	Copy() Kunstructured
-	GetFieldValue(string) (string, error)
+	GetFieldValue(string) (interface{}, error)
+	GetString(string) (string, error)
 	GetStringSlice(string) ([]string, error)
+	GetBool(path string) (bool, error)
+	GetFloat64(path string) (float64, error)
+	GetInt64(path string) (int64, error)
+	GetSlice(path string) ([]interface{}, error)
+	GetStringMap(path string) (map[string]string, error)
+	GetMap(path string) (map[string]interface{}, error)
 	MarshalJSON() ([]byte, error)
 	UnmarshalJSON([]byte) error
 	GetGvk() gvk.Gvk

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -182,7 +182,7 @@ func (r *Resource) NeedHashSuffix() bool {
 
 // GetNamespace returns the namespace the resource thinks it's in.
 func (r *Resource) GetNamespace() string {
-	namespace, _ := r.GetFieldValue("metadata.namespace")
+	namespace, _ := r.GetString("metadata.namespace")
 	// if err, namespace is empty, so no need to check.
 	return namespace
 }

--- a/pkg/transformers/mutatefield_test.go
+++ b/pkg/transformers/mutatefield_test.go
@@ -79,7 +79,7 @@ func makeTestDeployment() ifc.Kunstructured {
 }
 
 func getFieldValue(t *testing.T, obj ifc.Kunstructured, fieldName string) string {
-	v, err := obj.GetFieldValue(fieldName)
+	v, err := obj.GetString(fieldName)
 	if err != nil {
 		t.Fatalf("unexpected field error: %v", err)
 	}

--- a/pkg/transformers/refvars_test.go
+++ b/pkg/transformers/refvars_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestVarRef(t *testing.T) {
 	type given struct {
-		varMap map[string]string
+		varMap map[string]interface{}
 		fs     []config.FieldSpec
 		res    resmap.ResMap
 	}
@@ -31,9 +31,11 @@ func TestVarRef(t *testing.T) {
 		{
 			description: "var replacement in map[string]",
 			given: given{
-				varMap: map[string]string{
+				varMap: map[string]interface{}{
 					"FOO": "replacementForFoo",
 					"BAR": "replacementForBar",
+					"BAZ": int64(5),
+					"BOO": true,
 				},
 				fs: []config.FieldSpec{
 					{Gvk: gvk.Gvk{Version: "v1", Kind: "ConfigMap"}, Path: "data"},
@@ -48,6 +50,10 @@ func TestVarRef(t *testing.T) {
 						"data": map[string]interface{}{
 							"item1": "$(FOO)",
 							"item2": "bla",
+							"item3": "$(BAZ)",
+							"item4": "$(BAZ)+$(BAZ)",
+							"item5": "$(BOO)",
+							"item6": "if $(BOO)",
 						},
 					}).ResMap(),
 			},
@@ -62,6 +68,10 @@ func TestVarRef(t *testing.T) {
 						"data": map[string]interface{}{
 							"item1": "replacementForFoo",
 							"item2": "bla",
+							"item3": int64(5),
+							"item4": "5+5",
+							"item5": true,
+							"item6": "if true",
 						}}).ResMap(),
 				unused: []string{"BAR"},
 			},

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -84,10 +84,10 @@ type Kustomization struct {
 	Replicas []Replica `json:"replicas,omitempty" yaml:"replicas,omitempty"`
 
 	// Vars allow things modified by kustomize to be injected into a
-	// container specification. A var is a name (e.g. FOO) associated
+	// kubernetes object specification. A var is a name (e.g. FOO) associated
 	// with a field in a specific resource instance.  The field must
-	// contain a value of type string, and defaults to the name field
-	// of the instance.  Any appearance of "$(FOO)" in the container
+	// contain a value of type string/bool/int/float, and defaults to the name field
+	// of the instance.  Any appearance of "$(FOO)" in the object
 	// spec will be replaced at kustomize build time, after the final
 	// value of the specified field has been determined.
 	Vars []Var `json:"vars,omitempty" yaml:"vars,omitempty"`


### PR DESCRIPTION
This change provides two main improvements:

It provides int/float/bool variables support.
Possible usage: Extracting replica count from one statefulset
   and used it to be another statefulset

It improves the fieldSpec support for the variable by allowing indexing:
spec.template.spec.containers[1].command[1]
