### PR TITLE
Address replacement of digest by ImageTransformer

### DIFF
--- a/plugin/builtin/ImageTagTransformer.go
+++ b/plugin/builtin/ImageTagTransformer.go
@@ -149,7 +149,7 @@ func (p *ImageTagTransformerPlugin) findContainers(obj map[string]interface{}) e
 
 func isImageMatched(s, t string) bool {
 	// Tag values are limited to [a-zA-Z0-9_.-].
-	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.-]*)?$")
+	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.-]*)?$")
 	return pattern.MatchString(s)
 }
 
@@ -175,7 +175,7 @@ func split(imageName string) (name string, tag string) {
 	}
 
 	i := ic
-	if ic < 0 {
+	if ia > 0 {
 		i = ia
 	}
 

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -150,7 +150,7 @@ func (p *plugin) findContainers(obj map[string]interface{}) error {
 
 func isImageMatched(s, t string) bool {
 	// Tag values are limited to [a-zA-Z0-9_.-].
-	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.-]*)?$")
+	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.-]*)?$")
 	return pattern.MatchString(s)
 }
 
@@ -176,7 +176,7 @@ func split(imageName string) (name string, tag string) {
 	}
 
 	i := ic
-	if ic < 0 {
+	if ia > 0 {
 		i = ia
 	}
 

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -10,7 +10,7 @@ import (
 	plugins_test "sigs.k8s.io/kustomize/v3/pkg/plugins/test"
 )
 
-func TestImageTagTransformer(t *testing.T) {
+func TestImageTagTransformerNewTag(t *testing.T) {
 	tc := plugins_test.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
@@ -36,18 +36,22 @@ metadata:
 spec:
   template:
     spec:
-      initContainers:
-      - name: nginx2
-        image: my-nginx:1.8.0
-      - name: init-alpine
-        image: alpine:1.8.0
       containers:
-      - name: ngnix
-        image: nginx:1.7.9
-      - name: repliaced-with-digest
-        image: foobar:1
-      - name: postgresdb
-        image: postgres:1.8.0
+      - image: nginx:1.7.9
+        name: nginx-tagged
+      - image: nginx:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx
+        name: nginx-notag
+      - image: nginx@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
 `)
 
 	th.AssertActualEqualsExpected(rm, `
@@ -61,14 +65,307 @@ spec:
     spec:
       containers:
       - image: nginx:v2
-        name: ngnix
+        name: nginx-tagged
+      - image: nginx:v2
+        name: nginx-latest
       - image: foobar:1
-        name: repliaced-with-digest
+        name: replaced-with-digest
       - image: postgres:1.8.0
         name: postgresdb
       initContainers:
-      - image: my-nginx:1.8.0
-        name: nginx2
+      - image: nginx:v2
+        name: nginx-notag
+      - image: nginx:v2
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+}
+func TestImageTagTransformerNewImage(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin(
+		"builtin", "", "ImageTagTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: notImportantHere
+imageTag:
+  name: nginx
+  newName: busybox
+`, `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        name: nginx-tagged
+      - image: nginx:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx
+        name: nginx-notag
+      - image: nginx@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox:1.7.9
+        name: nginx-tagged
+      - image: busybox:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: busybox
+        name: nginx-notag
+      - image: busybox@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+}
+
+func TestImageTagTransformerNewImageAndTag(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin(
+		"builtin", "", "ImageTagTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: notImportantHere
+imageTag:
+  name: nginx
+  newName: busybox
+  newTag: v2
+`, `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        name: nginx-tagged
+      - image: nginx:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx
+        name: nginx-notag
+      - image: nginx@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox:v2
+        name: nginx-tagged
+      - image: busybox:v2
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: busybox:v2
+        name: nginx-notag
+      - image: busybox:v2
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+}
+
+func TestImageTagTransformerNewDigest(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin(
+		"builtin", "", "ImageTagTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: notImportantHere
+imageTag:
+  name: nginx
+  Digest: sha256:222222222222222222
+`, `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        name: nginx-tagged
+      - image: nginx:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx
+        name: nginx-notag
+      - image: nginx@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx@sha256:222222222222222222
+        name: nginx-tagged
+      - image: nginx@sha256:222222222222222222
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx@sha256:222222222222222222
+        name: nginx-notag
+      - image: nginx@sha256:222222222222222222
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+}
+
+func TestImageTagTransformerNewImageAndDigest(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin(
+		"builtin", "", "ImageTagTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: notImportantHere
+imageTag:
+  name: nginx
+  newName: busybox
+  Digest: sha256:222222222222222222
+`, `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        name: nginx-tagged
+      - image: nginx:latest
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: nginx
+        name: nginx-notag
+      - image: nginx@sha256:111111111111111111
+        name: nginx-sha256
+      - image: alpine:1.8.0
+        name: init-alpine
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox@sha256:222222222222222222
+        name: nginx-tagged
+      - image: busybox@sha256:222222222222222222
+        name: nginx-latest
+      - image: foobar:1
+        name: replaced-with-digest
+      - image: postgres:1.8.0
+        name: postgresdb
+      initContainers:
+      - image: busybox@sha256:222222222222222222
+        name: nginx-notag
+      - image: busybox@sha256:222222222222222222
+        name: nginx-sha256
       - image: alpine:1.8.0
         name: init-alpine
 `)


### PR DESCRIPTION

- Fixes issue [Issue 1357](https://github.com/kubernetes-sigs/kustomize/issues/1357)
- Add more tests.
- Temporary cherry picked two additional fixes since master branch can't built without those and the corresponding [PR](https://github.com/kubernetes-sigs/kustomize/pull/1355) which includes them has not been merged yet. Will need rebase as soon the CI fixes are merged.