### PR TITLE
fix wordpress example to use `bases:` instead of `resources:`

### DIFF
--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -51,7 +51,7 @@ Create a new kustomization with two bases,
 <!-- @createKustomization @test -->
 ```
 cat <<EOF >$DEMO_HOME/kustomization.yaml
-resources:
+bases:
 - wordpress
 - mysql
 namePrefix: demo-

--- a/examples/wordpress/kustomization.yaml
+++ b/examples/wordpress/kustomization.yaml
@@ -1,4 +1,4 @@
-resources:
+bases:
 - wordpress
 - mysql
 patchesStrategicMerge:


### PR DESCRIPTION
to avoid error:

```
kustomize build wordpress
Error: rawResources failed to read Resources: Load from path wordpress failed: 'wordpress' must be a file (got d='xxx/kustomize/examples/wordpress/wordpress')

```