### PR TITLE
Fix some random Go nits.

### DIFF
--- a/k8sdeps/kunstruct/helper.go
+++ b/k8sdeps/kunstruct/helper.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package kunstruct provides unstructured from api machinery and factory for creating unstructured
 package kunstruct
@@ -44,13 +31,12 @@ func appendNonEmpty(section *PathSection, field string) {
 	}
 }
 
-func parseFields(path string) ([]PathSection, error) {
+func parseFields(path string) (result []PathSection, err error) {
 	section := newPathSection()
-	sectionset := []PathSection{}
 	if !strings.Contains(path, "[") {
 		section.fields = strings.Split(path, ".")
-		sectionset = append(sectionset, section)
-		return sectionset, nil
+		result = append(result, section)
+		return result, nil
 	}
 
 	start := 0
@@ -73,7 +59,7 @@ func parseFields(path string) ([]PathSection, error) {
 		case ']':
 			if insideParentheses {
 				// Assign this index to the current
-				// PathSection, save it to the set, then begin
+				// PathSection, save it to the result, then begin
 				// a new PathSection
 				tmpIdx, err := strconv.Atoi(path[start:i])
 				if err == nil {
@@ -83,7 +69,7 @@ func parseFields(path string) ([]PathSection, error) {
 					// We have detected the downwardapi syntax
 					appendNonEmpty(&section, path[start:i])
 				}
-				sectionset = append(sectionset, section)
+				result = append(result, section)
 				section = newPathSection()
 
 				start = i + 1
@@ -95,15 +81,15 @@ func parseFields(path string) ([]PathSection, error) {
 	}
 	if start < len(path)-1 {
 		appendNonEmpty(&section, path[start:])
-		sectionset = append(sectionset, section)
+		result = append(result, section)
 	}
 
-	for _, section := range sectionset {
+	for _, section := range result {
 		for i, f := range section.fields {
 			if strings.HasPrefix(f, "\"") || strings.HasPrefix(f, "'") {
 				section.fields[i] = strings.Trim(f, "\"'")
 			}
 		}
 	}
-	return sectionset, nil
+	return result, nil
 }

--- a/k8sdeps/kunstruct/helper_test.go
+++ b/k8sdeps/kunstruct/helper_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package kunstruct
 

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -146,7 +146,7 @@ var registry = make(map[string]Configurable)
 func (l *Loader) loadGoPlugin(id resid.ResId) (Configurable, error) {
 	regId := relativePluginPath(id)
 	if c, ok := registry[regId]; ok {
-		return copy(c), nil
+		return copyPlugin(c), nil
 	}
 	absPath := l.absolutePluginPath(id)
 	p, err := plugin.Open(absPath + ".so")
@@ -164,11 +164,11 @@ func (l *Loader) loadGoPlugin(id resid.ResId) (Configurable, error) {
 		return nil, fmt.Errorf("plugin %s not configurable", regId)
 	}
 	registry[regId] = c
-	return copy(c), nil
+	return copyPlugin(c), nil
 }
 
-func copy(i interface{}) Configurable {
-	indirect := reflect.Indirect(reflect.ValueOf(i))
+func copyPlugin(c Configurable) Configurable {
+	indirect := reflect.Indirect(reflect.ValueOf(c))
 	newIndirect := reflect.New(indirect.Type())
 	newIndirect.Elem().Set(reflect.ValueOf(indirect.Interface()))
 	newNamed := newIndirect.Interface()

--- a/pkg/target/transformerplugin_test.go
+++ b/pkg/target/transformerplugin_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"sigs.k8s.io/kustomize/v3/pkg/plugins"
-
-	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
 )
 
 func writeDeployment(th *kusttest_test.KustTestHarness, path string) {

--- a/pkg/target/transformersarrays_test.go
+++ b/pkg/target/transformersarrays_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 )
 
 func makeStatefulSetKustomization(th *kusttest_test.KustTestHarness) {

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
@@ -19,8 +19,8 @@ type plugin struct {
 	t transformers.Transformer
 }
 
-//noinspection GoUnusedGlobalVariable
 //nolint: golint
+//noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
 func (p *plugin) makePrefixSuffixPluginConfig() ([]byte, error) {

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
@@ -21,8 +21,8 @@ type plugin struct {
 	Keys []string `json:"keys,omitempty" yaml:"keys,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
 //nolint: golint
+//noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
 var database = map[string]string{

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
@@ -19,8 +19,8 @@ type plugin struct {
 	Port string `json:"port,omitempty" yaml:"port,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
 //nolint: golint
+//noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
 const tmpl = `

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
@@ -24,8 +24,8 @@ type metaData struct {
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
 //nolint: golint
+//noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
 func (p *plugin) makePrefixSuffixPluginConfig(n string) ([]byte, error) {


### PR DESCRIPTION
an array allocation, some misplaced lint annotations, and a method named 'copy' (reserved word)