### PR TITLE
migrate Deployment from apps/v1beta2 to apps/v1

### DIFF
--- a/examples/ldap/README.md
+++ b/examples/ldap/README.md
@@ -148,7 +148,7 @@ The staging customization adds a configMap.
 > ```
 as well as 2 replica
 > ```cat $OVERLAYS/staging/deployment.yaml
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: ldap
@@ -167,7 +167,7 @@ curl -s -o "$OVERLAYS/production/#1" "$CONTENT/overlays/production\
 
 The production customization adds 6 replica as well as a consistent disk.
 > ```cat $OVERLAYS/production/deployment.yaml
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: ldap

--- a/examples/ldap/base/deployment.yaml
+++ b/examples/ldap/base/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ldap

--- a/examples/ldap/overlays/production/deployment.yaml
+++ b/examples/ldap/overlays/production/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ldap

--- a/examples/ldap/overlays/staging/deployment.yaml
+++ b/examples/ldap/overlays/staging/deployment.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ldap

--- a/examples/mySql/README.md
+++ b/examples/mySql/README.md
@@ -115,7 +115,7 @@ The output should contain:
 > spec:
 >   ....
 > ---
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   ....
@@ -156,7 +156,7 @@ resources.
 <!-- @createPatchFile @testAgainstLatestRelease -->
 ```
 cat <<'EOF' > $DEMO_HOME/persistent-disk.yaml
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: mysql

--- a/examples/mySql/deployment.yaml
+++ b/examples/mySql/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: mysql

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -105,7 +105,7 @@ steps. Add an environment variable through the patch and add a file to the confi
 <!-- @customizeConfigMap @testAgainstLatestRelease -->
 ```
 cat <<EOF >$DEMO_HOME/patch.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sbdemo
@@ -216,7 +216,7 @@ cat $DEMO_HOME/memorylimit_patch.yaml
 The output contains
 
 > ```
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: sbdemo
@@ -254,7 +254,7 @@ cat $DEMO_HOME/healthcheck_patch.yaml
 The output contains
 
 > ```
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: sbdemo

--- a/examples/springboot/base/deployment.yaml
+++ b/examples/springboot/base/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sbdemo

--- a/examples/springboot/overlays/production/healthcheck_patch.yaml
+++ b/examples/springboot/overlays/production/healthcheck_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sbdemo

--- a/examples/springboot/overlays/production/memorylimit_patch.yaml
+++ b/examples/springboot/overlays/production/memorylimit_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sbdemo

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -76,7 +76,7 @@ curl -s -o "$DEMO_HOME/#1.yaml" \
 ```
 The patch has following content
 > ```
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: wordpress

--- a/examples/wordpress/mysql/deployment.yaml
+++ b/examples/wordpress/mysql/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: mysql

--- a/examples/wordpress/patch.yaml
+++ b/examples/wordpress/patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress

--- a/examples/wordpress/wordpress/deployment.yaml
+++ b/examples/wordpress/wordpress/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   name: wordpress

--- a/examples/zh/vars.md
+++ b/examples/zh/vars.md
@@ -76,7 +76,7 @@ curl -s -o "$DEMO_HOME/#1.yaml" \
 ```
 该 patch 内容如下：
 > ```yaml
-> apiVersion: apps/v1beta2
+> apiVersion: apps/v1
 > kind: Deployment
 > metadata:
 >   name: wordpress


### PR DESCRIPTION
`apps/v1beta2` is deprecated and removed in k8s v1.16.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/