### PR TITLE
Move pluginator to kustomize Go API v3.3.0

### DIFF
--- a/pluginator/go.mod
+++ b/pluginator/go.mod
@@ -2,4 +2,4 @@ module sigs.k8s.io/kustomize/pluginator
 
 go 1.12
 
-require sigs.k8s.io/kustomize/v3 v3.2.0
+require sigs.k8s.io/kustomize/v3 v3.3.0

--- a/pluginator/go.sum
+++ b/pluginator/go.sum
@@ -33,6 +33,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1/YsqVWoWNLQO+fusocsw354rqGTZtAgw=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.6+incompatible h1:tfrHha8zJ01ywiOEC1miGY8st1/igzWB8OmvPgoYX7w=
 github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -152,6 +153,7 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63 h1:nTT4s92Dgz2HlrB2NaMgvlfqHH39OgMhA7z3PK7PGD4=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190620125010-da37f6c1e481 h1:IaSjLMT6WvkoZZjspGxy3rdaTEmWLoRm49WbtVUi9sA=
 github.com/mailru/easyjson v0.0.0-20190620125010-da37f6c1e481/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matoous/godox v0.0.0-20190910121045-032ad8106c86/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -358,6 +360,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 sigs.k8s.io/kustomize/pluginator v1.0.0/go.mod h1:i8HdU5FdH1zDjCKiFf5CNl7slsc0QffyKsY2OuPynJ0=
 sigs.k8s.io/kustomize/v3 v3.2.0/go.mod h1:ztX4zYc/QIww3gSripwF7TBOarBTm5BvyAMem0kCzOE=
+sigs.k8s.io/kustomize/v3 v3.3.0 h1:xonXqm4Lpd17zGrLXX/3t81KeWNQIU/++Wo8LQohRns=
+sigs.k8s.io/kustomize/v3 v3.3.0/go.mod h1:STVEDXXV/PoFIQPMI8uVcrYME/YnMIp1+lyBnK4xgik=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -190,9 +190,9 @@ requires.
 # Update the following as needed, obviously.
 
 if [ "$module" != "api" ]; then
-  go mod edit -dropreplace=sigs.k8s.io/kustomize/v3    $module/go.mod
-  go mod edit -require=sigs.k8s.io/kustomize/v4@v4.0.1 $module/go.mod
-  git commit -a -m "Drop API module replacement"
+  # go mod edit -dropreplace=sigs.k8s.io/kustomize/v3    $module/go.mod
+  # go mod edit -require=sigs.k8s.io/kustomize/v4@v4.0.1 $module/go.mod
+  # git commit -a -m "Drop API module replacement"
 fi
 ```
 
@@ -222,7 +222,7 @@ git ls-remote --tags upstream
 ### define the release tag
 
 ```
-tag="v${major}.v${minor}.${patch}"
+tag="v${major}.${minor}.${patch}"
 if [ "$module" != "api" ]; then
   # must prefix the tag with submodule name
   tag="${module}/${tag}"

--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -56,16 +56,13 @@ EOF
   pluginator)
     cat <<EOF >>$config
 builds:
-- main: ./main.go
-  binary: pluginator
+- binary: pluginator
   goos:
   - linux
   - darwin
   - windows
   goarch:
    - amd64
-archive:
-  format: binary
 EOF
     ;;
   *)

--- a/releasing/localbuild.sh
+++ b/releasing/localbuild.sh
@@ -74,5 +74,5 @@ cloud-build-local \
 echo " "
 echo "Result of local build:"
 echo "##########################################"
-tree ./kustomize/dist
+tree ./$module/dist
 echo "##########################################"


### PR DESCRIPTION
After this, we'll introduce tag `pluginator/v1.0.1` since this is just a patch, with no change in pluginator behavior.

