### PR TITLE
Fix compile kustomize example.

### DIFF
--- a/docs/plugins/goPluginCaveats.md
+++ b/docs/plugins/goPluginCaveats.md
@@ -52,8 +52,8 @@ kustomize and the plugin_.
 
 This means a one-time run of
 ```
-GOPATH=${whatever} go get \
-    sigs.k8s.io/kustomize/cmd/kustomize@${releaseVersion}
+GOPATH=${whatever} GO111MODULE=on go get \
+    sigs.k8s.io/kustomize/v3/cmd/kustomize@${releaseVersion}
 ```
 
 and then a normal development cycle using

--- a/docs/plugins/goPluginCaveats.md
+++ b/docs/plugins/goPluginCaveats.md
@@ -52,8 +52,7 @@ kustomize and the plugin_.
 
 This means a one-time run of
 ```
-GOPATH=${whatever} GO111MODULE=on go get \
-    sigs.k8s.io/kustomize/v3/cmd/kustomize@${releaseVersion}
+GOPATH=${whatever} GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3
 ```
 
 and then a normal development cycle using


### PR DESCRIPTION
I was running into #1234 and found the documentation didn't work for me.

I added `GO111MODULE=on` to fix an error:
```
go: cannot use path@version syntax in GOPATH mode
```

and corrected the module URL (added `v3`).