### PR TITLE
Addresses slice case with notNamespaceable objects

### DIFF
--- a/k8sdeps/transformer/patch/conflictdetector.go
+++ b/k8sdeps/transformer/patch/conflictdetector.go
@@ -40,7 +40,7 @@ func (jmp *jsonMergePatch) findConflict(
 		if i == conflictingPatchIdx {
 			continue
 		}
-		if !patches[conflictingPatchIdx].OrgId().GvknEquals(patch.OrgId()) {
+		if !patches[conflictingPatchIdx].OrgId().Equals(patch.OrgId()) {
 			continue
 		}
 		conflict, err := mergepatch.HasConflicts(
@@ -100,7 +100,7 @@ func (smp *strategicMergePatch) findConflict(
 		if i == conflictingPatchIdx {
 			continue
 		}
-		if !patches[conflictingPatchIdx].OrgId().GvknEquals(patch.OrgId()) {
+		if !patches[conflictingPatchIdx].OrgId().Equals(patch.OrgId()) {
 			continue
 		}
 		conflict, err := strategicpatch.MergingMapsHaveConflicts(

--- a/k8sdeps/transformer/patch/transformer.go
+++ b/k8sdeps/transformer/patch/transformer.go
@@ -101,7 +101,7 @@ func (tf *transformer) mergePatches() (resmap.ResMap, error) {
 	rc := resmap.New()
 	for ix, patch := range tf.patches {
 		id := patch.OrgId()
-		existing := rc.GetMatchingResourcesByOriginalId(id.GvknEquals)
+		existing := rc.GetMatchingResourcesByOriginalId(id.Equals)
 		if len(existing) == 0 {
 			rc.Append(patch)
 			continue

--- a/pkg/accumulator/resaccumulator.go
+++ b/pkg/accumulator/resaccumulator.go
@@ -64,6 +64,8 @@ func (ra *ResAccumulator) GetTransformerConfig() *config.TransformerConfig {
 
 func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {
 	for _, v := range incoming {
+		// TODO(jeb): Do not change GvknEquals to Equals until the
+		// namespace is part of the variable declaration.
 		matched := ra.resMap.GetMatchingResourcesByOriginalId(
 			resid.NewResId(v.ObjRef.GVK(), v.ObjRef.Name).GvknEquals)
 		if len(matched) > 1 {

--- a/pkg/transformers/namereference.go
+++ b/pkg/transformers/namereference.go
@@ -117,7 +117,7 @@ func (o *nameReferenceTransformer) getNewNameFunc(
 			for _, res := range referralCandidates.Resources() {
 				id := res.OrgId()
 				if id.IsSelected(&target) && res.GetOriginalName() == oldName {
-					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.GvknEquals)
+					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.Equals)
 					// If there's more than one match, there's no way
 					// to know which one to pick, so emit error.
 					if len(matches) > 1 {
@@ -149,7 +149,7 @@ func (o *nameReferenceTransformer) getNewNameFunc(
 				indexes := indexOf(res.GetOriginalName(), names)
 				id := res.OrgId()
 				if id.IsSelected(&target) && len(indexes) > 0 {
-					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.GvknEquals)
+					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.Equals)
 					if len(matches) > 1 {
 						return nil, fmt.Errorf(
 							"slice case - multiple matches for %s:\n %v",


### PR DESCRIPTION
Attempt to fix  conflict in names when cluster wide objects are in the list.
Comparator in namereference.go replaces from id.GvkEquals to id.Equals (which includes id AND namespace).

Seems to fix: https://github.com/kubernetes-sigs/kustomize/issues/1044
Seems to fix: https://github.com/kubernetes-sigs/kustomize/issues/1264