### PR TITLE
Handle ordering patch with SMP delete directives

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -339,6 +339,11 @@ patchesStrategicMerge:
             image: nignx:latest
 ```
 
+Note that kustomize does not support more than one patch
+for the same object that contain a _delete_ directive. To remove
+several fields / slice elements from an object create a single
+patch that performs all the needed deletions.
+
 ### patchesJson6902
 
 Each entry in this list should resolve to

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -376,9 +376,8 @@ value is a list.
 
 To change this
 default behavior, add a _directive_.  Recognized
-directives include _replace_ (the default), _merge_
-(avoid replacing a list), _delete_ and a few more
-(see [these notes][strategic-merge]).
+directives in YAML patches are _replace_ (the default)
+and _delete_ (see [these notes][strategic-merge]).
 
 Note that for custom resources, SMPs are treated as
 [json merge patches][JSONMergePatch].


### PR DESCRIPTION
Currently if there are multiple patches that target the same object which include a SMP `$patch: delete` directive the ordering of the patches impacts the results.

This PR adds logic to check for these directives in the patches and will automatically reorder them to prevent the delete directive from being dropped. In the case that both include delete directives the merge will now produce an error instead of silently dropping the second delete.

Fixes #1354