### PR TITLE
fix string trim in normalizeGitHostSpec func

### DIFF
--- a/pkg/git/repospec.go
+++ b/pkg/git/repospec.go
@@ -200,7 +200,7 @@ func normalizeGitHostSpec(host string) string {
 		}
 	}
 	if strings.HasPrefix(s, "git::") {
-		host = strings.TrimLeft(s, "git::")
+		host = strings.TrimPrefix(s, "git::")
 	}
 	return host
 }


### PR DESCRIPTION
TrimLeft is char based, and TrimPrefix is word based, that's what we want here,
please see here: https://play.golang.org/p/IkiVXB8OEQo
