### PR TITLE
Fix commonLabels spec for volumeClaimTemplates

### DIFF
--- a/pkg/transformers/config/defaultconfig/commonlabels.go
+++ b/pkg/transformers/config/defaultconfig/commonlabels.go
@@ -111,7 +111,7 @@ commonLabels:
   kind: StatefulSet
 
 - path: spec/volumeClaimTemplates/metadata/labels
-  create: true
+  create: false
   group: apps
   kind: StatefulSet
 


### PR DESCRIPTION
Currently, setting a `commonLabels` on the `kustomization.yaml` and having a `statefulset` in the resources makes `kustomize` generate a malformed `volumeClaimTemplates` :
```
...
volumeClaimTemplates:
    metadata:
      labels:
        application: segmentor
...
```

This PR fixes the problem by making `kustomize` not create the `volumeClaimTemplates` if it's not present.