### PR TITLE
Support node configmap namereference.

### DIFF
--- a/api/konfig/builtinpluginconsts/namereference.go
+++ b/api/konfig/builtinpluginconsts/namereference.go
@@ -114,6 +114,8 @@ nameReference:
     kind: CronJob
   - path: spec/jobTemplate/spec/template/spec/initContainers/envFrom/configMapRef/name
     kind: CronJob
+  - path: spec/configSource/configMap
+    kind: Node
 
 - kind: Secret
   version: v1


### PR DESCRIPTION
This lets kustomize maintain the name of a configmap used for dynamic kubelet configuration out of the box.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#nodeconfigsource-v1-core