### PR TITLE
Improve plugin home defaulting.

### DIFF
--- a/api/plugins/compiler/compiler_test.go
+++ b/api/plugins/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/filesys"
 	. "sigs.k8s.io/kustomize/api/plugins/compiler"
 )
 
@@ -18,7 +19,7 @@ func TestCompiler(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to make temp dir: %v", err)
 	}
-	srcRoot, err := DefaultSrcRoot()
+	srcRoot, err := DefaultSrcRoot(filesys.MakeFsOnDisk())
 	if err != nil {
 		t.Error(err)
 	}

--- a/api/plugins/loader/loader_test.go
+++ b/api/plugins/loader/loader_test.go
@@ -57,7 +57,12 @@ func TestLoader(t *testing.T) {
 
 	ldr := loadertest.NewFakeLoader("/foo")
 
-	pLdr := NewLoader(pgmconfig.EnabledPluginConfig(), rmF)
+	c, err := pgmconfig.EnabledPluginConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pLdr := NewLoader(c, rmF)
 	if pLdr == nil {
 		t.Fatal("expect non-nil loader")
 	}

--- a/api/target/diamondcomposition_test.go
+++ b/api/target/diamondcomposition_test.go
@@ -231,7 +231,7 @@ func definePatchDirStructure(th *kusttest_test.KustTestHarness) {
 
 // Fails due to file load restrictor.
 func TestIssue1251_Patches_ProdVsDev_Failure(t *testing.T) {
-	th := kusttest_test.NewKustTestHarnessAllowPlugins(t, "/app/prod")
+	th := kusttest_test.NewKustTestHarness(t, "/app/prod")
 	definePatchDirStructure(th)
 
 	th.WriteK("/app/prod", `

--- a/api/target/plugindir_test.go
+++ b/api/target/plugindir_test.go
@@ -65,7 +65,11 @@ metadata:
 	rf := resmap.NewFactory(resource.NewFactory(
 		kunstruct.NewKunstructuredFactoryImpl()), nil)
 
-	pl := pLdr.NewLoader(pgmconfig.EnabledPluginConfig(), rf)
+	c, err := pgmconfig.EnabledPluginConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pl := pLdr.NewLoader(c, rf)
 	tg, err := target.NewKustTarget(
 		ldr, valtest_test.MakeFakeValidator(), rf, transformer.NewFactoryImpl(), pl)
 	if err != nil {

--- a/api/testutils/kusttest/kusttestharness.go
+++ b/api/testutils/kusttest/kusttestharness.go
@@ -40,8 +40,11 @@ func NewKustTestHarness(t *testing.T, path string) *KustTestHarness {
 }
 
 func NewKustTestHarnessAllowPlugins(t *testing.T, path string) *KustTestHarness {
-	return NewKustTestHarnessFull(
-		t, path, fLdr.RestrictionRootOnly, pgmconfig.EnabledPluginConfig())
+	c, err := pgmconfig.EnabledPluginConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewKustTestHarnessFull(t, path, fLdr.RestrictionRootOnly, c)
 }
 
 func NewKustTestHarnessNoLoadRestrictor(t *testing.T, path string) *KustTestHarness {
@@ -100,7 +103,10 @@ func (th *KustTestHarness) FromMap(m map[string]interface{}) *resource.Resource 
 	return th.rf.RF().FromMap(m)
 }
 
-func (th *KustTestHarness) FromMapAndOption(m map[string]interface{}, args *types.GeneratorArgs, option *types.GeneratorOptions) *resource.Resource {
+func (th *KustTestHarness) FromMapAndOption(
+	m map[string]interface{},
+	args *types.GeneratorArgs,
+	option *types.GeneratorOptions) *resource.Resource {
 	return th.rf.RF().FromMapAndOption(m, args, option)
 }
 

--- a/api/testutils/kusttest/plugintestenv.go
+++ b/api/testutils/kusttest/plugintestenv.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/pgmconfig"
 	"sigs.k8s.io/kustomize/api/plugins/compiler"
 )
@@ -75,7 +76,7 @@ func (x *PluginTestEnv) makeCompiler() *compiler.Compiler {
 	if err != nil {
 		x.t.Error(err)
 	}
-	srcRoot, err := compiler.DefaultSrcRoot()
+	srcRoot, err := compiler.DefaultSrcRoot(filesys.MakeFsOnDisk())
 	if err != nil {
 		x.t.Error(err)
 	}

--- a/api/types/errunabletofind.go
+++ b/api/types/errunabletofind.go
@@ -1,0 +1,40 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type errUnableToFind struct {
+	// What are we unable to find?
+	what string
+	// What things did we try?
+	attempts []Pair
+}
+
+func (e *errUnableToFind) Error() string {
+	var m []string
+	for _, p := range e.attempts {
+		m = append(m, "('"+p.Value+"'; "+p.Key+")")
+	}
+	return fmt.Sprintf(
+		"unable to find plugin root - tried: %s", strings.Join(m, ", "))
+}
+
+func NewErrUnableToFind(w string, a []Pair) *errUnableToFind {
+	return &errUnableToFind{what: w, attempts: a}
+}
+
+func IsErrUnableToFind(err error) bool {
+	_, ok := err.(*errUnableToFind)
+	if ok {
+		return true
+	}
+	_, ok = errors.Cause(err).(*errUnableToFind)
+	return ok
+}

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -5,6 +5,7 @@ package build
 
 import (
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -108,7 +109,11 @@ func (o *Options) makeOptions() *krusty.Options {
 		DoPrune:              false,
 	}
 	if isFlagEnablePluginsSet() {
-		opts.PluginConfig = pgmconfig.EnabledPluginConfig()
+		c, err := pgmconfig.EnabledPluginConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts.PluginConfig = c
 	} else {
 		opts.PluginConfig = pgmconfig.DisabledPluginConfig()
 	}


### PR DESCRIPTION
Makes it possible to run api tests in goland without setting GOPATH outside.
Plugin homes attempted:
 -  `$KUSTOMIZE_PLUGIN_HOME`
 -  `$XDG_CONFIG_HOME/kustomize/plugin`
 -  `$HOME/.config/kustomize/plugin`
 -  `$HOME/kustomize/plugin`
