### PR TITLE
Rename DataSources to KvPairSources and remove deprecated env field.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -438,7 +438,6 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b h1:DxJ5nJdkhDlLok9K6qO+5290kphD
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f h1:Cq7MalBHYACRd6EesksG1Q8EoIAKOsiZviGKbOLIej4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize/pluginator v1.0.0 h1:aeLqD8CIaqr++49YrcuRUcXl5vVKYLhCSfwXUi3ifQ4=
 sigs.k8s.io/kustomize/pluginator v1.0.0/go.mod h1:i8HdU5FdH1zDjCKiFf5CNl7slsc0QffyKsY2OuPynJ0=
 sigs.k8s.io/kustomize/v3 v3.2.0/go.mod h1:ztX4zYc/QIww3gSripwF7TBOarBTm5BvyAMem0kCzOE=

--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -86,7 +86,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "envConfigMap",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						EnvSources: []string{
 							filepath.Join("configmap", "app.env"),
 						},
@@ -101,7 +101,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "fileConfigMap",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						FileSources: []string{
 							filepath.Join("configmap", "app-init.ini"),
 							filepath.Join("configmap", "app.bin"),
@@ -117,7 +117,7 @@ func TestConstructConfigMap(t *testing.T) {
 			input: types.ConfigMapArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "literalConfigMap",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						LiteralSources: []string{"a=x", "b=y", "c=\"Hello World\"", "d='true'"},
 					},
 				},

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -83,7 +83,7 @@ func TestConstructSecret(t *testing.T) {
 			input: types.SecretArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "envSecret",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						EnvSources: []string{"secret/app.env"},
 					},
 				},
@@ -96,7 +96,7 @@ func TestConstructSecret(t *testing.T) {
 			input: types.SecretArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "fileSecret",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						FileSources: []string{"secret/app-init.ini"},
 					},
 				},
@@ -109,7 +109,7 @@ func TestConstructSecret(t *testing.T) {
 			input: types.SecretArgs{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "literalSecret",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						LiteralSources: []string{"a=x", "b=y"},
 					},
 				},

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -375,11 +375,8 @@ k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208/go.mod h1:nfDlWeOsu3pUf4y
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize/pluginator v1.0.0/go.mod h1:i8HdU5FdH1zDjCKiFf5CNl7slsc0QffyKsY2OuPynJ0=
 sigs.k8s.io/kustomize/v3 v3.2.0/go.mod h1:ztX4zYc/QIww3gSripwF7TBOarBTm5BvyAMem0kCzOE=
