### PR TITLE
Fix typo in the go plugin guide

### DIFF
--- a/docs/plugins/goPluginGuidedExample.md
+++ b/docs/plugins/goPluginGuidedExample.md
@@ -207,7 +207,8 @@ cat <<EOF >$MYAPP/secGenerator.yaml
 apiVersion: ${apiVersion}
 kind: ${kind}
 metadata:
-  name: forbiddenValues
+  name: mySecretGenerator
+name: forbiddenValues
 namespace: production
 file: myEncryptedData.yaml
 keys:


### PR DESCRIPTION
While going through the [go plugin guide](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/plugins/goPluginGuidedExample.md) I ran into an issue with the plugin configuration yaml in the guide not matching what the plugin actually wanted.

The plugin is pulling the name for the generated secret from a top level [`.Name`](https://github.com/monopole/sopsencodedsecrets/blob/master/SopsEncodedSecrets.go#L24) field in the config struct and not from the `ObjectMeta` name which is the only one provided in the example.

This PR just corrects the minor typo in the example YAML to make it work correctly with the plugin.