### PR TITLE
cleanup on errors in git loader

### DIFF
--- a/pkg/loader/fileloader.go
+++ b/pkg/loader/fileloader.go
@@ -204,12 +204,15 @@ func newLoaderAtGitClone(
 	repoSpec *git.RepoSpec,
 	v ifc.Validator, fSys fs.FileSystem,
 	referrer *fileLoader, cloner git.Cloner) (ifc.Loader, error) {
+	cleaner := repoSpec.Cleaner(fSys)
 	err := cloner(repoSpec)
 	if err != nil {
+		cleaner()
 		return nil, err
 	}
 	root, f, err := fSys.CleanedAbs(repoSpec.AbsPath())
 	if err != nil {
+		cleaner()
 		return nil, err
 	}
 	// We don't know that the path requested in repoSpec
@@ -217,6 +220,7 @@ func newLoaderAtGitClone(
 	// inside.  That just happened, hence the error check
 	// is here.
 	if f != "" {
+		cleaner()
 		return nil, fmt.Errorf(
 			"'%s' refers to file '%s'; expecting directory",
 			repoSpec.AbsPath(), f)
@@ -230,7 +234,7 @@ func newLoaderAtGitClone(
 		repoSpec:       repoSpec,
 		fSys:           fSys,
 		cloner:         cloner,
-		cleaner:        repoSpec.Cleaner(fSys),
+		cleaner:        cleaner,
 	}, nil
 }
 


### PR DESCRIPTION
Temporary directories created during git clone were not being cleaned up if [newLoaderAtGitClone](https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/loader/fileloader.go#L203) returns an error.

This builds on what was done in https://github.com/kubernetes-sigs/kustomize/pull/1457.

Fixes https://github.com/kubernetes-sigs/kustomize/issues/1076