### PR TITLE
Fix 1281

### DIFF
--- a/pkg/target/kusttarget_configplugin.go
+++ b/pkg/target/kusttarget_configplugin.go
@@ -65,11 +65,11 @@ func (kt *KustTarget) configureBuiltinTransformers(
 	configurators := []transformerConfigurator{
 		kt.configureBuiltinNamespaceTransformer,
 		kt.configureBuiltinNameTransformer,
-		kt.configureBuiltinImageTagTransformer,
 		kt.configureBuiltinLabelTransformer,
 		kt.configureBuiltinAnnotationsTransformer,
 		kt.configureBuiltinPatchJson6902Transformer,
 		kt.configureBuiltinReplicaCountTransformer,
+		kt.configureBuiltinImageTagTransformer,
 	}
 	var result []transformers.Transformer
 	for _, f := range configurators {

--- a/pkg/target/transformersimage_test.go
+++ b/pkg/target/transformersimage_test.go
@@ -174,7 +174,7 @@ spec:
   template:
     spec:
       containers:
-      - image: costello
+      - image: costello:v8
       dnsPolicy: None
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Fixes #1281, by changing the order of the builtin transformers.

FWIW, one can get whatever order one wants by using the builtin transformers exclusively via the `transformers:` field.
