### PR TITLE
update edit fix to convert the old patches to patchesStrategicMerge

### DIFF
--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -61,6 +61,7 @@ func determineFieldOrder() []string {
 		"CommonAnnotations",
 		"PatchesStrategicMerge",
 		"PatchesJson6902",
+		"Patches",
 		"ConfigMapGenerator",
 		"SecretGenerator",
 		"GeneratorOptions",
@@ -73,9 +74,7 @@ func determineFieldOrder() []string {
 	}
 
 	// Add deprecated fields here.
-	deprecated := map[string]bool{
-		"Patches": true,
-	}
+	deprecated := map[string]bool{}
 
 	// Account for the inlined TypeMeta fields.
 	var result []string

--- a/pkg/target/extendedpatch_test.go
+++ b/pkg/target/extendedpatch_test.go
@@ -923,6 +923,107 @@ spec:
 `)
 }
 
+func TestExtendedPatchWithoutTarget(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app/base")
+	makeCommonFileForExtendedPatchTest(th)
+	th.WriteK("/app/base", `
+resources:
+- deployment.yaml
+- service.yaml
+patches:
+- path: patch.yaml
+`)
+	th.WriteF("/app/base/patch.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: busybox
+  annotations:
+    new-key: new-value
+`)
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: nginx-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: nginx-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  annotations:
+    new-key: new-value
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+      - image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/ps
+          name: busybox-persistent-storage
+      volumes:
+      - emptyDir: {}
+        name: busybox-persistent-storage
+      - configMap:
+          name: configmap-in-base
+        name: configmap-in-base
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: busybox
+  name: busybox
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app: busybox
+`)
+}
+
 func TestExtendedPatchNoMatchMultiplePatch(t *testing.T) {
 	th := kusttest_test.NewKustTestHarness(t, "/app/base")
 	makeCommonFileForExtendedPatchTest(th)

--- a/pkg/target/kusttarget_configplugin.go
+++ b/pkg/target/kusttarget_configplugin.go
@@ -200,7 +200,7 @@ func (kt *KustTarget) configureBuiltinPatchTransformer(
 		Target *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
 	}
 	for _, patch := range kt.kustomization.Patches {
-		c.Target = &patch.Target
+		c.Target = patch.Target
 		c.Patch = patch.Patch
 		c.Path = patch.Path
 		p := builtin.NewPatchTransformerPlugin()

--- a/pkg/types/fix.go
+++ b/pkg/types/fix.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package types holds struct definitions that should find a better home.
+package types
+
+import (
+	"log"
+	"regexp"
+
+	"sigs.k8s.io/yaml"
+)
+
+// FixKustomizationPreUnmarshalling modies the raw data
+// before marshalling - e.g. changes old field names to
+// new field names.
+func FixKustomizationPreUnmarshalling(data []byte) []byte {
+	deprecateFieldsMap := map[string]string{
+		"imageTags:": "images:",
+	}
+	for oldname, newname := range deprecateFieldsMap {
+		pattern := regexp.MustCompile(oldname)
+		data = pattern.ReplaceAll(data, []byte(newname))
+	}
+
+	if useLegacyPatch(data) {
+		pattern := regexp.MustCompile("patches:")
+		data = pattern.ReplaceAll(data, []byte("patchesStrategicMerge:"))
+	}
+
+	return data
+}
+
+func useLegacyPatch(data []byte) bool {
+	found := false
+
+	var object map[string]interface{}
+	err := yaml.Unmarshal(data, &object)
+	if err != nil {
+		log.Fatalf("invalid content from %s\n", string(data))
+	}
+	if rawPatches, ok := object["patches"]; ok {
+		patches, ok := rawPatches.([]interface{})
+		if !ok {
+			log.Fatalf("invalid patches from %v\n", rawPatches)
+		}
+		for _, p := range patches {
+			_, ok := p.(string)
+			if ok {
+				found = true
+			}
+		}
+	}
+	return found
+}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -5,8 +5,6 @@
 package types
 
 import (
-	"regexp"
-
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"sigs.k8s.io/kustomize/v3/pkg/image"
 )
@@ -195,20 +193,6 @@ func (k *Kustomization) EnforceFields() []string {
 	return errs
 }
 
-// FixKustomizationPreUnmarshalling modies the raw data
-// before marshalling - e.g. changes old field names to
-// new field names.
-func FixKustomizationPreUnmarshalling(data []byte) []byte {
-	deprecateFieldsMap := map[string]string{
-		"imageTags:": "images:",
-	}
-	for oldname, newname := range deprecateFieldsMap {
-		pattern := regexp.MustCompile(oldname)
-		data = pattern.ReplaceAll(data, []byte(newname))
-	}
-	return data
-}
-
 // GeneratorArgs contains arguments common to generators.
 type GeneratorArgs struct {
 	// Namespace for the configmap, optional
@@ -385,7 +369,7 @@ type Patch struct {
 	Patch string `json:"patch,omitempty" yaml:"patch,omitempty"`
 
 	// Target points to the resources that the patch is applied to
-	Target Selector `json:"target,omitempty" yaml:"target,omitempty"`
+	Target *Selector `json:"target,omitempty" yaml:"target,omitempty"`
 }
 
 // Selector specifies a set of resources.

--- a/plugin/builtin/PatchTransformer.go
+++ b/plugin/builtin/PatchTransformer.go
@@ -87,6 +87,7 @@ func (p *PatchTransformerPlugin) Transform(m resmap.ResMap) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
 	if p.Target == nil {

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -88,6 +88,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
 	if p.Target == nil {


### PR DESCRIPTION
As mentioned in the previous PR #1355, we can make `kustomize edit fix` to convert the `patches` from the old format to `patchesStrategicMerge`
For example, the patches like
```
patches:
- patch1.yaml
- patch2.yaml
```
is converted to
```
patchesStrategicMerge:
- path: patch1.yaml
- path: patch2.yaml
```

Added unit tests for `edit fix`.

Also added a unit tests to make sure the build works after this conversion.