### PR TITLE
Do not prefix/suffix APIService resources

### DIFF
--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -32,6 +32,9 @@ var prefixSuffixFieldSpecsToSkip = []config.FieldSpec{
 	{
 		Gvk: gvk.Gvk{Kind: "CustomResourceDefinition"},
 	},
+	{
+		Gvk: gvk.Gvk{Group: "apiregistration.k8s.io", Kind: "APIService"},
+	},
 }
 
 func (p *plugin) Config(

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -41,6 +41,11 @@ kind: CustomResourceDefinition
 metadata:
   name: crd
 ---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -60,6 +65,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -95,6 +105,11 @@ kind: CustomResourceDefinition
 metadata:
   name: crd
 ---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -117,6 +132,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Same as for CRDs, APIService resources should not be prefixed/suffixed.