### PR TITLE
Simplify escaping of characters in CRD example readme

### DIFF
--- a/examples/transformerconfigs/crd/README.md
+++ b/examples/transformerconfigs/crd/README.md
@@ -77,11 +77,11 @@ spec:
     name: crdsecret
   beeRef:
     name: bee
-    action: \$(BEE_ACTION)
+    action: $(BEE_ACTION)
   containers:
   - command:
     - "echo"
-    - "\$(BEE_ACTION)"
+    - "$(BEE_ACTION)"
     image: myapp
 EOF
 ```


### PR DESCRIPTION
Without this fix, I kept getting
```
kustomize build 
Error: accumulating resources: accumulating resources from 'resources.yaml': YAML file [resources.yaml] encounters a format error.
error converting YAML to JSON: yaml: line 14: found unknown escape character
```