### PR TITLE
Name Prefix and Suffix Transformation for multi level level kustomize context

### DIFF
--- a/pkg/resmap/resmap_test.go
+++ b/pkg/resmap/resmap_test.go
@@ -356,7 +356,7 @@ func TestSubsetThatCouldBeReferencedByResource(t *testing.T) {
 	r4 := rf.FromMap(
 		map[string]interface{}{
 			"apiVersion": "v1",
-			"kind":       "ConfigMap",
+			"kind":       "Deployment",
 			"metadata": map[string]interface{}{
 				"name":      "charlie",
 				"namespace": "happy",
@@ -365,7 +365,7 @@ func TestSubsetThatCouldBeReferencedByResource(t *testing.T) {
 	r5 := rf.FromMap(
 		map[string]interface{}{
 			"apiVersion": "v1",
-			"kind":       "Deployment",
+			"kind":       "ConfigMap",
 			"metadata": map[string]interface{}{
 				"name":      "charlie",
 				"namespace": "happy",
@@ -408,12 +408,12 @@ func TestSubsetThatCouldBeReferencedByResource(t *testing.T) {
 		"happy namespace no prefix": {
 			filter: r3,
 			expected: resmaptest_test.NewRmBuilder(t, rf).
-				AddR(r3).AddR(r4).AddR(r7).ResMap(),
+				AddR(r3).AddR(r4).AddR(r5).AddR(r6).AddR(r7).ResMap(),
 		},
 		"happy namespace with prefix": {
 			filter: r5,
 			expected: resmaptest_test.NewRmBuilder(t, rf).
-				AddR(r5).AddR(r6).AddR(r7).ResMap(),
+				AddR(r3).AddR(r4).AddR(r5).AddR(r6).AddR(r7).ResMap(),
 		},
 		"cluster level": {
 			filter: r7,

--- a/pkg/target/resourceconflict_test.go
+++ b/pkg/target/resourceconflict_test.go
@@ -4,7 +4,6 @@
 package target_test
 
 import (
-	"strings"
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
@@ -16,6 +15,7 @@ resources:
 - serviceaccount.yaml
 - rolebinding.yaml
 - clusterrolebinding.yaml
+- clusterrole.yaml
 namePrefix: pfx-
 nameSuffix: -sfx
 `)
@@ -32,7 +32,7 @@ metadata:
   name: rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: role
 subjects:
 - kind: ServiceAccount
@@ -45,11 +45,21 @@ metadata:
   name: rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: role
 subjects:
 - kind: ServiceAccount
   name: serviceaccount
+`)
+	th.WriteF("/app/base/clusterrole.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
 `)
 }
 
@@ -97,8 +107,8 @@ metadata:
   name: pfx-rolebinding-sfx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: pfx-role-sfx
 subjects:
 - kind: ServiceAccount
   name: pfx-serviceaccount-sfx
@@ -109,11 +119,25 @@ metadata:
   name: pfx-rolebinding-sfx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: pfx-role-sfx
 subjects:
 - kind: ServiceAccount
   name: pfx-serviceaccount-sfx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pfx-role-sfx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 `)
 }
 
@@ -137,8 +161,8 @@ metadata:
   name: a-pfx-rolebinding-sfx-suffixA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
 subjects:
 - kind: ServiceAccount
   name: a-pfx-serviceaccount-sfx-suffixA
@@ -149,11 +173,25 @@ metadata:
   name: a-pfx-rolebinding-sfx-suffixA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
 subjects:
 - kind: ServiceAccount
   name: a-pfx-serviceaccount-sfx-suffixA
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: a-pfx-role-sfx-suffixA
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 `)
 }
 
@@ -177,8 +215,8 @@ metadata:
   name: b-pfx-rolebinding-sfx-suffixB
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
 subjects:
 - kind: ServiceAccount
   name: b-pfx-serviceaccount-sfx-suffixB
@@ -189,11 +227,25 @@ metadata:
   name: b-pfx-rolebinding-sfx-suffixB
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
 subjects:
 - kind: ServiceAccount
   name: b-pfx-serviceaccount-sfx-suffixB
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: b-pfx-role-sfx-suffixB
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 `)
 }
 
@@ -218,8 +270,8 @@ metadata:
   name: a-pfx-rolebinding-sfx-suffixA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
 subjects:
 - kind: ServiceAccount
   name: a-pfx-serviceaccount-sfx-suffixA
@@ -230,11 +282,25 @@ metadata:
   name: a-pfx-rolebinding-sfx-suffixA
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
 subjects:
 - kind: ServiceAccount
   name: a-pfx-serviceaccount-sfx-suffixA
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: a-pfx-role-sfx-suffixA
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -247,8 +313,8 @@ metadata:
   name: b-pfx-rolebinding-sfx-suffixB
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
 subjects:
 - kind: ServiceAccount
   name: b-pfx-serviceaccount-sfx-suffixB
@@ -259,11 +325,25 @@ metadata:
   name: b-pfx-rolebinding-sfx-suffixB
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: role
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
 subjects:
 - kind: ServiceAccount
   name: b-pfx-serviceaccount-sfx-suffixB
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: b-pfx-role-sfx-suffixB
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
 `)
 }
 
@@ -289,12 +369,100 @@ metadata:
   name: serviceaccount
 `)
 
-	_, err := th.MakeKustTarget().MakeCustomizedResMap()
-	if err == nil {
-		t.Fatalf("Expected resource conflict.")
-	}
-	if !strings.Contains(
-		err.Error(), "multiple matches for ~G_v1_ServiceAccount") {
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)
 	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: a-serviceaccount-suffixA
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: a-pfx-serviceaccount-sfx-suffixA
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: a-pfx-rolebinding-sfx-suffixA
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
+subjects:
+- kind: ServiceAccount
+  name: a-pfx-serviceaccount-sfx-suffixA
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: a-pfx-rolebinding-sfx-suffixA
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: a-pfx-role-sfx-suffixA
+subjects:
+- kind: ServiceAccount
+  name: a-pfx-serviceaccount-sfx-suffixA
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: a-pfx-role-sfx-suffixA
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: b-pfx-serviceaccount-sfx-suffixB
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: b-pfx-rolebinding-sfx-suffixB
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
+subjects:
+- kind: ServiceAccount
+  name: b-pfx-serviceaccount-sfx-suffixB
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: b-pfx-rolebinding-sfx-suffixB
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: b-pfx-role-sfx-suffixB
+subjects:
+- kind: ServiceAccount
+  name: b-pfx-serviceaccount-sfx-suffixB
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: b-pfx-role-sfx-suffixB
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+`)
 }

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -50,22 +50,40 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
-	if len(p.Prefix) == 0 && len(p.Suffix) == 0 {
-		return nil
-	}
+
+	// Even if both the Prefix and Suffix are empty we want
+	// to proceed with the transformation. This allows to add contextual
+	// information to the resources (AddNamePrefix and AddNameSuffix).
+
 	for _, r := range m.Resources() {
 		if p.shouldSkip(r.OrgId()) {
+			// Don't change the actual definition
+			// of a CRD.
 			continue
 		}
 		id := r.OrgId()
+		// current default configuration contains
+		// only one entry: "metadata/name" with no GVK
 		for _, path := range p.FieldSpecs {
 			if !id.IsSelected(&path.Gvk) {
+				// With the currrent default configuration,
+				// because no Gvk is specified, so a wild
+				// card
 				continue
 			}
+
 			if smellsLikeANameChange(&path) {
+				// "metadata/name" is the only field.
+				// this will add a prefix and a suffix
+				// to the resource even if those are
+				// empty
 				r.AddNamePrefix(p.Prefix)
 				r.AddNameSuffix(p.Suffix)
 			}
+
+			// the addPrefixSuffix method will not
+			// change the name if both the prefix and suffix
+			// are empty.
 			err := transformers.MutateField(
 				r.Map(),
 				path.PathSlice(),


### PR DESCRIPTION
This PR builds on the "OuterMost" Prefix and Suffix usage for the name transformation.

Current code was unable to deal properly with a last level of kustomize that was combining two sub levels. In such as case the outermost prefix and suffix where often empty.

This PR is using the stack of prefixes and suffixes accumulated during the name prefix/suffix transformation to handle properly the namereference transformation.

The ResCtx (Resource Context) interface has been introduced. It is currently relying on name prefix and suffix but long term it should be possible to extend it to use a filename or a commit id equivalent to identify a kustomize content (a.k.a a folder with a kustomization.yaml).
