### PR TITLE
Need to rerun make generate-code when changing a built-in plugin

### DIFF
--- a/plugin/builtin/PrefixSuffixTransformer.go
+++ b/plugin/builtin/PrefixSuffixTransformer.go
@@ -26,6 +26,9 @@ var prefixSuffixFieldSpecsToSkip = []config.FieldSpec{
 	{
 		Gvk: gvk.Gvk{Kind: "CustomResourceDefinition"},
 	},
+	{
+		Gvk: gvk.Gvk{Group: "apiregistration.k8s.io", Kind: "APIService"},
+	},
 }
 
 func (p *PrefixSuffixTransformerPlugin) Config(


### PR DESCRIPTION
Pull request #1526 which hard-code the prefix/suffix transformer handling of APIService is incomplete.