### PR TITLE
Move pluginator main.go from plugin to cmd directory.

### DIFF
--- a/cmd/pluginator/main.go
+++ b/cmd/pluginator/main.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-// See plugin/doc.go for an explanation.
+// See /plugin/doc.go for an explanation.
 package main
 
 import (

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/hashtransformer/HashTransformer.go
+++ b/plugin/builtin/hashtransformer/HashTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/inventorytransformer/InventoryTransformer.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/builtin/secretgenerator/SecretGenerator.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate go run sigs.k8s.io/kustomize/plugin/pluginator
+//go:generate go run sigs.k8s.io/kustomize/cmd/pluginator
 package main
 
 import (

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -4,14 +4,12 @@
 /*
 
 Package plugin contains builtin and example
-plugins, tests and test libraries, and a code
-generator for converting a plugin to statically
-loadable code (see pluginator).
+plugins, tests and test libraries.
 
-See ../../docs/plugins.md for a description of
+See /docs/plugins.md for a description of
 writing and testing a plugin.  The information
 here is supplemental to that, and more oriented to
-how the builting plugins work.
+how the builtin plugins work.
 
 
 HOW PLUGINS RUN

--- a/plugin/generateBuiltins.sh
+++ b/plugin/generateBuiltins.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 #
-# This script creates the generator and
+# Generate the Go code for the generator and
 # transformer factory functions in
+#
 #   sigs.k8s.io/kustomize/plugin/builtin
-# by generating code based on the plugins
-# found below that directory.
+#
+# from the raw plugin directories found _below_
+# that directory.
 
 set -e
 


### PR DESCRIPTION
It's a utility that isn't needed for third-party plugin authoring or storage so its a little out of place in the plugin directory.  