### PR TITLE
Fix typo: kubectl v1.15 -> kubectl v1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ these [instructions](docs/INSTALL.md).
 Browse the [docs](docs) or jump right into the
 tested [examples](examples).
 
-kustomize [v2.0.3] is available in [kubectl v1.14][kubectl].
+kustomize [v2.0.3] is available in [kubectl v1.14 and v1.15][kubectl].
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ these [instructions](docs/INSTALL.md).
 Browse the [docs](docs) or jump right into the
 tested [examples](examples).
 
-kustomize [v2.0.3] is available in [kubectl v1.15][kubectl].
+kustomize [v2.0.3] is available in [kubectl v1.14][kubectl].
 
 
 ## Usage


### PR DESCRIPTION
Match version number to the version in the link.