### PR TITLE
Account for Namespace value during patch transformations

### DIFF
--- a/k8sdeps/transformer/patch/conflictdetector.go
+++ b/k8sdeps/transformer/patch/conflictdetector.go
@@ -40,7 +40,7 @@ func (jmp *jsonMergePatch) findConflict(
 		if i == conflictingPatchIdx {
 			continue
 		}
-		if !patches[conflictingPatchIdx].OrgId().GvknEquals(patch.OrgId()) {
+		if !patches[conflictingPatchIdx].OrgId().Equals(patch.OrgId()) {
 			continue
 		}
 		conflict, err := mergepatch.HasConflicts(
@@ -100,7 +100,7 @@ func (smp *strategicMergePatch) findConflict(
 		if i == conflictingPatchIdx {
 			continue
 		}
-		if !patches[conflictingPatchIdx].OrgId().GvknEquals(patch.OrgId()) {
+		if !patches[conflictingPatchIdx].OrgId().Equals(patch.OrgId()) {
 			continue
 		}
 		conflict, err := strategicpatch.MergingMapsHaveConflicts(

--- a/k8sdeps/transformer/patch/transformer.go
+++ b/k8sdeps/transformer/patch/transformer.go
@@ -101,7 +101,7 @@ func (tf *transformer) mergePatches() (resmap.ResMap, error) {
 	rc := resmap.New()
 	for ix, patch := range tf.patches {
 		id := patch.OrgId()
-		existing := rc.GetMatchingResourcesByOriginalId(id.GvknEquals)
+		existing := rc.GetMatchingResourcesByOriginalId(id.Equals)
 		if len(existing) == 0 {
 			rc.Append(patch)
 			continue

--- a/k8sdeps/transformer/patch/transformer_test.go
+++ b/k8sdeps/transformer/patch/transformer_test.go
@@ -9,571 +9,757 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resmaptest"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 )
 
+// simple utility function to add an namespace in a resource
+// map used as base, patch or expected result.
+func addNamespace(namespace string, base map[string]interface{}) map[string]interface{} {
+	metadata := base["metadata"].(map[string]interface{})
+	metadata["namespace"] = namespace
+	return base
+}
+
+// unExpectedError function handles unexpected error
+func unExpectedError(t *testing.T, name string, err error) {
+	t.Fatalf("%q; - unexpected error %v", name, err)
+}
+
+// compareExpectedError compares the expectedError and the actualError return by GetFieldValue
+func compareExpectedError(t *testing.T, name string, err error, errorMsg string) {
+	if err == nil {
+		t.Fatalf("%q; - should return error, but no error returned", name)
+	}
+
+	if !strings.Contains(err.Error(), errorMsg) {
+		t.Fatalf("%q; - expected error: \"%s\", got error: \"%v\"",
+			name, errorMsg, err.Error())
+	}
+}
+
+// compareValues compares the expectedValue and actualValue returned by Transform
+func compareValues(t *testing.T, name string, expectedValue resmap.ResMap, actualValue resmap.ResMap) {
+	if !reflect.DeepEqual(expectedValue, actualValue) {
+		err := expectedValue.ErrorIfNotEqualLists(actualValue)
+		t.Logf("%q; actual doesn't match expected: %v", name, err)
+	}
+}
+
 var rf = resource.NewFactory(
 	kunstruct.NewKunstructuredFactoryImpl())
 
-func TestOverlayRun(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"old-label": "old-value",
-						},
-					},
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx",
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"another-label": "foo",
-						},
-					},
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "SOMEENV",
-										"value": "BAR",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}),
-	}
-	expected := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"old-label":     "old-value",
-							"another-label": "foo",
-						},
-					},
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "SOMEENV",
-										"value": "BAR",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(base, expected) {
-		err = expected.ErrorIfNotEqualLists(base)
-		t.Fatalf("actual doesn't match expected: %v", err)
-	}
-}
+const Deployment string = "Deployment"
+const MyCRD string = "MyCRD"
 
