### PR TITLE
Allow diamond structure of kustomize import

### DIFF
--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -216,9 +216,11 @@ func (m *resWrangler) Append(res *resource.Resource) error {
 	id := res.CurId()
 	if r := m.GetMatchingResourcesByCurrentId(id.Equals); len(r) > 0 {
 		// This allows diamond import of resources.
-		// Only errors if the resources are different because they have
-		// been loaded from a different source.
-		if !res.Equals(r[0]) {
+		// We can assert the same resource as been loaded because there is
+		// only one resource in the list with the same name and
+		// value of the resource we intend to append is identical to the one
+		// we already added to the list.
+		if len(r) > 1 || !res.Equals(r[0]) {
 			return fmt.Errorf(
 				"may not add resource with an already registered id: %s", id)
 		}

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -215,8 +215,14 @@ func (m *resWrangler) Resources() []*resource.Resource {
 func (m *resWrangler) Append(res *resource.Resource) error {
 	id := res.CurId()
 	if r := m.GetMatchingResourcesByCurrentId(id.Equals); len(r) > 0 {
-		return fmt.Errorf(
-			"may not add resource with an already registered id: %s", id)
+		// This allows diamond import of resources.
+		// Only errors if the resources are different because they have
+		// been loaded from a different source.
+		if !res.Equals(r[0]) {
+			return fmt.Errorf(
+				"may not add resource with an already registered id: %s", id)
+		}
+		return nil
 	}
 	m.rList = append(m.rList, res)
 	return nil

--- a/pkg/target/diamondcomposition_test.go
+++ b/pkg/target/diamondcomposition_test.go
@@ -6,7 +6,6 @@ package target_test
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
@@ -136,14 +135,11 @@ resources:
 - ../restart
 `)
 
-	_, err := th.MakeKustTarget().MakeCustomizedResMap()
-	if err == nil {
-		t.Fatalf("Expected resource accumulation error")
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
 	}
-	if !strings.Contains(
-		err.Error(), "already registered id: apps_v1_Deployment|~X|my-deployment") {
-		t.Fatalf("Unexpected err: %v", err)
-	}
+	th.AssertActualEqualsExpected(m, expectedPatchedDeployment)
 }
 
 const expectedPatchedDeployment = `

--- a/pkg/target/diamonds_test.go
+++ b/pkg/target/diamonds_test.go
@@ -222,3 +222,244 @@ metadata:
   name: prod-t-federation
 `)
 }
+
+// This example demonstrate a simple sharing
+// of a configmap and variables between
+// component1 and component2 before being
+// aggregated into myapp
+//
+//             myapp
+//          /    |    \
+//    component1 | component2
+//          \    |    /
+//             common
+//
+
+type diamonImportTest struct{}
+
+func (ut *diamonImportTest) writeKustCommon(th *kusttest_test.KustTestHarness) {
+	th.WriteK("/diamondimport/common/", `
+resources:
+- configmap.yaml
+
+vars:
+- name: ConfigMap.global.data.user
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: global
+  fieldref:
+    fieldpath: data.user
+`)
+}
+func (ut *diamonImportTest) writeKustComponent2(th *kusttest_test.KustTestHarness) {
+	th.WriteK("/diamondimport/component2/", `
+resources:
+- ../common
+- deployment.yaml
+`)
+}
+func (ut *diamonImportTest) writeKustComponent1(th *kusttest_test.KustTestHarness) {
+	th.WriteK("/diamondimport/component1/", `
+resources:
+- ../common
+- deployment.yaml
+`)
+}
+func (ut *diamonImportTest) writeKustMyApp(th *kusttest_test.KustTestHarness) {
+	th.WriteK("/diamondimport/myapp/", `
+resources:
+- ../common
+- ../component1
+- ../component2
+`)
+}
+func (ut *diamonImportTest) writeCommonConfigMap(th *kusttest_test.KustTestHarness) {
+	th.WriteF("/diamondimport/common/configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: global
+data:
+  settings: |
+     database: mydb
+     port: 3000
+  user: myuser
+`)
+}
+func (ut *diamonImportTest) writeComponent2(th *kusttest_test.KustTestHarness) {
+	th.WriteF("/diamondimport/component2/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: component2
+  labels:
+     app: component2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: component2
+  template:
+    metadata:
+      labels:
+        app: component2
+    spec:
+      containers:
+      - name: component2
+        image: k8s.gcr.io/busybox
+        env:
+        - name: APP_USER
+          value: $(ConfigMap.global.data.user)
+        command: [ "/bin/sh", "-c", "cat /etc/config/component2 && sleep 60" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: global
+          items:
+          - key: settings
+            path: component2
+`)
+}
+func (ut *diamonImportTest) writeComponent1(th *kusttest_test.KustTestHarness) {
+	th.WriteF("/diamondimport/component1/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: component1
+  labels:
+     app: component1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: component1
+  template:
+    metadata:
+      labels:
+        app: component1
+    spec:
+      containers:
+      - name: component1
+        image: k8s.gcr.io/busybox
+        env:
+        - name: APP_USER
+          value: $(ConfigMap.global.data.user)
+        command: [ "/bin/sh", "-c", "cat /etc/config/component1 && sleep 60" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: global
+          items:
+          - key: settings
+            path: component1
+`)
+}
+func TestSimpleDiamondImport(t *testing.T) {
+	ut := &diamonImportTest{}
+	th := kusttest_test.NewKustTestHarness(t, "/diamondimport/myapp")
+	ut.writeKustCommon(th)
+	ut.writeKustComponent1(th)
+	ut.writeKustComponent2(th)
+	ut.writeKustMyApp(th)
+	ut.writeCommonConfigMap(th)
+	ut.writeComponent1(th)
+	ut.writeComponent2(th)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		// Error before this Resource.Append fix.
+		// may not add resource with an already registered id: ~G_v1_ConfigMap|~X|global
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  settings: |
+    database: mydb
+    port: 3000
+  user: myuser
+kind: ConfigMap
+metadata:
+  name: global
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: component1
+  name: component1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: component1
+  template:
+    metadata:
+      labels:
+        app: component1
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - cat /etc/config/component1 && sleep 60
+        env:
+        - name: APP_USER
+          value: myuser
+        image: k8s.gcr.io/busybox
+        name: component1
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+      volumes:
+      - configMap:
+          items:
+          - key: settings
+            path: component1
+          name: global
+        name: config-volume
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: component2
+  name: component2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: component2
+  template:
+    metadata:
+      labels:
+        app: component2
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - cat /etc/config/component2 && sleep 60
+        env:
+        - name: APP_USER
+          value: myuser
+        image: k8s.gcr.io/busybox
+        name: component2
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+      volumes:
+      - configMap:
+          items:
+          - key: settings
+            path: component2
+          name: global
+        name: config-volume
+`)
+}

--- a/pkg/types/var.go
+++ b/pkg/types/var.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -125,11 +126,16 @@ func (vs *VarSet) MergeSlice(incoming []Var) error {
 // Merge absorbs another Var with error on name collision.
 // Empty fields in incoming Var is defaulted.
 func (vs *VarSet) Merge(v Var) error {
-	if vs.Contains(v) {
-		return fmt.Errorf(
-			"var '%s' already encountered", v.Name)
-	}
 	v.defaulting()
+	if vs.Contains(v) {
+		// Only return an error if a variable with the same
+		// name already exists
+		if !reflect.DeepEqual(v, vs.set[v.Name]) {
+			return fmt.Errorf(
+				"var '%s' already encountered", v.Name)
+		}
+		return nil
+	}
 	vs.set[v.Name] = v
 	return nil
 }


### PR DESCRIPTION
- This situation happens in project which try to aggregate multiple
  components in different folders sharing the same base folder.
- Improve ResMap Append to allow diamond includes by comparing Id and Resource during Append.
- Improve VarSet Merge method to allow diamond includes by comparing Name and Value during Merge.

It addresses the following issues:
[Support composition in kustomize #1251](https://github.com/kubernetes-sigs/kustomize/issues/1251)

and

[Error when composing several identical bases that use the same var: "var ... already encountered" #1248](https://github.com/kubernetes-sigs/kustomize/issues/1248)
