### PR TITLE
fix: windows builds

### DIFF
--- a/pkg/plugins/execplugin.go
+++ b/pkg/plugins/execplugin.go
@@ -160,6 +160,9 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Cleanup plugin config file after execution
+	defer os.Remove(args[0])
+
 	cmd := exec.Command(p.path, args...)
 	cmd.Env = p.getEnv()
 	cmd.Stdin = bytes.NewReader(input)

--- a/pkg/plugins/execplugin.go
+++ b/pkg/plugins/execplugin.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
@@ -108,7 +107,7 @@ func (p *ExecPlugin) writeConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	syscall.Mkfifo(tmpFile.Name(), 0600)
+
 	stdout, err := os.OpenFile(tmpFile.Name(), os.O_RDWR, 0600)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
v2.1.0+ and v3.0.0+ introduced a call to `syscall.MkFifo` around plugin execution. This breaks cross-compilation on Windows for any package trying to import a version of Kustomize newer than 2.0.3.

As far as I can tell, using the named pipe here is not really necessary? We already have a tmpfile on the real FS with mode RW, and Kustomize is writing to the config file for the plugin (there is no one reading the other end). Let me know if I am missing anything. 