### PR TITLE
Fix typo in patches definition

### DIFF
--- a/plugin/builtin/PatchStrategicMergeTransformer.go
+++ b/plugin/builtin/PatchStrategicMergeTransformer.go
@@ -15,7 +15,7 @@ type PatchStrategicMergeTransformerPlugin struct {
 	rf            *resmap.Factory
 	loadedPatches []*resource.Resource
 	Paths         []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Patches       string                      `json:patches,omitempty" yaml:"patches,omitempty"`
+	Patches       string                      `json:"patches,omitempty" yaml:"patches,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
@@ -18,7 +18,7 @@ type plugin struct {
 	rf            *resmap.Factory
 	loadedPatches []*resource.Resource
 	Paths         []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Patches       string                      `json:patches,omitempty" yaml:"patches,omitempty"`
+	Patches       string                      `json:"patches,omitempty" yaml:"patches,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable


### PR DESCRIPTION
Simple typo fix: add missing `"` character.