### PR TITLE
Update springboot with the new configMapGenerator API

### DIFF
--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -85,9 +85,11 @@ cat kustomization.yaml
 
 > ```
 > configMapGenerator:
-> - files:
->   - application.properties
->   name: demo-configmap
+> - KVSources:
+>  - args:
+>    - application.properties
+>    name: files
+>  name: demo-configmap
 > ```
 
 ### Customize configMap
@@ -137,10 +139,12 @@ cat kustomization.yaml
 `kustomization.yaml`'s configMapGenerator section should contain:
 > ```
 > configMapGenerator:
-> - files:
->   - application.properties
->   - application-prod.properties
->   name: demo-configmap
+> - KVSources:
+>  - args:
+>    - application.properties
+>    - application-prod.properties
+>    name: files
+>  name: demo-configmap
 > ```
 
 ### Name Customization


### PR DESCRIPTION
When I went to run through the demo with the most recent version of `kustomize` (current master, or else a few commits behind), the output from running through the steps in the README was different than what was listed in the README. I was using the listed output as a reference for configMapGenerators and got an incorrect configuration as a result.