### PR TITLE
Fix yaml formatting of replicas count when count is 0

### DIFF
--- a/pkg/types/replica.go
+++ b/pkg/types/replica.go
@@ -12,5 +12,5 @@ type Replica struct {
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// The number of replicas required.
-	Count int64 `json:"count,omitempty" yaml:"count,omitempty"`
+	Count int64 `json:"count" yaml:"count"`
 }


### PR DESCRIPTION
Previously, a count of 0 would cause the count field to be omitted from the yaml.