### PR TITLE
Support for raw configuration targets in Kustomize

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
 	golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/api/ifc/ifc.go
+++ b/api/ifc/ifc.go
@@ -5,6 +5,8 @@
 package ifc
 
 import (
+	"path/filepath"
+
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/types"
 )
@@ -36,6 +38,10 @@ type Loader interface {
 	Load(location string) ([]byte, error)
 	// Cleanup cleans the loader
 	Cleanup() error
+	// Walk walks a directory
+	Walk(path string, walkFn filepath.WalkFunc) error
+	// IsKustomizeBaseDirectory returns true if the directory is kustomizable
+	IsKustomizeBaseDirectory(path string) bool
 }
 
 // Kunstructured allows manipulation of k8s objects


### PR DESCRIPTION
Resource directories which do not contain an Kustomization.yaml (or equivalent) files will have the raw resources recursively read from the directories.
