### PR TITLE
ConfigMap Generators with identical name in different namespaces

### DIFF
--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -215,8 +215,9 @@ func writeIndividualFiles(
 
 			// Preserve backward compatibility with kustomize 2.1.0.
 			// No need to cluter filename with namespace if all the objects
-			// are in the same namespace.
-			if (nsNeeded) && (namespace != "cluster-wide") {
+			// are in the same namespace. The not namespaceable objects
+			// are grouped in the "%no_namespace%" bucket.
+			if (nsNeeded) && (namespace != "%no_namespace%") {
 				basename = fmt.Sprintf(
 					"%s_%s",
 					strings.ToLower(namespace),

--- a/pkg/commands/build/build.go
+++ b/pkg/commands/build/build.go
@@ -202,22 +202,41 @@ func NewCmdBuildPrune(
 
 func writeIndividualFiles(
 	fSys fs.FileSystem, folderPath string, m resmap.ResMap) error {
-	for _, res := range m.Resources() {
-		filename := filepath.Join(
-			folderPath,
-			fmt.Sprintf(
+
+	byNamespace := m.GroupedByNamespace()
+	nsNeeded := len(byNamespace) > 1
+	for namespace, nresources := range byNamespace {
+		for _, res := range nresources {
+			basename := fmt.Sprintf(
 				"%s_%s.yaml",
 				strings.ToLower(res.GetGvk().String()),
 				strings.ToLower(res.GetName()),
-			),
-		)
-		out, err := yaml.Marshal(res.Map())
-		if err != nil {
-			return err
-		}
-		err = fSys.WriteFile(filename, out)
-		if err != nil {
-			return err
+			)
+
+			// Preserve backward compatibility with kustomize 2.1.0.
+			// No need to cluter filename with namespace if all the objects
+			// are in the same namespace.
+			if (nsNeeded) && (namespace != "cluster-wide") {
+				basename = fmt.Sprintf(
+					"%s_%s",
+					strings.ToLower(namespace),
+					strings.ToLower(basename),
+				)
+			}
+
+			filename := filepath.Join(
+				folderPath,
+				basename,
+			)
+
+			out, err := yaml.Marshal(res.Map())
+			if err != nil {
+				return err
+			}
+			err = fSys.WriteFile(filename, out)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -180,3 +180,40 @@ func (x Gvk) IsClusterKind() bool {
 	}
 	return false
 }
+
+var notNamespaceableKinds = []string{
+	"APIService",
+	"CSIDriver",
+	"CSINode",
+	"CertificateSigningRequest",
+	"ClusterRole",
+	"ClusterRoleBinding",
+	"ComponentStatus",
+	"CustomResourceDefinition",
+	"MutatingWebhookConfiguration",
+	"Namespace",
+	"Node",
+	"PersistentVolume",
+	"PodSecurityPolicy",
+	"PodSecurityPolicy",
+	"PriorityClass",
+	"RuntimeClass",
+	"SelfSubjectAccessReview",
+	"SelfSubjectRulesReview",
+	"StorageClass",
+	"SubjectAccessReview",
+	"TokenReview",
+	"ValidatingWebhookConfiguration",
+	"VolumeAttachment",
+}
+
+// IsNamespaceableKind returns true if x is a namespable Gvk
+// Implements https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#not-all-objects-are-in-a-namespace
+func (x Gvk) IsNamespaceableKind() bool {
+	for _, k := range notNamespaceableKinds {
+		if k == x.Kind {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -160,27 +160,6 @@ func (x Gvk) IsSelected(selector *Gvk) bool {
 	return true
 }
 
-var clusterLevelKinds = []string{
-	"APIService",
-	"ClusterRoleBinding",
-	"ClusterRole",
-	"CustomResourceDefinition",
-	"Namespace",
-	"PersistentVolume",
-	"MutatingWebhookConfiguration",
-	"ValidatingWebhookConfiguration",
-}
-
-// IsClusterKind returns true if x is a cluster-level Gvk
-func (x Gvk) IsClusterKind() bool {
-	for _, k := range clusterLevelKinds {
-		if k == x.Kind {
-			return true
-		}
-	}
-	return false
-}
-
 var notNamespaceableKinds = []string{
 	"APIService",
 	"CSIDriver",
@@ -207,7 +186,7 @@ var notNamespaceableKinds = []string{
 	"VolumeAttachment",
 }
 
-// IsNamespaceableKind returns true if x is a namespable Gvk
+// IsNamespaceableKind returns true if x is a namespeable Gvk
 // Implements https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#not-all-objects-are-in-a-namespace
 func (x Gvk) IsNamespaceableKind() bool {
 	for _, k := range notNamespaceableKinds {

--- a/pkg/resid/resid.go
+++ b/pkg/resid/resid.go
@@ -93,5 +93,25 @@ func (id ResId) GvknEquals(o ResId) bool {
 // Equals returns true if the other id matches
 // namespace/Group/Version/Kind/name.
 func (id ResId) Equals(o ResId) bool {
-	return id.Namespace == o.Namespace && id.GvknEquals(o)
+	return id.IsNsEquals(o) && id.GvknEquals(o)
+}
+
+// IsNsEquals returns true if the other id matches namespace
+// or both are in the default namespace
+// or both are not namespaceable id.
+func (id ResId) IsNsEquals(o ResId) bool {
+	return id.Namespace == o.Namespace ||
+		(id.IsInDefaultNs() && o.IsInDefaultNs()) ||
+		(!id.IsNamespaceable() && !o.IsNamespaceable())
+}
+
+// IsInDefaultNs returns true if id is a namespable ResId and the Namespace
+// is either not set or set to "default"
+func (id ResId) IsInDefaultNs() bool {
+	return id.IsNamespaceable() && (id.Namespace == "" || id.Namespace == "default")
+}
+
+// IsNamespaceable returns true if id is a namespable ResId
+func (id ResId) IsNamespaceable() bool {
+	return id.IsNamespaceableKind()
 }

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -354,7 +354,8 @@ func (m *resWrangler) GetById(id resid.ResId) (*resource.Resource, error) {
 func (m *resWrangler) GroupedByNamespace() map[string][]*resource.Resource {
 	byNamespace := make(map[string][]*resource.Resource)
 	for _, res := range m.rList {
-		namespace := "cluster-wide"
+		// Add to the notNamespaceable bucket by default.
+		namespace := "%no_namespace%"
 
 		if res.OrgId().IsNamespaceable() {
 			namespace = res.OrgId().Namespace

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -488,12 +488,12 @@ func (m *resWrangler) makeCopy(copier resCopier) ResMap {
 func (m *resWrangler) SubsetThatCouldBeReferencedByResource(
 	inputRes *resource.Resource) ResMap {
 	inputId := inputRes.OrgId()
-	if inputId.IsClusterKind() {
+	if !inputId.IsNamespaceableKind() {
 		return m
 	}
 	result := New()
 	for _, r := range m.Resources() {
-		if r.OrgId().IsClusterKind() || inputRes.InSameFuzzyNamespace(r) {
+		if !r.OrgId().IsNamespaceableKind() || inputRes.InSameFuzzyNamespace(r) {
 			err := result.Append(r)
 			if err != nil {
 				panic(err)

--- a/plugin/builtin/NamespaceTransformer.go
+++ b/plugin/builtin/NamespaceTransformer.go
@@ -62,7 +62,7 @@ const metaNamespace = "metadata/namespace"
 // object itself doesn't live in a namespace).
 func doIt(id resid.ResId, fs *config.FieldSpec) bool {
 	return fs.Path != metaNamespace ||
-		(fs.Path == metaNamespace && !id.IsClusterKind())
+		(fs.Path == metaNamespace && id.IsNamespaceableKind())
 }
 
 func (p *NamespaceTransformerPlugin) changeNamespace(

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -63,7 +63,7 @@ const metaNamespace = "metadata/namespace"
 // object itself doesn't live in a namespace).
 func doIt(id resid.ResId, fs *config.FieldSpec) bool {
 	return fs.Path != metaNamespace ||
-		(fs.Path == metaNamespace && !id.IsClusterKind())
+		(fs.Path == metaNamespace && id.IsNamespaceableKind())
 }
 
 func (p *plugin) changeNamespace(


### PR DESCRIPTION
- Added a new equal method to resid which accounts for potential default
  value of namespace field.
- Added corresponding unit tests.
- Change the fail test for issue #1155

Should address the following issues:
- [Merging generator fails when namespace of base and overlay differ](https://github.com/kubernetes-sigs/kustomize/issues/1219)
-  [configMapGenerator can't make multiple identically named ConfigMaps with different namespaces](https://github.com/kubernetes-sigs/kustomize/issues/1155)