### PR TITLE
Deal with goreleaser field deprecations.

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -60,9 +60,9 @@ builds:
   - darwin
   - windows
   goarch:
-   - amd64
-archive:
-  name_template: "{{ .ProjectName }}_${tSemver}_{{ .Os }}_{{ .Arch }}"
+  - amd64
+archives:
+-  name_template: "${module}_${tSemver}_{{ .Os }}_{{ .Arch }}"
 EOF
 
 cat $configFile

--- a/releasing/cloudbuild_api.yaml
+++ b/releasing/cloudbuild_api.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: "gcr.io/cloud-builders/git@sha256:477015d9bb2bc4780f505a4497f10ee581a28fccfa553821cc540cc64bdc37b9"
+- name: "gcr.io/cloud-builders/git"
   args: [fetch, --tags, --depth=100]
 - name: "goreleaser/goreleaser:v0.120.3"
   entrypoint: /bin/sh


### PR DESCRIPTION
and unfortunately goreleaser 477015d looks buggy, so switching back to latest to roll dice.