### PR TITLE
Delete tmp directory on clone failure

### DIFF
--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -204,7 +204,7 @@ func newLoaderAtGitClone(
 	repoSpec *git.RepoSpec,
 	v ifc.Validator, fSys fs.FileSystem,
 	referrer *fileLoader, cloner git.Cloner) (ifc.Loader, error) {
-	err := cloner(repoSpec)
+	err := cloner(repoSpec, fSys)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously:
```
$ ls $TMPDIR | grep kustomize | wc -l
    11
$ ./kustomize build git@github.com:jrab89/not-a-repo.git
Error: trouble fetching master: exit status 128
$ ls $TMPDIR | grep kustomize | wc -l
    12
```

With this PR:
```
$ ls $TMPDIR | grep kustomize | wc -l
    12
$ ./kustomize build git@github.com:jrab89/not-a-repo.git
Error: trouble fetching master: exit status 128
$ ls $TMPDIR | grep kustomize | wc -l
    12
```
Fixes #1076