-func TestMultiplePatches(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx",
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "SOMEENV",
-										"value": "BAR",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}),
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name": "nginx",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "ANOTHERENV",
-										"value": "HELLO",
-									},
-								},
-							},
-							map[string]interface{}{
-								"name":  "busybox",
-								"image": "busybox",
-							},
-						},
-					},
-				},
-			},
-		}),
-	}
-	expected := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "ANOTHERENV",
-										"value": "HELLO",
-									},
-									map[string]interface{}{
-										"name":  "SOMEENV",
-										"value": "BAR",
-									},
-								},
-							},
-							map[string]interface{}{
-								"name":  "busybox",
-								"image": "busybox",
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(base, expected) {
-		err = expected.ErrorIfNotEqualLists(base)
-		t.Fatalf("actual doesn't match expected: %v", err)
-	}
-}
+// baseResource produces a base object which used to test
+// patch transformation
+// Also the structure is matching the Deployment syntax
+// the kind can be replaced to allow testing using CRD
+// without access to the schema
+func baseResource(kind string) map[string]interface{} {
 
-func TestMultiplePatchesWithConflict(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx",
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:latest",
-								"env": []interface{}{
-									map[string]interface{}{
-										"name":  "SOMEENV",
-										"value": "BAR",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}),
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name": "deploy1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:1.7.9",
-							},
-						},
-					},
-				},
-			},
-		}),
-	}
-
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err == nil {
-		t.Fatalf("did not get expected error")
-	}
-	if !strings.Contains(err.Error(), "conflict") {
-		t.Fatalf("expected error to contain %q but get %v", "conflict", err)
-	}
-}
-
-func TestPatchesWithWrongNamespace(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name":      "deploy1",
-				"namespace": "namespace1",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx",
-							},
-						},
-					},
-				},
-			},
-		}).ResMap()
-
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
-			"metadata": map[string]interface{}{
-				"name":      "deploy1",
-				"namespace": "namespace2",
-			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
-						"containers": []interface{}{
-							map[string]interface{}{
-								"name":  "nginx",
-								"image": "nginx:1.7.9",
-							},
-						},
-					},
-				},
-			},
-		}),
-	}
-
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err == nil {
-		t.Fatalf("did not get expected error")
-	}
-	if !strings.Contains(err.Error(), "failed to find unique target for patch") {
-		t.Fatalf("expected error to contain %q but get %v", "failed to find target for patch", err)
-	}
-}
-
-func TestNoSchemaOverlayRun(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"A": "X",
-					"B": "Y",
-				},
-			},
-		}).ResMap()
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"B": nil,
-					"C": "Z",
-				},
-			},
-		}),
-	}
-	expected := resmaptest_test.NewRmBuilder(t, rf).
-		Add(
-			map[string]interface{}{
-				"apiVersion": "example.com/v1",
-				"kind":       "Foo",
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
 				"metadata": map[string]interface{}{
-					"name": "my-foo",
+					"labels": map[string]interface{}{
+						"old-label": "old-value",
+					},
 				},
 				"spec": map[string]interface{}{
-					"bar": map[string]interface{}{
-						"A": "X",
-						"C": "Z",
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx",
+						},
 					},
 				},
-			}).ResMap()
+			},
+		},
+	}
 
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err = expected.ErrorIfNotEqualLists(base); err != nil {
-		t.Fatalf("actual doesn't match expected: %v", err)
+}
+
+// addContainerAndEnvPatch produces a patch object which adds
+// an entry in the env slice of the first/nginx container
+// as well as adding a label in the metadata
+// Note that for SMP/WithSchema merge, the "name:nginx" entry
+// is mandatory
+func addLabelAndEnvPatch(kind string) map[string]interface{} {
+
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"some-label": "some-value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "nginx",
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "SOMEENV",
+									"value": "SOMEVALUE",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
-func TestNoSchemaMultiplePatches(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"A": "X",
-					"B": "Y",
+// addContainerAndEnvPatch produces a patch object which adds
+// an entry in the env slice of the first/nginx container
+// as well as adding a second container in the container list
+// Note that for SMP/WithSchema merge, the "name:nginx" entry
+// is mandatory
+func addContainerAndEnvPatch(kind string) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name": "nginx",
+							"env": []interface{}{
+								map[string]interface{}{
+									"name":  "ANOTHERENV",
+									"value": "ANOTHERVALUE",
+								},
+							},
+						},
+						map[string]interface{}{
+							"name":  "anothercontainer",
+							"image": "anotherimage",
+						},
+					},
 				},
 			},
-		}).ResMap()
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"B": nil,
-					"C": "Z",
-				},
-			},
-		}),
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"C": "Z",
-					"D": "W",
-				},
-				"baz": map[string]interface{}{
-					"hello": "world",
-				},
-			},
-		}),
-	}
-	expected := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"A": "X",
-					"C": "Z",
-					"D": "W",
-				},
-				"baz": map[string]interface{}{
-					"hello": "world",
-				},
-			},
-		}).ResMap()
-
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	err = lt.Transform(base)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err = expected.ErrorIfNotEqualLists(base); err != nil {
-		t.Fatalf("actual doesn't match expected: %v", err)
+		},
 	}
 }
 
