### PR TITLE
Support for ignoring specific Resources via annotation.

### DIFF
--- a/api/k8sdeps/kunstruct/factory_test.go
+++ b/api/k8sdeps/kunstruct/factory_test.go
@@ -106,6 +106,25 @@ metadata:
 			expectedErr: false,
 		},
 		{
+			name: "localConfigYaml",
+			input: []byte(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie-skip
+  annotations:
+    # this annotation causes the Resource to be ignored by kustomize
+    config.kubernetes.io/local-config: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie 
+`),
+			expectedOut: []ifc.Kunstructured{testConfigMap},
+			expectedErr: false,
+		},
+		{
 			name: "garbageInOneOfTwoObjects",
 			input: []byte(`
 apiVersion: v1


### PR DESCRIPTION
Resources annotated with `config.kubernetes.io/local-config` will be ignored by Kustomize