### PR TITLE
FieldPath syntax backward compatibility

### DIFF
--- a/k8sdeps/kunstruct/helper.go
+++ b/k8sdeps/kunstruct/helper.go
@@ -76,10 +76,13 @@ func parseFields(path string) ([]PathSection, error) {
 				// PathSection, save it to the set, then begin
 				// a new PathSection
 				tmpIdx, err := strconv.Atoi(path[start:i])
-				if err != nil {
-					return nil, fmt.Errorf("invalid index %s", path)
+				if err == nil {
+					// We have detected an integer so an array.
+					section.idx = tmpIdx
+				} else {
+					// We have detected the downwardapi syntax
+					appendNonEmpty(&section, path[start:i])
 				}
-				section.idx = tmpIdx
 				sectionset = append(sectionset, section)
 				section = newPathSection()
 

--- a/k8sdeps/kunstruct/helper_test.go
+++ b/k8sdeps/kunstruct/helper_test.go
@@ -94,10 +94,10 @@ func TestParseField(t *testing.T) {
 			errorExpected: false,
 		},
 		{
-			name:          "validStructSubFieldNoneIntIndex",
-			pathToField:   "complextree[thisisnotanint]",
-			errorExpected: true,
-			errorMsg:      "invalid index complextree[thisisnotanint]",
+			name:          "validStructDownwardAPI",
+			pathToField:   `metadata.labels["app.kubernetes.io/component"]`,
+			expectedValue: buildPath(-1, "metadata", "labels", "app.kubernetes.io/component"),
+			errorExpected: false,
 		},
 		{
 			name:          "invalidIndexInIndex",


### PR DESCRIPTION
This pull request restores the ability to use the K8s Downward API like manner in the field spec definition:

```yaml
vars:
- fieldref:
    fieldPath: metadata.labels["app.kubernetes.io/component"]
  name: component
  objref:
    apiVersion: v1
    kind: Service
    name: foo
```