### PR TITLE
Pin api HEAD to pluginator v2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,10 @@ $(MYGOBIN)/goimports:
 	cd api; \
 	go install golang.org/x/tools/cmd/goimports
 
-# TODO: need a new release of the API, followed by a new pluginator.
-# pluginator v1.1.0 is too old for the code currently needed in the API.
-# Can release a new one at any time, just haven't done so.
-# When one has been released,
-#  - uncomment the pluginator line in './api/internal/tools/tools.go'
-#  - pin the version tag in './api/go.mod' to match the new release
-#  - change the following to 'cd api; go install sigs.k8s.io/kustomize/pluginator'
+# Version pinned by api/go.mod
 $(MYGOBIN)/pluginator:
-	cd pluginator; \
-	go install .
+	cd api; \
+	go install sigs.k8s.io/kustomize/pluginator/v2
 
 .PHONY: install-tools
 install-tools: \

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,16 +3,15 @@ module sigs.k8s.io/kustomize/api
 go 1.13
 
 require (
-	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-openapi/spec v0.19.4
 	github.com/golangci/golangci-lint v1.19.1
-	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/monopole/mdrip v1.0.0
 	github.com/pkg/errors v0.8.1
 	golang.org/x/tools v0.0.0-20190912215617-3720d1ec3678
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
+	sigs.k8s.io/kustomize/pluginator/v2 v2.0.0
 	sigs.k8s.io/kustomize/pseudo/k8s v0.1.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -452,6 +452,9 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b h1:DxJ5nJdkhDlLok9K6qO+5290kphD
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f h1:Cq7MalBHYACRd6EesksG1Q8EoIAKOsiZviGKbOLIej4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.2.0/go.mod h1:zVtMg179jW1gr74jo9fc2Ac9dLYLTZZThc3DDb9lDW4=
+sigs.k8s.io/kustomize/pluginator/v2 v2.0.0 h1:sES7e09G19Q0VjRp4ATSYKpTXoWaX8WMSHfw6u3G2Ok=
+sigs.k8s.io/kustomize/pluginator/v2 v2.0.0/go.mod h1:zrXhTv8BAKt0egmZX/8AtMOSFUSWM9YuoHvvqz8/eHE=
 sigs.k8s.io/kustomize/pseudo/k8s v0.0.0-20191108212413-1f86a0ca5d6c h1:t7fk+ljA3Ru4pro+/0RuOAZcODDhByL1fvIdyHLhjTY=
 sigs.k8s.io/kustomize/pseudo/k8s v0.0.0-20191108212413-1f86a0ca5d6c/go.mod h1:bl/gVJgYYhJZCZdYU2BfnaKYAlqFkgbJEkpl302jEss=
 sigs.k8s.io/kustomize/pseudo/k8s v0.1.0 h1:otg4dLFc03c3gzl+2CV8GPGcd1kk8wjXwD+UhhcCn5I=

--- a/api/internal/tools/tools.go
+++ b/api/internal/tools/tools.go
@@ -14,6 +14,6 @@ import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	// for integration tests driven by the examples
 	_ "github.com/monopole/mdrip"
-	// TODO: See comment in Makefile.
-	//_ "sigs.k8s.io/kustomize/pluginator"
+	// for generating code for builtin plugins
+	_ "sigs.k8s.io/kustomize/pluginator/v2"
 )


### PR DESCRIPTION
The theory here is that the generated code used by the API should be made by a well defined code generator (rather than whatever sits at HEAD).  So - use the same one available on the release page, the same one an external plugin author would use.

We'll see how it goes, can easily unpin (and use what's at head) if a dependency problem arises.
