### PR TITLE
Fix typo yaml declaration of APIVersion field of Kustomization type

### DIFF
--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -17,7 +17,7 @@ const (
 // No need for a direct dependence; the fields are stable.
 type TypeMeta struct {
 	Kind       string `json:"kind,omitempty" yaml:"kind,omitempty"`
-	APIVersion string `json:"apiVersion,omitempty" yaml:"apiversion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
 
 // Kustomization holds the information needed to generate customized k8s api resources.


### PR DESCRIPTION
The yaml field of the kustomization.yaml should be apiVersion but is declared as apiversion.

This particular annotations doesn't seem to be used. Even the commands (edit, ..create) command do not use it and marshall generic map[string]interface{} into yaml files.