-func TestNoSchemaMultiplePatchesWithConflict(t *testing.T) {
-	base := resmaptest_test.NewRmBuilder(t, rf).
-		Add(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"A": "X",
-					"B": "Y",
+// addContainerAndEnvPatch produces a patch object which replaces
+// the value of the image field in the first/nginx container
+// Note that for SMP/WithSchema merge, the "name:nginx" entry
+// is mandatory
+func changeImagePatch(kind string, newImage string) map[string]interface{} {
+
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": newImage,
+						},
+					},
 				},
 			},
-		}).ResMap()
-	patch := []*resource.Resource{
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
+		},
+	}
+}
+
+// utility method building the expected output of a SMP
+// TODO(jeb): nginxContainer part of the tree is still singled out
+// to highlight the difference in behavior with JSONPatch
+func expectedResultSMP() map[string]interface{} {
+
+	// This will have been merged using StrategicMergePatch
+	nginxContainer := map[string]interface{}{
+		"name":  "nginx",
+		"image": "nginx", // main difference with JSONPatch
+		"env": []interface{}{
+			map[string]interface{}{
+				"name":  "SOMEENV",
+				"value": "SOMEVALUE",
 			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"B": nil,
-					"C": "Z",
-				},
-			},
-		}),
-		rf.FromMap(map[string]interface{}{
-			"apiVersion": "example.com/v1",
-			"kind":       "Foo",
-			"metadata": map[string]interface{}{
-				"name": "my-foo",
-			},
-			"spec": map[string]interface{}{
-				"bar": map[string]interface{}{
-					"C": "NOT_Z",
-				},
-			},
-		}),
+		},
 	}
 
-	lt, err := NewTransformer(patch, rf)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       Deployment,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"old-label":  "old-value",
+						"some-label": "some-value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						nginxContainer,
+					},
+				},
+			},
+		},
 	}
