### PR TITLE
Remove minecraft version check from chart plugin tests.

### DIFF
--- a/pkg/kusttest/kusttestharness.go
+++ b/pkg/kusttest/kusttestharness.go
@@ -196,6 +196,11 @@ func hint(a, b string) string {
 
 func (th *KustTestHarness) AssertActualEqualsExpected(
 	m resmap.ResMap, expected string) {
+	th.AssertActualEqualsExpectedWithTweak(m, nil, expected)
+}
+
+func (th *KustTestHarness) AssertActualEqualsExpectedWithTweak(
+	m resmap.ResMap, tweaker func([]byte) []byte, expected string) {
 	if m == nil {
 		th.t.Fatalf("Map should not be nil.")
 	}
@@ -207,6 +212,9 @@ func (th *KustTestHarness) AssertActualEqualsExpected(
 	actual, err := m.AsYaml()
 	if err != nil {
 		th.t.Fatalf("Unexpected err: %v", err)
+	}
+	if tweaker != nil {
+		actual = tweaker(actual)
 	}
 	if string(actual) != expected {
 		th.reportDiffAndFail(actual, expected)

--- a/pkg/target/chartinflatorplugin_test.go
+++ b/pkg/target/chartinflatorplugin_test.go
@@ -8,9 +8,10 @@
 package target_test
 
 import (
+	"regexp"
 	"testing"
 
-	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
@@ -53,7 +54,11 @@ chartName: minecraft
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
-	th.AssertActualEqualsExpected(m, `
+	chartName := regexp.MustCompile("chart: minecraft-[0-9.]+")
+	th.AssertActualEqualsExpectedWithTweak(m,
+		func(x []byte) []byte {
+			return chartName.ReplaceAll(x, []byte("chart: minecraft-SOMEVERSION"))
+		}, `
 apiVersion: v1
 data:
   rcon-password: Q0hBTkdFTUUh
@@ -61,7 +66,7 @@ kind: Secret
 metadata:
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: LOOOOOOOONG-release-name-minecraft
@@ -74,7 +79,7 @@ metadata:
     volume.alpha.kubernetes.io/storage-class: default
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: LOOOOOOOONG-release-name-minecraft-datadir
@@ -90,7 +95,7 @@ kind: Service
 metadata:
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: LOOOOOOOONG-release-name-minecraft

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -8,6 +8,7 @@
 package main_test
 
 import (
+	"regexp"
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
@@ -34,7 +35,11 @@ metadata:
   name: notImportantHere
 chartName: minecraft`)
 
-	th.AssertActualEqualsExpected(m, `
+	chartName := regexp.MustCompile("chart: minecraft-[0-9.]+")
+	th.AssertActualEqualsExpectedWithTweak(m,
+		func(x []byte) []byte {
+			return chartName.ReplaceAll(x, []byte("chart: minecraft-SOMEVERSION"))
+		}, `
 apiVersion: v1
 data:
   rcon-password: Q0hBTkdFTUUh
@@ -42,7 +47,7 @@ kind: Secret
 metadata:
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: release-name-minecraft
@@ -55,7 +60,7 @@ metadata:
     volume.alpha.kubernetes.io/storage-class: default
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: release-name-minecraft-datadir
@@ -71,7 +76,7 @@ kind: Service
 metadata:
   labels:
     app: release-name-minecraft
-    chart: minecraft-1.1.2
+    chart: minecraft-SOMEVERSION
     heritage: Tiller
     release: release-name
   name: release-name-minecraft


### PR DESCRIPTION
remove version dependent code from tests in the chart inflator