### PR TITLE
Fixes to create sub-command

### DIFF
--- a/pkg/commands/create/create.go
+++ b/pkg/commands/create/create.go
@@ -63,12 +63,12 @@ func NewCmdCreate(fSys fs.FileSystem, uf ifc.KunstructuredFactory) *cobra.Comman
 		"Set the value of the namespace field in the customization file.")
 	c.Flags().StringVar(
 		&opts.annotations,
-		"annotation",
+		"annotations",
 		"",
 		"Add one or more common annotations.")
 	c.Flags().StringVar(
 		&opts.labels,
-		"label",
+		"labels",
 		"",
 		"Add one or more common labels.")
 	c.Flags().StringVar(
@@ -95,11 +95,15 @@ func NewCmdCreate(fSys fs.FileSystem, uf ifc.KunstructuredFactory) *cobra.Comman
 }
 
 func runCreate(opts createFlags, fSys fs.FileSystem, uf ifc.KunstructuredFactory) error {
-	resources, err := util.GlobPatterns(fSys, strings.Split(opts.resources, ","))
-	if err != nil {
-		return err
+	var resources []string
+	var err error
+	if opts.resources != "" {
+		resources, err = util.GlobPatterns(fSys, strings.Split(opts.resources, ","))
+		if err != nil {
+			return err
+		}
 	}
-	if _, err := kustfile.NewKustomizationFile(fSys); err == nil {
+	if _, err = kustfile.NewKustomizationFile(fSys); err == nil {
 		return fmt.Errorf("kustomization file already exists")
 	}
 	if opts.detectResources {

--- a/pkg/commands/create/create_test.go
+++ b/pkg/commands/create/create_test.go
@@ -132,6 +132,12 @@ metadata:
 	fakeFS.WriteFile("/README.md", []byte(`
 # Not a k8s resource
 This file is not a valid kubernetes object.`))
+	fakeFS.WriteFile("/non-k8s.yaml", []byte(`
+# Not a k8s resource
+other: yaml
+foo:
+- bar
+- baz`))
 	fakeFS.Mkdir("/sub")
 	fakeFS.WriteFile("/sub/test.yaml", []byte(`
 apiVersion: v1
@@ -141,6 +147,12 @@ metadata:
 	fakeFS.WriteFile("/sub/README.md", []byte(`
 # Not a k8s resource
 This file in a subdirectory is not a valid kubernetes object.`))
+	fakeFS.WriteFile("/sub/non-k8s.yaml", []byte(`
+# Not a k8s resource
+other: yaml
+foo:
+- bar
+- baz`))
 	fakeFS.Mkdir("/overlay")
 	fakeFS.WriteFile("/overlay/test.yaml", []byte(`
 apiVersion: v1

--- a/pkg/commands/util/util.go
+++ b/pkg/commands/util/util.go
@@ -33,6 +33,9 @@ func GlobPatterns(fsys fs.FileSystem, patterns []string) ([]string, error) {
 // `key:value` into a map.
 func ConvertToMap(input string, kind string) (map[string]string, error) {
 	result := make(map[string]string)
+	if input == "" {
+		return result, nil
+	}
 	inputs := strings.Split(input, ",")
 	for _, input := range inputs {
 		c := strings.Index(input, ":")


### PR DESCRIPTION
PR #1414 introduced a new `create` subcommand. Unfortunately a few minor issues with the command came along for the ride.

Inconsistent pluralization in the flags for setting commandLabels and commonAnnotiations.

`--resources` vs `--label` and `--annotation`.

Running with out `--resources` set will trigger a useless and confusing log message from `util.GlobPatterns`.

```shell
kustomize create
2019/08/21 08:27:21  has no match
```

Running without `--label` or `--annotation` will produce erroneous values of for their relevant fields.

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
commonAnnotations:
  "": ""
commonLabels:
  "": ""
```

Also adds a non-k8s object YAML file to the detect resources test to ensure the detection logic doesn't include them in the resources slice.