### PR TITLE
Fix indirect cycle detection for git resources

### DIFF
--- a/pkg/git/cloner.go
+++ b/pkg/git/cloner.go
@@ -18,6 +18,7 @@ package git
 
 import (
 	"bytes"
+	"log"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -45,8 +46,10 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		repoSpec.Dir.String())
 	var out bytes.Buffer
 	cmd.Stdout = &out
+	cmd.Stderr = &out
 	err = cmd.Run()
 	if err != nil {
+		log.Printf("Error initializing empty git repo: %s", out.String())
 		return errors.Wrapf(
 			err,
 			"trouble initializing empty git repo in %s",
@@ -60,9 +63,11 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"origin",
 		repoSpec.CloneSpec())
 	cmd.Stdout = &out
+	cmd.Stderr = &out
 	cmd.Dir = repoSpec.Dir.String()
 	err = cmd.Run()
 	if err != nil {
+		log.Printf("Error setting git remote: %s", out.String())
 		return errors.Wrapf(
 			err,
 			"trouble adding remote %s",
@@ -78,9 +83,11 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"origin",
 		repoSpec.Ref)
 	cmd.Stdout = &out
+	cmd.Stderr = &out
 	cmd.Dir = repoSpec.Dir.String()
 	err = cmd.Run()
 	if err != nil {
+		log.Printf("Error performing git fetch: %s", out.String())
 		return errors.Wrapf(err, "trouble fetching %s", repoSpec.Ref)
 	}
 
@@ -90,9 +97,11 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"--hard",
 		"FETCH_HEAD")
 	cmd.Stdout = &out
+	cmd.Stderr = &out
 	cmd.Dir = repoSpec.Dir.String()
 	err = cmd.Run()
 	if err != nil {
+		log.Printf("Error performing git reset: %s", out.String())
 		return errors.Wrapf(
 			err, "trouble hard resetting empty repository to %s", repoSpec.Ref)
 	}

--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -179,7 +179,7 @@ func (fl *fileLoader) New(path string) (ifc.Loader, error) {
 			return nil, err
 		}
 		return newLoaderAtGitClone(
-			repoSpec, fl.validator, fl.fSys, fl.referrer, fl.cloner)
+			repoSpec, fl.validator, fl.fSys, fl, fl.cloner)
 	}
 	if filepath.IsAbs(path) {
 		return nil, fmt.Errorf("new root '%s' cannot be absolute", path)

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -329,9 +330,11 @@ func (kt *KustTarget) accumulateResources(
 				return err
 			}
 		} else {
-			err = kt.accumulateFile(ra, path)
-			if err != nil {
-				return err
+			err2 := kt.accumulateFile(ra, path)
+			if err2 != nil {
+				// Log ldr.New() error to highlight git failures.
+				log.Print(err.Error())
+				return err2
 			}
 		}
 	}


### PR DESCRIPTION
Indirect cycles (`A -> B -> A`) in git resources are not detected. 

The cycle detection isn't working in this case due to a simple bug in how the parent loader reference is setup when creating a child loader. This is fixed simply by having the parent loader pass itself rather than its own parent when setting up the child loader.

Also this type of error is currently difficult for a user to troubleshoot as the cycle detection error (as well as any other git clone related error) is not included in the output. Adds logging of the loader error in the case that falling back to direct file loading fails as well as logging git binary output on errors.

Resolves #1447 