### PR TITLE
Add some kustomization tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,6 @@
 # (or is used by) the travis/pre-commit.sh script
 
 all:
-        ./travis/pre-commit.sh
+	./travis/pre-commit.sh
+
+.PHONY: all

--- a/api/target/accumulation_test.go
+++ b/api/target/accumulation_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target_test
+
+import (
+	"testing"
+
+	. "sigs.k8s.io/kustomize/api/target"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestTargetMustHaveKustomizationFile(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app")
+	th.WriteF("/app/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: aService
+`)
+	th.WriteF("/app/deeper/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: anotherService
+`)
+	_, err := th.MakeKustTargetOrErr()
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !IsMissingKustomizationFileError(err) {
+		t.Fatalf("unexpected error: %q", err)
+	}
+}
+
+func TestResourceDirectoryMustHaveKustomizationFile(t *testing.T) {
+	th := kusttest_test.NewKustTestHarness(t, "/app")
+	th.WriteK("/app", `
+resources:
+- base
+`)
+	th.WriteF("/app/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  selector:
+    backend: bungie
+  ports:
+    - port: 7002
+`)
+	_, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err == nil {
+		t.Fatalf("expected an error")
+	}
+	if !IsMissingKustomizationFileError(err) {
+		t.Fatalf("unexpected error: %q", err)
+	}
+}

--- a/api/testutils/kusttest/kusttestharness.go
+++ b/api/testutils/kusttest/kusttestharness.go
@@ -63,13 +63,17 @@ func NewKustTestHarnessFull(
 }
 
 func (th *KustTestHarness) MakeKustTarget() *target.KustTarget {
-	kt, err := target.NewKustTarget(
-		th.ldr, valtest_test.MakeFakeValidator(), th.rf,
-		transformer.NewFactoryImpl(), th.pl)
+	kt, err := th.MakeKustTargetOrErr()
 	if err != nil {
 		th.t.Fatalf("Unexpected construction error %v", err)
 	}
 	return kt
+}
+
+func (th *KustTestHarness) MakeKustTargetOrErr() (*target.KustTarget, error) {
+	return target.NewKustTarget(
+		th.ldr, valtest_test.MakeFakeValidator(), th.rf,
+		transformer.NewFactoryImpl(), th.pl)
 }
 
 func (th *KustTestHarness) WriteF(dir string, content string) {


### PR DESCRIPTION
Phil's #1707 exposed a disturbing lack of coverage over what happens if a kustomization file is missing from a target.  Adding some tests, so we can adjust them in dealing with missing K files.