### PR TITLE
Update broken URL in Exec Plugin Tutorial

### DIFF
--- a/docs/plugins/execPluginGuidedExample.md
+++ b/docs/plugins/execPluginGuidedExample.md
@@ -201,7 +201,7 @@ chmod a+x $MY_PLUGIN_DIR/SillyConfigMapGenerator
 ```
 mkdir -p $DEMO/bin
 gh=https://github.com/kubernetes-sigs/kustomize/releases/download
-url=$gh/v3.0.0-pre/kustomize_3.0.0-pre_linux_amd64
+url=$gh/v3.0.0/kustomize_3.0.0_linux_amd64
 curl -o $DEMO/bin/kustomize -L $url
 chmod u+x $DEMO/bin/kustomize
 ```


### PR DESCRIPTION
- link created in the scripts of [Exec plugin on linux in 60 seconds](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/plugins/execPluginGuidedExample.md) to download the kustomize executable does not work
- used the [releases page](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.0.0) to fix