### PR TITLE
Demonstrate new capabilities in pkg/target testing

### DIFF
--- a/pkg/target/variableref_test.go
+++ b/pkg/target/variableref_test.go
@@ -52,6 +52,13 @@ vars:
         apiVersion: apps/v1beta1
    fieldref:
         fieldpath: metadata.name
+ - name: CDB_HTTP_PORT
+   objref:
+        kind: StatefulSet
+        name: cockroachdb
+        apiVersion: apps/v1beta1
+   fieldref:
+        fieldpath: spec.template.spec.containers[0].ports[1].containerPort
  - name: CDB_STATEFULSET_SVC
    objref:
         kind: Service
@@ -108,8 +115,8 @@ spec:
   - port: 26257
     targetPort: 26257
     name: grpc
-  - port: 8080
-    targetPort: 8080
+  - port: $(CDB_HTTP_PORT)
+    targetPort: $(CDB_HTTP_PORT)
     name: http
   clusterIP: None
   selector:
@@ -131,8 +138,8 @@ spec:
     targetPort: 26257
     name: grpc
   # The secondary port serves the UI as well as health and debug endpoints.
-  - port: 8080
-    targetPort: 8080
+  - port: $(CDB_HTTP_PORT)
+    targetPort: $(CDB_HTTP_PORT)
     name: http
   selector:
     app: cockroachdb

--- a/pkg/transformers/config/defaultconfig/varreference.go
+++ b/pkg/transformers/config/defaultconfig/varreference.go
@@ -172,6 +172,12 @@ varReference:
 - path: spec/template/spec/initContainers/volumeMounts/mountPath
   kind: ReplicaSet
 
+- path: spec/ports/port
+  kind: Service
+
+- path: spec/ports/targetPort
+  kind: Service
+
 - path: spec/template/spec/containers/args
   kind: StatefulSet
 


### PR DESCRIPTION
As port request, improve pkg/target testing:

CDB_HTTP_PORT: Extract the HTTP port from the container section end (spec.template.spec.containers[0].ports[1].containerPort) and use it in the service definition as $(CDB_HTTP_PORT). This demonstrates both the indexing capabilities in the variable fieldspec as well as the ability to handle int64.

Also enable variable replacement for Service object.