### PR TITLE
properly omitempty for 'inventory' in 'kustomize'

### DIFF
--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -139,7 +139,7 @@ type Kustomization struct {
 
 	// Inventory appends an object that contains the record
 	// of all other objects, which can be used in apply, prune and delete
-	Inventory *Inventory `json:"inventory,omitempty" yaml:"inventory:omitempty"`
+	Inventory *Inventory `json:"inventory,omitempty" yaml:"inventory,omitempty"`
 }
 
 //go:generate stringer -type=GarbagePolicy


### PR DESCRIPTION
With the current 'yaml:"inventory:omitempty"', 'inventory:omitempty' is used as the literal name for the yaml field.

I'm pretty sure this is just a typo.