### PR TITLE
add note about GO111MODULE for source install

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,8 +30,11 @@ Requires [Go] v1.12 or higher:
 go install sigs.k8s.io/kustomize/v3/cmd/kustomize
 ```
 
-**NOTE**: The above uses a versioned import path. You will need to run the
-above with `GO111MODULE=on`.
+> With [Go v1.12](https://golang.org/doc/go1.12#modules), prefix the above command with `GO111MODULE=on`, e.g.
+> ```
+> GO111MODULE=on go install sigs.k8s.io/kustomize/v3/cmd/kustomize
+> ```
+> This shouldn't be necessary with [Go v1.13](https://golang.org/doc/go1.13#modules).
 
 ### Other methods
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,6 +30,9 @@ Requires [Go] v1.12 or higher:
 go install sigs.k8s.io/kustomize/v3/cmd/kustomize
 ```
 
+**NOTE**: The above uses a versioned import path. You will need to run the
+above with `GO111MODULE=on`.
+
 ### Other methods
 
 #### macOS


### PR DESCRIPTION
It's not immediately obvious that in order to
get the `go install sigs.k8s.io/kustomize/v3/cmd/kustomize` instructions
to work successfully, you need to have `GO111MODULE=on` set, so I added
a note about that.

Issues #1536, #1314