### PR TITLE
Handle git:: prefix in urls containing _git

### DIFF
--- a/pkg/git/repospec.go
+++ b/pkg/git/repospec.go
@@ -90,7 +90,7 @@ func NewRepoSpecFromUrl(n string) (*RepoSpec, error) {
 	if filepath.IsAbs(n) {
 		return nil, fmt.Errorf("uri looks like abs path: %s", n)
 	}
-	host, orgRepo, path, gitRef, gitSuffix := parseGithubUrl(n)
+	host, orgRepo, path, gitRef, gitSuffix := parseGitUrl(n)
 	if orgRepo == "" {
 		return nil, fmt.Errorf("url lacks orgRepo: %s", n)
 	}
@@ -112,13 +112,13 @@ const (
 // From strings like git@github.com:someOrg/someRepo.git or
 // https://github.com/someOrg/someRepo?ref=someHash, extract
 // the parts.
-func parseGithubUrl(n string) (
+func parseGitUrl(n string) (
 	host string, orgRepo string, path string, gitRef string, gitSuff string) {
 
 	if strings.Contains(n, gitDelimiter) {
 		index := strings.Index(n, gitDelimiter)
 		// Adding _git/ to host
-		host = n[:index+len(gitDelimiter)]
+		host = normalizeGitHostSpec(n[:index+len(gitDelimiter)])
 		orgRepo = strings.Split(strings.Split(n[index+len(gitDelimiter):], "/")[0], "?")[0]
 		path, gitRef = peelQuery(n[index+len(gitDelimiter)+len(orgRepo):])
 		return

--- a/pkg/git/repospec_test.go
+++ b/pkg/git/repospec_test.go
@@ -187,6 +187,12 @@ func TestNewRepoSpecFromUrl_CloneSpecs(t *testing.T) {
 			absPath:   notCloned.Join("somedir"),
 			ref:       "v1.0.0",
 		},
+		{
+			input:     "git::https://itfs.mycompany.com/collection/project/_git/somerepos",
+			cloneSpec: "https://itfs.mycompany.com/collection/project/_git/somerepos",
+			absPath:   notCloned.String(),
+			ref:       "",
+		},
 	}
 	for _, testcase := range testcases {
 		rs, err := NewRepoSpecFromUrl(testcase.input)


### PR DESCRIPTION
When a git clone url contains `_git` the parsed host is not run through `normalizeGitHostSpec` which will leave a `git::` prefix in place. This PR ensures this prefix is removed for these urls.

Additionally renames `parseGithubUrl` to `parseGitUrl` to reflect that it is handling more git providers than just GitHub at this point.

Related to #1410 
