### PR TITLE
add validation transformer

### DIFF
--- a/pkg/kusttest/kusttestharness.go
+++ b/pkg/kusttest/kusttestharness.go
@@ -120,6 +120,21 @@ func (th *KustTestHarness) LoadAndRunGenerator(
 
 func (th *KustTestHarness) LoadAndRunTransformer(
 	config, input string) resmap.ResMap {
+	resMap, err := th.runTransformer(config, input)
+	if err != nil {
+		th.t.Fatalf("Err: %v", err)
+	}
+	return resMap
+}
+
+func (th *KustTestHarness) ErrorFromLoadAndRunTransformer(
+	config, input string) error {
+	_, err := th.runTransformer(config, input)
+	return err
+}
+
+func (th *KustTestHarness) runTransformer(
+	config, input string) (resmap.ResMap, error) {
 	transConfig, err := th.rf.RF().FromBytes([]byte(config))
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
@@ -133,10 +148,7 @@ func (th *KustTestHarness) LoadAndRunTransformer(
 		th.t.Fatalf("Err: %v", err)
 	}
 	err = g.Transform(resMap)
-	if err != nil {
-		th.t.Fatalf("Err: %v", err)
-	}
-	return resMap
+	return resMap, err
 }
 
 func tabToSpace(input string) string {

--- a/pkg/plugins/execplugin.go
+++ b/pkg/plugins/execplugin.go
@@ -148,7 +148,7 @@ func (p *ExecPlugin) Transform(rm resmap.ResMap) error {
 	// invoke the plugin with resources as the input
 	output, err := p.invokePlugin(resources)
 	if err != nil {
-		return err
+		return fmt.Errorf("%v %s", err, string(output))
 	}
 
 	// update the original ResMap based on the output

--- a/plugin/someteam.example.com/v1/validator/Validator
+++ b/plugin/someteam.example.com/v1/validator/Validator
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+
+# Validator transformer plugin by kubeval
+# https://github.com/instrumenta/kubeval
+#
+# Assumes that kubeval is available from $PATH
+#
+# Reads Kubernetes resources from stdin
+# Validates them and output in the stdout
+#
+# Example execution:
+# cat <raw K8s yaml> | ./plugin/someteam.example.com/v1/Validator
+
+if ! [ -x "$(command -v kubeval)" ]; then
+  echo "Error: kubeval is not installed."
+  exit 1
+fi
+
+temp_file=$(mktemp)
+output_file=$(mktemp)
+cat - > $temp_file
+
+kubeval $temp_file > $output_file
+
+if [ $? -eq 0 ]; then
+    cat $temp_file
+    rm $temp_file $output_file
+    exit 0
+fi
+
+cat $output_file
+rm $temp_file $output_file
+exit 1
+

--- a/plugin/someteam.example.com/v1/validator/validator_test.go
+++ b/plugin/someteam.example.com/v1/validator/validator_test.go
@@ -1,0 +1,79 @@
+// +build notravis
+
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main_test
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/kustomize/pkg/kusttest"
+	"sigs.k8s.io/kustomize/plugin"
+)
+
+func TestValidatorHappy(t *testing.T) {
+	tc := plugin.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: someteam.example.com/v1
+kind: Validator
+metadata:
+  name: notImportantHere
+`,
+		`apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    foo: bar
+  name: some-cm
+data:
+  foo: bar
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+data:
+  foo: bar
+kind: ConfigMap
+metadata:
+  annotations:
+    foo: bar
+  name: some-cm
+`)
+}
+
+func TestValidatorUnHappy(t *testing.T) {
+	tc := plugin.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	err := th.ErrorFromLoadAndRunTransformer(`
+apiVersion: someteam.example.com/v1
+kind: Validator
+metadata:
+  name: notImportantHere
+`,
+		`apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations: {}
+  name: some-cm
+data:
+- foo: bar
+`)
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !strings.Contains(err.Error(),
+		"data: Invalid type. Expected: object, given: array") {
+		t.Fatalf("incorrect error %v", err)
+	}
+}

--- a/travis/pre-commit.sh
+++ b/travis/pre-commit.sh
@@ -40,6 +40,10 @@ function testNoTravisGoTest {
   go test -v sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/chartinflator/... \
     -run TestChartInflator -tags=notravis
   mdrip --mode test --label helmtest README.md ./examples/chart.md
+  go test -v sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/validator/... \
+       -run TestValidatorHappy -tags=notravis
+  go test -v sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/validator/... \
+       -run TestValidatorUnHappy -tags=notravis
 }
 
 function testExamples {


### PR DESCRIPTION
Add a validation transformer using the binary `kubeval`.

The validation transformer triggers `kubeval` and saves the output in a file.
The transformer returns different output and exit code depending on `kubeval` results.

Added two unit tests for this transformer:
- one for a valid resource
- one for an invalid resource (This invalid resource passed `kustomize build`)