### PR TITLE
quote PATH to run `make` successfully even if PATH includes whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 MYGOBIN := $(shell go env GOPATH)/bin
 PATH := $(PATH):$(MYGOBIN)
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := env PATH="$(PATH)" /bin/bash
 
 .PHONY: all
 all: pre-commit


### PR DESCRIPTION
fixes #1796 