### PR TITLE
Make krusty package - high-level CLI-like package.

### DIFF
--- a/api/krusty/doc.go
+++ b/api/krusty/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package krusty holds a very high level API to kustomize.
+// The functions here should be similar to the CLI api.
+package krusty

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty
+
+import (
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/api/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/api/k8sdeps/validator"
+	fLdr "sigs.k8s.io/kustomize/api/loader"
+	"sigs.k8s.io/kustomize/api/plugins/builtins"
+	"sigs.k8s.io/kustomize/api/plugins/config"
+	pLdr "sigs.k8s.io/kustomize/api/plugins/loader"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/api/target"
+)
+
+// Kustomizer performs kustomizations.  It's meant to behave
+// similarly to the kustomize CLI, and can be used instead of
+// performing an exec to a kustomize CLI subprocess.
+// To use, load a filesystem with kustomization files (any
+// number of overlays and bases), then make a Kustomizer
+// injected with the given fileystem, then call Build.
+type Kustomizer struct {
+	fSys    filesys.FileSystem
+	options *Options
+}
+
+// MakeDefaultKustomizer returns a Kustomizer with default configuration.
+func MakeDefaultKustomizer() *Kustomizer {
+	return MakeKustomizer(filesys.MakeFsOnDisk(), MakeDefaultOptions())
+}
+
+// MakeKustomizer returns an instance of Kustomizer.
+func MakeKustomizer(fSys filesys.FileSystem, o *Options) *Kustomizer {
+	return &Kustomizer{fSys: fSys, options: o}
+}
+
+// Run performs a kustomization.
+//
+// It uses its internal filesystem reference to read the file at
+// the given path argument, interpret it as a kustomization.yaml
+// file, perform the kustomization it represents, and return the
+// resulting YAML as bytes.
+//
+// Any files referenced by the kustomization must be present in the
+// internal filesystem.  One may call Run any number of times,
+// on any number of internal paths (e.g. the filesystem may contain
+// multiple overlays, and Run can be called on each of them).
+func (b *Kustomizer) Run(path string) ([]byte, error) {
+	pf := transformer.NewFactoryImpl()
+	rf := resmap.NewFactory(
+		resource.NewFactory(
+			kunstruct.NewKunstructuredFactoryImpl()),
+		pf)
+	lr := fLdr.RestrictionNone
+	if b.options.RestrictToRootOnly {
+		lr = fLdr.RestrictionRootOnly
+	}
+	ldr, err := fLdr.NewLoader(lr, path, b.fSys)
+	if err != nil {
+		return nil, err
+	}
+	defer ldr.Cleanup()
+	kt, err := target.NewKustTarget(
+		ldr,
+		validator.NewKustValidator(),
+		rf,
+		pf,
+		pLdr.NewLoader(config.DefaultPluginConfig(), rf),
+	)
+	if err != nil {
+		return nil, err
+	}
+	m, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		return nil, err
+	}
+	if b.options.DoLegacyResourceSort {
+		builtins.NewLegacyOrderTransformerPlugin().Transform(m)
+	}
+	return m.AsYaml()
+}

--- a/api/krusty/kustomizer_test.go
+++ b/api/krusty/kustomizer_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: move most of the tests in the api/target package to this package.
+package krusty_test
+
+import (
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"testing"
+)
+
+// TODO: make this more like kusttest_test.AssertActualEqualsExpected
+func assertOutput(t *testing.T, actual []byte, expected string) {
+	if string(actual) != expected {
+		t.Fatalf("Err: expected:\n%s\nbut got:\n%s\n", expected, actual)
+	}
+}
+
+func TestSomething1(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	b := krusty.MakeKustomizer(fSys, krusty.MakeDefaultOptions())
+	_, err := b.Run("hey")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "got file 'hey', but 'hey' must be a directory to be a root" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -1,0 +1,29 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty
+
+// Options holds high-level configuration options, e.g.
+// are plugins enabled, should the loader be restricted to
+// the kustomization root, etc.
+type Options struct {
+	// When true, sort the resources before emitting them,
+	// per a particular sort order.  When false, don't do the
+	// sort, and instead respect the depth-first resource input
+	// order as specified by the kustomization file(s).
+	DoLegacyResourceSort bool
+	// When true, the files referenced by a kustomization file
+	// must be in or under the directory holding the kustomization
+	// file itself.  When false, the kustomization file may specify
+	// absolute or relative paths to patch or resources files outside
+	// its own tree.
+	RestrictToRootOnly bool
+}
+
+// MakeDefaultOptions returns a default instance of Options.
+func MakeDefaultOptions() *Options {
+	return &Options{
+		DoLegacyResourceSort: true,
+		RestrictToRootOnly:   true,
+	}
+}

--- a/hack/awker.sh
+++ b/hack/awker.sh
@@ -1,16 +1,14 @@
 function showDeps {
   echo "==== begin $1 =================================="
   find $1 -name "*.go" |\
-    xargs grep \"sigs.k8s.io/kustomize/??? |\
-    grep -v "/api/" |\
-    sed 's|"sigs.k8s.io/kustomize/v3/||' |\
-    awk '{ printf "%40s  %s\n", $2, $1 }' |\
-    sed 's|"  \./| |' |\
-    sed 's|:$||' |\
+    xargs grep \"sigs.k8s.io/kustomize/api/ |\
+		sed 's|:\s"| |' |\
+    sed 's|"$||' |\
+    awk '{ printf "%60s  %s\n", $2, $1 }' |\
+		sed 's|sigs.k8s.io/kustomize/api/||' |\
     sort | uniq
   echo "==== end $1 =================================="
 }
 
-
 showDeps ./plugin
-showDeps ./kustomize
+#showDeps ./kustomize


### PR DESCRIPTION
This will simplify kubectl integration, and allow reduction of API surface.