### PR TITLE
Add namespace to variable definition

### DIFF
--- a/pkg/types/var.go
+++ b/pkg/types/var.go
@@ -54,6 +54,7 @@ type Target struct {
 	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 	gvk.Gvk    `json:",inline,omitempty" yaml:",inline,omitempty"`
 	Name       string `json:"name" yaml:"name"`
+	Namespace  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
 // FieldSelector contains the fieldPath to an object field.


### PR DESCRIPTION
- This allows disambiguation of variable with different names point at object with the same kind and name but in different namespace.
- no namespace in the variable declaration is considered as a the "wild card" value not the "default" value
- fixes issue 1298.