### PR TITLE
Refactor exec plugin load to error if plugin isn't executable

### DIFF
--- a/api/plugins/execplugin/execplugin.go
+++ b/api/plugins/execplugin/execplugin.go
@@ -44,8 +44,15 @@ type ExecPlugin struct {
 	h *resmap.PluginHelpers
 }
 
-func NewExecPlugin(p string) *ExecPlugin {
-	return &ExecPlugin{path: p}
+func NewExecPlugin(p string) (*ExecPlugin, error) {
+	f, err := os.Stat(p)
+	if err != nil {
+		return nil, err
+	}
+	if f.Mode()&0111 == 0000 {
+		return nil, fmt.Errorf("unable to execute plugin on path: %s", p)
+	}
+	return &ExecPlugin{path: p}, nil
 }
 
 func (p *ExecPlugin) Path() string {
@@ -58,15 +65,6 @@ func (p *ExecPlugin) Args() []string {
 
 func (p *ExecPlugin) Cfg() []byte {
 	return p.cfg
-}
-
-// isAvailable checks to see if the plugin is available
-func (p *ExecPlugin) IsAvailable() bool {
-	f, err := os.Stat(p.path)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return f.Mode()&0111 != 0000
 }
 
 func (p *ExecPlugin) Config(h *resmap.PluginHelpers, config []byte) error {

--- a/api/plugins/execplugin/execplugin_test.go
+++ b/api/plugins/execplugin/execplugin_test.go
@@ -5,6 +5,7 @@ package execplugin_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/api/plugins/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -43,10 +44,13 @@ s/$BAR/bar/g
  \ \ \ 
 `))
 
-	p := NewExecPlugin(
+	p, err := NewExecPlugin(
 		loader.AbsolutePluginPath(
 			config.DefaultPluginConfig(),
 			pluginConfig.OrgId()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err.Error())
+	}
 
 	yaml, err := pluginConfig.AsYAML()
 	if err != nil {
@@ -114,7 +118,10 @@ func strptr(s string) *string {
 }
 
 func TestUpdateResourceOptions(t *testing.T) {
-	p := NewExecPlugin("")
+	p, err := NewExecPlugin("")
+	if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error: %v", err.Error())
+	}
 	rf := resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl())
 	in := resmap.New()
 	expected := resmap.New()
@@ -159,7 +166,10 @@ func TestUpdateResourceOptions(t *testing.T) {
 }
 
 func TestUpdateResourceOptionsWithInvalidHashAnnotationValues(t *testing.T) {
-	p := NewExecPlugin("")
+	p, err := NewExecPlugin("")
+	if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error: %v", err.Error())
+	}
 	rf := resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl())
 	cases := []string{
 		"",

--- a/api/plugins/loader/loader.go
+++ b/api/plugins/loader/loader.go
@@ -5,6 +5,7 @@ package loader
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"plugin"
 	"reflect"
@@ -145,9 +146,12 @@ func (l *Loader) makeBuiltinPlugin(r resid.Gvk) (resmap.Configurable, error) {
 }
 
 func (l *Loader) loadPlugin(resId resid.ResId) (resmap.Configurable, error) {
-	p := execplugin.NewExecPlugin(l.absolutePluginPath(resId))
-	if p.IsAvailable() {
+	p, err := execplugin.NewExecPlugin(l.absolutePluginPath(resId))
+	if err == nil {
 		return p, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
 	}
 	c, err := l.loadGoPlugin(resId)
 	if err != nil {


### PR DESCRIPTION
This addresses issue #1236. Changed the order of execution a bit around and made the existing tests pass accordingly.