### PR TITLE
add PriorityClass to the order list

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -95,6 +95,7 @@ var orderFirst = []string{
 	"Secret",
 	"Service",
 	"LimitRange",
+	"PriorityClass",
 	"Deployment",
 	"StatefulSet",
 	"CronJob",


### PR DESCRIPTION
Right now `PriorityClass` is created after pod creation. 
This can pose a problem as the given reference is missing.
> The value of such a PriorityClass is used only for Pods created after the PriorityClass is added.

So, it has to be created **before** pod creation.