### PR TITLE
Update the diamond composition test case

### DIFF
--- a/pkg/target/diamondcomposition_test.go
+++ b/pkg/target/diamondcomposition_test.go
@@ -49,7 +49,7 @@ spec:
 `
 
 // Here's a composite kustomization, that combines multiple overlays
-// (replicas, dns and metadata) which patch the same base resource.
+// (probes, dns and restart policies) which patch the same base resource.
 //
 // The base resource is a deployment and the overlays patch aspects
 // of it, without using any of the `namePrefix`, `nameSuffix` or `namespace`
@@ -75,6 +75,7 @@ metadata:
 spec:
   template:
     spec:
+      dnsPolicy: "None"
       containers:
       - name: my-deployment
         image: my-image


### PR DESCRIPTION
Refactor the existing base, so that one of the overlays patches an
already present field of the base resource. Previously, all overlays
added a new field in the base deployment, which made this case easier to
solve, with a merge of the produced YAMLs from each overlay.

Also, fix a typo in the comments.