### PR TITLE
Simplify name reference candidate resmap building

### DIFF
--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -552,7 +552,7 @@ func (m *resWrangler) makeCopy(copier resCopier) ResMap {
 // SubsetThatCouldBeReferencedByResource implements ResMap.
 func (m *resWrangler) SubsetThatCouldBeReferencedByResource(
 	inputRes *resource.Resource) ResMap {
-	result := New()
+	result := newOne()
 	inputId := inputRes.CurId()
 	isInputIdNamespaceable := inputId.IsNamespaceableKind()
 	rctxm := inputRes.PrefixesSuffixesEquals
@@ -563,13 +563,14 @@ func (m *resWrangler) SubsetThatCouldBeReferencedByResource(
 		resId := r.CurId()
 		if (!isInputIdNamespaceable || !resId.IsNamespaceableKind() || resId.IsNsEquals(inputId)) &&
 			r.InSameKustomizeCtx(rctxm) {
-			err := result.Append(r)
-			if err != nil {
-				panic(err)
-			}
+			result.append(r)
 		}
 	}
 	return result
+}
+
+func (m *resWrangler) append(res *resource.Resource) {
+	m.rList = append(m.rList, res)
 }
 
 // AppendAll implements ResMap.


### PR DESCRIPTION
The name reference transformation process contains several nested loops that produces an exponential increase in runtime as the number of resources increases. This PR is a small start to improve the runtime of the build process for large resource counts.

Currently when the candidate resource resmap is created the objects are added using the resmap.Append method which performs additional validation that the new object does not already exist. Since we are constructing this new resmap from an existing resmap this check is not needed and can be simplified to an unchecked append to the resource list.

For a kustomization with 500 deployments the current runtime for v3.0.3 on my system is ~25 seconds
```shell
$ time kustomize_3.0.3 build 500-deployments >/dev/null
kustomize_3.0.3 build 500-deployments > /dev/null  24.24s user 0.23s system 123% cpu 19.783 total
```

With this change that runtime has dropped to below a second.
```
time ./kustomize_HEAD build 500-deployments >/dev/null
./kustomize_HEAD build 500-deployments > /dev/null  0.84s user 0.10s system 139% cpu 0.674 total
```