### PR TITLE
Improve config package names and reduce API exposure.

### DIFF
--- a/api/konfig/builtinpluginconsts/commonannotations.go
+++ b/api/konfig/builtinpluginconsts/commonannotations.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const commonAnnotationFieldSpecs = `
 commonAnnotations:

--- a/api/konfig/builtinpluginconsts/commonlabels.go
+++ b/api/konfig/builtinpluginconsts/commonlabels.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const commonLabelFieldSpecs = `
 commonLabels:

--- a/api/konfig/builtinpluginconsts/defaultconfig.go
+++ b/api/konfig/builtinpluginconsts/defaultconfig.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 import (
 	"bytes"

--- a/api/konfig/builtinpluginconsts/doc.go
+++ b/api/konfig/builtinpluginconsts/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package builtinpluginconsts provides builtin plugin
+// configuration data.  Builtin plugins can also be
+// configured individually with plugin config files,
+// in which case the constants in this package are ignored.
+package builtinpluginconsts

--- a/api/konfig/builtinpluginconsts/images.go
+++ b/api/konfig/builtinpluginconsts/images.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const (
 	// imageFieldSpecs is left empty since `containers` and `initContainers`

--- a/api/konfig/builtinpluginconsts/nameprefix.go
+++ b/api/konfig/builtinpluginconsts/nameprefix.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const (
 	namePrefixFieldSpecs = `

--- a/api/konfig/builtinpluginconsts/namereference.go
+++ b/api/konfig/builtinpluginconsts/namereference.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const (
 	nameReferenceFieldSpecs = `

--- a/api/konfig/builtinpluginconsts/namespace.go
+++ b/api/konfig/builtinpluginconsts/namespace.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const (
 	namespaceFieldSpecs = `

--- a/api/konfig/builtinpluginconsts/replicas.go
+++ b/api/konfig/builtinpluginconsts/replicas.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const replicasFieldSpecs = `
 replicas:

--- a/api/konfig/builtinpluginconsts/varreference.go
+++ b/api/konfig/builtinpluginconsts/varreference.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package consts
+package builtinpluginconsts
 
 const (
 	varReferenceFieldSpecs = `

--- a/api/konfig/doc.go
+++ b/api/konfig/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package pgmconfig provides configuration methods and constants
+// Package konfig provides configuration methods and constants
 // for the kustomize API.
-package pgmconfig
+package konfig

--- a/api/konfig/general.go
+++ b/api/konfig/general.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package pgmconfig
+package konfig
 
 // RecognizedKustomizationFileNames is a list of file names
 // that kustomize recognizes.

--- a/api/konfig/plugins.go
+++ b/api/konfig/plugins.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package pgmconfig
+package konfig
 
 import (
 	"os"

--- a/api/konfig/plugins_test.go
+++ b/api/konfig/plugins_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package pgmconfig
+package konfig
 
 import (
 	"os"

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -4,7 +4,7 @@
 package krusty
 
 import (
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -35,6 +35,6 @@ func MakeDefaultOptions() *Options {
 		DoLegacyResourceSort: true,
 		LoadRestrictions:     types.LoadRestrictionsRootOnly,
 		DoPrune:              false,
-		PluginConfig:         pgmconfig.DisabledPluginConfig(),
+		PluginConfig:         konfig.DisabledPluginConfig(),
 	}
 }

--- a/api/loader/fileloader_test.go
+++ b/api/loader/fileloader_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/git"
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 type testData struct {
@@ -374,7 +374,7 @@ func TestNewLoaderAtGitClone(t *testing.T) {
 	fSys.MkdirAll(coRoot + "/" + pathInRepo)
 	fSys.WriteFile(
 		coRoot+"/"+pathInRepo+"/"+
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		[]byte(`
 whatever
 `))

--- a/api/plugins/builtinconfig/consts/doc.go
+++ b/api/plugins/builtinconfig/consts/doc.go
@@ -1,5 +1,0 @@
-// Copyright 2019 The Kubernetes Authors.
-// SPDX-License-Identifier: Apache-2.0
-
-// Package consts provides builtin plugin configuration data.
-package consts

--- a/api/plugins/builtinconfig/transformerconfig.go
+++ b/api/plugins/builtinconfig/transformerconfig.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/api/plugins/builtinconfig/consts"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -33,7 +33,7 @@ func MakeEmptyConfig() *TransformerConfig {
 // MakeDefaultConfig returns a default TransformerConfig.
 func MakeDefaultConfig() *TransformerConfig {
 	c, err := makeTransformerConfigFromBytes(
-		consts.GetDefaultFieldSpecs())
+		builtinpluginconsts.GetDefaultFieldSpecs())
 	if err != nil {
 		log.Fatalf("Unable to make default transformconfig: %v", err)
 	}

--- a/api/plugins/compiler/compiler.go
+++ b/api/plugins/compiler/compiler.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 // Compiler creates Go plugin object files.
@@ -31,32 +31,32 @@ type Compiler struct {
 // DefaultSrcRoot guesses where the user
 // has her ${g}/${v}/$lower(${k})/${k}.go files.
 func DefaultSrcRoot(fSys filesys.FileSystem) (string, error) {
-	return pgmconfig.FirstDirThatExistsElseError(
-		"source directory", fSys, []pgmconfig.NotedFunc{
+	return konfig.FirstDirThatExistsElseError(
+		"source directory", fSys, []konfig.NotedFunc{
 			{
 				Note: "old style $GOPATH",
 				F: func() string {
 					return filepath.Join(
 						os.Getenv("GOPATH"),
-						"src", pgmconfig.DomainName,
-						pgmconfig.ProgramName, pgmconfig.RelPluginHome)
+						"src", konfig.DomainName,
+						konfig.ProgramName, konfig.RelPluginHome)
 				},
 			},
 			{
 				Note: "HOME with literal 'gopath'",
 				F: func() string {
 					return filepath.Join(
-						pgmconfig.HomeDir(), "gopath",
-						"src", pgmconfig.DomainName,
-						pgmconfig.ProgramName, pgmconfig.RelPluginHome)
+						konfig.HomeDir(), "gopath",
+						"src", konfig.DomainName,
+						konfig.ProgramName, konfig.RelPluginHome)
 				},
 			},
 			{
 				Note: "home directory",
 				F: func() string {
 					return filepath.Join(
-						pgmconfig.HomeDir(), pgmconfig.DomainName,
-						pgmconfig.ProgramName, pgmconfig.RelPluginHome)
+						konfig.HomeDir(), konfig.DomainName,
+						konfig.ProgramName, konfig.RelPluginHome)
 				},
 			},
 		})

--- a/api/plugins/execplugin/execplugin_test.go
+++ b/api/plugins/execplugin/execplugin_test.go
@@ -10,7 +10,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/internal/loadertest"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	. "sigs.k8s.io/kustomize/api/plugins/execplugin"
 	"sigs.k8s.io/kustomize/api/plugins/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -45,7 +45,7 @@ s/$BAR/bar/g
 
 	p := NewExecPlugin(
 		loader.AbsolutePluginPath(
-			pgmconfig.DisabledPluginConfig(),
+			konfig.DisabledPluginConfig(),
 			pluginConfig.OrgId()))
 	// Not checking to see if the plugin is executable,
 	// because this test does not run it.

--- a/api/plugins/loader/loader.go
+++ b/api/plugins/loader/loader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/plugins/execplugin"
 	"sigs.k8s.io/kustomize/api/resid"
@@ -103,7 +103,7 @@ func (l *Loader) absolutePluginPath(id resid.ResId) string {
 func isBuiltinPlugin(res *resource.Resource) bool {
 	// TODO: the special string should appear in Group, not Version.
 	return res.GetGvk().Group == "" &&
-		res.GetGvk().Version == pgmconfig.BuiltinPluginApiVersion
+		res.GetGvk().Version == konfig.BuiltinPluginApiVersion
 }
 
 func (l *Loader) loadAndConfigurePlugin(
@@ -188,11 +188,11 @@ func (l *Loader) loadGoPlugin(id resid.ResId) (resmap.Configurable, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "plugin %s fails to load", absPath)
 	}
-	symbol, err := p.Lookup(pgmconfig.PluginSymbol)
+	symbol, err := p.Lookup(konfig.PluginSymbol)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "plugin %s doesn't have symbol %s",
-			regId, pgmconfig.PluginSymbol)
+			regId, konfig.PluginSymbol)
 	}
 	c, ok := symbol.(resmap.Configurable)
 	if !ok {

--- a/api/plugins/loader/loader_test.go
+++ b/api/plugins/loader/loader_test.go
@@ -8,7 +8,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/internal/loadertest"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	. "sigs.k8s.io/kustomize/api/plugins/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -57,7 +57,7 @@ func TestLoader(t *testing.T) {
 
 	ldr := loadertest.NewFakeLoader("/foo")
 
-	c, err := pgmconfig.EnabledPluginConfig()
+	c, err := konfig.EnabledPluginConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/target/baseandoverlaysmall_test.go
+++ b/api/target/baseandoverlaysmall_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
@@ -300,7 +300,7 @@ spec:
 func TestSharedPatchDisAllowed(t *testing.T) {
 	th := kusttest_test.NewKustTestHarnessFull(
 		t, "/app/overlay",
-		loader.RestrictionRootOnly, pgmconfig.DisabledPluginConfig())
+		loader.RestrictionRootOnly, konfig.DisabledPluginConfig())
 	writeSmallBase(th)
 	th.WriteK("/app/overlay", `
 commonLabels:
@@ -332,7 +332,7 @@ spec:
 func TestSharedPatchAllowed(t *testing.T) {
 	th := kusttest_test.NewKustTestHarnessFull(
 		t, "/app/overlay",
-		loader.RestrictionNone, pgmconfig.DisabledPluginConfig())
+		loader.RestrictionNone, konfig.DisabledPluginConfig())
 	writeSmallBase(th)
 	th.WriteK("/app/overlay", `
 commonLabels:

--- a/api/target/kusttarget.go
+++ b/api/target/kusttarget.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/accumulator"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/plugins/builtinconfig"
 	"sigs.k8s.io/kustomize/api/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/plugins/builtins"
@@ -85,7 +85,7 @@ func commaOr(q []string) string {
 func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 	var content []byte
 	match := 0
-	for _, kf := range pgmconfig.RecognizedKustomizationFileNames() {
+	for _, kf := range konfig.RecognizedKustomizationFileNames() {
 		c, err := ldr.Load(kf)
 		if err == nil {
 			match += 1
@@ -110,7 +110,7 @@ type errMissingKustomization struct {
 func (e *errMissingKustomization) Error() string {
 	return fmt.Sprintf(
 		"unable to find one of %v in directory '%s'",
-		commaOr(quoted(pgmconfig.RecognizedKustomizationFileNames())),
+		commaOr(quoted(konfig.RecognizedKustomizationFileNames())),
 		e.path)
 }
 

--- a/api/target/plugindir_test.go
+++ b/api/target/plugindir_test.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/api/konfig"
 	fLdr "sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
 	pLdr "sigs.k8s.io/kustomize/api/plugins/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -65,7 +65,7 @@ metadata:
 	rf := resmap.NewFactory(resource.NewFactory(
 		kunstruct.NewKunstructuredFactoryImpl()), nil)
 
-	c, err := pgmconfig.EnabledPluginConfig()
+	c, err := konfig.EnabledPluginConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/testutils/kusttest/kusttestharness.go
+++ b/api/testutils/kusttest/kusttestharness.go
@@ -12,14 +12,14 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/loadertest"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	fLdr "sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
-	"sigs.k8s.io/kustomize/api/plugins/builtinconfig/consts"
 	pLdr "sigs.k8s.io/kustomize/api/plugins/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/target"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -36,11 +36,11 @@ type KustTestHarness struct {
 
 func NewKustTestHarness(t *testing.T, path string) *KustTestHarness {
 	return NewKustTestHarnessFull(
-		t, path, fLdr.RestrictionRootOnly, pgmconfig.DisabledPluginConfig())
+		t, path, fLdr.RestrictionRootOnly, konfig.DisabledPluginConfig())
 }
 
 func NewKustTestHarnessAllowPlugins(t *testing.T, path string) *KustTestHarness {
-	c, err := pgmconfig.EnabledPluginConfig()
+	c, err := konfig.EnabledPluginConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func NewKustTestHarnessAllowPlugins(t *testing.T, path string) *KustTestHarness 
 
 func NewKustTestHarnessNoLoadRestrictor(t *testing.T, path string) *KustTestHarness {
 	return NewKustTestHarnessFull(
-		t, path, fLdr.RestrictionNone, pgmconfig.DisabledPluginConfig())
+		t, path, fLdr.RestrictionNone, konfig.DisabledPluginConfig())
 }
 
 func NewKustTestHarnessFull(
@@ -89,7 +89,7 @@ func (th *KustTestHarness) WriteK(dir string, content string) {
 	th.WriteF(
 		filepath.Join(
 			dir,
-			pgmconfig.DefaultKustomizationFileName()), `
+			konfig.DefaultKustomizationFileName()), `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 `+content)
@@ -111,7 +111,7 @@ func (th *KustTestHarness) FromMapAndOption(
 }
 
 func (th *KustTestHarness) WriteDefaultConfigs(fName string) {
-	m := consts.GetDefaultFieldSpecsAsMap()
+	m := builtinpluginconsts.GetDefaultFieldSpecsAsMap()
 	var content []byte
 	for _, tCfg := range m {
 		content = append(content, []byte(tCfg)...)

--- a/api/testutils/kusttest/plugintestenv.go
+++ b/api/testutils/kusttest/plugintestenv.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/plugins/compiler"
 )
 
@@ -71,7 +71,7 @@ func (x *PluginTestEnv) makeCompiler() *compiler.Compiler {
 	//    $objRoot
 	// so set things up accordingly.
 	objRoot := filepath.Join(
-		x.workDir, pgmconfig.ProgramName, pgmconfig.RelPluginHome)
+		x.workDir, konfig.ProgramName, konfig.RelPluginHome)
 	err := os.MkdirAll(objRoot, os.ModePerm)
 	if err != nil {
 		x.t.Error(err)
@@ -100,14 +100,14 @@ func (x *PluginTestEnv) removeWorkDir() {
 }
 
 func (x *PluginTestEnv) setEnv() {
-	x.oldXdg, x.wasSet = os.LookupEnv(pgmconfig.XdgConfigHomeEnv)
-	os.Setenv(pgmconfig.XdgConfigHomeEnv, x.workDir)
+	x.oldXdg, x.wasSet = os.LookupEnv(konfig.XdgConfigHomeEnv)
+	os.Setenv(konfig.XdgConfigHomeEnv, x.workDir)
 }
 
 func (x *PluginTestEnv) resetEnv() {
 	if x.wasSet {
-		os.Setenv(pgmconfig.XdgConfigHomeEnv, x.oldXdg)
+		os.Setenv(konfig.XdgConfigHomeEnv, x.oldXdg)
 	} else {
-		os.Unsetenv(pgmconfig.XdgConfigHomeEnv)
+		os.Unsetenv(konfig.XdgConfigHomeEnv)
 	}
 }

--- a/hack/whatApi.sh
+++ b/hack/whatApi.sh
@@ -20,7 +20,7 @@ function whatApi {
     grep -v " resid " |\
     grep -v " resmap " |\
     grep -v " testutils/" |\
-    grep -v "types "
+    grep -v " types "
   echo "==== end $1 =================================="
 }
 

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/krusty"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/yaml"
@@ -57,7 +57,7 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "build {path}",
 		Short: "Print configuration per contents of " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example:      examples,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -87,7 +87,7 @@ func (o *Options) Validate(args []string) (err error) {
 	if len(args) > 1 {
 		return errors.New(
 			"specify one path to " +
-				pgmconfig.DefaultKustomizationFileName())
+				konfig.DefaultKustomizationFileName())
 	}
 	if len(args) == 0 {
 		o.kustomizationPath = CWD
@@ -109,13 +109,13 @@ func (o *Options) makeOptions() *krusty.Options {
 		DoPrune:              false,
 	}
 	if isFlagEnablePluginsSet() {
-		c, err := pgmconfig.EnabledPluginConfig()
+		c, err := konfig.EnabledPluginConfig()
 		if err != nil {
 			log.Fatal(err)
 		}
 		opts.PluginConfig = c
 	} else {
-		opts.PluginConfig = pgmconfig.DisabledPluginConfig()
+		opts.PluginConfig = konfig.DisabledPluginConfig()
 	}
 	return opts
 }

--- a/kustomize/internal/commands/build/build_test.go
+++ b/kustomize/internal/commands/build/build_test.go
@@ -6,7 +6,7 @@ package build
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 func TestNewOptionsToSilenceCodeInspectionError(t *testing.T) {
@@ -28,7 +28,7 @@ func TestBuildValidate(t *testing.T) {
 		{"path", []string{"too", "many"},
 			"",
 			"specify one path to " +
-				pgmconfig.DefaultKustomizationFileName()},
+				konfig.DefaultKustomizationFileName()},
 	}
 	for _, mycase := range cases {
 		opts := Options{}

--- a/kustomize/internal/commands/commands.go
+++ b/kustomize/internal/commands/commands.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/k8sdeps/validator"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/build"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/config"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/create"
@@ -26,7 +26,7 @@ func NewDefaultCommand() *cobra.Command {
 	stdOut := os.Stdout
 
 	c := &cobra.Command{
-		Use:   pgmconfig.ProgramName,
+		Use:   konfig.ProgramName,
 		Short: "Manages declarative configuration of Kubernetes",
 		Long: `
 Manages declarative configuration of Kubernetes.

--- a/kustomize/internal/commands/config/config.go
+++ b/kustomize/internal/commands/config/config.go
@@ -8,9 +8,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/plugins/builtinconfig/consts"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 )
 
 // NewCmdConfig returns an instance of 'config' subcommand.
@@ -89,7 +88,7 @@ func (o *saveOptions) Complete(fSys filesys.FileSystem) error {
 
 // RunSave saves the default transformer configurations local directory
 func (o *saveOptions) RunSave(fSys filesys.FileSystem) error {
-	m := consts.GetDefaultFieldSpecsAsMap()
+	m := builtinpluginconsts.GetDefaultFieldSpecsAsMap()
 	for tname, tcfg := range m {
 		filename := filepath.Join(o.saveDirectory, tname+".yaml")
 		err := fSys.WriteFile(filename, []byte(tcfg))

--- a/kustomize/internal/commands/create/create.go
+++ b/kustomize/internal/commands/create/create.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/util"
 )
@@ -162,7 +162,7 @@ func detectResources(fSys filesys.FileSystem, uf ifc.KunstructuredFactory, base 
 			}
 			// If a sub-directory contains an existing kustomization file add the
 			// directory as a resource and do not decend into it.
-			for _, kfilename := range pgmconfig.RecognizedKustomizationFileNames() {
+			for _, kfilename := range konfig.RecognizedKustomizationFileNames() {
 				if fSys.Exists(filepath.Join(path, kfilename)) {
 					paths = append(paths, path)
 					return filepath.SkipDir

--- a/kustomize/internal/commands/edit/add/addmetadata.go
+++ b/kustomize/internal/commands/edit/add/addmetadata.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/util"
@@ -48,7 +48,7 @@ func newCmdAddAnnotation(fSys filesys.FileSystem, v func(map[string]string) erro
 	cmd := &cobra.Command{
 		Use: "annotation",
 		Short: "Adds one or more commonAnnotations to " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		add annotation {annotationKey1:annotationValue1},{annotationKey2:annotationValue2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +69,7 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	cmd := &cobra.Command{
 		Use: "label",
 		Short: "Adds one or more commonLabels to " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		add label {labelKey1:labelValue1},{labelKey2:labelValue2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/internal/commands/edit/patch/strategicmerge.go
+++ b/kustomize/internal/commands/edit/patch/strategicmerge.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package patch
 

--- a/kustomize/internal/commands/edit/remove/removemetadata.go
+++ b/kustomize/internal/commands/edit/remove/removemetadata.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/kustfile"
 )
@@ -48,7 +48,7 @@ func newCmdRemoveAnnotation(fSys filesys.FileSystem, v func([]string) error) *co
 	cmd := &cobra.Command{
 		Use: "annotation",
 		Short: "Removes one or more commonAnnotations from " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		remove annotation {annotationKey1},{annotationKey2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +69,7 @@ func newCmdRemoveLabel(fSys filesys.FileSystem, v func([]string) error) *cobra.C
 	cmd := &cobra.Command{
 		Use: "label",
 		Short: "Removes one or more commonLabels from " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		remove label {labelKey1},{labelKey2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/internal/commands/edit/remove/removepatch.go
+++ b/kustomize/internal/commands/edit/remove/removepatch.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/patch"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/util"
@@ -26,7 +26,7 @@ func newCmdRemovePatch(fSys filesys.FileSystem) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "patch",
 		Short: "Removes one or more patches from " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		remove patch {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/internal/commands/edit/remove/removeresource.go
+++ b/kustomize/internal/commands/edit/remove/removeresource.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/kustfile"
 )
 
@@ -24,7 +24,7 @@ func newCmdRemoveResource(fSys filesys.FileSystem) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "resource",
 		Short: "Removes one or more resource file paths from " +
-			pgmconfig.DefaultKustomizationFileName(),
+			konfig.DefaultKustomizationFileName(),
 		Example: `
 		remove resource my-resource.yml
 		remove resource resource1.yml resource2.yml resource3.yml

--- a/kustomize/internal/commands/kustfile/kustomizationfile.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 )
@@ -119,7 +119,7 @@ func NewKustomizationFile(fSys filesys.FileSystem) (*kustomizationFile, error) {
 func (mf *kustomizationFile) validate() error {
 	match := 0
 	var path []string
-	for _, kfilename := range pgmconfig.RecognizedKustomizationFileNames() {
+	for _, kfilename := range konfig.RecognizedKustomizationFileNames() {
 		if mf.fSys.Exists(kfilename) {
 			match += 1
 			path = append(path, kfilename)
@@ -130,7 +130,7 @@ func (mf *kustomizationFile) validate() error {
 	case 0:
 		return fmt.Errorf(
 			"Missing kustomization file '%s'.\n",
-			pgmconfig.DefaultKustomizationFileName())
+			konfig.DefaultKustomizationFileName())
 	case 1:
 		mf.path = path[0]
 	default:

--- a/kustomize/internal/commands/kustfile/kustomizationfile_test.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/internal/commands/testutils"
 )
@@ -104,7 +104,7 @@ configMapGenerator:
   - baz=qux
   name: my-configmap
 `
-	for _, n := range pgmconfig.RecognizedKustomizationFileNames() {
+	for _, n := range konfig.RecognizedKustomizationFileNames() {
 		fSys := filesys.MakeFsInMemory()
 		fSys.WriteFile(n, []byte(kcontent))
 		k, err := NewKustomizationFile(fSys)

--- a/kustomize/internal/commands/testutils/testutils.go
+++ b/kustomize/internal/commands/testutils/testutils.go
@@ -5,7 +5,7 @@ package testutils_test
 
 import (
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/api/pgmconfig"
+	"sigs.k8s.io/kustomize/api/konfig"
 )
 
 const (
@@ -38,10 +38,10 @@ func WriteTestKustomization(fSys filesys.FileSystem) {
 
 // WriteTestKustomizationWith writes content to a well known file name.
 func WriteTestKustomizationWith(fSys filesys.FileSystem, bytes []byte) {
-	fSys.WriteFile(pgmconfig.DefaultKustomizationFileName(), bytes)
+	fSys.WriteFile(konfig.DefaultKustomizationFileName(), bytes)
 }
 
 // ReadTestKustomization reads content from a well known file name.
 func ReadTestKustomization(fSys filesys.FileSystem) ([]byte, error) {
-	return fSys.ReadFile(pgmconfig.DefaultKustomizationFileName())
+	return fSys.ReadFile(konfig.DefaultKustomizationFileName())
 }


### PR DESCRIPTION
- `pgmconfig` becomes `konfig`, since it configures the API directly, and the kustomize program indirectly.  Using `konfig` instead of `config` since the latter is overused / collision avoidance.
- `consts` becomes `builtinpluginconsts` since that's what they are and consts is overused.
- file names change as needed.

