### PR TITLE
Keep var refernce in resources

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -31,8 +31,9 @@ import (
 // paired with a GenerationBehavior.
 type Resource struct {
 	ifc.Kunstructured
-	options *types.GenArgs
-	refBy   []resid.ResId
+	options     *types.GenArgs
+	refBy       []resid.ResId
+	refVarNames []string
 }
 
 func (r *Resource) KunstructEqual(o *Resource) bool {
@@ -58,6 +59,11 @@ func (r *Resource) DeepCopy() *Resource {
 		refby := make([]resid.ResId, len(r.refBy))
 		copy(refby, r.refBy)
 		rc.refBy = refby
+	}
+	if len(r.refVarNames) > 0 {
+		refVarNames := make([]string, len(r.refVarNames))
+		copy(refVarNames, r.refVarNames)
+		rc.refVarNames = refVarNames
 	}
 	return rc
 }
@@ -96,6 +102,16 @@ func (r *Resource) GetRefBy() []resid.ResId {
 // AppendRefBy appends a ResId into the refBy list
 func (r *Resource) AppendRefBy(id resid.ResId) {
 	r.refBy = append(r.refBy, id)
+}
+
+// GetRefVarNames returns vars that refer to current resource
+func (r *Resource) GetRefVarNames() []string {
+	return r.refVarNames
+}
+
+// AppendRefVarName appends a name of a var into the refVar list
+func (r *Resource) AppendRefVarName(variable types.Var) {
+	r.refVarNames = append(r.refVarNames, variable.Name)
 }
 
 // Merge performs merge with other resource.

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/gvk"
 	"sigs.k8s.io/kustomize/pkg/resid"
 	. "sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/types"
 )
 
 var factory = NewFactory(
@@ -121,6 +122,14 @@ func TestDeepCopy(t *testing.T) {
 			},
 		})
 	r.AppendRefBy(resid.NewResId(gvk.Gvk{Group: "somegroup", Kind: "MyKind"}, "random"))
+
+	var1 := types.Var{
+		Name: "SERVICE_ONE",
+		ObjRef: types.Target{
+			Gvk:  gvk.Gvk{Version: "v1", Kind: "Service"},
+			Name: "backendOne"},
+	}
+	r.AppendRefVarName(var1)
 
 	cr := r.DeepCopy()
 	if !reflect.DeepEqual(r, cr) {

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -228,11 +228,6 @@ func (kt *KustTarget) AccumulateTarget() (
 		return nil, errors.Wrapf(
 			err, "merging config %v", tConfig)
 	}
-	err = ra.MergeVars(kt.kustomization.Vars)
-	if err != nil {
-		return nil, errors.Wrapf(
-			err, "merging vars %v", kt.kustomization.Vars)
-	}
 	crdTc, err := config.LoadConfigFromCRDs(kt.ldr, kt.kustomization.Crds)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -248,7 +243,15 @@ func (kt *KustTarget) AccumulateTarget() (
 		return nil, err
 	}
 	err = kt.runTransformers(ra)
-	return ra, err
+	if err != nil {
+		return nil, err
+	}
+	err = ra.MergeVars(kt.kustomization.Vars)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "merging vars %v", kt.kustomization.Vars)
+	}
+	return ra, nil
 }
 
 func (kt *KustTarget) runGenerators(


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/kustomize/issues/1036

Keep a referenced variable name in resources, so when merge vars, we only search the resources in one accumulator.