### PR TITLE
add replacements field

### DIFF
--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -79,6 +79,11 @@ type Kustomization struct {
 	// value of the specified field has been determined.
 	Vars []Var `json:"vars,omitempty" yaml:"vars,omitempty"`
 
+	// Replacements defines substitutions including source and destinations.
+	// It is used to inject a field from one Kubernetes resource into another Kubernetes
+	// resources. It can also inject a literal string into a Kubernetes resources.
+	Replacements []Replacement `json:"replacements,omitempty" yaml:"replacements,omitempty"`
+
 	//
 	// Operands - what kustomize operates on.
 	//

--- a/pkg/types/replacement.go
+++ b/pkg/types/replacement.go
@@ -1,0 +1,27 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// Replacement defines how to perform a substitution
+// where it is from and where it is to.
+type Replacement struct {
+	From *From `json:"from" yaml:"from"`
+	To   *To   `json:"To" yaml:"to"`
+}
+
+// From defines where a substitution is from
+// It can from two different kinds of sources
+//  - from a field of one resource
+//  - from a string
+type From struct {
+	ObjRef   *Target `json:"objref,omitempty" yaml:"objref,omitempty"`
+	FieldRef string  `json:"fieldref,omitempty" yaml:"fiedldref,omitempty"`
+	Value    string  `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+// To defines where a substitution is to.
+type To struct {
+	Target    *Selector `json:"target,omitempty" yaml:"target,omitempty"`
+	FieldRefs []string  `json:"fieldrefs,omitempty" yaml:"fieldrefs,omitempty"`
+}


### PR DESCRIPTION
The replacement fields is to support substitution
- Both the source and destination need to be specified in kustomization.yaml
- The source can be from a fieldref of one resource
- The source can be from a literal value as well
- The destination has a `Target` and a list of `fieldrefs`, where `Target` uses `Selector` to filter targets, which is also used in the patches for multi objects.

Example:
```
replacements:
  - from:
      value: nginx:newtag
    to:
      target:
        kind: Deployment
      fieldrefs:
        - spec.template.spec.containers[name=nginx].image
  - from:
      value: busybox:latest
    to:
      target:
        kind: Deployment
      fieldrefs:
        - spec.template.spec.containers.1.image
  - from:
      objref:
        kind: Deployment
        name: deploy
      fieldref: spec.template.spec.containers
    to:
      target:
        kind: Deployment
        name: deploy2
      fieldrefs:
      - spec.template.spec.containers
```