### PR TITLE
Start pluglib, a set of public, plugin specific functions.

### DIFF
--- a/k8sdeps/kunstruct/kunstruct.go
+++ b/k8sdeps/kunstruct/kunstruct.go
@@ -20,7 +20,7 @@ package kunstruct
 import (
 	"encoding/json"
 	"fmt"
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/k8sdeps/transformer/patch/conflictdetector.go
+++ b/k8sdeps/transformer/patch/conflictdetector.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"

--- a/pkg/plugins/compiler.go
+++ b/pkg/plugins/compiler.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package plugins
 
@@ -50,7 +37,6 @@ func DefaultSrcRoot() (string, error) {
 		os.Getenv("GOPATH"), "src",
 		pgmconfig.DomainName,
 		pgmconfig.ProgramName, pgmconfig.PluginRoot)
-
 	if FileExists(root) {
 		return root, nil
 	}

--- a/pkg/plugins/execplugin_test.go
+++ b/pkg/plugins/execplugin_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package plugins
 
@@ -60,7 +47,7 @@ s/$BAR/bar/g
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	p.Config(ldr, rf, yaml)
+	p.Config(resmap.NewPluginHelpers(ldr, rf), yaml)
 
 	expected := "/kustomize/plugin/someteam.example.com/v1/sedtransformer/SedTransformer"
 	if !strings.HasSuffix(p.path, expected) {

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -123,7 +123,7 @@ func (l *Loader) loadAndConfigurePlugin(
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshalling yaml from res %s", res.OrgId())
 	}
-	err = c.Config(ldr, l.rf, yaml)
+	err = c.Config(resmap.NewPluginHelpers(ldr, l.rf), yaml)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "plugin %s fails configuration", res.OrgId())

--- a/pkg/plugins/loader_test.go
+++ b/pkg/plugins/loader_test.go
@@ -6,10 +6,11 @@ package plugins_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/internal/loadertest"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	. "sigs.k8s.io/kustomize/v3/pkg/plugins"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 )
@@ -42,7 +43,7 @@ port: "12345"
 )
 
 func TestLoader(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -30,14 +30,32 @@ type Generator interface {
 	Generate() (ResMap, error)
 }
 
-// Something that's configurable accepts a config
-// object (typically YAML in []byte form), and an
-// ifc.Loader to possible read more configuration
-// from the file system (e.g. patch files) and
-// a resource factory to build any type-sensitive
-// parts.  The factory could probably be factored out.
+// Something that's configurable accepts an
+// instance of PluginHelpers and a raw config
+// object (YAML in []byte form).
 type Configurable interface {
-	Config(ldr ifc.Loader, rf *Factory, config []byte) error
+	Config(h *PluginHelpers, config []byte) error
+}
+
+// NewPluginHelpers makes an instance of PluginHelpers.
+func NewPluginHelpers(ldr ifc.Loader, rf *Factory) *PluginHelpers {
+	return &PluginHelpers{ldr: ldr, rf: rf}
+}
+
+// PluginHelpers holds things that any or all plugins might need.
+// This should be available to each plugin, in addition to
+// any plugin-specific configuration.
+type PluginHelpers struct {
+	ldr ifc.Loader
+	rf  *Factory
+}
+
+func (c *PluginHelpers) Loader() ifc.Loader {
+	return c.ldr
+}
+
+func (c *PluginHelpers) ResmapFactory() *Factory {
+	return c.rf
 }
 
 type GeneratorPlugin interface {

--- a/pkg/target/chartinflatorplugin_test.go
+++ b/pkg/target/chartinflatorplugin_test.go
@@ -11,8 +11,9 @@ import (
 	"regexp"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 // This is an example of using a helm chart as a base,
@@ -29,7 +30,7 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflatorPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/pkg/target/customconfigofbuiltinplugin_test.go
+++ b/pkg/target/customconfigofbuiltinplugin_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
+	"sigs.k8s.io/kustomize/v3/pluglib"
 )
 
 // Demo custom configuration of a builtin transformation.
 // This is a NamePrefixer that only touches Deployments
 // and Services.
 func TestCustomNamePrefixer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -103,7 +103,7 @@ metadata:
 
 // Demo custom configuration as a base.
 func TestReusableCustomNamePrefixer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/target/diamondcomposition_test.go
+++ b/pkg/target/diamondcomposition_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
+	"sigs.k8s.io/kustomize/v3/pluglib"
 )
 
 const patchAddProbe = `
@@ -340,7 +340,7 @@ patchesStrategicMerge:
 }
 
 func TestIssue1251_Plugins_ProdVsDev(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -380,7 +380,7 @@ transformers:
 }
 
 func TestIssue1251_Plugins_Local(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -430,7 +430,7 @@ jsonOp: '%s'
 
 // Remote in the sense that they are bundled in a different kustomization.
 func TestIssue1251_Plugins_Bundled(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/target/inlinepatch_test.go
+++ b/pkg/target/inlinepatch_test.go
@@ -4,8 +4,9 @@
 package target_test
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 )
 
 func makeResourcesForPatchTest(th *kusttest_test.KustTestHarness) {

--- a/pkg/target/kusttarget.go
+++ b/pkg/target/kusttarget.go
@@ -377,7 +377,7 @@ func (kt *KustTarget) configureBuiltinPlugin(
 				err, "builtin %s marshal", bpt)
 		}
 	}
-	err = p.Config(kt.ldr, kt.rFactory, y)
+	err = p.Config(resmap.NewPluginHelpers(kt.ldr, kt.rFactory), y)
 	if err != nil {
 		return errors.Wrapf(err, "builtin %s config: %v", bpt, y)
 	}

--- a/pkg/target/namespaces_test.go
+++ b/pkg/target/namespaces_test.go
@@ -4,9 +4,10 @@
 package target_test
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 )
 
 func TestNamespacedSecrets(t *testing.T) {

--- a/pkg/target/plugindir_test.go
+++ b/pkg/target/plugindir_test.go
@@ -9,13 +9,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/filesys"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/plugins"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
@@ -23,7 +24,7 @@ import (
 )
 
 func TestPluginDir(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/pkg/target/transformerplugin_test.go
+++ b/pkg/target/transformerplugin_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
+	"sigs.k8s.io/kustomize/v3/pluglib"
 )
 
 func writeDeployment(th *kusttest_test.KustTestHarness, path string) {
@@ -50,7 +50,7 @@ metadata:
 }
 
 func TestOrderedTransformers(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -96,7 +96,7 @@ spec:
 }
 
 func TestPluginsNotEnabled(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -119,7 +119,7 @@ transformers:
 }
 
 func TestSedTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
@@ -187,7 +187,7 @@ metadata:
 }
 
 func TestTransformedTransformers(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/pkg/transformers/config/namebackreferences_test.go
+++ b/pkg/transformers/config/namebackreferences_test.go
@@ -18,8 +18,9 @@ package config
 
 import (
 	"reflect"
-	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"testing"
+
+	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 )
 
 func TestMergeAll(t *testing.T) {

--- a/pkg/transformers/mutatefield_test.go
+++ b/pkg/transformers/mutatefield_test.go
@@ -18,9 +18,10 @@ package transformers
 
 import (
 	"fmt"
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
-	"testing"
 )
 
 type noopMutator struct {

--- a/pkg/transformers/refvars.go
+++ b/pkg/transformers/refvars.go
@@ -18,6 +18,7 @@ package transformers
 
 import (
 	"fmt"
+
 	"sigs.k8s.io/kustomize/v3/pkg/expansion"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"

--- a/plugin/builtin/AnnotationsTransformer.go
+++ b/plugin/builtin/AnnotationsTransformer.go
@@ -2,7 +2,6 @@
 package builtin
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
@@ -16,7 +15,7 @@ type AnnotationsTransformerPlugin struct {
 }
 
 func (p *AnnotationsTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Annotations = nil
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/ConfigMapGenerator.go
+++ b/plugin/builtin/ConfigMapGenerator.go
@@ -2,22 +2,20 @@
 package builtin
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 type ConfigMapGeneratorPlugin struct {
-	ldr              ifc.Loader
-	rf               *resmap.Factory
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.ConfigMapArgs
 }
 
 func (p *ConfigMapGeneratorPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
+	h *resmap.PluginHelpers, config []byte) (err error) {
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.ConfigMapArgs = types.ConfigMapArgs{}
 	err = yaml.Unmarshal(config, p)
@@ -27,13 +25,13 @@ func (p *ConfigMapGeneratorPlugin) Config(
 	if p.ConfigMapArgs.Namespace == "" {
 		p.ConfigMapArgs.Namespace = p.Namespace
 	}
-	p.ldr = ldr
-	p.rf = rf
+	p.h = h
 	return
 }
 
 func (p *ConfigMapGeneratorPlugin) Generate() (resmap.ResMap, error) {
-	return p.rf.FromConfigMapArgs(p.ldr, &p.GeneratorOptions, p.ConfigMapArgs)
+	return p.h.ResmapFactory().FromConfigMapArgs(
+		p.h.Loader(), &p.GeneratorOptions, p.ConfigMapArgs)
 }
 
 func NewConfigMapGeneratorPlugin() resmap.GeneratorPlugin {

--- a/plugin/builtin/HashTransformer.go
+++ b/plugin/builtin/HashTransformer.go
@@ -13,8 +13,8 @@ type HashTransformerPlugin struct {
 }
 
 func (p *HashTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
-	p.hasher = rf.RF().Hasher()
+	h *resmap.PluginHelpers, config []byte) (err error) {
+	p.hasher = h.ResmapFactory().RF().Hasher()
 	return nil
 }
 

--- a/plugin/builtin/ImageTagTransformer.go
+++ b/plugin/builtin/ImageTagTransformer.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/image"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -22,7 +21,7 @@ type ImageTagTransformerPlugin struct {
 }
 
 func (p *ImageTagTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.ImageTag = image.Image{}
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/InventoryTransformer.go
+++ b/plugin/builtin/InventoryTransformer.go
@@ -4,28 +4,24 @@ package builtin
 import (
 	"fmt"
 
-	"sigs.k8s.io/kustomize/v3/pkg/resource"
-
 	"sigs.k8s.io/kustomize/v3/pkg/hasher"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/inventory"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 type InventoryTransformerPlugin struct {
-	ldr              ifc.Loader
-	rf               *resmap.Factory
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	Policy           string `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
 func (p *InventoryTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
-	p.ldr = ldr
-	p.rf = rf
+	h *resmap.PluginHelpers, c []byte) (err error) {
+	p.h = h
 	err = yaml.Unmarshal(c, p)
 	if err != nil {
 		return err
@@ -74,7 +70,8 @@ func (p *InventoryTransformerPlugin) Transform(m resmap.ResMap) error {
 		return err
 	}
 
-	cm, err := p.rf.RF().MakeConfigMap(p.ldr, opts, &args)
+	cm, err := p.h.ResmapFactory().RF().MakeConfigMap(
+		p.h.Loader(), opts, &args)
 	if err != nil {
 		return err
 	}

--- a/plugin/builtin/LabelTransformer.go
+++ b/plugin/builtin/LabelTransformer.go
@@ -2,7 +2,6 @@
 package builtin
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
@@ -16,7 +15,7 @@ type LabelTransformerPlugin struct {
 }
 
 func (p *LabelTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Labels = nil
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/LegacyOrderTransformer.go
+++ b/plugin/builtin/LegacyOrderTransformer.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 )
@@ -19,7 +18,7 @@ type LegacyOrderTransformerPlugin struct{}
 
 // Nothing needed for configuration.
 func (p *LegacyOrderTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	return nil
 }
 

--- a/plugin/builtin/NamespaceTransformer.go
+++ b/plugin/builtin/NamespaceTransformer.go
@@ -4,7 +4,6 @@ package builtin
 import (
 	"fmt"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
@@ -21,7 +20,7 @@ type NamespaceTransformerPlugin struct {
 }
 
 func (p *NamespaceTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Namespace = ""
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/PatchJson6902Transformer.go
+++ b/plugin/builtin/PatchJson6902Transformer.go
@@ -4,7 +4,7 @@ package builtin
 import (
 	"fmt"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
@@ -23,8 +23,8 @@ type PatchJson6902TransformerPlugin struct {
 }
 
 func (p *PatchJson6902TransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
-	p.ldr = ldr
+	h *resmap.PluginHelpers, c []byte) (err error) {
+	p.ldr = h.Loader()
 	err = yaml.Unmarshal(c, p)
 	if err != nil {
 		return err

--- a/plugin/builtin/PrefixSuffixTransformer.go
+++ b/plugin/builtin/PrefixSuffixTransformer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -32,7 +31,7 @@ var prefixSuffixFieldSpecsToSkip = []config.FieldSpec{
 }
 
 func (p *PrefixSuffixTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Prefix = ""
 	p.Suffix = ""
 	p.FieldSpecs = nil

--- a/plugin/builtin/ReplicaCountTransformer.go
+++ b/plugin/builtin/ReplicaCountTransformer.go
@@ -4,7 +4,6 @@ package builtin
 import (
 	"fmt"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -21,7 +20,7 @@ type ReplicaCountTransformerPlugin struct {
 }
 
 func (p *ReplicaCountTransformerPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 
 	p.Replica = types.Replica{}
 	p.FieldSpecs = nil
@@ -29,7 +28,6 @@ func (p *ReplicaCountTransformerPlugin) Config(
 }
 
 func (p *ReplicaCountTransformerPlugin) Transform(m resmap.ResMap) error {
-
 	found := false
 	for i, replicaSpec := range p.FieldSpecs {
 		matcher := p.createMatcher(i)

--- a/plugin/builtin/SecretGenerator.go
+++ b/plugin/builtin/SecretGenerator.go
@@ -2,22 +2,19 @@
 package builtin
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 type SecretGeneratorPlugin struct {
-	ldr              ifc.Loader
-	rf               *resmap.Factory
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.SecretArgs
 }
 
-func (p *SecretGeneratorPlugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
+func (p *SecretGeneratorPlugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.SecretArgs = types.SecretArgs{}
 	err = yaml.Unmarshal(config, p)
@@ -27,13 +24,13 @@ func (p *SecretGeneratorPlugin) Config(
 	if p.SecretArgs.Namespace == "" {
 		p.SecretArgs.Namespace = p.Namespace
 	}
-	p.ldr = ldr
-	p.rf = rf
+	p.h = h
 	return
 }
 
 func (p *SecretGeneratorPlugin) Generate() (resmap.ResMap, error) {
-	return p.rf.FromSecretArgs(p.ldr, &p.GeneratorOptions, p.SecretArgs)
+	return p.h.ResmapFactory().FromSecretArgs(
+		p.h.Loader(), &p.GeneratorOptions, p.SecretArgs)
 }
 
 func NewSecretGeneratorPlugin() resmap.GeneratorPlugin {

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
@@ -22,7 +21,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Annotations = nil
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
+	"sigs.k8s.io/kustomize/v3/pluglib"
 )
 
 func TestAnnotationsTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
@@ -5,15 +5,13 @@
 package main
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 type plugin struct {
-	ldr              ifc.Loader
-	rf               *resmap.Factory
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.ConfigMapArgs
@@ -23,7 +21,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
+	h *resmap.PluginHelpers, config []byte) (err error) {
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.ConfigMapArgs = types.ConfigMapArgs{}
 	err = yaml.Unmarshal(config, p)
@@ -33,11 +31,11 @@ func (p *plugin) Config(
 	if p.ConfigMapArgs.Namespace == "" {
 		p.ConfigMapArgs.Namespace = p.Namespace
 	}
-	p.ldr = ldr
-	p.rf = rf
+	p.h = h
 	return
 }
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
-	return p.rf.FromConfigMapArgs(p.ldr, &p.GeneratorOptions, p.ConfigMapArgs)
+	return p.h.ResmapFactory().FromConfigMapArgs(
+		p.h.Loader(), &p.GeneratorOptions, p.ConfigMapArgs)
 }

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestConfigMapGenerator(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/hashtransformer/HashTransformer.go
+++ b/plugin/builtin/hashtransformer/HashTransformer.go
@@ -19,8 +19,8 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
-	p.hasher = rf.RF().Hasher()
+	h *resmap.PluginHelpers, config []byte) (err error) {
+	p.hasher = h.ResmapFactory().RF().Hasher()
 	return nil
 }
 

--- a/plugin/builtin/hashtransformer/HashTransformer_test.go
+++ b/plugin/builtin/hashtransformer/HashTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestHashTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/image"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -28,7 +27,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.ImageTag = image.Image{}
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestImageTagTransformerNewTag(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -82,7 +83,7 @@ spec:
 `)
 }
 func TestImageTagTransformerNewImage(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -154,7 +155,7 @@ spec:
 }
 
 func TestImageTagTransformerNewImageAndTag(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -227,7 +228,7 @@ spec:
 }
 
 func TestImageTagTransformerNewDigest(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -299,7 +300,7 @@ spec:
 }
 
 func TestImageTagTransformerNewImageAndDigest(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
@@ -6,8 +6,9 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 const (
@@ -59,7 +60,7 @@ metadata:
 )
 
 func TestInventoryTransformerCollect(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -80,7 +81,7 @@ policy: GarbageCollect
 }
 
 func TestInventoryTransformerIgnore(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -101,7 +102,7 @@ policy: GarbageIgnore
 }
 
 func TestInventoryTransformerDefaultPolicy(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
@@ -22,7 +21,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Labels = nil
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/labeltransformer/LabelTransformer_test.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestLabelTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 )
@@ -25,7 +24,7 @@ var KustomizePlugin plugin
 
 // Nothing needed for configuration.
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	return nil
 }
 

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestLegacyOrderTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -7,7 +7,6 @@ package main
 import (
 	"fmt"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
@@ -27,7 +26,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Namespace = ""
 	p.FieldSpecs = nil
 	return yaml.Unmarshal(c, p)

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestNamespaceTransformer1(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -190,7 +191,7 @@ metadata:
 }
 
 func TestNamespaceTransformerClusterLevelKinds(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -241,7 +242,7 @@ fieldSpecs:
 }
 
 func TestNamespaceTransformerObjectConflict(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
@@ -7,7 +7,7 @@ package main
 import (
 	"fmt"
 
-	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
@@ -29,8 +29,8 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
-	p.ldr = ldr
+	h *resmap.PluginHelpers, c []byte) (err error) {
+	p.ldr = h.Loader()
 	err = yaml.Unmarshal(c, p)
 	if err != nil {
 		return err

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 const target = `
@@ -29,7 +30,7 @@ spec:
 `
 
 func TestPatchJson6902TransformerMissingFile(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -58,7 +59,7 @@ path: jsonpatch.json
 }
 
 func TestBadPatchJson6902Transformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -87,7 +88,7 @@ jsonOp: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyJson6902Transformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -115,7 +116,7 @@ target:
 }
 
 func TestBothSpecifiedJson6902Transformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -151,7 +152,7 @@ jsonOp: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Clust
 }
 
 func TestPatchJson6902TransformerFromJsonFile(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -201,7 +202,7 @@ spec:
 }
 
 func TestPatchJson6902TransformerFromYamlFile(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -251,7 +252,7 @@ spec:
 }
 
 func TestPatchJson6902TransformerWithInlineJSON(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -292,7 +293,7 @@ spec:
 }
 
 func TestPatchJson6902TransformerWithInlineYAML(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 const (
@@ -59,7 +60,7 @@ spec:
 )
 
 func TestPatchStrategicMergeTransformerMissingFile(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -86,7 +87,7 @@ paths:
 }
 
 func TestBadPatchStrategicMergeTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -111,7 +112,7 @@ patches: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyPatchStrategicMergeTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -134,7 +135,7 @@ metadata:
 }
 
 func TestPatchStrategicMergeTransformerFromFiles(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -184,7 +185,7 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerWithInlineJSON(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -219,7 +220,7 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerWithInlineYAML(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -271,7 +272,7 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerMultiplePatches(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -348,7 +349,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerMultiplePatchesWithConflicts(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -409,7 +410,7 @@ paths:
 }
 
 func TestStrategicMergeTransformerWrongNamespace(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -452,7 +453,7 @@ paths:
 }
 
 func TestStrategicMergeTransformerNoSchema(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -492,7 +493,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatches(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -548,7 +549,7 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatchesWithConflict(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -884,7 +885,7 @@ func TestSinglePatch(t *testing.T) {
 		},
 	}
 
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 	tc.BuildGoPlugin(
 		"builtin", "", "PatchStrategicMergeTransformer")
@@ -987,7 +988,7 @@ func TestMultiplePatches(t *testing.T) {
 		},
 	}
 
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 	tc.BuildGoPlugin(
 		"builtin", "", "PatchStrategicMergeTransformer")
@@ -1118,7 +1119,7 @@ func TestMultiplePatchesWithConflict(t *testing.T) {
 		},
 	}
 
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 	tc.BuildGoPlugin(
 		"builtin", "", "PatchStrategicMergeTransformer")
@@ -1227,7 +1228,7 @@ func TestMultipleNamespaces(t *testing.T) {
 		},
 	}
 
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 	tc.BuildGoPlugin(
 		"builtin", "", "PatchStrategicMergeTransformer")
@@ -1249,7 +1250,7 @@ func TestMultipleNamespaces(t *testing.T) {
 }
 
 func TestPatchStrategicMergeTransformerPatchDelete(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 const (
@@ -66,7 +67,7 @@ spec:
 )
 
 func TestPatchTransformerMissingFile(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -90,7 +91,7 @@ path: patch.yaml
 }
 
 func TestPatchTransformerBadPatch(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -114,7 +115,7 @@ patch: "thisIsNotAPatch"
 }
 
 func TestPatchTransformerMissingSelector(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -138,7 +139,7 @@ patch: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Cluste
 }
 
 func TestPatchTransformerBothEmptyPathAndPatch(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -161,7 +162,7 @@ metadata:
 }
 
 func TestPatchTransformerBothNonEmptyPathAndPatch(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -186,7 +187,7 @@ Patch: "something"
 }
 
 func TestPatchTransformerFromFiles(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -268,7 +269,7 @@ spec:
 }
 
 func TestPatchTransformerWithInline(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"sigs.k8s.io/kustomize/v3/pkg/gvk"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -38,7 +37,7 @@ var prefixSuffixFieldSpecsToSkip = []config.FieldSpec{
 }
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.Prefix = ""
 	p.Suffix = ""
 	p.FieldSpecs = nil

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestPrefixSuffixTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
@@ -7,7 +7,6 @@ package main
 import (
 	"fmt"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers"
@@ -27,7 +26,7 @@ type plugin struct {
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) (err error) {
+	h *resmap.PluginHelpers, c []byte) (err error) {
 
 	p.Replica = types.Replica{}
 	p.FieldSpecs = nil
@@ -35,7 +34,6 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
-
 	found := false
 	for i, replicaSpec := range p.FieldSpecs {
 		matcher := p.createMatcher(i)

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestReplicaCountTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(
@@ -153,7 +154,7 @@ spec:
 }
 
 func TestMatchesCurrentID(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin("builtin", "", "PrefixSuffixTransformer")
@@ -199,7 +200,7 @@ spec:
 }
 
 func TestNoMatch(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin("builtin", "", "ReplicaCountTransformer")

--- a/plugin/builtin/secretgenerator/SecretGenerator.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator.go
@@ -5,15 +5,13 @@
 package main
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
 )
 
 type plugin struct {
-	ldr              ifc.Loader
-	rf               *resmap.Factory
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	types.GeneratorOptions
 	types.SecretArgs
@@ -22,8 +20,7 @@ type plugin struct {
 //noinspection GoUnusedGlobalVariable
 var KustomizePlugin plugin
 
-func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, config []byte) (err error) {
+func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.GeneratorOptions = types.GeneratorOptions{}
 	p.SecretArgs = types.SecretArgs{}
 	err = yaml.Unmarshal(config, p)
@@ -33,11 +30,11 @@ func (p *plugin) Config(
 	if p.SecretArgs.Namespace == "" {
 		p.SecretArgs.Namespace = p.Namespace
 	}
-	p.ldr = ldr
-	p.rf = rf
+	p.h = h
 	return
 }
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
-	return p.rf.FromSecretArgs(p.ldr, &p.GeneratorOptions, p.SecretArgs)
+	return p.h.ResmapFactory().FromSecretArgs(
+		p.h.Loader(), &p.GeneratorOptions, p.SecretArgs)
 }

--- a/plugin/builtin/secretgenerator/SecretGenerator_test.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestSecretGenerator(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -104,7 +104,7 @@ Generated plugins are used in kustomize via
   import "sigs.k8s.io/kustomize/v3/plugin/builtin
   ...
   g := builtin.NewSecretGenerator()
-  g.Config(l, rf, k)
+  g.Config(h, k)
   resources, err := g.Generate()
   err = g.Transform(resources)
   // Eventually emit resources.

--- a/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestBashedConfigMapPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -11,8 +11,9 @@ import (
 	"regexp"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 // This test requires having the helm binary on the PATH.
@@ -20,7 +21,7 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflator(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
 	"sigs.k8s.io/kustomize/v3/plugin/builtin"
@@ -35,8 +34,7 @@ func (p *plugin) makePrefixSuffixPluginConfig() ([]byte, error) {
 	return yaml.Marshal(s)
 }
 
-func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, _ []byte) error {
+func (p *plugin) Config(h *resmap.PluginHelpers, _ []byte) error {
 	// Ignore the incoming c, compute new config.
 	c, err := p.makePrefixSuffixPluginConfig()
 	if err != nil {
@@ -44,7 +42,7 @@ func (p *plugin) Config(
 			err, "dateprefixer makeconfig")
 	}
 	prefixer := builtin.NewPrefixSuffixTransformerPlugin()
-	err = prefixer.Config(ldr, rf, c)
+	err = prefixer.Config(h, c)
 	if err != nil {
 		return errors.Wrapf(
 			err, "prefixsuffix configure")

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestDatePrefixerPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/gogetter/GoGetter_test.go
+++ b/plugin/someteam.example.com/v1/gogetter/GoGetter_test.go
@@ -10,14 +10,15 @@ package main_test
 import (
 	"testing"
 
-	kusttest_test "sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
+	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
 )
 
 // This test requires having the go-getter binary on the PATH.
 //
 func TestGoGetter(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
@@ -45,7 +46,7 @@ metadata:
 }
 
 func TestGoGetterUrl(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
@@ -74,7 +75,7 @@ metadata:
 }
 
 func TestGoGetterCommand(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(
@@ -103,7 +104,7 @@ metadata:
 }
 
 func TestGoGetterSubPath(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/printworkdir/PrintWorkDir_test.go
+++ b/plugin/someteam.example.com/v1/printworkdir/PrintWorkDir_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func shouldContain(t *testing.T, s []byte, x string) {
@@ -18,7 +19,7 @@ func shouldContain(t *testing.T, s []byte, x string) {
 }
 
 func TestPrintWorkDirPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin(

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -13,8 +12,7 @@ import (
 // A secret generator example that gets data
 // from a database (simulated by a hardcoded map).
 type plugin struct {
-	rf               *resmap.Factory
-	ldr              ifc.Loader
+	h                *resmap.PluginHelpers
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// List of keys to use in database lookups
 	Keys []string `json:"keys,omitempty" yaml:"keys,omitempty"`
@@ -32,10 +30,8 @@ var database = map[string]string{
 	"SIMPSON":   "homer",
 }
 
-func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) error {
-	p.rf = rf
-	p.ldr = ldr
+func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
+	p.h = h
 	return yaml.Unmarshal(c, p)
 }
 
@@ -51,5 +47,5 @@ func (p *plugin) Generate() (resmap.ResMap, error) {
 				args.LiteralSources, k+"="+v)
 		}
 	}
-	return p.rf.FromSecretArgs(p.ldr, nil, args)
+	return p.h.ResmapFactory().FromSecretArgs(p.h.Loader(), nil, args)
 }

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestSecretsFromDatabasePlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
+++ b/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestSedTransformer(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "SedTransformer")

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"text/template"
 
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -39,9 +38,8 @@ spec:
     app: dev
 `
 
-func (p *plugin) Config(
-	_ ifc.Loader, rf *resmap.Factory, config []byte) error {
-	p.rf = rf
+func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) error {
+	p.rf = h.ResmapFactory()
 	return yaml.Unmarshal(config, p)
 }
 

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestSomeServiceGeneratorPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
@@ -37,8 +36,7 @@ func (p *plugin) makePrefixSuffixPluginConfig(n string) ([]byte, error) {
 	return yaml.Marshal(s)
 }
 
-func (p *plugin) Config(
-	ldr ifc.Loader, rf *resmap.Factory, c []byte) error {
+func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 	err := yaml.Unmarshal(c, p)
 	if err != nil {
 		return err
@@ -48,7 +46,7 @@ func (p *plugin) Config(
 		return err
 	}
 	prefixer := builtin.NewPrefixSuffixTransformerPlugin()
-	err = prefixer.Config(ldr, rf, c)
+	err = prefixer.Config(h, c)
 	if err != nil {
 		return errors.Wrapf(
 			err, "stringprefixer configure")

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
@@ -6,12 +6,13 @@ package main_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestStringPrefixerPlugin(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildGoPlugin(

--- a/plugin/someteam.example.com/v1/validator/validator_test.go
+++ b/plugin/someteam.example.com/v1/validator/validator_test.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/pluglib"
+
 	"sigs.k8s.io/kustomize/v3/pkg/kusttest"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins/testenv"
 )
 
 func TestValidatorHappy(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")
@@ -49,7 +50,7 @@ metadata:
 }
 
 func TestValidatorUnHappy(t *testing.T) {
-	tc := testenv.NewEnvForTest(t).Set()
+	tc := pluglib.NewEnvForTest(t).Set()
 	defer tc.Reset()
 
 	tc.BuildExecPlugin("someteam.example.com", "v1", "Validator")

--- a/pluginator/go.mod
+++ b/pluginator/go.mod
@@ -2,15 +2,6 @@ module sigs.k8s.io/kustomize/pluginator
 
 go 1.13
 
-require (
-	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/google/gofuzz v1.0.0 // indirect
-	github.com/googleapis/gnostic v0.3.0 // indirect
-	github.com/json-iterator/go v1.1.6 // indirect
-	github.com/mailru/easyjson v0.0.0-20190620125010-da37f6c1e481 // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	k8s.io/klog v0.3.3 // indirect
-	sigs.k8s.io/kustomize/v3 v3.3.1
-)
+require sigs.k8s.io/kustomize/v3 v3.3.1
 
 replace sigs.k8s.io/kustomize/v3 v3.3.1 => ../

--- a/pluglib/envfortest.go
+++ b/pluglib/envfortest.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package testenv
+package pluglib
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
The `v4` goal is that anything not used by plugins or by the kustomize binary will go to `internal`, and the rest to public, top level packages as we drain `pkg`.

The final names of the packages is in flux, but the basic truth is that `pkg` must be drained.

This PR moves code needed for plugin testing up to the public package currently called `pluglib` for temporary lack of a better name. Wanted something at the top level with a name alphabetically close to `plugin` (exists).  Could not use `plugins` since its too easily confused with the existing toplevel `plugin` dir (which houses the plugins themselves.

Also, plugin configuration helpers like the Loader and ResMap factory have been gathered into one object to pass to plugin `Config` so we won't have massive PR's in the future should we need to refactor what's needed by `Config`.
