### PR TITLE
Pin the cloudbuild step container tags.

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -4,10 +4,11 @@ set -x
 
 # Script to run http://goreleaser.com
 
+# Removed from `build` stanza
+# binary: $module
+
 module=$1
 shift
-
-cd $module
 
 configFile=$(mktemp)
 cat <<EOF >$configFile
@@ -30,7 +31,7 @@ release:
     owner: kubernetes-sigs
     name: kustomize
 builds:
-- binary: $module
+- main: ./$module/main.go
   ldflags: >
     -s
     -X sigs.k8s.io/kustomize/api/provenance.version={{.Version}}

--- a/releasing/cloudbuild_api.yaml
+++ b/releasing/cloudbuild_api.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: "gcr.io/cloud-builders/git"
+- name: "gcr.io/cloud-builders/git@sha256:477015d9bb2bc4780f505a4497f10ee581a28fccfa553821cc540cc64bdc37b9"
   args: [fetch, --tags, --depth=100]
-- name: goreleaser/goreleaser
+- name: "goreleaser/goreleaser:v0.120.3"
   entrypoint: /bin/sh
   args: ["releasing/cloudbuild.sh", "api"]
   secretEnv: ['GITHUB_TOKEN']

--- a/releasing/cloudbuild_kustomize.yaml
+++ b/releasing/cloudbuild_kustomize.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: "gcr.io/cloud-builders/git"
+- name: "gcr.io/cloud-builders/git@sha256:477015d9bb2bc4780f505a4497f10ee581a28fccfa553821cc540cc64bdc37b9"
   args: [fetch, --tags, --depth=100]
-- name: goreleaser/goreleaser
+- name: "goreleaser/goreleaser:v0.120.3"
   entrypoint: /bin/sh
   args: ["releasing/cloudbuild.sh", "kustomize"]
   secretEnv: ['GITHUB_TOKEN']

--- a/releasing/cloudbuild_pluginator.yaml
+++ b/releasing/cloudbuild_pluginator.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: "gcr.io/cloud-builders/git"
+- name: "gcr.io/cloud-builders/git@sha256:477015d9bb2bc4780f505a4497f10ee581a28fccfa553821cc540cc64bdc37b9"
   args: [fetch, --tags, --depth=100]
-- name: goreleaser/goreleaser
+- name: "goreleaser/goreleaser:v0.120.3"
   entrypoint: /bin/sh
   args: ["releasing/cloudbuild.sh", "pluginator"]
   secretEnv: ['GITHUB_TOKEN']

--- a/releasing/localbuild.sh
+++ b/releasing/localbuild.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-
-# Usage - from repo root, enter:
 #
-# module=(kustomize|pluginator|api)
-# ./releasing/localbuild.sh $module
+# To test the release process, this script attempts to
+# use Google cloudbuild configuration to create a release
+# locally.
 #
-# The script attempts to use cloudbuild configuration
-# to create a release "locally".
+# Usage: from the repo root, enter:
+#
+#     module=kustomize
+#     module=pluginator  # pick one
+#     module=api
+#
+#     ./releasing/localbuild.sh $module
+#
 #
 # See https://cloud.google.com/cloud-build/docs/build-debug-locally
 #
@@ -58,8 +63,7 @@ sed -i '2,3d'  $config
 # Add the --snapshot flag to suppress the
 # github release and leave the build output
 # in the kustomize/dist directory.
-sed -i 's|"\]$|", "--snapshot"]|' \
-    $config
+sed -i 's|"\]$|", "--snapshot"]|' $config
 
 echo "Executing cloud-build-local with:"
 echo "========================="
@@ -75,5 +79,5 @@ cloud-build-local \
 echo " "
 echo "Result of local build:"
 echo "##########################################"
-tree ./$module/dist
+tree ./dist
 echo "##########################################"


### PR DESCRIPTION
No particular reason for picking these particular tags - just want stability, and using latest is unstable.

