### PR TITLE
Fix quick curl instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,12 +16,14 @@ opsys=darwin
 opsys=windows
 opsys=linux
 
-curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-  grep browser_download |\
-  grep $opsys |\
-  cut -d '"' -f 4 |\
-  xargs curl -O -L
-mv kustomize_kustomize\.v*_${opsys}_amd64 kustomize
+curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
+    grep browser_download |\
+    grep $opsys |\
+    grep kustomize_kustomize |\
+    head -n1 |\
+    cut -d '"' -f 4 |\
+    xargs curl -O -L && \
+mv kustomize_kustomize\.v*_${opsys}_amd64 kustomize && \
 chmod u+x kustomize
 ```
 


### PR DESCRIPTION
Fixes #1680 

The release of the Go API broke the quick install instructions in INSTALL.md. This PR implements @nigimaster's suggestion from the discussion in #1680. 