### PR TITLE
Consider also currentId when replacing/merging resources

### DIFF
--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -603,8 +603,10 @@ func (m *resWrangler) AbsorbAll(other ResMap) error {
 func (m *resWrangler) appendReplaceOrMerge(
 	res *resource.Resource) error {
 	id := res.CurId()
-	// Maybe also try by current id if nothing matches?
 	matches := m.GetMatchingResourcesByOriginalId(id.Equals)
+	if len(matches) == 0 {
+		matches = m.GetMatchingResourcesByCurrentId(id.Equals)
+	}
 	switch len(matches) {
 	case 0:
 		switch res.Behavior() {


### PR DESCRIPTION
When merging resources such as the output of a `configMapGenerator`, we need to consider the `CurrentId`, otherwise, we cannot extend a common base definition twice by adding different prefixes, and then further kustomize them.

This fixes #1442.