### PR TITLE
Resolve Vars at a directory level

### DIFF
--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -112,7 +112,7 @@ func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {
 		matched := ra.resMap.GetMatchingResourcesByOriginalId(idMatcher)
 		if len(matched) > 1 {
 			return fmt.Errorf(
-				"found %d resId matches for var %s "+
+				"found %d resId matches for var %v "+
 					"(unable to disambiguate)",
 				len(matched), v)
 		}
@@ -174,7 +174,7 @@ func (ra *ResAccumulator) findVarValueFromResources(v types.Var) (interface{}, e
 // for substitution wherever the $(var.Name) occurs.
 func (ra *ResAccumulator) makeVarReplacementMap() (map[string]interface{}, error) {
 	result := map[string]interface{}{}
-	for _, v := range ra.AccumulatedVars() {
+	for _, v := range ra.Vars() {
 		s, err := ra.findVarValueFromResources(v)
 		if err != nil {
 			return nil, err
@@ -244,6 +244,9 @@ func (ra *ResAccumulator) ResolveDirectoryVars() error {
 	t := newRefVarTransformer(
 		replacementMap, ra.tConfig.VarReference)
 	err := ra.Transform(t)
+	if err != nil {
+		return err
+	}
 	if len(t.UnusedVars()) > 0 {
 		for _, i := range t.UnusedVars() {
 			unusedVar := ra.varSet.Get(i)

--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -163,7 +163,7 @@ func (ra *ResAccumulator) ResolveVars() error {
 }
 
 // if a resource is not found dont error, assume we will find it later.
-func (ra *ResAccumulator) makeVarDirectoryReplacementMap() (map[string]interface{}, error) {
+func (ra *ResAccumulator) makeVarDirectoryReplacementMap() map[string]interface{} {
 	result := map[string]interface{}{}
 	for _, v := range ra.Vars() {
 		s, err := ra.findVarValueFromResources(v)
@@ -174,22 +174,19 @@ func (ra *ResAccumulator) makeVarDirectoryReplacementMap() (map[string]interface
 		result[v.Name] = s
 	}
 
-	return result, nil
+	return result
 }
 
 // allows for vars to not have a found resource at the time of directory resolution
 func (ra *ResAccumulator) ResolveDirectoryVars() error {
-	replacementMap, err := ra.makeVarDirectoryReplacementMap()
-	if err != nil {
-		return err
-	}
+	replacementMap := ra.makeVarDirectoryReplacementMap()
 	varSetCopy := types.NewVarSet()
 	if len(replacementMap) == 0 {
 		return nil
 	}
 	t := newRefVarTransformer(
 		replacementMap, ra.tConfig.VarReference)
-	err = ra.Transform(t)
+	err := ra.Transform(t)
 	if len(t.UnusedVars()) > 0 {
 		for _, i := range t.UnusedVars() {
 			unusedVar := ra.varSet.Get(i)

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -229,8 +229,9 @@ func (kt *KustTarget) AccumulateTarget() (
 		return nil, err
 	}
 	// append unresolved vars to kustomize vars in hope of finding reference in current resource
-	kt.kustomization.Vars = append(kt.kustomization.Vars, ra.Vars()...)
+	kt.kustomization.Vars = append(kt.kustomization.Vars, ra.UnaccumulatedVars()...)
 	ra.DeleteVars()
+	ra.DeleteUnaccumulatedVars()
 
 	err = ra.MergeVars(kt.kustomization.Vars)
 	if err != nil {

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -228,10 +228,18 @@ func (kt *KustTarget) AccumulateTarget() (
 	if err != nil {
 		return nil, err
 	}
+	// append unresolved vars to kustomize vars in hope of finding refrence in current resource
+	kt.kustomization.Vars = append(kt.kustomization.Vars, ra.Vars()...)
+	ra.DeleteVars()
+
 	err = ra.MergeVars(kt.kustomization.Vars)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "merging vars %v", kt.kustomization.Vars)
+	}
+	err = ra.ResolveDirectoryVars()
+	if err != nil {
+		return nil, err
 	}
 	return ra, nil
 }

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -228,7 +228,7 @@ func (kt *KustTarget) AccumulateTarget() (
 	if err != nil {
 		return nil, err
 	}
-	// append unresolved vars to kustomize vars in hope of finding refrence in current resource
+	// append unresolved vars to kustomize vars in hope of finding reference in current resource
 	kt.kustomization.Vars = append(kt.kustomization.Vars, ra.Vars()...)
 	ra.DeleteVars()
 

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -309,7 +309,6 @@ vars:
     name: kelley
   fieldref:
     fieldpath: metadata.name
-  immediateSubstitution: true
 
 `)
 	th.WriteF("/app/base1/pod.yaml", `
@@ -340,7 +339,6 @@ vars:
     name: grimaldi
   fieldref:
     fieldpath: metadata.name
-  immediateSubstitution: true
 `)
 	th.WriteF("/app/base2/pod.yaml", `
 apiVersion: v1
@@ -1626,7 +1624,7 @@ spec:
       containers:
       - env:
         - name: DISCOVERY_SERVICE
-          value: dev-elasticsearch.monitoring.svc.cluster.local
+          value: base-dev-elasticsearch.monitoring.svc.cluster.local
         name: elasticsearch
 ---
 apiVersion: v1
@@ -1650,7 +1648,7 @@ spec:
       containers:
       - env:
         - name: DISCOVERY_SERVICE
-          value: test-elasticsearch.monitoring.svc.cluster.local
+          value: base-test-elasticsearch.monitoring.svc.cluster.local
         name: elasticsearch
 ---
 apiVersion: v1

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -131,14 +131,7 @@ resources:
 - ../base1
 - ../base2
 `)
-<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/overlay", th.MakeDefaultOptions())
-=======
-	m, err := th.MakeKustTarget().MakeCustomizedResMap()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
->>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -252,14 +245,7 @@ vars:
     fieldpath: metadata.test
   immediateSubstitution: true
 `)
-<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/overlay", th.MakeDefaultOptions())
-=======
-	m, err := th.MakeKustTarget().MakeCustomizedResMap()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
->>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -385,7 +371,7 @@ spec:
 }
 
 func TestBasicVarCollision(t *testing.T) {
-	th := kusttest_test.NewKustTestHarness(t, "/app/overlay")
+	th := kusttest_test.MakeHarness(t)
 	th.WriteK("/app/base1", `
 namePrefix: base1-
 resources:
@@ -451,7 +437,7 @@ resources:
 - ../base1
 - ../base2
 `)
-	_, err := th.MakeKustTarget().MakeCustomizedResMap()
+	err := th.RunWithErr("/app/overlay", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("should have an error")
 	}
@@ -652,14 +638,7 @@ resources:
 - ../o1
 - ../o2
 `)
-<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/top", th.MakeDefaultOptions())
-=======
-	m, err := th.MakeKustTarget().MakeCustomizedResMap()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
->>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -129,7 +129,14 @@ resources:
 - ../base1
 - ../base2
 `)
+<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+=======
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+>>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -240,7 +247,14 @@ vars:
   fieldref:
     fieldpath: metadata.test
 `)
+<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+=======
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+>>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -556,7 +570,14 @@ resources:
 - ../o1
 - ../o2
 `)
+<<<<<<< HEAD:api/krusty/variableref_test.go
 	m := th.Run("/app/top", th.MakeDefaultOptions())
+=======
+	m, err := th.MakeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+>>>>>>> restructure:api/target/variableref_test.go
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod

--- a/api/types/var.go
+++ b/api/types/var.go
@@ -33,6 +33,8 @@ type Var struct {
 	// If unspecified, this defaults to fieldPath: $defaultFieldPath
 	FieldRef FieldSelector `json:"fieldref,omitempty" yaml:"fieldref,omitempty"`
 
+	// ImmediateSubstitution is a flag used to tell kustomize when it should do
+	// var replacements on a build level
 	ImmediateSubstitution bool `json:"immediateSubstitution" yaml:"immediateSubstitution"`
 }
 

--- a/api/types/var.go
+++ b/api/types/var.go
@@ -32,6 +32,8 @@ type Var struct {
 	// replacing $(FOO).
 	// If unspecified, this defaults to fieldPath: $defaultFieldPath
 	FieldRef FieldSelector `json:"fieldref,omitempty" yaml:"fieldref,omitempty"`
+
+	ImmediateSubstitution bool `json:"immediateSubstitution" yaml:"immediateSubstitution"`
 }
 
 // Target refers to a kubernetes object by Group, Version, Kind and Name
@@ -74,6 +76,11 @@ func (v *Var) Defaulting() {
 		v.FieldRef.FieldPath = defaultFieldPath
 	}
 	v.ObjRef.GVK()
+}
+
+// IsImmediateSubstitution Checks if var should substitute immediate
+func (v *Var) IsImmediateSubstitution() bool {
+	return v.ImmediateSubstitution
 }
 
 // DeepEqual returns true if var a and b are Equals.

--- a/api/types/var_test.go
+++ b/api/types/var_test.go
@@ -154,7 +154,7 @@ func TestVarSetCopy(t *testing.T) {
 	set2 := set1.Copy()
 	for _, varInSet1 := range set1.AsSlice() {
 		if v := set2.Get(varInSet1.Name); v == nil {
-			t.Fatalf("set %v should contain a Var named %s", set2.AsSlice(), varInSet1)
+			t.Fatalf("set %v should contain a Var named %v", set2.AsSlice(), varInSet1)
 		} else if !set2.Contains(*v) {
 			t.Fatalf("set %v should contain %v", set2.AsSlice(), v)
 		}
@@ -168,4 +168,22 @@ func TestVarSetCopy(t *testing.T) {
 	if set1.Contains(w) {
 		t.Fatalf("set %v should not contain %v", set1.AsSlice(), w)
 	}
+}
+
+func TestIsImmediateSubstitution(t *testing.T) {
+	v := &Var{
+		Name: "SOME_VARIABLE_NAME",
+		ObjRef: Target{
+			Gvk: resid.Gvk{
+				Version: "v1",
+				Kind:    "Secret",
+			},
+			Name: "my-secret",
+		},
+		ImmediateSubstitution: true,
+	}
+	if !v.IsImmediateSubstitution() {
+		t.Fatalf("expected true, got %v", v.ImmediateSubstitution)
+	}
+
 }

--- a/kustomize/internal/commands/kustfile/kustomizationfile_test.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile_test.go
@@ -132,6 +132,7 @@ resources:
 vars:
 - fieldref:
     fieldPath: metadata.name
+  immediateSubstitution: false
   name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
@@ -156,7 +157,6 @@ patchesStrategicMerge:
 		t.Fatalf("Unexpected Error: %v", err)
 	}
 	bytes, _ := fSys.ReadFile(mf.path)
-
 	if !reflect.DeepEqual(kustomizationContentWithComments, bytes) {
 		t.Fatal("written kustomization with comments is not the same as original one")
 	}
@@ -219,6 +219,7 @@ kind: kustomization
 vars:
 - fieldref:
     fieldPath: metadata.name
+  immediateSubstitution: false
   name: MY_SERVICE_NAME
   objref:
     apiVersion: v1

--- a/kustomize/internal/commands/kustfile/kustomizationfile_test.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile_test.go
@@ -132,7 +132,6 @@ resources:
 vars:
 - fieldref:
     fieldPath: metadata.name
-  immediateSubstitution: false
   name: MY_SERVICE_NAME
   objref:
     apiVersion: v1
@@ -219,7 +218,6 @@ kind: kustomization
 vars:
 - fieldref:
     fieldPath: metadata.name
-  immediateSubstitution: false
   name: MY_SERVICE_NAME
   objref:
     apiVersion: v1


### PR DESCRIPTION
fixes: https://github.com/kubernetes-sigs/kustomize/issues/506

Adds functionality to resolve vars at a directory level, resolved vars will not propagate up and cause collisions, unresolved vars still propagate upwards/downwards.

Prefixes resolve at the time of var substitution and if referenced var changes at higher level already substituted var will not change.