### PR TITLE
Remove go testing flags from kustomize help

### DIFF
--- a/pkg/plugins/loader_test.go
+++ b/pkg/plugins/loader_test.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/internal/loadertest"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	. "sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 )
@@ -41,7 +42,7 @@ port: "12345"
 )
 
 func TestLoader(t *testing.T) {
-	tc := NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/plugins/test/envfortest.go
+++ b/pkg/plugins/test/envfortest.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package plugins
+package test
 
 import (
 	"io/ioutil"
@@ -12,13 +12,14 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/pgmconfig"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
 )
 
 // EnvForTest manages the plugin test environment.
 // It sets/resets XDG_CONFIG_HOME, makes/removes a temp objRoot.
 type EnvForTest struct {
 	t        *testing.T
-	compiler *Compiler
+	compiler *plugins.Compiler
 	workDir  string
 	oldXdg   string
 	wasSet   bool
@@ -61,7 +62,7 @@ func (x *EnvForTest) BuildExecPlugin(g, v, k string) {
 	}
 }
 
-func (x *EnvForTest) makeCompiler() *Compiler {
+func (x *EnvForTest) makeCompiler() *plugins.Compiler {
 	// The plugin loader wants to find object code under
 	//    $XDG_CONFIG_HOME/kustomize/plugins
 	// and the compiler writes object code to
@@ -73,11 +74,11 @@ func (x *EnvForTest) makeCompiler() *Compiler {
 	if err != nil {
 		x.t.Error(err)
 	}
-	srcRoot, err := DefaultSrcRoot()
+	srcRoot, err := plugins.DefaultSrcRoot()
 	if err != nil {
 		x.t.Error(err)
 	}
-	return NewCompiler(srcRoot, objRoot)
+	return plugins.NewCompiler(srcRoot, objRoot)
 }
 
 func (x *EnvForTest) createWorkDir() {

--- a/pkg/target/chartinflatorplugin_test.go
+++ b/pkg/target/chartinflatorplugin_test.go
@@ -28,7 +28,7 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflatorPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/pkg/target/diamondcomposition_test.go
+++ b/pkg/target/diamondcomposition_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 const patchAddProbe = `
@@ -340,7 +340,7 @@ patchesStrategicMerge:
 }
 
 func TestIssue1251_Plugins_ProdVsDev(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -380,7 +380,7 @@ transformers:
 }
 
 func TestIssue1251_Plugins_Local(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -430,7 +430,7 @@ jsonOp: '%s'
 
 // Remote in the sense that they are bundled in a different kustomization.
 func TestIssue1251_Plugins_Bundled(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/target/plugindir_test.go
+++ b/pkg/target/plugindir_test.go
@@ -12,9 +12,10 @@ import (
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
@@ -22,7 +23,7 @@ import (
 )
 
 func TestPluginDir(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/pkg/target/transformerplugin_test.go
+++ b/pkg/target/transformerplugin_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func writeDeployment(th *kusttest_test.KustTestHarness, path string) {
@@ -50,7 +50,7 @@ metadata:
 }
 
 func TestOrderedTransformers(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -96,7 +96,7 @@ spec:
 }
 
 func TestPluginsNotEnabled(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -119,7 +119,7 @@ transformers:
 }
 
 func TestSedTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
@@ -187,7 +187,7 @@ metadata:
 }
 
 func TestTransformedTransformers(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestAnnotationsTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestConfigMapGenerator(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/hashtransformer/HashTransformer_test.go
+++ b/plugin/builtin/hashtransformer/HashTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestHashTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestImageTagTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
@@ -6,8 +6,8 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 const (
@@ -59,7 +59,7 @@ metadata:
 )
 
 func TestInventoryTransformerCollect(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -80,7 +80,7 @@ policy: GarbageCollect
 }
 
 func TestInventoryTransformerIgnore(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -101,7 +101,7 @@ policy: GarbageIgnore
 }
 
 func TestInventoryTransformerDefaultPolicy(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/labeltransformer/LabelTransformer_test.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestLabelTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestLegacyOrderTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestNamespaceTransformer1(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -174,7 +174,7 @@ metadata:
 }
 
 func TestNamespaceTransformerClusterLevelKinds(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 const target = `
@@ -29,7 +29,7 @@ spec:
 `
 
 func TestPatchJson6902TransformerMissingFile(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -58,7 +58,7 @@ path: jsonpatch.json
 }
 
 func TestBadPatchJson6902Transformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -87,7 +87,7 @@ jsonOp: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyJson6902Transformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -115,7 +115,7 @@ target:
 }
 
 func TestBothSpecifiedJson6902Transformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -151,7 +151,7 @@ jsonOp: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Clust
 }
 
 func TestPatchJson6902TransformerFromJsonFile(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -201,7 +201,7 @@ spec:
 }
 
 func TestPatchJson6902TransformerFromYamlFile(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -251,7 +251,7 @@ spec:
 }
 
 func TestPatchJson6902TransformerWithInline(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestPrefixSuffixTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestReplicaCountTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/secretgenerator/SecretGenerator_test.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestSecretGenerator(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestBashedConfigMapPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 // This test requires having the helm binary on the PATH.
@@ -19,7 +19,7 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflator(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestDatePrefixerPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/printworkdir/PrintWorkDir_test.go
+++ b/plugin/someteam.example.com/v1/printworkdir/PrintWorkDir_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func shouldContain(t *testing.T, s []byte, x string) {
@@ -18,7 +18,7 @@ func shouldContain(t *testing.T, s []byte, x string) {
 }
 
 func TestPrintWorkDirPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestSecretsFromDatabasePlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
+++ b/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestSedTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "SedTransformer")

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestSomeServiceGeneratorPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestStringPrefixerPlugin(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/validator/validator_test.go
+++ b/plugin/someteam.example.com/v1/validator/validator_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 func TestValidatorHappy(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")
@@ -49,7 +49,7 @@ metadata:
 }
 
 func TestValidatorUnHappy(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")


### PR DESCRIPTION
Currently all kustomize help output includes the go test framework flags which is distracting and confusing for new users.

```
...
Flags:
  -h, --help                            help for kustomize
      --test.bench regexp               run only benchmarks matching regexp
      --test.benchmem                   print memory allocations for benchmarks
      --test.benchtime d                run each benchmark for duration d (default 1s)
...
```

This PR moves the logic in `pkg/plugins/envfortest.go` into a new package and updates all the builtin plugins test code to handle the change. The demo [plugin](https://github.com/monopole/sopsencodedsecrets) referenced in the plugin walkthrough would also need to be updated to reflect this change.

This change will break the tests of any existing out of tree plugins.

Related to #1320 