### PR TITLE
Update curl installation instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,15 +8,18 @@ are available on the [release page].
 
 Or...
 
-## Quickly curl the latest binary
+## Quickly curl a tagged release from GitHub
 
 ```
+# Kustomize release tag
+tag=v3.2.3
+
 # pick one
 opsys=darwin
 opsys=windows
 opsys=linux
 
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
+curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/kustomize/$tag |\
   grep browser_download |\
   grep $opsys |\
   cut -d '"' -f 4 |\


### PR DESCRIPTION
The most recent release in this repository breaks the current installation instructions using curl, as it now considers https://github.com/kubernetes-sigs/kustomize/releases/tag/api%2Fv0.1.1 the latest version, which does not ship the Kustomize CLI binary.

As an alternative to providing instructions to install the latest version, I propose updating the docs on how to install a particular tagged release instead, which is already the case for the second installation example in the docs.