### PR TITLE
WIP: Attempt to improve conflict detection during namereference transformation

### DIFF
--- a/pkg/target/variableref_test.go
+++ b/pkg/target/variableref_test.go
@@ -525,7 +525,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cockroachdb
+  name: cluster-cockroachdb
   labels:
     app: cockroachdb
 rules:
@@ -562,7 +562,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cockroachdb
+  name: cluster-cockroachdb
 subjects:
 - kind: ServiceAccount
   name: cockroachdb
@@ -727,7 +727,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: cockroachdb
-  name: dev-base-cockroachdb
+  name: dev-base-cluster-cockroachdb
 rules:
 - apiGroups:
   - certificates.k8s.io
@@ -762,7 +762,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dev-base-cockroachdb
+  name: dev-base-cluster-cockroachdb
 subjects:
 - kind: ServiceAccount
   name: dev-base-cockroachdb

--- a/pkg/transformers/config/defaultconfig/namereference.go
+++ b/pkg/transformers/config/defaultconfig/namereference.go
@@ -356,5 +356,7 @@ nameReference:
     kind: PersistentVolumeClaim
   - path: spec/volumeClaimTemplates/spec/storageClassName
     kind: StatefulSet
+  - path: rules/resourceNames
+    kind: ClusterRole
 `
 )

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -883,6 +883,48 @@ func TestNameReferenceClusterWide(t *testing.T) {
 	}
 }
 
+// TestNameReferenceClusterWideUnhappy creates serviceAccount and clusterRoleBinding
+func TestNameReferenceClusterWideUnhappy(t *testing.T) {
+	rf := resource.NewFactory(
+		kunstruct.NewKunstructuredFactoryImpl())
+	m := resmaptest_test.NewRmBuilder(t, rf).
+		// Add a PersistentVolume to have a clusterwide resource
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "PersistentVolume",
+			"metadata": map[string]interface{}{
+				"name": prefixedname,
+			}}).
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "storage.k8s.io/v1",
+			"kind":       "StorageClass",
+			"metadata": map[string]interface{}{
+				"name": suffixedname,
+			}}).
+		AddWithName(orgname, map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": modifiedname,
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"resources": []interface{}{
+						"persistentvolumes",
+					},
+					"resourceNames": []interface{}{
+						orgname,
+					},
+				},
+			}}).ResMap()
+
+	nrt := NewNameReferenceTransformer(defaultTransformerConfig.NameReference)
+	err := nrt.Transform(m)
+	if err == nil {
+		// This should actually fail.
+	}
+}
+
 // TestNameReferenceNamespaceTransformation creates serviceAccount and clusterRoleBinding
 // object with the same original names (uniquename) in different namespaces
 // and with different current Id.


### PR DESCRIPTION
This PR is attempting to fix [Issue](https://github.com/kubernetes-sigs/kustomize/issues/1381)

The key idea is to "optimize" the loop accross the fieldpath to create the list of potential target GVK before invoking mutatefield.

The current algorithm makes that the first target GVK in the list change the namereference and the subsequent conflicting target to no conflict anymore because the original name has been replaced by the current name,
