### PR TITLE
Retain replicas field in edit marshal path

### DIFF
--- a/pkg/commands/kustfile/kustomizationfile.go
+++ b/pkg/commands/kustfile/kustomizationfile.go
@@ -67,6 +67,7 @@ func determineFieldOrder() []string {
 		"GeneratorOptions",
 		"Vars",
 		"Images",
+		"Replicas",
 		"Configurations",
 		"Generators",
 		"Transformers",

--- a/pkg/commands/kustfile/kustomizationfile_test.go
+++ b/pkg/commands/kustfile/kustomizationfile_test.go
@@ -46,6 +46,7 @@ func TestFieldOrder(t *testing.T) {
 		"GeneratorOptions",
 		"Vars",
 		"Images",
+		"Replicas",
 		"Configurations",
 		"Generators",
 		"Transformers",


### PR DESCRIPTION
The `Replicas` field is missing from the kustfile.determineFieldOrder function which is causing it to be removed from the kustomization file when the edit sub-command is used.

Trivial fix to this problem by adding the missing field. Also verified this is the only current field that is missing.

Related to #1427 