-	err = lt.Transform(base)
-	if err == nil {
-		t.Fatalf("did not get expected error")
+}
+
+// utility method building the expected output of a JsonPatch.
+// TODO(jeb): imagename parameter is only here to deal with what
+// seems to be a bug in conflictdetector and JSON patch
+func expectedResultJsonPatch(imagename string) map[string]interface{} {
+
+	// This will have been merged using JSON Patch
+	nginxContainer := map[string]interface{}{
+		"name": "nginx",
+		"env": []interface{}{
+			map[string]interface{}{
+				"name":  "SOMEENV",
+				"value": "SOMEVALUE",
+			},
+		},
 	}
-	if !strings.Contains(err.Error(), "conflict") {
-		t.Fatalf("expected error to contain %q but get %v", "conflict", err)
+
+	// This piece of code is only here to deal
+	// a bug in conflictdetector
+	if imagename != "" {
+		nginxContainer = map[string]interface{}{
+			"name":  "nginx",
+			"image": imagename,
+		}
+	}
+
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       MyCRD,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"old-label":  "old-value",
+						"some-label": "some-value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						nginxContainer,
+					},
+				},
+			},
+		},
+	}
+}
+
+// utility method to build the expected result of a multipatch
+// the order of the patches still have influence especially
+// in the insertion location within arrays.
+func expectedResultMultiPatch(kind string, reversed bool) map[string]interface{} {
+	envs := []interface{}{
+		map[string]interface{}{
+			"name":  "ANOTHERENV",
+			"value": "ANOTHERVALUE",
+		},
+		map[string]interface{}{
+			"name":  "SOMEENV",
+			"value": "SOMEVALUE",
+		},
+	}
+
+	if reversed {
+		envs = []interface{}{
+			map[string]interface{}{
+				"name":  "SOMEENV",
+				"value": "SOMEVALUE",
+			},
+			map[string]interface{}{
+				"name":  "ANOTHERENV",
+				"value": "ANOTHERVALUE",
+			},
+		}
+
+	}
+
+	return map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name": "deploy1",
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"old-label":  "old-value",
+						"some-label": "some-value",
+					},
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:latest",
+							"env":   envs,
+						},
+						map[string]interface{}{
+							"name":  "anothercontainer",
+							"image": "anotherimage",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestOverlayRun validates the single patch use cases
+// regarless of the schema availibility, which in turns
+// relies on StrategicMergePatch or simple JSON Patch.
+func TestOverlayRun(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          resmap.ResMap
+		patch         []*resource.Resource
+		expected      resmap.ResMap
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name: "withschema",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultSMP()).ResMap(),
+		},
+		{
+			name: "noschema",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultJsonPatch("")).ResMap(),
+		},
+	}
+	for _, test := range tests {
+		lt, err := NewTransformer(test.patch, rf)
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+
+		err = lt.Transform(test.base)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+		compareValues(t, test.name, test.base, test.expected)
+	}
+}
+
+// TestMultiplePatches checks that the patches are applied
+// properly, that the same result is obtained,
+// regardless of the order of the patches and regardless
+// of the schema availibility (SMP vs JSON)
+func TestMultiplePatches(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          resmap.ResMap
+		patch         []*resource.Resource
+		expected      resmap.ResMap
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name: "withschema-label-image-container",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+				rf.FromMap(addContainerAndEnvPatch(Deployment)),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultMultiPatch(Deployment, false)).ResMap(),
+		},
+		{
+			name: "withschema-image-container-label",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+				rf.FromMap(addContainerAndEnvPatch(Deployment)),
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultMultiPatch(Deployment, true)).ResMap(),
+		},
+		{
+			name: "withschema-container-label-image",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addContainerAndEnvPatch(Deployment)),
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultMultiPatch(Deployment, true)).ResMap(),
+		},
+		{
+			name: "noschema-label-image-container",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+				rf.FromMap(addContainerAndEnvPatch(MyCRD)),
+			},
+			// This should work
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "noschema-image-container-label",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+				rf.FromMap(addContainerAndEnvPatch(MyCRD)),
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+			},
+			// This should work
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "noschema-container-label-image",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addContainerAndEnvPatch(MyCRD)),
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+			},
+			// This should work
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+	}
+	for _, test := range tests {
+		lt, err := NewTransformer(test.patch, rf)
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+
+		err = lt.Transform(test.base)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+		compareValues(t, test.name, test.base, test.expected)
+	}
+
+}
+
+// TestMultiplePatchesWithConflict checks that the conflict are
+// detected regardless of the order of the patches and regardless
+// of the schema availibility (SMP vs JSON)
+func TestMultiplePatchesWithConflict(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          resmap.ResMap
+		patch         []*resource.Resource
+		expected      resmap.ResMap
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name: "withschema-label-latest-1.7.9",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:1.7.9")),
+			},
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "withschema-latest-label-1.7.9",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:1.7.9")),
+			},
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "withschema-1.7.9-label-latest",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(Deployment, "nginx:1.7.9")),
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+			},
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "withschema-1.7.9-latest-label",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(Deployment, "nginx:1.7.9")),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:latest")),
+				rf.FromMap(addLabelAndEnvPatch(Deployment)),
+				rf.FromMap(changeImagePatch(Deployment, "nginx:nginx")),
+			},
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "noschema-label-latest-1.7.9",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:1.7.9")),
+			},
+			errorExpected: true,
+			errorMsg:      "conflict",
+		},
+		{
+			name: "noschema-latest-label-1.7.9",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:1.7.9")),
+			},
+			errorExpected: false,
+			//TODO(jeb): Why is there no conflict detected ?
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultJsonPatch("nginx:1.7.9")).ResMap(),
+		},
+		{
+			name: "noschema-1.7.9-label-latest",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:1.7.9")),
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+			},
+			errorExpected: false,
+			//TODO(jeb): Why is there no conflict detected ?
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(expectedResultJsonPatch("nginx:latest")).ResMap(),
+		},
+		{
+			name: "noschema-1.7.9-latest-label",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:1.7.9")),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:latest")),
+				rf.FromMap(addLabelAndEnvPatch(MyCRD)),
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:nginx")),
+			},
+			errorExpected: true,
+		},
+	}
+	for _, test := range tests {
+		lt, err := NewTransformer(test.patch, rf)
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+
+		err = lt.Transform(test.base)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+		compareValues(t, test.name, test.base, test.expected)
+	}
+}
+
+// TestMultipleNamespaces before the same patch
+// on two objects have the same name but in a different namespaces
+func TestMultipleNamespaces(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          resmap.ResMap
+		patch         []*resource.Resource
+		expected      resmap.ResMap
+		errorExpected bool
+		errorMsg      string
+	}{
+		{
+			name: "withschema-ns1-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(Deployment))).
+				Add(addNamespace("ns2", baseResource(Deployment))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns1", addLabelAndEnvPatch(Deployment))),
+				rf.FromMap(addNamespace("ns2", addLabelAndEnvPatch(Deployment))),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", expectedResultSMP())).
+				Add(addNamespace("ns2", expectedResultSMP())).
+				ResMap(),
+		},
+		{
+			name: "noschema-ns1-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(MyCRD))).
+				Add(addNamespace("ns2", baseResource(MyCRD))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns1", addLabelAndEnvPatch(MyCRD))),
+				rf.FromMap(addNamespace("ns2", addLabelAndEnvPatch(MyCRD))),
+			},
+			errorExpected: false,
+			expected: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", expectedResultJsonPatch(""))).
+				Add(addNamespace("ns2", expectedResultJsonPatch(""))).
+				ResMap(),
+		},
+		{
+			name: "withschema-ns1-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(Deployment))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns2", changeImagePatch(Deployment, "nginx:1.7.9"))),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+		{
+			name: "withschema-nil-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(Deployment)).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns2", changeImagePatch(Deployment, "nginx:1.7.9"))),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+		{
+			name: "withschema-ns1-nil",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(Deployment))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(Deployment, "nginx:1.7.9")),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+		{
+			name: "noschema-ns1-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(MyCRD))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns2", changeImagePatch(MyCRD, "nginx:1.7.9"))),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+		{
+			name: "noschema-nil-ns2",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(baseResource(MyCRD)).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(addNamespace("ns2", changeImagePatch(MyCRD, "nginx:1.7.9"))),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+		{
+			name: "noschema-ns1-nil",
+			base: resmaptest_test.NewRmBuilder(t, rf).
+				Add(addNamespace("ns1", baseResource(MyCRD))).
+				ResMap(),
+			patch: []*resource.Resource{
+				rf.FromMap(changeImagePatch(MyCRD, "nginx:1.7.9")),
+			},
+			errorExpected: true,
+			errorMsg:      "failed to find unique target for patch",
+		},
+	}
+
+	for _, test := range tests {
+		lt, err := NewTransformer(test.patch, rf)
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+
+		err = lt.Transform(test.base)
+		if test.errorExpected {
+			compareExpectedError(t, test.name, err, test.errorMsg)
+			continue
+		}
+		if err != nil {
+			unExpectedError(t, test.name, err)
+		}
+		compareValues(t, test.name, test.base, test.expected)
 	}
 }

