### PR TITLE
Improve error reporting in the PatchTransformer plugin

### DIFF
--- a/api/target/kusttarget.go
+++ b/api/target/kusttarget.go
@@ -377,13 +377,12 @@ func (kt *KustTarget) configureBuiltinPlugin(
 	if c != nil {
 		y, err = yaml.Marshal(c)
 		if err != nil {
-			return errors.Wrapf(
-				err, "builtin %s marshal", bpt)
+			return fmt.Errorf("unable to marshal builtin plugin %s configuration: %v", bpt, err)
 		}
 	}
 	err = p.Config(resmap.NewPluginHelpers(kt.ldr, kt.validator, kt.rFactory), y)
 	if err != nil {
-		return errors.Wrapf(err, "builtin %s config: %v", bpt, y)
+		return fmt.Errorf("unable to process %s with builtin plugin %s: %v", y, bpt, err)
 	}
 	return nil
 }

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -57,7 +57,7 @@ func (p *plugin) Config(
 	patchJson, errJson := jsonPatchFromBytes(in)
 	if errSM != nil && errJson != nil {
 		err = fmt.Errorf(
-			"Strategic Merge Patch strategy is failing with: %v, JSON patch 6902 strategy is failing with: %v", p.Path, errSM, errJson)
+			"Strategic Merge Patch strategy is failing with: %v, JSON patch 6902 strategy is failing with: %v", errSM, errJson)
 		return
 	}
 	if errSM == nil && errJson != nil {

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -57,7 +57,7 @@ func (p *plugin) Config(
 	patchJson, errJson := jsonPatchFromBytes(in)
 	if errSM != nil && errJson != nil {
 		err = fmt.Errorf(
-			"unable to get either a Strategic Merge Patch or JSON patch 6902 from %s", p.Patch)
+			"Strategic Merge Patch strategy is failing with: %v, JSON patch 6902 strategy is failing with: %v", p.Path, errSM, errJson)
 		return
 	}
 	if errSM == nil && errJson != nil {
@@ -68,7 +68,7 @@ func (p *plugin) Config(
 	}
 	if patchSM != nil && patchJson != nil {
 		err = fmt.Errorf(
-			"a patch can't be both a Strategic Merge Patch and JSON patch 6902 %s", p.Patch)
+			"a patch can't be both a Strategic Merge Patch and JSON patch 6902 %s", p.Path)
 	}
 
 	return nil


### PR DESCRIPTION
This PR improves error reporting in the PatchTransformer plugin.

Given the following `kustomize.yaml` file

```
---

bases:
  - ../../base-modules/simulator

patches:
  - path: patches/platform-settings-daemonset.yml
    target:
      kind: DaemonSet
      labelSelector: "app.kubernetes.io/name=simulator"
```

and a patch file with the wrong yaml indentation

```
---

apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: simulator
spec:
  template:
    spec:
       volumes:
        - name: simulator-config
          hostPath:
            path: /etc/simulator/
            type: DirectoryOrCreate
      initContainers:
        - name: configure-simulator
          image: simulator-init:7
          command:
            - "configure-simulator"
          volumeMounts:
          - name: platform-config-ansible
               mountPath: /etc/simulator/
```

Kustomize fails with 

```
Error: builtin PatchTransformer config: [112 97 116 104 58 32 112 97 116 99 104 101 115 47 112 108 97 116 102 111 114 109 45 115 101 116 116 105 110 103 115 45 100 97 101 109 111 110 115 101 116 46 121 109 108 10 116 97 114 103 101 116 58 10 32 32 107 105 110 100 58 32 68 97 101 109 111 110 83 101 116 10 32 32 108 97 98 101 108 83 101 108 101 99 116 111 114 58 32 97 112 112 46 107 117 98 101 114 110 101 116 101 115 46 105 111 47 110 97 109 101 61 115 105 109 117 108 97 116 111 114 10]: unable to get either a Strategic Merge Patch or JSON patch 6902 from
```

This PR changes the output of the message above to

```
Error: unable to process path: patches/platform-settings-daemonset.yml
target:
  kind: DaemonSet
  labelSelector: app.kubernetes.io/name=simulator
 with builtin plugin PatchTransformer: Strategic Merge Patch strategy is failing with: patches/platform-settings-daemonset.yml, JSON patch 6902 strategy is failing with: error converting YAML to JSON: yaml: line 30: mapping values are not allowed in this context%!(EXTRA *errors.errorString=yaml: line 30: mapping values are not allowed in this context)
```