### PR TITLE
Add support to render charts using '.Release.Name' and .Release.Namespace'

### DIFF
--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -15,6 +15,8 @@
 #  chartHome: /abs/path/local/chart/storage
 #  helmHome: /abs/path/to/helm/config
 #  helmBin: /abs/path/to/helmBin
+#  releaseNam: nameOfHelmRelease
+#  releaseNamespace: namespaceWhereHelmWouldApply
 #
 # fetches the given chart from stable/$chartName,
 # and inflates it to stdout, using the given values file.
@@ -44,6 +46,8 @@ function parseYaml {
     [ "$k" == "values" ] && valuesFile=$v
     [ "$k" == "helmHome" ] && helmHome=$v
     [ "$k" == "helmBin" ] && helmBin=$v
+    [ "$k" == "releaseName" ] && releaseName=$v
+    [ "$k" == "releaseNamespace" ] && releaseNamespace=$v
   done <"$file"
 
   # Trim leading space
@@ -51,6 +55,8 @@ function parseYaml {
   chartHome="${chartHome#"${chartHome%%[![:space:]]*}"}"
   valuesFile="${valuesFile#"${valuesFile%%[![:space:]]*}"}"
   helmBin="${helmBin#"${helmBin%%[![:space:]]*}"}"
+  releaseName="${releaseName#"${releaseName%%[![:space:]]*}"}"
+  releaseNamespace="${releaseNamespace#"${releaseNamespace%%[![:space:]]*}"}"
 }
 
 TMP_DIR=$(mktemp -d)
@@ -75,6 +81,14 @@ if [ -z "$valuesFile" ]; then
   valuesFile=$chartHome/$chartName/values.yaml
 fi
 
+if [ -z "$releaseName" ]; then
+  releaseName=release-name
+fi
+
+if [ -z "$releaseNamespace" ]; then
+  releaseNamespace=default
+fi
+
 function doHelm {
   $helmBin --home $helmHome $@
 }
@@ -89,6 +103,8 @@ if [ ! -d "$chartHome/$chartName" ]; then
 fi
 
 doHelm template \
+    --name $releaseName \
+    --namespace $releaseNamespace \
     --values $valuesFile \
     $chartHome/$chartName
 


### PR DESCRIPTION
There are charts that compose environment variables by using this two `helm` parameters and its deploy gets broken if they are not correctly specified.
In e.g. [redis](https://github.com/helm/charts/blob/master/stable/redis/templates/redis-slave-statefulset.yaml#L129) uses `.Release.Namespace` to provide redis-slaves with the corresponding redis-master internal k8s FQDN and if it's not specified during rendering the `helm` template, it defaults to `default` namespace; leading the cluster to an non-functional status.

I've added two variables to be read from the `chartInflator.yaml` file and made them to default to the current values set by `helm` if they are not specified, which are:
* `releaseName=release-name`
* `releaseNamespace=default`

Note that if you want to maintain generic `kustomize` files to use between different releases, it might be a good idea to leave the `releaseName` as default, since it will be frequently used as selector (`metadata.name`) for the kustomization. In e.g., this is one:
```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-redis-slave
spec:
  template:
    spec:
      securityContext:
        sysctls:
        - name: net.core.somaxconn
          value: "10000"
```
I usually do `kustomize $KUSTOMIZE_DIR | sed "s|release-name|${RELEASE_NAME}" > helm.yaml` to overcome this. I found no problem for the namespace use case, tho.