--- a/pkg/accumulator/resaccumulator.go
+++ b/pkg/accumulator/resaccumulator.go
@@ -64,6 +64,8 @@ func (ra *ResAccumulator) GetTransformerConfig() *config.TransformerConfig {
 
 func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {
 	for _, v := range incoming {
+		// TODO(jeb): Do not change GvknEquals to Equals until the
+		// namespace is part of the variable declaration.
 		matched := ra.resMap.GetMatchingResourcesByOriginalId(
 			resid.NewResId(v.ObjRef.GVK(), v.ObjRef.Name).GvknEquals)
 		if len(matched) > 1 {

--- a/pkg/resmaptest/rmbuilder.go
+++ b/pkg/resmaptest/rmbuilder.go
@@ -62,6 +62,14 @@ func (rm *rmBuilder) AddWithNs(ns string, m map[string]interface{}) *rmBuilder {
 	return rm
 }
 
+func (rm *rmBuilder) AddWithNsAndName(ns string, n string, m map[string]interface{}) *rmBuilder {
+	err := rm.m.Append(rm.rf.FromMapWithNamespaceAndName(ns, n, m))
+	if err != nil {
+		rm.t.Fatalf("test setup failure: %v", err)
+	}
+	return rm
+}
+
 func (rm *rmBuilder) ReplaceResource(m map[string]interface{}) *rmBuilder {
 	r := rm.rf.FromMap(m)
 	_, err := rm.m.Replace(r)

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -43,6 +43,11 @@ func (rf *Factory) FromMapWithNamespace(n string, m map[string]interface{}) *Res
 	return rf.makeOne(rf.kf.FromMap(m), nil).setOriginalNs(n)
 }
 
+// FromMapWithNamespaceAndName returns a new instance with the given "original" namespace.
+func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
+	return rf.makeOne(rf.kf.FromMap(m), nil).setOriginalNs(ns).setOriginalName(n)
+}
+
 // FromMapAndOption returns a new instance of Resource with given options.
 func (rf *Factory) FromMapAndOption(
 	m map[string]interface{}, args *types.GeneratorArgs, option *types.GeneratorOptions) *Resource {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -126,7 +126,7 @@ func (r *Resource) GetOutermostNameSuffix() string {
 }
 
 func (r *Resource) InSameFuzzyNamespace(o *Resource) bool {
-	return r.GetNamespace() == o.GetNamespace() &&
+	return r.CurId().IsNsEquals(o.CurId()) &&
 		r.GetOutermostNamePrefix() == o.GetOutermostNamePrefix() &&
 		r.GetOutermostNameSuffix() == o.GetOutermostNameSuffix()
 }

--- a/pkg/target/namespaces_test.go
+++ b/pkg/target/namespaces_test.go
@@ -5,6 +5,7 @@ package target_test
 
 import (
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	"strings"
 	"testing"
 )
 
@@ -92,4 +93,235 @@ rules:
   verbs:
   - get
 `)
+}
+
+const recreate1298_dev string = `
+resources:
+- elasticsearch-dev-service.yaml
+vars:
+- name: elasticsearch-dev-service-name
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: elasticsearch-dev-protocol
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: spec.ports[0].protocol
+`
+
+const recreate1298_test string = `
+resources:
+- elasticsearch-test-service.yaml
+vars:
+- name: elasticsearch-test-service-name
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: elasticsearch-test-protocol
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: spec.ports[0].protocol
+`
+
+const recreate1298_onefolder string = `
+resources:
+- elasticsearch-test-service.yaml
+- elasticsearch-dev-service.yaml
+vars:
+- name: elasticsearch-test-service-name
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: elasticsearch-test-protocol
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: spec.ports[0].protocol
+- name: elasticsearch-dev-service-name
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: elasticsearch-dev-protocol
+  objref:
+    kind: Service
+    name: elasticsearch
+    apiVersion: v1
+  fieldref:
+    fieldpath: spec.ports[0].protocol
+`
+
+const recreate1298_twofolders string = `
+resources:
+- ../dev
+- ../test
+`
+
+const recreate1298_devresources string = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: dev
+spec:
+  template:
+    spec:
+      containers:
+        - name: elasticsearch
+          env:
+            - name: DISCOVERY_SERVICE
+              value: "$(elasticsearch-dev-service-name).monitoring.svc.cluster.local"
+            - name: DISCOVERY_PROTOCOL
+              value: "$(elasticsearch-dev-protocol)"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: dev
+spec:
+  ports:
+    - name: transport
+      port: 9300
+      protocol: TCP
+  clusterIP: None
+`
+
+const recreate1298_testresources string = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: elasticsearch
+          env:
+            - name: DISCOVERY_SERVICE
+              value: "$(elasticsearch-test-service-name).monitoring.svc.cluster.local"
+            - name: DISCOVERY_PROTOCOL
+              value: "$(elasticsearch-test-protocol)"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: test
+spec:
+  ports:
+    - name: transport
+      port: 9300
+      protocol: UDP
+  clusterIP: None
+`
+
+const expectedOutput string = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: dev
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: DISCOVERY_SERVICE
+          value: elasticsearch.monitoring.svc.cluster.local
+        - name: DISCOVERY_PROTOCOL
+          value: TCP
+        name: elasticsearch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: dev
+spec:
+  clusterIP: None
+  ports:
+  - name: transport
+    port: 9300
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: test
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: DISCOVERY_SERVICE
+          value: elasticsearch.monitoring.svc.cluster.local
+        - name: DISCOVERY_PROTOCOL
+          value: UDP
+        name: elasticsearch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: test
+spec:
+  clusterIP: None
+  ports:
+  - name: transport
+    port: 9300
+    protocol: UDP
+`
+
+func TestVariablesInTwoFolder(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/recreate1298/twofolders")
+	th.WriteK("/recreate1298/twofolders", recreate1298_twofolders)
+	th.WriteK("/recreate1298/dev", recreate1298_dev)
+	th.WriteK("/recreate1298/test", recreate1298_test)
+	th.WriteF("/recreate1298/dev/elasticsearch-dev-service.yaml", recreate1298_devresources)
+	th.WriteF("/recreate1298/test/elasticsearch-test-service.yaml", recreate1298_testresources)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, expectedOutput)
+}
+
+func TestVariablesInOneFolder(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/recreate1298/onefolder")
+	th.WriteK("/recreate1298/onefolder", recreate1298_onefolder)
+	th.WriteF("/recreate1298/onefolder/elasticsearch-dev-service.yaml", recreate1298_devresources)
+	th.WriteF("/recreate1298/onefolder/elasticsearch-test-service.yaml", recreate1298_testresources)
+	_, err := th.MakeKustTarget().MakeCustomizedResMap()
+	// This requires the namespace to be added to the variable declaration.
+	// The expected output would then be identical regardless if the
+	// the files are in one or two folders.
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "unable to disambiguate") {
+		t.Fatalf("unexpected error %v", err)
+	}
+
 }

--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -281,10 +281,10 @@ nameReference:
 - kind: ServiceAccount
   version: v1
   fieldSpecs:
-  - path: subjects/name
+  - path: subjects
     kind: RoleBinding
     group: rbac.authorization.k8s.io
-  - path: subjects/name
+  - path: subjects
     kind: ClusterRoleBinding
     group: rbac.authorization.k8s.io
   - path: spec/serviceAccountName

--- a/pkg/transformers/namereference.go
+++ b/pkg/transformers/namereference.go
@@ -117,7 +117,7 @@ func (o *nameReferenceTransformer) getNewNameFunc(
 			for _, res := range referralCandidates.Resources() {
 				id := res.OrgId()
 				if id.IsSelected(&target) && res.GetOriginalName() == oldName {
-					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.GvknEquals)
+					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.Equals)
 					// If there's more than one match, there's no way
 					// to know which one to pick, so emit error.
 					if len(matches) > 1 {
@@ -149,7 +149,7 @@ func (o *nameReferenceTransformer) getNewNameFunc(
 				indexes := indexOf(res.GetOriginalName(), names)
 				id := res.OrgId()
 				if id.IsSelected(&target) && len(indexes) > 0 {
-					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.GvknEquals)
+					matches := referralCandidates.GetMatchingResourcesByOriginalId(id.Equals)
 					if len(matches) > 1 {
 						return nil, fmt.Errorf(
 							"slice case - multiple matches for %s:\n %v",

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/pkg/gvk"
+	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resmaptest"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
@@ -466,6 +468,7 @@ func TestNameReferenceHappyRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -497,7 +500,7 @@ func TestNameReferenceUnhappyRun(t *testing.T) {
 						},
 					},
 				}).ResMap(),
-			expectedErr: "is expected to be string"},
+			expectedErr: "is expected to be"},
 		{
 			resMap: resmaptest_test.NewRmBuilder(t, rf).Add(
 				map[string]interface{}{
@@ -517,7 +520,7 @@ func TestNameReferenceUnhappyRun(t *testing.T) {
 						},
 					},
 				}).ResMap(),
-			expectedErr: "is expected to be either a string or a []interface{}"},
+			expectedErr: "is expected to be"},
 	}
 
 	nrt := NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
