### PR TITLE
enable extended patch transformer and add tests

### DIFF
--- a/pkg/target/chartinflatorplugin_test.go
+++ b/pkg/target/chartinflatorplugin_test.go
@@ -8,10 +8,10 @@
 package target_test
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
 	"testing"
 
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 // This is an example of using a helm chart as a base,

--- a/pkg/target/extendedpatch_test.go
+++ b/pkg/target/extendedpatch_test.go
@@ -922,3 +922,226 @@ spec:
     app: busybox
 `)
 }
+
+func TestExtendedPatchNoMatchMultiplePatch(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: no-match
+- path: patch.yaml
+  target:
+    name: busybox
+    kind: Job
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchMultiplePatchOverlapping(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch1.yaml
+  target:
+    labelSelector: app=busybox
+- path: patch2.yaml
+  target:
+    name: busybox
+    kind: Deployment
+`)
+	th.WriteF("/app/base/patch1.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key-from-patch1: new-value
+`)
+	th.WriteF("/app/base/patch2.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key-from-patch2: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key-from-patch1: new-value
+    new-key-from-patch2: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    new-key-from-patch1: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}

--- a/pkg/target/extendedpatch_test.go
+++ b/pkg/target/extendedpatch_test.go
@@ -1,0 +1,924 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+)
+
+func makeCommonFileForExtendedPatchTest(th *kusttest_test.KustTestHarness) {
+	th.WriteF("/app/base/deployment.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - name: nginx-persistent-storage
+          mountPath: /tmp/ps
+      volumes:
+      - name: nginx-persistent-storage
+        emptyDir: {}
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  labels:
+    app: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - name: busybox
+        image: busybox
+        volumeMounts:
+        - name: busybox-persistent-storage
+          mountPath: /tmp/ps
+      volumes:
+      - name: busybox-persistent-storage
+        emptyDir: {}
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+`)
+	th.WriteF("/app/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: busybox
+  labels:
+    app: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchNameSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: busybox
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchGvkSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    kind: Deployment
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchLabelSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    labelSelector: app=nginx
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchNameGvkSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: busybox
+    kind: Deployment
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchNameLabelSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: .*
+    labelSelector: app=busybox
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchGvkLabelSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    kind: Deployment
+    labelSelector: app=busybox
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchNameGvkLabelSelector(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: busybox
+    kind: Deployment
+    labelSelector: app=busybox
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
+func TestExtendedPatchNoMatch(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+  target:
+    name: no-match
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -200,7 +200,6 @@ func (k *Kustomization) EnforceFields() []string {
 // new field names.
 func FixKustomizationPreUnmarshalling(data []byte) []byte {
 	deprecateFieldsMap := map[string]string{
-		"patches:":   "patchesStrategicMerge:",
 		"imageTags:": "images:",
 	}
 	for oldname, newname := range deprecateFieldsMap {

--- a/plugin/builtin/PatchTransformer.go
+++ b/plugin/builtin/PatchTransformer.go
@@ -114,10 +114,11 @@ func (p *PatchTransformerPlugin) Transform(m resmap.ResMap) error {
 			}
 		}
 		if p.loadedPatch != nil {
-			p.loadedPatch.SetName(resource.GetName())
-			p.loadedPatch.SetNamespace(resource.GetNamespace())
-			p.loadedPatch.SetGvk(resource.GetGvk())
-			err = resource.Patch(p.loadedPatch.Kunstructured)
+			patchCopy := p.loadedPatch.DeepCopy()
+			patchCopy.SetName(resource.GetName())
+			patchCopy.SetNamespace(resource.GetNamespace())
+			patchCopy.SetGvk(resource.GetGvk())
+			err = resource.Patch(patchCopy.Kunstructured)
 			if err != nil {
 				return err
 			}

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 const (
@@ -58,7 +58,7 @@ spec:
 )
 
 func TestPatchStrategicMergeTransformerMissingFile(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -83,7 +83,7 @@ paths:
 }
 
 func TestBadPatchStrategicMergeTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -108,7 +108,7 @@ patches: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyPatchStrategicMergeTransformer(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -131,7 +131,7 @@ metadata:
 }
 
 func TestPatchStrategicMergeTransformerFromFiles(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -181,7 +181,7 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerWithInline(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -216,7 +216,7 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerMultiplePatches(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -293,7 +293,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerMultiplePatchesWithConflicts(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -354,7 +354,7 @@ paths:
 }
 
 func TestStrategicMergeTransformerWrongNamespace(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -397,7 +397,7 @@ paths:
 }
 
 func TestStrategicMergeTransformerNoSchema(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -437,7 +437,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatches(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -493,7 +493,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatchesWithConflict(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -115,10 +115,11 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			}
 		}
 		if p.loadedPatch != nil {
-			p.loadedPatch.SetName(resource.GetName())
-			p.loadedPatch.SetNamespace(resource.GetNamespace())
-			p.loadedPatch.SetGvk(resource.GetGvk())
-			err = resource.Patch(p.loadedPatch.Kunstructured)
+			patchCopy := p.loadedPatch.DeepCopy()
+			patchCopy.SetName(resource.GetName())
+			patchCopy.SetNamespace(resource.GetNamespace())
+			patchCopy.SetGvk(resource.GetGvk())
+			err = resource.Patch(patchCopy.Kunstructured)
 			if err != nil {
 				return err
 			}

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -4,10 +4,11 @@
 package main_test
 
 import (
-	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
 	"strings"
 	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
 const (
@@ -65,7 +66,7 @@ spec:
 )
 
 func TestPatchTransformerMissingFile(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -89,7 +90,7 @@ path: patch.yaml
 }
 
 func TestPatchTransformerBadPatch(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -113,7 +114,7 @@ patch: "thisIsNotAPatch"
 }
 
 func TestPatchTransformerMissingSelector(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -137,7 +138,7 @@ patch: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Cluste
 }
 
 func TestPatchTransformerBothEmptyPathAndPatch(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -160,7 +161,7 @@ metadata:
 }
 
 func TestPatchTransformerBothNonEmptyPathAndPatch(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -185,7 +186,7 @@ Patch: "something"
 }
 
 func TestPatchTransformerFromFiles(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -267,7 +268,7 @@ spec:
 }
 
 func TestPatchTransformerWithInline(t *testing.T) {
-	tc := plugins.NewEnvForTest(t).Set()
+	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(


### PR DESCRIPTION
part of #720

enable extended patch transformer in kustomization by adding and triggering the config function

add unit tests for extended transformer to select targets
- by name
- by group, version, kind
- by label selector
- by name and group, version, kind
- by name and label selector
- by group, version, kind and label selector
- by name, group, version, kind and label selector
- no match