### PR TITLE
use ObjectMeta

### DIFF
--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -183,9 +183,8 @@ func (kt *KustTarget) computeInventory(
 
 	p := builtin.NewInventoryTransformerPlugin()
 	var c struct {
-		Policy    string
-		Name      string
-		Namespace string
+		Policy           string
+		types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	}
 	c.Name = inv.ConfigMap.Name
 	c.Namespace = inv.ConfigMap.Namespace

--- a/pkg/target/kusttarget_configplugin.go
+++ b/pkg/target/kusttarget_configplugin.go
@@ -129,8 +129,8 @@ func (kt *KustTarget) configureBuiltinNamespaceTransformer(
 	tConfig *config.TransformerConfig) (
 	result []transformers.Transformer, err error) {
 	var c struct {
-		Namespace  string
-		FieldSpecs []config.FieldSpec
+		types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+		FieldSpecs       []config.FieldSpec
 	}
 	c.Namespace = kt.kustomization.Namespace
 	c.FieldSpecs = tConfig.NameSpace

--- a/plugin/builtin/ConfigMapGenerator.go
+++ b/plugin/builtin/ConfigMapGenerator.go
@@ -9,8 +9,9 @@ import (
 )
 
 type ConfigMapGeneratorPlugin struct {
-	ldr ifc.Loader
-	rf  *resmap.Factory
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.ConfigMapArgs
 }
@@ -25,6 +26,12 @@ func (p *ConfigMapGeneratorPlugin) Config(
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.ConfigMapArgs = types.ConfigMapArgs{}
 	err = yaml.Unmarshal(config, p)
+	if p.ConfigMapArgs.Name == "" {
+		p.ConfigMapArgs.Name = p.Name
+	}
+	if p.ConfigMapArgs.Namespace == "" {
+		p.ConfigMapArgs.Namespace = p.Namespace
+	}
 	p.ldr = ldr
 	p.rf = rf
 	return

--- a/plugin/builtin/InventoryTransformer.go
+++ b/plugin/builtin/InventoryTransformer.go
@@ -16,11 +16,10 @@ import (
 )
 
 type InventoryTransformerPlugin struct {
-	ldr       ifc.Loader
-	rf        *resmap.Factory
-	Policy    string `json:"policy,omitempty" yaml:"policy,omitempty"`
-	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Policy           string `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable

--- a/plugin/builtin/NamespaceTransformer.go
+++ b/plugin/builtin/NamespaceTransformer.go
@@ -9,13 +9,14 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
+	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 // Change or set the namespace of non-cluster level resources.
 type NamespaceTransformerPlugin struct {
-	Namespace  string             `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	FieldSpecs []config.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	FieldSpecs       []config.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable

--- a/plugin/builtin/SecretGenerator.go
+++ b/plugin/builtin/SecretGenerator.go
@@ -9,8 +9,9 @@ import (
 )
 
 type SecretGeneratorPlugin struct {
-	ldr ifc.Loader
-	rf  *resmap.Factory
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.SecretArgs
 }
@@ -25,6 +26,12 @@ func (p *SecretGeneratorPlugin) Config(
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.SecretArgs = types.SecretArgs{}
 	err = yaml.Unmarshal(config, p)
+	if p.SecretArgs.Name == "" {
+		p.SecretArgs.Name = p.Name
+	}
+	if p.SecretArgs.Namespace == "" {
+		p.SecretArgs.Namespace = p.Namespace
+	}
 	p.ldr = ldr
 	p.rf = rf
 	return

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
@@ -12,8 +12,9 @@ import (
 )
 
 type plugin struct {
-	ldr ifc.Loader
-	rf  *resmap.Factory
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.ConfigMapArgs
 }
@@ -26,6 +27,12 @@ func (p *plugin) Config(
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.ConfigMapArgs = types.ConfigMapArgs{}
 	err = yaml.Unmarshal(config, p)
+	if p.ConfigMapArgs.Name == "" {
+		p.ConfigMapArgs.Name = p.Name
+	}
+	if p.ConfigMapArgs.Namespace == "" {
+		p.ConfigMapArgs.Namespace = p.Namespace
+	}
 	p.ldr = ldr
 	p.rf = rf
 	return

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
@@ -30,8 +30,7 @@ COLOR=red
 apiVersion: builtin
 kind: ConfigMapGenerator
 metadata:
-  name: myMapGen
-name: myMap
+  name: myMap
 envs:
 - devops.env
 - uxteam.env

--- a/plugin/builtin/inventorytransformer/InventoryTransformer.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer.go
@@ -19,11 +19,10 @@ import (
 )
 
 type plugin struct {
-	ldr       ifc.Loader
-	rf        *resmap.Factory
-	Policy    string `json:"policy,omitempty" yaml:"policy,omitempty"`
-	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Policy           string `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable

--- a/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
@@ -71,10 +71,9 @@ func TestInventoryTransformerCollect(t *testing.T) {
 apiVersion: builtin
 kind: InventoryTransformer
 metadata:
-  name: notImportantHere
+  name: pruneCM
+  namespace: default
 policy: GarbageCollect
-name: pruneCM
-namespace: default
 `, content)
 
 	th.AssertActualEqualsExpected(rm, inv)
@@ -93,10 +92,9 @@ func TestInventoryTransformerIgnore(t *testing.T) {
 apiVersion: builtin
 kind: InventoryTransformer
 metadata:
-  name: notImportantHere
+  name: pruneCM
+  namespace: default
 policy: GarbageIgnore
-name: pruneCM
-namespace: default
 `, content)
 
 	th.AssertActualEqualsExpected(rm, content+"---"+inv)
@@ -115,9 +113,8 @@ func TestInventoryTransformerDefaultPolicy(t *testing.T) {
 apiVersion: builtin
 kind: InventoryTransformer
 metadata:
-  name: notImportantHere
-name: pruneCM
-namespace: default
+  name: pruneCM
+  namespace: default
 `, content)
 
 	th.AssertActualEqualsExpected(rm, content+"---"+inv)

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -11,13 +11,14 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
+	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
 	"sigs.k8s.io/yaml"
 )
 
 // Change or set the namespace of non-cluster level resources.
 type plugin struct {
-	Namespace  string             `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	FieldSpecs []config.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -24,7 +24,7 @@ apiVersion: builtin
 kind: NamespaceTransformer
 metadata:
   name: notImportantHere
-namespace: test
+  namespace: test
 fieldSpecs:
 - path: metadata/namespace
   create: true
@@ -166,7 +166,7 @@ apiVersion: builtin
 kind: NamespaceTransformer
 metadata:
   name: notImportantHere
-namespace: test
+  namespace: test
 fieldSpecs:
 - path: metadata/namespace
   create: true

--- a/plugin/builtin/secretgenerator/SecretGenerator.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator.go
@@ -12,8 +12,9 @@ import (
 )
 
 type plugin struct {
-	ldr ifc.Loader
-	rf  *resmap.Factory
+	ldr              ifc.Loader
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.SecretArgs
 }
@@ -26,6 +27,12 @@ func (p *plugin) Config(
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.SecretArgs = types.SecretArgs{}
 	err = yaml.Unmarshal(config, p)
+	if p.SecretArgs.Name == "" {
+		p.SecretArgs.Name = p.Name
+	}
+	if p.SecretArgs.Namespace == "" {
+		p.SecretArgs.Namespace = p.Namespace
+	}
 	p.ldr = ldr
 	p.rf = rf
 	return

--- a/plugin/builtin/secretgenerator/SecretGenerator_test.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator_test.go
@@ -34,9 +34,8 @@ consectetur adipiscing elit.
 apiVersion: builtin
 kind: SecretGenerator
 metadata:
-  name: exampleSecGen
-name: mySecret
-namespace: whatever
+  name: mySecret
+  namespace: whatever
 behavior: merge
 envs:
 - a.env

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
@@ -13,10 +13,9 @@ import (
 // A secret generator example that gets data
 // from a database (simulated by a hardcoded map).
 type plugin struct {
-	rf        *resmap.Factory
-	ldr       ifc.Loader
-	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	rf               *resmap.Factory
+	ldr              ifc.Loader
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// List of keys to use in database lookups
 	Keys []string `json:"keys,omitempty" yaml:"keys,omitempty"`
 }

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
@@ -23,9 +23,8 @@ func TestSecretsFromDatabasePlugin(t *testing.T) {
 apiVersion: someteam.example.com/v1
 kind: SecretsFromDatabase
 metadata:
-  name: mySecretGenerator
-name: forbiddenValues
-namespace: production
+  name: forbiddenValues
+  namespace: production
 keys:
 - ROCKET
 - VEGETABLE

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
@@ -9,14 +9,15 @@ import (
 
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 // A simple generator example.  Makes one service.
 type plugin struct {
-	rf   *resmap.Factory
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
-	Port string `json:"port,omitempty" yaml:"port,omitempty"`
+	rf               *resmap.Factory
+	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Port             string `json:"port,omitempty" yaml:"port,omitempty"`
 }
 
 //nolint: golint
@@ -30,6 +31,7 @@ metadata:
   labels:
     app: dev
   name: {{.Name}}
+  namespace: {{.Namespace}}
 spec:
   ports:
   - port: {{.Port}}

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
@@ -23,8 +23,8 @@ func TestSomeServiceGeneratorPlugin(t *testing.T) {
 apiVersion: someteam.example.com/v1
 kind: SomeServiceGenerator
 metadata:
-  name: myGenerator
-name: my-service
+  name: my-service
+  namespace: test
 port: "12345"
 `)
 	th.AssertActualEqualsExpected(m, `
@@ -34,6 +34,7 @@ metadata:
   labels:
     app: dev
   name: my-service
+  namespace: test
 spec:
   ports:
   - port: 12345


### PR DESCRIPTION
Since plugin config files are k8s objects, they must have a metadata name field and optionally namespace. We might as well use those fields as _data for the plugin_ in situations where the plugin wants a field called `name` and/or `namespace`, en lieu of declaring a new field called `name` (or `namespace`).