-sigs.k8s.io/kustomize/v3 v3.3.1 h1:UOhJqkRINRODnKq24DoDAr4gxk2z2p9iFJWDT3OLBx8=
-sigs.k8s.io/kustomize/v3 v3.3.1/go.mod h1:2ojB+51Z+YIBpEOknAFX3U8f0XXa94PFcfXPccDxAfg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/resmap/factory_test.go
+++ b/pkg/resmap/factory_test.go
@@ -126,7 +126,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 				{
 					GeneratorArgs: types.GeneratorArgs{
 						Name: "envConfigMap",
-						DataSources: types.DataSources{
+						KvPairSources: types.KvPairSources{
 							EnvSources: []string{"app.env"},
 						},
 					},
@@ -152,7 +152,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 			input: []types.ConfigMapArgs{{
 				GeneratorArgs: types.GeneratorArgs{
 					Name: "fileConfigMap",
-					DataSources: types.DataSources{
+					KvPairSources: types.KvPairSources{
 						FileSources: []string{"app-init.ini"},
 					},
 				},
@@ -180,7 +180,7 @@ BAR=baz
 				{
 					GeneratorArgs: types.GeneratorArgs{
 						Name: "literalConfigMap",
-						DataSources: types.DataSources{
+						KvPairSources: types.KvPairSources{
 							LiteralSources: []string{"a=x", "b=y", "c=\"Good Morning\"", "d=\"false\""},
 						},
 					},
@@ -224,7 +224,7 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 		{
 			GeneratorArgs: types.GeneratorArgs{
 				Name: "apple",
-				DataSources: types.DataSources{
+				KvPairSources: types.KvPairSources{
 					LiteralSources: []string{
 						"DB_USERNAME=admin",
 						"DB_PASSWORD=somepw",

--- a/pkg/target/baseandoverlaymedium_test.go
+++ b/pkg/target/baseandoverlaymedium_test.go
@@ -132,8 +132,8 @@ patchesStrategicMerge:
 - deployment/deployment.yaml
 configMapGenerator:
 - name: app-env
-  env: configmap/db.env
   envs:
+  - configmap/db.env
   - configmap/units.ini
   - configmap/food.ini
 - name: app-config

--- a/pkg/types/generatorargs.go
+++ b/pkg/types/generatorargs.go
@@ -19,36 +19,6 @@ type GeneratorArgs struct {
 	//   'merge': merge with the existing one
 	Behavior string `json:"behavior,omitempty" yaml:"behavior,omitempty"`
 
-	// DataSources for the generator.
-	DataSources `json:",inline,omitempty" yaml:",inline,omitempty"`
-}
-
-// DataSources contains some generic sources for generators.
-type DataSources struct {
-	// LiteralSources is a list of literal
-	// pair sources. Each literal source should
-	// be a key and literal value, e.g. `key=value`
-	LiteralSources []string `json:"literals,omitempty" yaml:"literals,omitempty"`
-
-	// FileSources is a list of file "sources" to
-	// use in creating a list of key, value pairs.
-	// A source takes the form:  [{key}=]{path}
-	// If the "key=" part is missing, the key is the
-	// path's basename. If they "key=" part is present,
-	// it becomes the key (replacing the basename).
-	// In either case, the value is the file contents.
-	// Specifying a directory will iterate each named
-	// file in the directory whose basename is a
-	// valid configmap key.
-	FileSources []string `json:"files,omitempty" yaml:"files,omitempty"`
-
-	// EnvSources is a list of file paths.
-	// The contents of each file should be one
-	// key=value pair per line, e.g. a Docker
-	// or npm ".env" file or a ".ini" file
-	// (wikipedia.org/wiki/INI_file)
-	EnvSources []string `json:"envs,omitempty" yaml:"envs,omitempty"`
-
-	// Deprecated.  Use EnvSources instead.
-	EnvSource string `json:"env,omitempty" yaml:"env,omitempty"`
+	// KvPairSources for the generator.
+	KvPairSources `json:",inline,omitempty" yaml:",inline,omitempty"`
 }

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -153,21 +153,6 @@ func (k *Kustomization) FixKustomizationPostUnmarshalling() {
 	if k.Kind == "" {
 		k.Kind = KustomizationKind
 	}
-	// The EnvSource field is deprecated in favor of the list.
-	for i, g := range k.ConfigMapGenerator {
-		if g.EnvSource != "" {
-			k.ConfigMapGenerator[i].EnvSources =
-				append(g.EnvSources, g.EnvSource)
-			k.ConfigMapGenerator[i].EnvSource = ""
-		}
-	}
-	for i, g := range k.SecretGenerator {
-		if g.EnvSource != "" {
-			k.SecretGenerator[i].EnvSources =
-				append(g.EnvSources, g.EnvSource)
-			k.SecretGenerator[i].EnvSource = ""
-		}
-	}
 	for _, b := range k.Bases {
 		k.Resources = append(k.Resources, b)
 	}

--- a/pkg/types/kvpairsources.go
+++ b/pkg/types/kvpairsources.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// KvPairSources contains some generic sources for generators.
+type KvPairSources struct {
+	// LiteralSources is a list of literal
+	// pair sources. Each literal source should
+	// be a key and literal value, e.g. `key=value`
+	LiteralSources []string `json:"literals,omitempty" yaml:"literals,omitempty"`
+
+	// FileSources is a list of file "sources" to
+	// use in creating a list of key, value pairs.
+	// A source takes the form:  [{key}=]{path}
+	// If the "key=" part is missing, the key is the
+	// path's basename. If they "key=" part is present,
+	// it becomes the key (replacing the basename).
+	// In either case, the value is the file contents.
+	// Specifying a directory will iterate each named
+	// file in the directory whose basename is a
+	// valid configmap key.
+	FileSources []string `json:"files,omitempty" yaml:"files,omitempty"`
+
+	// EnvSources is a list of file paths.
+	// The contents of each file should be one
+	// key=value pair per line, e.g. a Docker
+	// or npm ".env" file or a ".ini" file
+	// (wikipedia.org/wiki/INI_file)
+	EnvSources []string `json:"envs,omitempty" yaml:"envs,omitempty"`
+}

--- a/pluginator/go.mod
+++ b/pluginator/go.mod
@@ -3,5 +3,3 @@ module sigs.k8s.io/kustomize/pluginator
 go 1.13
 
 require sigs.k8s.io/kustomize/v3 v3.3.1
-
-replace sigs.k8s.io/kustomize/v3 v3.3.1 => ../

--- a/pluginator/go.sum
+++ b/pluginator/go.sum
@@ -280,8 +280,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b h1:XfVGCX+0T4WOStkaOsJRllbsiImhB2jgVBGc9L0lPGc=
 golang.org/x/net v0.0.0-20190909003024-a7b16738d86b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191011234655-491137f69257 h1:ry8e2D+cwaV6hk7lb3aRTjjZo24shrbK0e11QEOkTIg=
-golang.org/x/net v0.0.0-20191011234655-491137f69257/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -324,7 +322,6 @@ golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDq
 golang.org/x/tools v0.0.0-20190910044552-dd2b5c81c578/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911230505-6bfd74cf029c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190912215617-3720d1ec3678/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191014141550-5fa5b1782b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -368,6 +365,7 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 sigs.k8s.io/kustomize/pluginator v1.0.0/go.mod h1:i8HdU5FdH1zDjCKiFf5CNl7slsc0QffyKsY2OuPynJ0=
 sigs.k8s.io/kustomize/v3 v3.2.0/go.mod h1:ztX4zYc/QIww3gSripwF7TBOarBTm5BvyAMem0kCzOE=
+sigs.k8s.io/kustomize/v3 v3.3.1 h1:UOhJqkRINRODnKq24DoDAr4gxk2z2p9iFJWDT3OLBx8=
 sigs.k8s.io/kustomize/v3 v3.3.1/go.mod h1:2ojB+51Z+YIBpEOknAFX3U8f0XXa94PFcfXPccDxAfg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=


### PR DESCRIPTION
The name DataSources is too generic for what's coming.

While here, remove the `env` field, which was deprecated in favor of `envs` (simply the plural form) last May (#1041).  No point taking this deprecated field along to v4.
