### PR TITLE
Fix kustomize install in integration test

### DIFF
--- a/examples/integration_tests.sh
+++ b/examples/integration_tests.sh
@@ -28,7 +28,7 @@
 # before running it.
 #
 # At time of writing, its 'call point' was in
-# https://github.com/kubernetes/test-infra/blob/master/jobs/config.json
+# https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
 
 function exitWith {
   local msg=$1
@@ -53,7 +53,7 @@ function setUpEnv {
     exitWith "Script must be run from $expectedRepo"
   fi
 
-  GO111MODULE=on go install . || \
+  GO111MODULE=on go install ./cmd/kustomize || \
     { exitWith "Failed to install kustomize."; }
 
   PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
There is a lot of red on the kustomize testgrid dashboard and that's sad, so lets not be sad and make that green. 😄 

https://testgrid.k8s.io/sig-cli-misc#kustomize-periodic-default-gke

The integration test script is attempting to install kustomize with `go install .`. Since #1194 the root of the repo doesn't contain the kustomize main and so this is failing. This PR simply updates the script to install from `./cmd/kustomize` where main lives now.

Additionally updates the url to the prow job that runs the integration test.