### PR TITLE
Add originalName field to resource.

### DIFF
--- a/pkg/accumulator/resaccumulator_test.go
+++ b/pkg/accumulator/resaccumulator_test.go
@@ -174,10 +174,9 @@ func TestResolveVarsVarNeedsDisambiguation(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	rm0 := resmap.FromMap(map[resid.ResId]*resource.Resource{
-		resid.NewResIdWithPrefixNamespace(
-			gvk.Gvk{Version: "v1", Kind: "Service"},
-			"backendOne", "", "fooNamespace"): rf.FromMap(
+	rm0 := resmap.New()
+	rm0.Append(
+		rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Service",
@@ -185,9 +184,7 @@ func TestResolveVarsVarNeedsDisambiguation(t *testing.T) {
 					"name":      "backendOne",
 					"namespace": "fooNamespace",
 				},
-			}),
-	})
-
+			}))
 	err = ra.AppendAll(rm0)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)

--- a/pkg/patch/transformer/factory.go
+++ b/pkg/patch/transformer/factory.go
@@ -59,14 +59,13 @@ func (f PatchJson6902Factory) makeOnePatchJson6902Transformer(p types.PatchJson6
 		return nil, fmt.Errorf("must specify the path for a json patch file")
 	}
 
-	targetId := resid.NewResIdWithPrefixNamespace(
+	targetId := resid.NewResIdWithNamespace(
 		gvk.Gvk{
 			Group:   p.Target.Group,
 			Version: p.Target.Version,
 			Kind:    p.Target.Kind,
 		},
 		p.Target.Name,
-		"",
 		p.Target.Namespace,
 	)
 

--- a/pkg/resid/resid.go
+++ b/pkg/resid/resid.go
@@ -38,6 +38,12 @@ type ResId struct {
 	Suffix string `json:"suffix,omitempty"`
 }
 
+// NewResIdWithNamespace creates new resource identifier
+// in a given namespace.
+func NewResIdWithNamespace(k gvk.Gvk, n, ns string) ResId {
+	return ResId{ItemId: ItemId{Gvk: k, Name: n, Namespace: ns}}
+}
+
 // NewResIdWithPrefixSuffixNamespace creates new resource identifier with a prefix, suffix and a namespace
 func NewResIdWithPrefixSuffixNamespace(k gvk.Gvk, n, p, s, ns string) ResId {
 	return ResId{ItemId: ItemId{Gvk: k, Name: n, Namespace: ns}, Prefix: p, Suffix: s}

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -46,24 +46,26 @@ metadata:
 	if ferr := l.AddFile("/whatever/project/deployment.yaml", []byte(resourceStr)); ferr != nil {
 		t.Fatalf("Error adding fake file: %v\n", ferr)
 	}
-	expected := FromMap(map[resid.ResId]*resource.Resource{
-		resid.NewResId(deploy, "dply1"): rf.FromMap(
-			map[string]interface{}{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata": map[string]interface{}{
-					"name": "dply1",
-				},
-			}),
-		resid.NewResId(deploy, "dply2"): rf.FromMap(
-			map[string]interface{}{
-				"apiVersion": "apps/v1",
-				"kind":       "Deployment",
-				"metadata": map[string]interface{}{
-					"name": "dply2",
-				},
-			}),
-		resid.NewResIdWithPrefixNamespace(deploy, "dply2", "", "test"): rf.FromMap(
+	expected := New()
+	expected.Append(rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "dply1",
+			},
+		}))
+	expected.Append(rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name": "dply2",
+			},
+		}))
+	expected.AppendWithId(
+		resid.NewResIdWithNamespace(deploy, "dply2", "test"),
+		rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "apps/v1",
 				"kind":       "Deployment",
@@ -71,8 +73,7 @@ metadata:
 					"name":      "dply2",
 					"namespace": "test",
 				},
