### PR TITLE
Allow replicas to find modified names.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -149,7 +149,6 @@ k8s.io/klog v0.3.3 h1:niceAagH1tzskmaie/icWd7ci1wbG7Bf2c6YGcQv+3c=
 k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 h1:5sW+fEHvlJI3Ngolx30CmubFulwH28DhKjGf70Xmtco=
 k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
-sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/kusttest/kusttestharness.go
+++ b/pkg/kusttest/kusttestharness.go
@@ -138,11 +138,16 @@ func (th *KustTestHarness) ErrorFromLoadAndRunTransformer(
 
 func (th *KustTestHarness) RunTransformer(
 	config, input string) (resmap.ResMap, error) {
-	transConfig, err := th.rf.RF().FromBytes([]byte(config))
+	resMap, err := th.rf.NewResMapFromBytes([]byte(input))
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
-	resMap, err := th.rf.NewResMapFromBytes([]byte(input))
+	return th.RunTransformerFromResMap(config, resMap)
+}
+
+func (th *KustTestHarness) RunTransformerFromResMap(
+	config string, resMap resmap.ResMap) (resmap.ResMap, error) {
+	transConfig, err := th.rf.RF().FromBytes([]byte(config))
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}

--- a/plugin/builtin/ReplicaCountTransformer.go
+++ b/plugin/builtin/ReplicaCountTransformer.go
@@ -34,8 +34,15 @@ func (p *ReplicaCountTransformerPlugin) Config(
 }
 
 func (p *ReplicaCountTransformerPlugin) Transform(m resmap.ResMap) error {
+
+	found := false
 	for i, replicaSpec := range p.FieldSpecs {
-		for _, res := range m.GetMatchingResourcesByOriginalId(p.createMatcher(i)) {
+		matcher := p.createMatcher(i)
+		matchOriginal := m.GetMatchingResourcesByOriginalId(matcher)
+		matchCurrent := m.GetMatchingResourcesByCurrentId(matcher)
+
+		for _, res := range append(matchOriginal, matchCurrent...) {
+			found = true
 			err := transformers.MutateField(
 				res.Map(), replicaSpec.PathSlice(),
 				replicaSpec.CreateIfNotPresent, p.addReplicas)
@@ -43,6 +50,15 @@ func (p *ReplicaCountTransformerPlugin) Transform(m resmap.ResMap) error {
 				return err
 			}
 		}
+	}
+
+	if !found {
+		gvks := make([]string, len(p.FieldSpecs))
+		for i, replicaSpec := range p.FieldSpecs {
+			gvks[i] = replicaSpec.Gvk.String()
+		}
+		return fmt.Errorf("Resource with name %s does not match a config with the following GVK %v",
+			p.Replica.Name, gvks)
 	}
 
 	return nil

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -151,3 +151,85 @@ spec:
       app: app
 `)
 }
+
+func TestMatchesCurrentID(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin("builtin", "", "PrefixSuffixTransformer")
+	tc.BuildGoPlugin("builtin", "", "ReplicaCountTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: PrefixSuffixTransformer
+metadata:
+  name: notImportantHere
+suffix: -test
+fieldSpecs:
+  - path: metadata/name
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment`)
+
+	rm, _ = th.RunTransformerFromResMap(`
+apiVersion: builtin
+kind: ReplicaCountTransformer
+metadata:
+  name: notImportantHere
+
+replica:
+  name: deployment-test
+  count: 23
+fieldSpecs:
+- path: spec/replicas
+  create: true
+  kind: Deployment`, rm)
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-test
+spec:
+  replicas: 23
+`)
+}
+
+func TestNoMatch(t *testing.T) {
+	tc := plugins_test.NewEnvForTest(t).Set()
+	defer tc.Reset()
+
+	tc.BuildGoPlugin("builtin", "", "ReplicaCountTransformer")
+
+	th := kusttest_test.NewKustTestPluginHarness(t, "/app")
+
+	err := th.ErrorFromLoadAndRunTransformer(`
+apiVersion: builtin
+kind: ReplicaCountTransformer
+metadata:
+  name: notImportantHere
+replica:
+  name: service
+  count: 3
+fieldSpecs:
+- path: spec/replicas
+  create: true
+  kind: Deployment
+`, `
+kind: Service
+metadata:
+  name: service
+spec:
+`)
+
+	if err == nil {
+		t.Fatalf("No match should return an error")
+	}
+	if err.Error() !=
+		"Resource with name service does not match a config with the following GVK [~G_~V_Deployment]" {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Fix #1399

Also allows to test for modified resmaps instead of directly loading
them.