### PR TITLE
Update Ingress apiVersion to networking.k8s.io/v1beta1

### DIFF
--- a/examples/jsonpatch.md
+++ b/examples/jsonpatch.md
@@ -16,7 +16,7 @@ resources:
 EOF
 
 cat <<EOF >$DEMO_HOME/ingress.yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -72,7 +72,7 @@ Apply the patch by adding _patchesJson6902_ field in kustomization.yaml
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
 patchesJson6902:
 - target:
-    group: extensions
+    group: networking.k8s.io
     version: v1beta1
     kind: Ingress
     name: my-ingress
@@ -102,7 +102,7 @@ If the patch is YAML-formatted, it will be parsed correctly:
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
 patchesJson6902:
 - target:
-    group: extensions
+    group: networking.k8s.io
     version: v1beta1
     kind: Ingress
     name: my-ingress

--- a/examples/zh/jsonpatch.md
+++ b/examples/zh/jsonpatch.md
@@ -16,7 +16,7 @@ resources:
 EOF
 
 cat <<EOF >$DEMO_HOME/ingress.yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -72,7 +72,7 @@ EOF
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
 patchesJson6902:
 - target:
-    group: extensions
+    group: networking.k8s.io
     version: v1beta1
     kind: Ingress
     name: my-ingress
@@ -106,7 +106,7 @@ test 1 == \
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
 patchesJson6902:
 - target:
-    group: extensions
+    group: networking.k8s.io
     version: v1beta1
     kind: Ingress
     name: my-ingress

--- a/pkg/target/variableref_test.go
+++ b/pkg/target/variableref_test.go
@@ -987,7 +987,7 @@ spec:
           containerPort: 80
 `)
 	th.WriteF("/app/base/ingress.yaml", `
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx
@@ -1066,7 +1066,7 @@ spec:
         - containerPort: 80
           name: http
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   labels:

--- a/pkg/transformers/namereference_test.go
+++ b/pkg/transformers/namereference_test.go
@@ -52,7 +52,7 @@ func TestNameReferenceHappyRun(t *testing.T) {
 			},
 		}).Add(
 		map[string]interface{}{
-			"group":      "extensions",
+			"group":      "networking.k8s.io",
 			"apiVersion": "v1beta1",
 			"kind":       "Ingress",
 			"metadata": map[string]interface{}{
@@ -375,7 +375,7 @@ func TestNameReferenceHappyRun(t *testing.T) {
 			},
 		}).ReplaceResource(
 		map[string]interface{}{
-			"group":      "extensions",
+			"group":      "networking.k8s.io",
 			"apiVersion": "v1beta1",
 			"kind":       "Ingress",
 			"metadata": map[string]interface{}{


### PR DESCRIPTION
Official Kubernetes Ingress documentation changed from extensions to networking.k8s.io in Kubernetes 1.14.

This PR updated the Ingress related examples for Kustomize to match that change. 