### PR TITLE
Automatically anchor resource selector patterns

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -283,7 +283,7 @@ patches:
     group: apps
     version: v1
     kind: Deployment
-    name: deploy
+    name: deploy.*
     labelSelector: "env=dev"
     annotationSelector: "zone=west"
 - patch: |-
@@ -294,6 +294,10 @@ patches:
     kind: MyKind
     labelSelector: "env=dev"        
 ```
+
+The `name` and `namespace` fields of the patch target selector are
+automatically anchored regular expressions. This means that the value `myapp`
+is equivalent to `^myapp$`. 
 
 ### patchesStrategicMerge
 

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -650,11 +650,18 @@ func (m *resWrangler) appendReplaceOrMerge(
 	return nil
 }
 
+func anchorRegex(pattern string) string {
+	if pattern == "" {
+		return pattern
+	}
+	return "^" + pattern + "$"
+}
+
 // Select returns a list of resources that
 // are selected by a Selector
 func (m *resWrangler) Select(s types.Selector) ([]*resource.Resource, error) {
-	ns := regexp.MustCompile(s.Namespace)
-	nm := regexp.MustCompile(s.Name)
+	ns := regexp.MustCompile(anchorRegex(s.Namespace))
+	nm := regexp.MustCompile(anchorRegex(s.Name))
 	var result []*resource.Resource
 	for _, r := range m.Resources() {
 		curId := r.CurId()

--- a/pkg/resmap/selector_test.go
+++ b/pkg/resmap/selector_test.go
@@ -41,6 +41,12 @@ metadata:
     app: name3
   annotations:
     bar: baz
+---
+apiVersion: group1/v1
+kind: Kind2
+metadata:
+  name: x-name1
+  namespace: x-default
 `))
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
@@ -56,13 +62,13 @@ func TestFindPatchTargets(t *testing.T) {
 	}{
 		{
 			target: types.Selector{
-				Name: "name*",
+				Name: "name.*",
 			},
 			count: 3,
 		},
 		{
 			target: types.Selector{
-				Name:               "name*",
+				Name:               "name.*",
 				AnnotationSelector: "foo=bar",
 			},
 			count: 2,
@@ -78,7 +84,7 @@ func TestFindPatchTargets(t *testing.T) {
 				Gvk: gvk.Gvk{
 					Kind: "Kind1",
 				},
-				Name: "name*",
+				Name: "name.*",
 			},
 			count: 2,
 		},
@@ -92,7 +98,7 @@ func TestFindPatchTargets(t *testing.T) {
 			target: types.Selector{
 				Name: "",
 			},
-			count: 3,
+			count: 4,
 		},
 		{
 			target: types.Selector{
@@ -104,17 +110,59 @@ func TestFindPatchTargets(t *testing.T) {
 			target: types.Selector{
 				Namespace: "",
 			},
-			count: 3,
+			count: 4,
 		},
 		{
 			target: types.Selector{
 				Namespace: "default",
-				Name:      "name*",
+				Name:      "name.*",
 				Gvk: gvk.Gvk{
 					Kind: "Kind1",
 				},
 			},
 			count: 1,
+		},
+		{
+			target: types.Selector{
+				Name: "^name.*",
+			},
+			count: 3,
+		},
+		{
+			target: types.Selector{
+				Name: "name.*$",
+			},
+			count: 3,
+		},
+		{
+			target: types.Selector{
+				Name: "^name.*$",
+			},
+			count: 3,
+		},
+		{
+			target: types.Selector{
+				Namespace: "^def.*",
+			},
+			count: 2,
+		},
+		{
+			target: types.Selector{
+				Namespace: "def.*$",
+			},
+			count: 2,
+		},
+		{
+			target: types.Selector{
+				Namespace: "^def.*$",
+			},
+			count: 2,
+		},
+		{
+			target: types.Selector{
+				Namespace: "default",
+			},
+			count: 2,
 		},
 	}
 	for _, testcase := range testcases {


### PR DESCRIPTION
Automatically add regular expression start and end of line anchors to resmap selector patterns.

This ensures patterns provided by users must match the entire name or namespace being selected.

Related to #1409 