### PR TITLE
Add test for name conflict with base reuse

### DIFF
--- a/pkg/target/basereusenameprefix_test.go
+++ b/pkg/target/basereusenameprefix_test.go
@@ -42,26 +42,26 @@ import (
 func TestBaseReuseNameConflict(t *testing.T) {
 	th := kusttest_test.NewKustTestHarness(t, "/app")
 	th.WriteK("/app/component1/base", `
-bases:
+resources:
   - ../../shared
 
 namePrefix: component1-
 `)
 	th.WriteK("/app/component1/overlay", `
-bases:
+resources:
   - ../base
 
 namePrefix: overlay-
 `)
 
 	th.WriteK("/app/component2/base", `
-bases:
+resources:
   - ../../shared
 
 namePrefix: component2-
 `)
 	th.WriteK("/app/component2/overlay", `
-bases:
+resources:
   - ../base
 
 namePrefix: overlay-
@@ -112,7 +112,7 @@ spec:
 `)
 
 	th.WriteK("/app", `
-bases:
+resources:
   - component1/overlay
   - component2/overlay
 `)

--- a/pkg/target/basereusenameprefix_test.go
+++ b/pkg/target/basereusenameprefix_test.go
@@ -1,0 +1,199 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
+)
+
+// Here is a structure of a kustomization of two components, component1
+// and component2, that both use a shared postgres definition, which
+// they would individually adjust. This test case checks that the name
+// prefix does not cause a name reference conflict.
+//
+//                   root
+//              /            \
+//  component1/overlay  component2/overlay
+//             |              |
+//    component1/base    component2/base
+//              \            /
+//                   base
+//
+// This is the directory layout:
+//
+// ├── component1
+// │   ├── base
+// │   │   └── kustomization.yaml
+// │   └── overlay
+// │       └── kustomization.yaml
+// ├── component2
+// │   ├── base
+// │   │   └── kustomization.yaml
+// │   └── overlay
+// │       └── kustomization.yaml
+// ├── shared
+// │   ├── kustomization.yaml
+// │   └── resources.yaml
+// ├── kustomization.yaml
+
+func TestBaseReuseNameConflict(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app")
+	th.WriteK("/app/component1/base", `
+bases:
+  - ../../shared
+
+namePrefix: component1-
+`)
+	th.WriteK("/app/component1/overlay", `
+bases:
+  - ../base
+
+namePrefix: overlay-
+`)
+
+	th.WriteK("/app/component2/base", `
+bases:
+  - ../../shared
+
+namePrefix: component2-
+`)
+	th.WriteK("/app/component2/overlay", `
+bases:
+  - ../base
+
+namePrefix: overlay-
+`)
+
+	th.WriteK("/app/shared", `
+resources:
+  - resources.yaml
+`)
+	th.WriteF("/app/shared/resources.yaml", `
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgres
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels: {}
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+        - name: postgres
+          image: postgres
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /var/lib/postgresql
+              name: data
+          ports:
+            - name: postgres
+              containerPort: 5432
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres
+`)
+
+	th.WriteK("/app", `
+bases:
+  - component1/overlay
+  - component2/overlay
+`)
+
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: overlay-component1-postgres
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overlay-component1-postgres
+spec:
+  selector:
+    matchLabels: {}
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - image: postgres
+        imagePullPolicy: IfNotPresent
+        name: postgres
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - mountPath: /var/lib/postgresql
+          name: data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: overlay-component1-postgres
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: overlay-component2-postgres
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overlay-component2-postgres
+spec:
+  selector:
+    matchLabels: {}
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - image: postgres
+        imagePullPolicy: IfNotPresent
+        name: postgres
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - mountPath: /var/lib/postgresql
+          name: data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: overlay-component2-postgres
+`)
+}


### PR DESCRIPTION
Add test case for #800: name reference conflicts when reusing the same base from two overlays, and then use those as bases again.

(The shared resource definition might contain more lines than necessary, but the problem does only occur when where is a reference between the Deployment and the PersistentVolumeClaim. Also, this give a bit of context about the real world usecase.)