### PR TITLE
Pluginator v2

### DIFF
--- a/pluginator/go.mod
+++ b/pluginator/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kustomize/pluginator
+module sigs.k8s.io/kustomize/pluginator/v2
 
 go 1.13
 


### PR DESCRIPTION
The CLI writes generated to a new location (the location desired by kustomize API v3.4.0) with different commentary in the code.  Its a good time to try moving to v2 in a binary only module.