### PR TITLE
Addresses issue discovered in attempting to patch K8s objects across different namespaces.

### DIFF
--- a/k8sdeps/transformer/patch/transformer.go
+++ b/k8sdeps/transformer/patch/transformer.go
@@ -45,6 +45,9 @@ func (tf *transformer) Transform(m resmap.ResMap) error {
 	}
 	for _, patch := range patches.Resources() {
 		target, err := tf.findPatchTarget(m, patch.OrgId())
+		if err != nil {
+			return err
+		}
 		merged := map[string]interface{}{}
 		versionedObj, err := scheme.Scheme.New(
 			toSchemaGvk(patch.OrgId().Gvk))


### PR DESCRIPTION
- Return an error when findTarget fails.
- Add unit test testing the change.

This address the issue related here: https://github.com/kubernetes-sigs/kustomize/issues/1203