### PR TITLE
Extract kv loader from file loader, and place in public package.

### DIFF
--- a/internal/loadertest/fakeloader.go
+++ b/internal/loadertest/fakeloader.go
@@ -10,8 +10,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/filesys"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
-	"sigs.k8s.io/kustomize/v3/pkg/types"
-	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 // FakeLoader encapsulates the delegate Loader and the fake file system.
@@ -36,8 +34,7 @@ func NewFakeLoaderWithRestrictor(
 	// Create fake filesystem and inject it into initial Loader.
 	fSys := filesys.MakeFsInMemory()
 	fSys.Mkdir(initialDir)
-	ldr, err := loader.NewLoader(
-		lr, validators.MakeFakeValidator(), initialDir, fSys)
+	ldr, err := loader.NewLoader(lr, initialDir, fSys)
 	if err != nil {
 		log.Fatalf("Unable to make loader: %v", err)
 	}
@@ -76,14 +73,4 @@ func (f FakeLoader) Load(location string) ([]byte, error) {
 // Cleanup delegates.
 func (f FakeLoader) Cleanup() error {
 	return f.delegate.Cleanup()
-}
-
-// Validator delegates.
-func (f FakeLoader) Validator() ifc.Validator {
-	return f.delegate.Validator()
-}
-
-// LoadKvPairs delegates.
-func (f FakeLoader) LoadKvPairs(args types.GeneratorArgs) ([]types.Pair, error) {
-	return f.delegate.LoadKvPairs(args)
 }

--- a/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/k8sdeps/configmapandsecret/configmapfactory.go
@@ -27,7 +27,7 @@ func makeFreshConfigMap(
 // MakeConfigMap returns a new ConfigMap, or nil and an error.
 func (f *Factory) MakeConfigMap(
 	args *types.ConfigMapArgs) (*v1.ConfigMap, error) {
-	all, err := f.ldr.LoadKvPairs(args.GeneratorArgs)
+	all, err := f.kvLdr.Load(args.KvPairSources)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading KV pairs")
 	}
@@ -48,7 +48,7 @@ func (f *Factory) MakeConfigMap(
 // addKvToConfigMap adds the given key and data to the given config map.
 // Error if key invalid, or already exists.
 func (f *Factory) addKvToConfigMap(configMap *v1.ConfigMap, p types.Pair) error {
-	if err := f.ldr.Validator().ErrIfInvalidKey(p.Key); err != nil {
+	if err := f.kvLdr.Validator().ErrIfInvalidKey(p.Key); err != nil {
 		return err
 	}
 	// If the configmap data contains byte sequences that are all in the UTF-8

--- a/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/v3/filesys"
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
@@ -141,9 +142,11 @@ func TestConstructConfigMap(t *testing.T) {
 	fSys.WriteFile(
 		filesys.RootedPath("configmap", "app.bin"),
 		[]byte{0xff, 0xfd})
-	ldr := loader.NewFileLoaderAtRoot(validators.MakeFakeValidator(), fSys)
+	kvLdr := kv.NewLoader(
+		loader.NewFileLoaderAtRoot(fSys),
+		validators.MakeFakeValidator())
 	for _, tc := range testCases {
-		f := NewFactory(ldr, tc.options)
+		f := NewFactory(kvLdr, tc.options)
 		cm, err := f.MakeConfigMap(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/k8sdeps/configmapandsecret/factory.go
+++ b/k8sdeps/configmapandsecret/factory.go
@@ -10,14 +10,14 @@ import (
 
 // Factory makes ConfigMaps and Secrets.
 type Factory struct {
-	ldr     ifc.Loader
+	kvLdr   ifc.KvLoader
 	options *types.GeneratorOptions
 }
 
 // NewFactory returns a new factory that makes ConfigMaps and Secrets.
 func NewFactory(
-	ldr ifc.Loader, o *types.GeneratorOptions) *Factory {
-	return &Factory{ldr: ldr, options: o}
+	kvLdr ifc.KvLoader, o *types.GeneratorOptions) *Factory {
+	return &Factory{kvLdr: kvLdr, options: o}
 }
 
 const keyExistsErrorMsg = "cannot add key %s, another key by that name already exists: %v"

--- a/k8sdeps/configmapandsecret/secretfactory.go
+++ b/k8sdeps/configmapandsecret/secretfactory.go
@@ -28,7 +28,7 @@ func makeFreshSecret(
 // MakeSecret returns a new secret.
 func (f *Factory) MakeSecret(
 	args *types.SecretArgs) (*corev1.Secret, error) {
-	all, err := f.ldr.LoadKvPairs(args.GeneratorArgs)
+	all, err := f.kvLdr.Load(args.KvPairSources)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (f *Factory) MakeSecret(
 }
 
 func (f *Factory) addKvToSecret(secret *corev1.Secret, keyName, data string) error {
-	if err := f.ldr.Validator().ErrIfInvalidKey(keyName); err != nil {
+	if err := f.kvLdr.Validator().ErrIfInvalidKey(keyName); err != nil {
 		return err
 	}
 	if _, entryExists := secret.Data[keyName]; entryExists {

--- a/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/v3/filesys"
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
@@ -126,9 +127,11 @@ func TestConstructSecret(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 	fSys.WriteFile("/secret/app.env", []byte("DB_USERNAME=admin\nDB_PASSWORD=somepw\n"))
 	fSys.WriteFile("/secret/app-init.ini", []byte("FOO=bar\nBAR=baz\n"))
-	ldr := loader.NewFileLoaderAtRoot(validators.MakeFakeValidator(), fSys)
+	kvLdr := kv.NewLoader(
+		loader.NewFileLoaderAtRoot(fSys),
+		validators.MakeFakeValidator())
 	for _, tc := range testCases {
-		f := NewFactory(ldr, tc.options)
+		f := NewFactory(kvLdr, tc.options)
 		cm, err := f.MakeSecret(&tc.input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/k8sdeps/kunstruct/factory.go
+++ b/k8sdeps/kunstruct/factory.go
@@ -73,11 +73,11 @@ func (kf *KunstructuredFactoryImpl) FromMap(
 
 // MakeConfigMap returns an instance of Kunstructured for ConfigMap
 func (kf *KunstructuredFactoryImpl) MakeConfigMap(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args *types.ConfigMapArgs) (ifc.Kunstructured, error) {
 	o, err := configmapandsecret.NewFactory(
-		ldr, options).MakeConfigMap(args)
+		kvLdr, options).MakeConfigMap(args)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +86,11 @@ func (kf *KunstructuredFactoryImpl) MakeConfigMap(
 
 // MakeSecret returns an instance of Kunstructured for Secret
 func (kf *KunstructuredFactoryImpl) MakeSecret(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args *types.SecretArgs) (ifc.Kunstructured, error) {
 	o, err := configmapandsecret.NewFactory(
-		ldr, options).MakeSecret(args)
+		kvLdr, options).MakeSecret(args)
 	if err != nil {
 		return nil, err
 	}

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -119,12 +119,12 @@ func (o *Options) RunBuild(
 	rf *resmap.Factory, ptf resmap.PatchFactory,
 	pl *plugins.Loader) error {
 	ldr, err := loader.NewLoader(
-		o.loadRestrictor, v, o.kustomizationPath, fSys)
+		o.loadRestrictor, o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, rf, ptf, pl)
+	kt, err := target.NewKustTarget(ldr, v, rf, ptf, pl)
 	if err != nil {
 		return err
 	}
@@ -140,12 +140,12 @@ func (o *Options) RunBuildPrune(
 	rf *resmap.Factory, ptf resmap.PatchFactory,
 	pl *plugins.Loader) error {
 	ldr, err := loader.NewLoader(
-		o.loadRestrictor, v, o.kustomizationPath, fSys)
+		o.loadRestrictor, o.kustomizationPath, fSys)
 	if err != nil {
 		return err
 	}
 	defer ldr.Cleanup()
-	kt, err := target.NewKustTarget(ldr, rf, ptf, pl)
+	kt, err := target.NewKustTarget(ldr, v, rf, ptf, pl)
 	if err != nil {
 		return err
 	}

--- a/kustomize/internal/commands/edit/add/all.go
+++ b/kustomize/internal/commands/edit/add/all.go
@@ -12,7 +12,7 @@ import (
 // NewCmdAdd returns an instance of 'add' subcommand.
 func NewCmdAdd(
 	fSys filesys.FileSystem,
-	ldr ifc.Loader,
+	ldr ifc.KvLoader,
 	kf ifc.KunstructuredFactory) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "add",

--- a/kustomize/internal/commands/edit/add/configmap.go
+++ b/kustomize/internal/commands/edit/add/configmap.go
@@ -14,7 +14,7 @@ import (
 // newCmdAddConfigMap returns a new command.
 func newCmdAddConfigMap(
 	fSys filesys.FileSystem,
-	ldr ifc.Loader,
+	ldr ifc.KvLoader,
 	kf ifc.KunstructuredFactory) *cobra.Command {
 	var flags flagsAndArgs
 	cmd := &cobra.Command{
@@ -89,7 +89,7 @@ func newCmdAddConfigMap(
 // Note: error may leave kustomization file in an undefined state.
 // Suggest passing a copy of kustomization file.
 func addConfigMap(
-	ldr ifc.Loader,
+	ldr ifc.KvLoader,
 	k *types.Kustomization,
 	flags flagsAndArgs, kf ifc.KunstructuredFactory) error {
 	args := findOrMakeConfigMapArgs(k, flags.Name)

--- a/kustomize/internal/commands/edit/add/configmap_test.go
+++ b/kustomize/internal/commands/edit/add/configmap_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/v3/filesys"
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
@@ -14,8 +15,12 @@ import (
 
 func TestNewAddConfigMapIsNotNil(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	ldr := loader.NewFileLoaderAtCwd(validators.MakeFakeValidator(), fSys)
-	if newCmdAddConfigMap(fSys, ldr, nil) == nil {
+	if newCmdAddConfigMap(
+		fSys,
+		kv.NewLoader(
+			loader.NewFileLoaderAtCwd(fSys),
+			validators.MakeFakeValidator()),
+			nil) == nil {
 		t.Fatal("newCmdAddConfigMap shouldn't be nil")
 	}
 }

--- a/kustomize/internal/commands/edit/add/secret.go
+++ b/kustomize/internal/commands/edit/add/secret.go
@@ -14,7 +14,7 @@ import (
 // newCmdAddSecret returns a new command.
 func newCmdAddSecret(
 	fSys filesys.FileSystem,
-	ldr ifc.Loader,
+	ldr ifc.KvLoader,
 	kf ifc.KunstructuredFactory) *cobra.Command {
 	var flags flagsAndArgs
 	cmd := &cobra.Command{
@@ -94,7 +94,7 @@ func newCmdAddSecret(
 // Note: error may leave kustomization file in an undefined state.
 // Suggest passing a copy of kustomization file.
 func addSecret(
-	ldr ifc.Loader,
+	ldr ifc.KvLoader,
 	k *types.Kustomization,
 	flags flagsAndArgs, kf ifc.KunstructuredFactory) error {
 	args := findOrMakeSecretArgs(k, flags.Name, flags.Type)

--- a/kustomize/internal/commands/edit/add/secret_test.go
+++ b/kustomize/internal/commands/edit/add/secret_test.go
@@ -6,6 +6,8 @@ package add
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/v3/kv"
+
 	"sigs.k8s.io/kustomize/v3/filesys"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
@@ -14,8 +16,12 @@ import (
 
 func TestNewCmdAddSecretIsNotNil(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	ldr := loader.NewFileLoaderAtCwd(validators.MakeFakeValidator(), fSys)
-	if newCmdAddSecret(fSys, ldr, nil) == nil {
+	if newCmdAddSecret(
+		fSys,
+		kv.NewLoader(
+			loader.NewFileLoaderAtCwd(fSys),
+			validators.MakeFakeValidator()),
+		nil) == nil {
 		t.Fatal("newCmdAddSecret shouldn't be nil")
 	}
 }

--- a/kustomize/internal/commands/edit/all.go
+++ b/kustomize/internal/commands/edit/all.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/remove"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/set"
 	"sigs.k8s.io/kustomize/v3/filesys"
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/loader"
 )
@@ -35,10 +36,13 @@ func NewCmdEdit(
 	}
 
 	c.AddCommand(
-		add.NewCmdAdd(fSys, loader.NewFileLoaderAtCwd(v, fSys), kf),
+		add.NewCmdAdd(
+			fSys,
+			kv.NewLoader(loader.NewFileLoaderAtCwd(fSys), v),
+			kf),
 		set.NewCmdSet(fSys, v),
 		fix.NewCmdFix(fSys),
-		remove.NewCmdRemove(fSys, loader.NewFileLoaderAtCwd(v, fSys)),
+		remove.NewCmdRemove(fSys, v),
 	)
 	return c
 }

--- a/kustomize/internal/commands/edit/remove/all.go
+++ b/kustomize/internal/commands/edit/remove/all.go
@@ -12,7 +12,7 @@ import (
 // NewCmdRemove returns an instance of 'remove' subcommand.
 func NewCmdRemove(
 	fSys filesys.FileSystem,
-	ldr ifc.Loader) *cobra.Command {
+	v ifc.Validator) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "remove",
 		Short: "Removes items from the kustomization file.",
@@ -35,8 +35,8 @@ func NewCmdRemove(
 	}
 	c.AddCommand(
 		newCmdRemoveResource(fSys),
-		newCmdRemoveLabel(fSys, ldr.Validator().MakeLabelNameValidator()),
-		newCmdRemoveAnnotation(fSys, ldr.Validator().MakeAnnotationNameValidator()),
+		newCmdRemoveLabel(fSys, v.MakeLabelNameValidator()),
+		newCmdRemoveAnnotation(fSys, v.MakeAnnotationNameValidator()),
 		newCmdRemovePatch(fSys),
 	)
 	return c

--- a/pkg/ifc/ifc.go
+++ b/pkg/ifc/ifc.go
@@ -20,6 +20,12 @@ type Validator interface {
 	IsEnvVarName(k string) error
 }
 
+// KvLoader reads and validates KV pairs.
+type KvLoader interface {
+	Validator() Validator
+	Load(args types.KvPairSources) (all []types.Pair, err error)
+}
+
 // Loader interface exposes methods to read bytes.
 type Loader interface {
 	// Root returns the root location for this Loader.
@@ -30,10 +36,6 @@ type Loader interface {
 	Load(location string) ([]byte, error)
 	// Cleanup cleans the loader
 	Cleanup() error
-	// Validator validates data for use in various k8s fields.
-	Validator() Validator
-	// Loads pairs.
-	LoadKvPairs(args types.GeneratorArgs) ([]types.Pair, error)
 }
 
 // Kunstructured allows manipulation of k8s objects
@@ -74,11 +76,11 @@ type KunstructuredFactory interface {
 	FromMap(m map[string]interface{}) Kunstructured
 	Hasher() KunstructuredHasher
 	MakeConfigMap(
-		ldr Loader,
+		kvLdr KvLoader,
 		options *types.GeneratorOptions,
 		args *types.ConfigMapArgs) (Kunstructured, error)
 	MakeSecret(
-		ldr Loader,
+		kvLdr KvLoader,
 		options *types.GeneratorOptions,
 		args *types.SecretArgs) (Kunstructured, error)
 }

--- a/pkg/kusttest/kusttestharness.go
+++ b/pkg/kusttest/kusttestharness.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/transformers/config/defaultconfig"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 // KustTestHarness helps test kustomization generation and transformation.
@@ -59,7 +60,8 @@ func NewKustTestHarnessFull(
 
 func (th *KustTestHarness) MakeKustTarget() *target.KustTarget {
 	kt, err := target.NewKustTarget(
-		th.ldr, th.rf, transformer.NewFactoryImpl(), th.pl)
+		th.ldr, validators.MakeFakeValidator(), th.rf,
+		transformer.NewFactoryImpl(), th.pl)
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}
@@ -113,7 +115,8 @@ func (th *KustTestHarness) LoadAndRunGenerator(
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
-	g, err := th.pl.LoadGenerator(th.ldr, res)
+	g, err := th.pl.LoadGenerator(
+		th.ldr, validators.MakeFakeValidator(), res)
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
@@ -154,7 +157,8 @@ func (th *KustTestHarness) RunTransformerFromResMap(
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
-	g, err := th.pl.LoadTransformer(th.ldr, transConfig)
+	g, err := th.pl.LoadTransformer(
+		th.ldr, validators.MakeFakeValidator(), transConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/loader/fileloader_test.go
+++ b/pkg/loader/fileloader_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/git"
 	"sigs.k8s.io/kustomize/v3/pkg/ifc"
 	"sigs.k8s.io/kustomize/v3/pkg/pgmconfig"
-	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 type testData struct {
@@ -65,7 +64,7 @@ func MakeFakeFs(td []testData) filesys.FileSystem {
 }
 
 func makeLoader() *fileLoader {
-	return NewFileLoaderAtRoot(validators.MakeFakeValidator(), MakeFakeFs(testCases))
+	return NewFileLoaderAtRoot(MakeFakeFs(testCases))
 
 }
 func TestLoaderLoad(t *testing.T) {
@@ -302,8 +301,7 @@ func TestRestrictionRootOnlyInRealLoader(t *testing.T) {
 
 	var l ifc.Loader
 
-	l = newLoaderOrDie(
-		RestrictionRootOnly, validators.MakeFakeValidator(), fSys, dir)
+	l = newLoaderOrDie(RestrictionRootOnly, fSys, dir)
 
 	l = doSanityChecksAndDropIntoBase(t, l)
 
@@ -336,8 +334,7 @@ func TestRestrictionNoneInRealLoader(t *testing.T) {
 
 	var l ifc.Loader
 
-	l = newLoaderOrDie(
-		RestrictionNone, validators.MakeFakeValidator(), fSys, dir)
+	l = newLoaderOrDie(RestrictionNone, fSys, dir)
 
 	l = doSanityChecksAndDropIntoBase(t, l)
 
@@ -400,7 +397,7 @@ whatever
 		t.Fatalf("unexpected err: %v\n", err)
 	}
 	l, err := newLoaderAtGitClone(
-		repoSpec, validators.MakeFakeValidator(), fSys, nil,
+		repoSpec, fSys, nil,
 		git.DoNothingCloner(filesys.ConfirmedDir(coRoot)))
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
@@ -443,7 +440,7 @@ func TestLoaderDisallowsLocalBaseFromRemoteOverlay(t *testing.T) {
 	// Establish that a local overlay can navigate
 	// to the local bases.
 	l1 = newLoaderOrDie(
-		RestrictionRootOnly, validators.MakeFakeValidator(), fSys, cloneRoot+"/foo/overlay")
+		RestrictionRootOnly, fSys, cloneRoot+"/foo/overlay")
 	if l1.Root() != cloneRoot+"/foo/overlay" {
 		t.Fatalf("unexpected root %s", l1.Root())
 	}
@@ -479,7 +476,7 @@ func TestLoaderDisallowsLocalBaseFromRemoteOverlay(t *testing.T) {
 		t.Fatalf("unexpected err: %v\n", err)
 	}
 	l1, err = newLoaderAtGitClone(
-		repoSpec, validators.MakeFakeValidator(), fSys, nil,
+		repoSpec, fSys, nil,
 		git.DoNothingCloner(filesys.ConfirmedDir(cloneRoot)))
 	if err != nil {
 		t.Fatalf("unexpected err: %v\n", err)
@@ -518,7 +515,7 @@ func TestLocalLoaderReferencingGitBase(t *testing.T) {
 		t.Fatalf("unexpected err:  %v\n", err)
 	}
 	l1 := newLoaderAtConfirmedDir(
-		RestrictionRootOnly, validators.MakeFakeValidator(), root, fSys, nil,
+		RestrictionRootOnly, root, fSys, nil,
 		git.DoNothingCloner(filesys.ConfirmedDir(cloneRoot)))
 	if l1.Root() != topDir {
 		t.Fatalf("unexpected root %s", l1.Root())
@@ -544,7 +541,7 @@ func TestRepoDirectCycleDetection(t *testing.T) {
 		t.Fatalf("unexpected err: %v\n", err)
 	}
 	l1 := newLoaderAtConfirmedDir(
-		RestrictionRootOnly, validators.MakeFakeValidator(), root, fSys, nil,
+		RestrictionRootOnly, root, fSys, nil,
 		git.DoNothingCloner(filesys.ConfirmedDir(cloneRoot)))
 	p1 := "github.com/someOrg/someRepo/foo"
 	rs1, err := git.NewRepoSpecFromUrl(p1)
@@ -573,7 +570,7 @@ func TestRepoIndirectCycleDetection(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	l0 := newLoaderAtConfirmedDir(
-		RestrictionRootOnly, validators.MakeFakeValidator(), root, fSys, nil,
+		RestrictionRootOnly, root, fSys, nil,
 		git.DoNothingCloner(filesys.ConfirmedDir(cloneRoot)))
 
 	p1 := "github.com/someOrg/someRepo1"

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -18,18 +18,17 @@ import (
 // the remote bases will all be root-only restricted.
 func NewLoader(
 	lr LoadRestrictorFunc,
-	v ifc.Validator,
 	target string, fSys filesys.FileSystem) (ifc.Loader, error) {
 	repoSpec, err := git.NewRepoSpecFromUrl(target)
 	if err == nil {
 		// The target qualifies as a remote git target.
 		return newLoaderAtGitClone(
-			repoSpec, v, fSys, nil, git.ClonerUsingGitExec)
+			repoSpec, fSys, nil, git.ClonerUsingGitExec)
 	}
 	root, err := demandDirectoryRoot(fSys, target)
 	if err != nil {
 		return nil, err
 	}
 	return newLoaderAtConfirmedDir(
-		lr, v, root, fSys, nil, git.ClonerUsingGitExec), nil
+		lr, root, fSys, nil, git.ClonerUsingGitExec), nil
 }

--- a/pkg/plugins/execplugin_test.go
+++ b/pkg/plugins/execplugin_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 func TestExecPluginConfig(t *testing.T) {
@@ -21,6 +22,7 @@ func TestExecPluginConfig(t *testing.T) {
 		resource.NewFactory(
 			kunstruct.NewKunstructuredFactoryImpl()), nil)
 	ldr := loadertest.NewFakeLoader(path)
+	v := validators.MakeFakeValidator()
 	pluginConfig := rf.RF().FromMap(
 		map[string]interface{}{
 			"apiVersion": "someteam.example.com/v1",
@@ -47,7 +49,7 @@ s/$BAR/bar/g
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	p.Config(resmap.NewPluginHelpers(ldr, rf), yaml)
+	p.Config(resmap.NewPluginHelpers(ldr, v, rf), yaml)
 
 	expected := "/kustomize/plugin/someteam.example.com/v1/sedtransformer/SedTransformer"
 	if !strings.HasSuffix(p.path, expected) {

--- a/pkg/plugins/loader.go
+++ b/pkg/plugins/loader.go
@@ -30,10 +30,10 @@ func NewLoader(
 }
 
 func (l *Loader) LoadGenerators(
-	ldr ifc.Loader, rm resmap.ResMap) ([]resmap.Generator, error) {
+	ldr ifc.Loader, v ifc.Validator, rm resmap.ResMap) ([]resmap.Generator, error) {
 	var result []resmap.Generator
 	for _, res := range rm.Resources() {
-		g, err := l.LoadGenerator(ldr, res)
+		g, err := l.LoadGenerator(ldr, v, res)
 		if err != nil {
 			return nil, err
 		}
@@ -43,8 +43,8 @@ func (l *Loader) LoadGenerators(
 }
 
 func (l *Loader) LoadGenerator(
-	ldr ifc.Loader, res *resource.Resource) (resmap.Generator, error) {
-	c, err := l.loadAndConfigurePlugin(ldr, res)
+	ldr ifc.Loader, v ifc.Validator, res *resource.Resource) (resmap.Generator, error) {
+	c, err := l.loadAndConfigurePlugin(ldr, v, res)
 	if err != nil {
 		return nil, err
 	}
@@ -56,10 +56,10 @@ func (l *Loader) LoadGenerator(
 }
 
 func (l *Loader) LoadTransformers(
-	ldr ifc.Loader, rm resmap.ResMap) ([]resmap.Transformer, error) {
+	ldr ifc.Loader, v ifc.Validator, rm resmap.ResMap) ([]resmap.Transformer, error) {
 	var result []resmap.Transformer
 	for _, res := range rm.Resources() {
-		t, err := l.LoadTransformer(ldr, res)
+		t, err := l.LoadTransformer(ldr, v, res)
 		if err != nil {
 			return nil, err
 		}
@@ -69,8 +69,8 @@ func (l *Loader) LoadTransformers(
 }
 
 func (l *Loader) LoadTransformer(
-	ldr ifc.Loader, res *resource.Resource) (resmap.Transformer, error) {
-	c, err := l.loadAndConfigurePlugin(ldr, res)
+	ldr ifc.Loader, v ifc.Validator, res *resource.Resource) (resmap.Transformer, error) {
+	c, err := l.loadAndConfigurePlugin(ldr, v, res)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func isBuiltinPlugin(res *resource.Resource) bool {
 }
 
 func (l *Loader) loadAndConfigurePlugin(
-	ldr ifc.Loader, res *resource.Resource) (c resmap.Configurable, err error) {
+	ldr ifc.Loader, v ifc.Validator, res *resource.Resource) (c resmap.Configurable, err error) {
 	if isBuiltinPlugin(res) {
 		// Instead of looking for and loading a .so file, just
 		// instantiate the plugin from a generated factory
@@ -123,7 +123,7 @@ func (l *Loader) loadAndConfigurePlugin(
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshalling yaml from res %s", res.OrgId())
 	}
-	err = c.Config(resmap.NewPluginHelpers(ldr, l.rf), yaml)
+	err = c.Config(resmap.NewPluginHelpers(ldr, v, l.rf), yaml)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "plugin %s fails configuration", res.OrgId())

--- a/pkg/plugins/loader_test.go
+++ b/pkg/plugins/loader_test.go
@@ -6,13 +6,13 @@ package plugins_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/v3/pluglib"
-
 	"sigs.k8s.io/kustomize/v3/internal/loadertest"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	. "sigs.k8s.io/kustomize/v3/pkg/plugins"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"sigs.k8s.io/kustomize/v3/pluglib"
 )
 
 const (
@@ -54,12 +54,12 @@ func TestLoader(t *testing.T) {
 	rmF := resmap.NewFactory(resource.NewFactory(
 		kunstruct.NewKunstructuredFactoryImpl()), nil)
 
-	l := NewLoader(ActivePluginConfig(), rmF)
-	if l == nil {
+	ldr := loadertest.NewFakeLoader("/foo")
+
+	pLdr := NewLoader(ActivePluginConfig(), rmF)
+	if pLdr == nil {
 		t.Fatal("expect non-nil loader")
 	}
-
-	ldr := loadertest.NewFakeLoader("/foo")
 
 	m, err := rmF.NewResMapFromBytes([]byte(
 		someServiceGenerator + "---\n" + secretGenerator))
@@ -67,7 +67,7 @@ func TestLoader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = l.LoadGenerators(ldr, m)
+	_, err = pLdr.LoadGenerators(ldr, validators.MakeFakeValidator(), m)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/resmap/factory.go
+++ b/pkg/resmap/factory.go
@@ -66,12 +66,12 @@ func (rmF *Factory) NewResMapFromBytes(b []byte) (ResMap, error) {
 // NewResMapFromConfigMapArgs returns a Resource slice given
 // a configmap metadata slice from kustomization file.
 func (rmF *Factory) NewResMapFromConfigMapArgs(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	argList []types.ConfigMapArgs) (ResMap, error) {
 	var resources []*resource.Resource
 	for _, args := range argList {
-		res, err := rmF.resF.MakeConfigMap(ldr, options, &args)
+		res, err := rmF.resF.MakeConfigMap(kvLdr, options, &args)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewResMapFromConfigMapArgs")
 		}
@@ -81,10 +81,10 @@ func (rmF *Factory) NewResMapFromConfigMapArgs(
 }
 
 func (rmF *Factory) FromConfigMapArgs(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args types.ConfigMapArgs) (ResMap, error) {
-	res, err := rmF.resF.MakeConfigMap(ldr, options, &args)
+	res, err := rmF.resF.MakeConfigMap(kvLdr, options, &args)
 	if err != nil {
 		return nil, err
 	}
@@ -94,12 +94,12 @@ func (rmF *Factory) FromConfigMapArgs(
 // NewResMapFromSecretArgs takes a SecretArgs slice, generates
 // secrets from each entry, and accumulates them in a ResMap.
 func (rmF *Factory) NewResMapFromSecretArgs(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	argsList []types.SecretArgs) (ResMap, error) {
 	var resources []*resource.Resource
 	for _, args := range argsList {
-		res, err := rmF.resF.MakeSecret(ldr, options, &args)
+		res, err := rmF.resF.MakeSecret(kvLdr, options, &args)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewResMapFromSecretArgs")
 		}
@@ -109,10 +109,10 @@ func (rmF *Factory) NewResMapFromSecretArgs(
 }
 
 func (rmF *Factory) FromSecretArgs(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args types.SecretArgs) (ResMap, error) {
-	res, err := rmF.resF.MakeSecret(ldr, options, &args)
+	res, err := rmF.resF.MakeSecret(kvLdr, options, &args)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resmap/resmap.go
+++ b/pkg/resmap/resmap.go
@@ -38,8 +38,8 @@ type Configurable interface {
 }
 
 // NewPluginHelpers makes an instance of PluginHelpers.
-func NewPluginHelpers(ldr ifc.Loader, rf *Factory) *PluginHelpers {
-	return &PluginHelpers{ldr: ldr, rf: rf}
+func NewPluginHelpers(ldr ifc.Loader, v ifc.Validator, rf *Factory) *PluginHelpers {
+	return &PluginHelpers{ldr: ldr, v: v, rf: rf}
 }
 
 // PluginHelpers holds things that any or all plugins might need.
@@ -47,6 +47,7 @@ func NewPluginHelpers(ldr ifc.Loader, rf *Factory) *PluginHelpers {
 // any plugin-specific configuration.
 type PluginHelpers struct {
 	ldr ifc.Loader
+	v   ifc.Validator
 	rf  *Factory
 }
 
@@ -56,6 +57,10 @@ func (c *PluginHelpers) Loader() ifc.Loader {
 
 func (c *PluginHelpers) ResmapFactory() *Factory {
 	return c.rf
+}
+
+func (c *PluginHelpers) Validator() ifc.Validator {
+	return c.v
 }
 
 type GeneratorPlugin interface {

--- a/pkg/resource/factory.go
+++ b/pkg/resource/factory.go
@@ -148,10 +148,10 @@ func (rf *Factory) SliceFromBytes(in []byte) ([]*Resource, error) {
 
 // MakeConfigMap makes an instance of Resource for ConfigMap
 func (rf *Factory) MakeConfigMap(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args *types.ConfigMapArgs) (*Resource, error) {
-	u, err := rf.kf.MakeConfigMap(ldr, options, args)
+	u, err := rf.kf.MakeConfigMap(kvLdr, options, args)
 	if err != nil {
 		return nil, err
 	}
@@ -164,10 +164,10 @@ func (rf *Factory) MakeConfigMap(
 
 // MakeSecret makes an instance of Resource for Secret
 func (rf *Factory) MakeSecret(
-	ldr ifc.Loader,
+	kvLdr ifc.KvLoader,
 	options *types.GeneratorOptions,
 	args *types.SecretArgs) (*Resource, error) {
-	u, err := rf.kf.MakeSecret(ldr, options, args)
+	u, err := rf.kf.MakeSecret(kvLdr, options, args)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/target/kusttarget_test.go
+++ b/pkg/target/kusttarget_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	. "sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 const (
@@ -184,7 +185,8 @@ func TestResources(t *testing.T) {
 
 func TestKustomizationNotFound(t *testing.T) {
 	_, err := NewKustTarget(
-		loadertest.NewFakeLoader("/foo"), nil, nil, nil)
+		loadertest.NewFakeLoader("/foo"),
+		validators.MakeFakeValidator(), nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected an error")
 	}

--- a/pkg/target/plugindir_test.go
+++ b/pkg/target/plugindir_test.go
@@ -59,7 +59,7 @@ metadata:
 	}
 
 	ldr, err := loader.NewLoader(
-		loader.RestrictionRootOnly, validators.MakeFakeValidator(), dir, fSys)
+		loader.RestrictionRootOnly, dir, fSys)
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
@@ -67,7 +67,8 @@ metadata:
 		kunstruct.NewKunstructuredFactoryImpl()), nil)
 
 	pl := plugins.NewLoader(plugins.ActivePluginConfig(), rf)
-	tg, err := target.NewKustTarget(ldr, rf, transformer.NewFactoryImpl(), pl)
+	tg, err := target.NewKustTarget(
+		ldr, validators.MakeFakeValidator(), rf, transformer.NewFactoryImpl(), pl)
 	if err != nil {
 		t.Fatalf("err %v", err)
 	}

--- a/pkg/types/kustomization.go
+++ b/pkg/types/kustomization.go
@@ -182,12 +182,6 @@ type PluginConfig struct {
 	Enabled bool
 }
 
-// Pair is a key value pair.
-type Pair struct {
-	Key   string
-	Value string
-}
-
 type PluginType string
 
 func (p PluginType) IsUndefined() bool {

--- a/pkg/types/kvpairsources.go
+++ b/pkg/types/kvpairsources.go
@@ -3,7 +3,7 @@
 
 package types
 
-// KvPairSources contains some generic sources for generators.
+// KvPairSources defines places to obtain key value pairs.
 type KvPairSources struct {
 	// LiteralSources is a list of literal
 	// pair sources. Each literal source should

--- a/pkg/types/pair.go
+++ b/pkg/types/pair.go
@@ -1,0 +1,10 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// Pair is a key value pair.
+type Pair struct {
+	Key   string
+	Value string
+}

--- a/plugin/builtin/ConfigMapGenerator.go
+++ b/plugin/builtin/ConfigMapGenerator.go
@@ -2,6 +2,7 @@
 package builtin
 
 import (
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -31,7 +32,8 @@ func (p *ConfigMapGeneratorPlugin) Config(
 
 func (p *ConfigMapGeneratorPlugin) Generate() (resmap.ResMap, error) {
 	return p.h.ResmapFactory().FromConfigMapArgs(
-		p.h.Loader(), &p.GeneratorOptions, p.ConfigMapArgs)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()),
+		&p.GeneratorOptions, p.ConfigMapArgs)
 }
 
 func NewConfigMapGeneratorPlugin() resmap.GeneratorPlugin {

--- a/plugin/builtin/InventoryTransformer.go
+++ b/plugin/builtin/InventoryTransformer.go
@@ -4,6 +4,7 @@ package builtin
 import (
 	"fmt"
 
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/hasher"
 	"sigs.k8s.io/kustomize/v3/pkg/inventory"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
@@ -71,7 +72,7 @@ func (p *InventoryTransformerPlugin) Transform(m resmap.ResMap) error {
 	}
 
 	cm, err := p.h.ResmapFactory().RF().MakeConfigMap(
-		p.h.Loader(), opts, &args)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()), opts, &args)
 	if err != nil {
 		return err
 	}

--- a/plugin/builtin/SecretGenerator.go
+++ b/plugin/builtin/SecretGenerator.go
@@ -2,6 +2,7 @@
 package builtin
 
 import (
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -30,7 +31,8 @@ func (p *SecretGeneratorPlugin) Config(h *resmap.PluginHelpers, config []byte) (
 
 func (p *SecretGeneratorPlugin) Generate() (resmap.ResMap, error) {
 	return p.h.ResmapFactory().FromSecretArgs(
-		p.h.Loader(), &p.GeneratorOptions, p.SecretArgs)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()),
+		&p.GeneratorOptions, p.SecretArgs)
 }
 
 func NewSecretGeneratorPlugin() resmap.GeneratorPlugin {

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -37,5 +38,6 @@ func (p *plugin) Config(
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
 	return p.h.ResmapFactory().FromConfigMapArgs(
-		p.h.Loader(), &p.GeneratorOptions, p.ConfigMapArgs)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()),
+		&p.GeneratorOptions, p.ConfigMapArgs)
 }

--- a/plugin/builtin/inventorytransformer/InventoryTransformer.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer.go
@@ -7,6 +7,7 @@ package main
 import (
 	"fmt"
 
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/hasher"
 	"sigs.k8s.io/kustomize/v3/pkg/inventory"
 	"sigs.k8s.io/kustomize/v3/pkg/resid"
@@ -77,7 +78,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	}
 
 	cm, err := p.h.ResmapFactory().RF().MakeConfigMap(
-		p.h.Loader(), opts, &args)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()), opts, &args)
 	if err != nil {
 		return err
 	}

--- a/plugin/builtin/secretgenerator/SecretGenerator.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -36,5 +37,6 @@ func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 
 func (p *plugin) Generate() (resmap.ResMap, error) {
 	return p.h.ResmapFactory().FromSecretArgs(
-		p.h.Loader(), &p.GeneratorOptions, p.SecretArgs)
+		kv.NewLoader(p.h.Loader(), p.h.Validator()),
+		&p.GeneratorOptions, p.SecretArgs)
 }

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"sigs.k8s.io/kustomize/v3/kv"
 	"sigs.k8s.io/kustomize/v3/pkg/resmap"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/yaml"
@@ -47,5 +48,6 @@ func (p *plugin) Generate() (resmap.ResMap, error) {
 				args.LiteralSources, k+"="+v)
 		}
 	}
-	return p.h.ResmapFactory().FromSecretArgs(p.h.Loader(), nil, args)
+	return p.h.ResmapFactory().FromSecretArgs(
+		kv.NewLoader(p.h.Loader(), p.h.Validator()), nil, args)
 }


### PR DESCRIPTION
It's needed by plugins at the moment, so it has to be public.
And it needs to be distinct from file loader, since not everything that needs a file loader needs a KV loader, and in fact the wrapping was opposite what it should have been. KV loading needs a file loader.
