### PR TITLE
Add test for ordered transformers.

### DIFF
--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -100,6 +100,7 @@ func (l *Loader) absolutePluginPath(id resid.ResId) string {
 	return AbsolutePluginPath(l.pc, id)
 }
 
+// TODO: https://github.com/kubernetes-sigs/kustomize/issues/1164
 func (l *Loader) loadAndConfigurePlugin(
 	ldr ifc.Loader, res *resource.Resource) (c Configurable, err error) {
 	if !l.pc.Enabled {

--- a/plugin/builtin/PreferredOrderTransformer.go
+++ b/plugin/builtin/PreferredOrderTransformer.go
@@ -2,9 +2,9 @@
 package builtin
 
 import (
+	"sigs.k8s.io/kustomize/pkg/ifc"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
-	"sigs.k8s.io/kustomize/pkg/transformers/config"
 	"sort"
 )
 
@@ -13,22 +13,18 @@ import (
 // dependencies (like Namespace, StorageClass, etc.)
 // first, and resources with a high number of dependencies
 // (like ValidatingWebhookConfiguration) last.
-type PreferredOrderTransformerPlugin struct {
-	Prefix     string             `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Suffix     string             `json:"suffix,omitempty" yaml:"suffix,omitempty"`
-	FieldSpecs []config.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
-}
+type PreferredOrderTransformerPlugin struct{}
 
 func NewPreferredOrderTransformerPlugin() *PreferredOrderTransformerPlugin {
 	return &PreferredOrderTransformerPlugin{}
 }
 
-/*
+// Nothing needed for configuration.
 func (p *PreferredOrderTransformerPlugin) Config(
 	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
 	return nil
 }
-*/
+
 func (p *PreferredOrderTransformerPlugin) Transform(m resmap.ResMap) error {
 	resources := make([]*resource.Resource, m.Size())
 	ids := m.AllIds()

--- a/plugin/builtin/preferredordertransformer/PreferredOrderTransformer.go
+++ b/plugin/builtin/preferredordertransformer/PreferredOrderTransformer.go
@@ -16,7 +16,7 @@ import (
 // dependencies (like Namespace, StorageClass, etc.)
 // first, and resources with a high number of dependencies
 // (like ValidatingWebhookConfiguration) last.
-type plugin struct {}
+type plugin struct{}
 
 var KustomizePlugin plugin
 


### PR DESCRIPTION
Now that we maintain load order, we can apply transformers in sequence.

This test found a bug #1164, but doesn't block stacking _different_ transformers.