@@ -587,6 +590,306 @@ func TestNameReferencePersistentVolumeHappyRun(t *testing.T) {
 	v2.AppendRefBy(c2.CurId())
 
 	if err := m1.ErrorIfNotEqualLists(m2); err != nil {
+		t.Fatalf("actual doesn't match expected: %v", err)
+	}
+}
+
+// utility map to create a deployment object
+// with (metadatanamespace, metadataname) as key
+// and pointing to "refname" secret and configmap
+func deploymentMap(metadatanamespace string, metadataname string,
+	configmapref string, secretref string) map[string]interface{} {
+	deployment := map[string]interface{}{
+		"group":      "apps",
+		"apiVersion": "v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"name": metadataname,
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "nginx",
+							"image": "nginx:1.7.9",
+							"env": []interface{}{
+								map[string]interface{}{
+									"name": "CM_FOO",
+									"valueFrom": map[string]interface{}{
+										"configMapKeyRef": map[string]interface{}{
+											"name": configmapref,
+											"key":  "somekey",
+										},
+									},
+								},
+								map[string]interface{}{
+									"name": "SECRET_FOO",
+									"valueFrom": map[string]interface{}{
+										"secretKeyRef": map[string]interface{}{
+											"name": secretref,
+											"key":  "somekey",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if metadatanamespace != "" {
+		metadata := deployment["metadata"].(map[string]interface{})
+		metadata["namespace"] = metadatanamespace
+	}
+	return deployment
+}
+
+// TestNameReferenceNamespace creates configmap, secret, deployment
+// serviceAccount and clusterRoleBinding object with the same original
+// names (uniquename) in different namespaces and with different current Id.
+func TestNameReferenceyNamespace(t *testing.T) {
+	defaultNs := "default"
+	ns1 := "ns1"
+	ns2 := "ns2"
+
+	orgname := "uniquename"
+	prefixedname := "prefix-uniquename"
+	suffixedname := "uniquename-suffix"
+	modifiedname := "modifiedname"
+
+	rf := resource.NewFactory(
+		kunstruct.NewKunstructuredFactoryImpl())
+	m := resmaptest_test.NewRmBuilder(t, rf).
+		// Add ConfigMap with the same org name in noNs, "ns1" and "ns2" namespaces
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			}}).
+		AddWithNsAndName(ns1, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      prefixedname,
+				"namespace": ns1,
+			}}).
+		AddWithNsAndName(ns2, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      suffixedname,
+				"namespace": ns2,
+			}}).
+		// Add Secret with the same org name in noNs, "ns1" and "ns2" namespaces
+		AddWithNsAndName(defaultNs, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      modifiedname,
+				"namespace": defaultNs,
+			}}).
+		AddWithNsAndName(ns1, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      prefixedname,
+				"namespace": ns1,
+			}}).
+		AddWithNsAndName(ns2, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      suffixedname,
+				"namespace": ns2,
+			}}).
+		// Add Deployment with the same org name in noNs, "ns1" and "ns2" namespaces
+		AddWithNsAndName(defaultNs, orgname, deploymentMap(defaultNs, modifiedname, modifiedname, modifiedname)).
+		AddWithNsAndName(ns1, orgname, deploymentMap(ns1, prefixedname, orgname, orgname)).
+		AddWithNsAndName(ns2, orgname, deploymentMap(ns2, suffixedname, orgname, orgname)).
+		// Add ServiceAccount with the same org name in noNs, "ns1" and "ns2" namespaces
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			}}).
+		AddWithNsAndName(ns1, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name":      prefixedname,
+				"namespace": ns1,
+			}}).
+		AddWithNsAndName(ns2, orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name":      suffixedname,
+				"namespace": ns2,
+			}}).
+		// Add a PersisitentVolume to have a clusterwide resources
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolume",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			}}).
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"resources": []interface{}{
+						"persistentvolumes",
+					},
+					"resourceNames": []interface{}{
+						orgname,
+					},
+				},
+			}}).
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRoleBinding",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			},
+			"roleRef": map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"name":       orgname,
+			},
+			"subjects": []interface{}{
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      orgname,
+					"namespace": defaultNs,
+				},
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      orgname,
+					"namespace": ns1,
+				},
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      orgname,
+					"namespace": ns2,
+				},
+			}}).ResMap()
+
+	expected := resmaptest_test.NewSeededRmBuilder(t, rf, m.ShallowCopy()).
+		ReplaceResource(deploymentMap(defaultNs, modifiedname, modifiedname, modifiedname)).
+		ReplaceResource(deploymentMap(ns1, prefixedname, prefixedname, prefixedname)).
+		ReplaceResource(deploymentMap(ns2, suffixedname, suffixedname, suffixedname)).
+		ReplaceResource(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"metadata": map[string]interface{}{
+					"name": modifiedname,
+				},
+				"rules": []interface{}{
+					map[string]interface{}{
+						"resources": []interface{}{
+							"persistentvolumes",
+						},
+						"resourceNames": []interface{}{
+							modifiedname,
+						},
+					},
+				}}).
+		ReplaceResource(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRoleBinding",
+				"metadata": map[string]interface{}{
+					"name": modifiedname,
+				},
+				"roleRef": map[string]interface{}{
+					"apiVersion": "rbac.authorization.k8s.io/v1",
+					"kind":       "ClusterRole",
+					"name":       modifiedname,
+				},
+				// The following tests required a change in
+				// getNameFunc implementation in order to leverage
+				// the namespace field.
+				"subjects": []interface{}{
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      modifiedname,
+						"namespace": defaultNs,
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      prefixedname,
+						"namespace": ns1,
+					},
+					map[string]interface{}{
+						"kind":      "ServiceAccount",
+						"name":      suffixedname,
+						"namespace": ns2,
+					},
+				},
+			}).ResMap()
+
+	clusterRoleId := resid.NewResId(
+		gvk.Gvk{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"}, modifiedname)
+	clusterRoleBindingId := resid.NewResId(
+		gvk.Gvk{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"}, modifiedname)
+	clusterRole, _ := expected.GetByCurrentId(clusterRoleId)
+	clusterRole.AppendRefBy(clusterRoleBindingId)
+
+	nrt := NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
+	err := nrt.Transform(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err = expected.ErrorIfNotEqualLists(m); err != nil {
+		t.Fatalf("actual doesn't match expected: %v", err)
+	}
+}
+
+// TestNameReferenceNamespace creates configmap, secret, deployment
+// It validates the change done is IsSameFuzzyNamespace which
+// uses the IsNsEquals method instead of the simple == operator.
+func TestNameReferenceCandidateSelection(t *testing.T) {
+	rf := resource.NewFactory(
+		kunstruct.NewKunstructuredFactoryImpl())
+	m := resmaptest_test.NewRmBuilder(t, rf).
+		AddWithName("cm1", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": "p1-cm1-hash",
+			}}).
+		AddWithNsAndName("default", "secret1", map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]interface{}{
+				"name":      "p1-secret1-hash",
+				"namespace": "default",
+			}}).
+		AddWithName("deploy1", deploymentMap("", "p1-deploy1", "cm1", "secret1")).
+		ResMap()
+
+	expected := resmaptest_test.NewSeededRmBuilder(t, rf, m.ShallowCopy()).
+		ReplaceResource(deploymentMap("", "p1-deploy1", "p1-cm1-hash", "p1-secret1-hash")).
+		ResMap()
+
+	nrt := NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
+	err := nrt.Transform(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
 }


### PR DESCRIPTION
At a high level, this PR changes the equality test from (Group,Version,Kind,Name) tuple to (Groupi,Version,Kind,Name,Namespace) tuple during patch transformation and collision detection. 

The ResId.Equals function account for the absence of value for object with cluster wide scope.

This PR also had a test demonstrating why such as change would be important for Variable target selection but not possible yet.