### PR TITLE
Add tree to necessary tools

### DIFF
--- a/docs/macDevGuide.md
+++ b/docs/macDevGuide.md
@@ -25,7 +25,7 @@ Add `kubeval` to your PATH
 [Instructions](https://www.topbug.net/blog/2013/04/14/install-and-use-gnu-command-line-tools-in-mac-os-x/)
 
 ```sh
-brew install coreutils wget gnu-sed
+brew install coreutils wget gnu-sed tree
 ```
 
 Add the new tools to your PATH


### PR DESCRIPTION
I don't believe "tree" is under the branch of gnu tools, so it might be misleading to put it under "Install gnu tools." Should we leave it like this or change the title to "Install gnu/unix tools"