### PR TITLE
BUG REPORT: failed to build on kustomize 3.0.0.

### DIFF
--- a/examples/patches-no-matches/base/deployment.yaml
+++ b/examples/patches-no-matches/base/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "k8s-sidecar-injector-prod"
+  namespace: "kube-system"
+  labels:
+    k8s-app: "k8s-sidecar-injector"
+    track: "prod"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: "k8s-sidecar-injector"
+        track: "prod"
+    spec:
+      serviceAccountName: k8s-sidecar-injector
+      volumes:
+      - name: secrets
+        secret:
+          secretName: k8s-sidecar-injector
+      containers:
+      - name: "k8s-sidecar-injector"
+        imagePullPolicy: Always
+        image: tumblr/k8s-sidecar-injector:latest
+        command: ["entrypoint.sh"]
+        args: []
+        ports:
+        - name: https
+          containerPort: 9443
+        - name: http-metrics
+          containerPort: 9000
+        volumeMounts:
+        - name: secrets
+          mountPath: /var/lib/secrets
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /health
+            port: https
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: 1Gi
+          limits:
+            cpu: "0.5"
+            memory: 2Gi
+        env:
+        - name: "TLS_CERT_FILE"
+          value: "/var/lib/secrets/sidecar-injector.crt"
+        - name: "TLS_KEY_FILE"
+          value: "/var/lib/secrets/sidecar-injector.key"
+        - name: "LOG_LEVEL"
+          value: "2"
+        - name: "CONFIG_DIR"
+          value: "conf/"
+        - name: "CONFIGMAP_LABELS"
+          value: "app=k8s-sidecar-injector"

--- a/examples/patches-no-matches/base/kustomization.yaml
+++ b/examples/patches-no-matches/base/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- deployment.yaml

--- a/examples/patches-no-matches/kustomization.yaml
+++ b/examples/patches-no-matches/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- base
+patches:
+- patches.yaml

--- a/examples/patches-no-matches/patches.yaml
+++ b/examples/patches-no-matches/patches.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "k8s-sidecar-injector-prod"
+spec:
+  template:
+    spec:
+      containers:
+      - name: "k8s-sidecar-injector"
+        env:
+        - name: "TLS_CERT_FILE"
+          value: "/var/lib/secrets/tls.crt"
+        - name: "TLS_KEY_FILE"
+          value: "/var/lib/secrets/tls.key"


### PR DESCRIPTION
Observed:

* It fails to patch object in base
* It can patch object in resources
* It works on bundled kustomize (v2.0.3) in kubectl v1.15

```
❯ kustomize version
Version: {KustomizeVersion:3.0.0 GitCommit:e0bac6ad192f33d993f11206e24f6cda1d04c4ec BuildDate:2019-07-03T18:21:24Z GoOs:darwin GoArch:amd64}

❯ kustomize build examples/patches-no-matches
Error: no matches for OriginalId extensions_v1beta1_Deployment|~X|k8s-sidecar-injector-prod; no matches for CurrentId extensions_v1beta1_Deployment|~X|k8s-sidecar-injector-prod; failed to find unique target for patch extensions_v1beta1_Deployment|k8s-sidecar-injector-prod

❯ kustomize build examples/patches-no-matches/base
apiVersion: extensions/v1beta1
kind: Deployment
...

❯ kubectl version
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.0", GitCommit:"e8462b5b5dc2584fdcd18e6bcfe9f1e4d970a529", GitTreeState:"clean", BuildDate:"2019-06-20T04:49:16Z", GoVersion:"go1.12.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.6", GitCommit:"b1d75deca493a24a2f87eb1efde1a569e52fc8d9", GitTreeState:"clean", BuildDate:"2018-12-16T04:30:10Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}

❯ kubectl kustomize examples/patches-no-matches
apiVersion: extensions/v1beta1
kind: Deployment
...
```