-			}),
-	})
+			}))
 	m, _ := rmF.FromFile(l, "deployment.yaml")
 	if m.Size() != 3 {
 		t.Fatalf("result should contain 3, but got %d", m.Size())

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -98,7 +98,8 @@ func TestResourceId(t *testing.T) {
 	}{
 		{
 			in: testConfigMap,
-			id: resid.NewResIdWithPrefixNamespace(gvk.Gvk{Version: "v1", Kind: "ConfigMap"}, "winnie", "", "hundred-acre-wood"),
+			id: resid.NewResIdWithNamespace(
+				gvk.Gvk{Version: "v1", Kind: "ConfigMap"}, "winnie", "hundred-acre-wood"),
 		},
 		{
 			in: testDeployment,

--- a/pkg/transformers/labelsandannotations_test.go
+++ b/pkg/transformers/labelsandannotations_test.go
@@ -28,20 +28,16 @@ import (
 )
 
 var service = gvk.Gvk{Version: "v1", Kind: "Service"}
-var secret = gvk.Gvk{Version: "v1", Kind: "Secret"}
 var cmap = gvk.Gvk{Version: "v1", Kind: "ConfigMap"}
 var ns = gvk.Gvk{Version: "v1", Kind: "Namespace"}
 var deploy = gvk.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"}
-var statefulset = gvk.Gvk{Group: "apps", Version: "v1", Kind: "StatefulSet"}
 var crd = gvk.Gvk{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 var job = gvk.Gvk{Group: "batch", Version: "v1", Kind: "Job"}
 var cronjob = gvk.Gvk{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
 var pv = gvk.Gvk{Version: "v1", Kind: "PersistentVolume"}
-var pvc = gvk.Gvk{Version: "v1", Kind: "PersistentVolumeClaim"}
 var cr = gvk.Gvk{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}
 var crb = gvk.Gvk{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}
 var sa = gvk.Gvk{Version: "v1", Kind: "ServiceAccount"}
-var ingress = gvk.Gvk{Kind: "Ingress"}
 var rf = resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl())
 var defaultTransformerConfig = config.MakeDefaultConfig()
 

--- a/pkg/transformers/namereference.go
+++ b/pkg/transformers/namereference.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package transformers
 

--- a/pkg/transformers/namespace_test.go
+++ b/pkg/transformers/namespace_test.go
@@ -110,7 +110,7 @@ func TestNamespaceRun(t *testing.T) {
 			}),
 	})
 	expected := resmap.FromMap(map[resid.ResId]*resource.Resource{
-		resid.NewResIdWithPrefixNamespace(ns, "ns1", "", ""): rf.FromMap(
+		resid.NewResIdWithNamespace(ns, "ns1", ""): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "Namespace",
@@ -118,7 +118,7 @@ func TestNamespaceRun(t *testing.T) {
 					"name": "ns1",
 				},
 			}),
-		resid.NewResIdWithPrefixNamespace(cmap, "cm1", "", "test"): rf.FromMap(
+		resid.NewResIdWithNamespace(cmap, "cm1", "test"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -127,7 +127,7 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resid.NewResIdWithPrefixNamespace(cmap, "cm2", "", "test"): rf.FromMap(
+		resid.NewResIdWithNamespace(cmap, "cm2", "test"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ConfigMap",
@@ -136,10 +136,10 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resid.NewResIdWithPrefixNamespace(cmap, "cm3", "", "test"): rf.FromMap(
+		resid.NewResIdWithNamespace(cmap, "cm3", "test"): rf.FromMap(
 			map[string]interface{}{},
 		),
-		resid.NewResIdWithPrefixNamespace(sa, "default", "", "test"): rf.FromMap(
+		resid.NewResIdWithNamespace(sa, "default", "test"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ServiceAccount",
@@ -148,7 +148,7 @@ func TestNamespaceRun(t *testing.T) {
 					"namespace": "test",
 				},
 			}),
-		resid.NewResIdWithPrefixNamespace(sa, "service-account", "", "test"): rf.FromMap(
+		resid.NewResIdWithNamespace(sa, "service-account", "test"): rf.FromMap(
 			map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "ServiceAccount",


### PR DESCRIPTION
Explicitly save the original name of a resource in the resource, outside the kunstructured section.
Another step towards detangling the mutable Id mess.