### PR TITLE
Raise the golinter bar.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,18 +4,29 @@ run:
 linters:
   disable-all: true
   enable:
+    - bodyclose
+    - deadcode
+    - depguard
     - dupl
     - goconst
     - gocyclo
     - gofmt
+    - goimports
     - golint
+    - gosec
+    # - gosimple (panics)
     - govet
     - ineffassign
     - interfacer
     - lll
     - misspell
     - nakedret
+    # - staticcheck (panics)
     - structcheck
+    # - stylecheck (panics)
+    # - typecheck (fails in lots of places)
+    - unconvert
+    # - unused (panics)
     - unparam
     - varcheck
 

--- a/api/internal/accumulator/namereferencetransformer_test.go
+++ b/api/internal/accumulator/namereferencetransformer_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 )
 
 func TestNameReferenceHappyRun(t *testing.T) {

--- a/api/internal/accumulator/refvartransformer_test.go
+++ b/api/internal/accumulator/refvartransformer_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 

--- a/api/internal/accumulator/resaccumulator_test.go
+++ b/api/internal/accumulator/resaccumulator_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 

--- a/api/internal/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/api/internal/k8sdeps/configmapandsecret/configmapfactory.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
+	corev1 "sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
 )
 
 func makeFreshConfigMap(
-	args *types.ConfigMapArgs) *v1.ConfigMap {
-	cm := &v1.ConfigMap{}
+	args *types.ConfigMapArgs) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{}
 	cm.APIVersion = "v1"
 	cm.Kind = "ConfigMap"
 	cm.Name = args.Name
@@ -26,7 +26,7 @@ func makeFreshConfigMap(
 
 // MakeConfigMap returns a new ConfigMap, or nil and an error.
 func (f *Factory) MakeConfigMap(
-	args *types.ConfigMapArgs) (*v1.ConfigMap, error) {
+	args *types.ConfigMapArgs) (*corev1.ConfigMap, error) {
 	all, err := f.kvLdr.Load(args.KvPairSources)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading KV pairs")
@@ -47,7 +47,7 @@ func (f *Factory) MakeConfigMap(
 
 // addKvToConfigMap adds the given key and data to the given config map.
 // Error if key invalid, or already exists.
-func (f *Factory) addKvToConfigMap(configMap *v1.ConfigMap, p types.Pair) error {
+func (f *Factory) addKvToConfigMap(configMap *corev1.ConfigMap, p types.Pair) error {
 	if err := f.kvLdr.Validator().ErrIfInvalidKey(p.Key); err != nil {
 		return err
 	}

--- a/api/internal/k8sdeps/configmapandsecret/configmapfactory_test.go
+++ b/api/internal/k8sdeps/configmapandsecret/configmapfactory_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	corev1 "sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
 	metav1 "sigs.k8s.io/kustomize/pseudo/k8s/apimachinery/pkg/apis/meta/v1"

--- a/api/internal/k8sdeps/configmapandsecret/secretfactory_test.go
+++ b/api/internal/k8sdeps/configmapandsecret/secretfactory_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	corev1 "sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
 	metav1 "sigs.k8s.io/kustomize/pseudo/k8s/apimachinery/pkg/apis/meta/v1"

--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -157,6 +157,7 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 		return nil, errors.Wrap(
 			err, "closing plugin config file "+f.Name())
 	}
+	//nolint:gosec
 	cmd := exec.Command(
 		p.path, append([]string{f.Name()}, p.args...)...)
 	cmd.Env = p.getEnv()

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	//nolint:gosec
 	secretGenerator = `
 apiVersion: builtin
 kind: SecretGenerator

--- a/api/internal/target/baseandoverlaymedium_test.go
+++ b/api/internal/target/baseandoverlaymedium_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func writeMediumBase(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/basereusenameprefix_test.go
+++ b/api/internal/target/basereusenameprefix_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // Here is a structure of a kustomization of two components, component1

--- a/api/internal/target/complexcomposition_test.go
+++ b/api/internal/target/complexcomposition_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const httpsService = `

--- a/api/internal/target/configmaps_test.go
+++ b/api/internal/target/configmaps_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // Generate a Secret and a ConfigMap from the same data

--- a/api/internal/target/crd_test.go
+++ b/api/internal/target/crd_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func writeBaseWithCrd(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/customconfig_test.go
+++ b/api/internal/target/customconfig_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeBaseReferencingCustomConfig(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/customconfigofbuiltinplugin_test.go
+++ b/api/internal/target/customconfigofbuiltinplugin_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // Demo custom configuration of a builtin transformation.

--- a/api/internal/target/diamondcomposition_test.go
+++ b/api/internal/target/diamondcomposition_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const patchAddProbe = `

--- a/api/internal/target/diamonds_test.go
+++ b/api/internal/target/diamonds_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // Here's a structure of two kustomizations,

--- a/api/internal/target/extendedpatch_test.go
+++ b/api/internal/target/extendedpatch_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeCommonFileForExtendedPatchTest(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/generatormergeandreplace_test.go
+++ b/api/internal/target/generatormergeandreplace_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
@@ -20,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSimpleBase(t *testing.T) {

--- a/api/internal/target/generatoroptions_test.go
+++ b/api/internal/target/generatoroptions_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSecretGenerator(t *testing.T) {

--- a/api/internal/target/inlinepatch_test.go
+++ b/api/internal/target/inlinepatch_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeResourcesForPatchTest(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/multiplepatch_test.go
+++ b/api/internal/target/multiplepatch_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
@@ -20,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeCommonFileForMultiplePatchTest(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/namespacedgenerators_test.go
+++ b/api/internal/target/namespacedgenerators_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestNamespacedGenerator(t *testing.T) {

--- a/api/internal/target/namespaces_test.go
+++ b/api/internal/target/namespaces_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestNamespacedSecrets(t *testing.T) {

--- a/api/internal/target/nullvalues_test.go
+++ b/api/internal/target/nullvalues_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestNullValues(t *testing.T) {

--- a/api/internal/target/pruneconfigmap_test.go
+++ b/api/internal/target/pruneconfigmap_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestPruneConfigMap(t *testing.T) {

--- a/api/internal/target/resourceconflict_test.go
+++ b/api/internal/target/resourceconflict_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func writeBase(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/transformersarrays_test.go
+++ b/api/internal/target/transformersarrays_test.go
@@ -6,7 +6,7 @@ package target_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeStatefulSetKustomization(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/transformersimage_test.go
+++ b/api/internal/target/transformersimage_test.go
@@ -1,25 +1,12 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package target_test
 
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func makeTransfomersImageBase(th *kusttest_test.KustTestHarness) {

--- a/api/internal/target/variableref_test.go
+++ b/api/internal/target/variableref_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestBasicVariableRef(t *testing.T) {

--- a/api/k8sdeps/kunstruct/hasher.go
+++ b/api/k8sdeps/kunstruct/hasher.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/hasher"
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
+	corev1 "sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
 	"sigs.k8s.io/kustomize/pseudo/k8s/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -50,7 +50,7 @@ func (h *kustHash) Hash(m ifc.Kunstructured) (string, error) {
 
 // configMapHash returns a hash of the ConfigMap.
 // The Data, Kind, and Name are taken into account.
-func configMapHash(cm *v1.ConfigMap) (string, error) {
+func configMapHash(cm *corev1.ConfigMap) (string, error) {
 	encoded, err := encodeConfigMap(cm)
 	if err != nil {
 		return "", err
@@ -64,7 +64,7 @@ func configMapHash(cm *v1.ConfigMap) (string, error) {
 
 // SecretHash returns a hash of the Secret.
 // The Data, Kind, Name, and Type are taken into account.
-func secretHash(sec *v1.Secret) (string, error) {
+func secretHash(sec *corev1.Secret) (string, error) {
 	encoded, err := encodeSecret(sec)
 	if err != nil {
 		return "", err
@@ -78,7 +78,7 @@ func secretHash(sec *v1.Secret) (string, error) {
 
 // encodeConfigMap encodes a ConfigMap.
 // Data, Kind, and Name are taken into account.
-func encodeConfigMap(cm *v1.ConfigMap) (string, error) {
+func encodeConfigMap(cm *corev1.ConfigMap) (string, error) {
 	// json.Marshal sorts the keys in a stable order in the encoding
 	m := map[string]interface{}{"kind": "ConfigMap", "name": cm.Name, "data": cm.Data}
 	if len(cm.BinaryData) > 0 {
@@ -93,7 +93,7 @@ func encodeConfigMap(cm *v1.ConfigMap) (string, error) {
 
 // encodeSecret encodes a Secret.
 // Data, Kind, Name, and Type are taken into account.
-func encodeSecret(sec *v1.Secret) (string, error) {
+func encodeSecret(sec *corev1.Secret) (string, error) {
 	// json.Marshal sorts the keys in a stable order in the encoding
 	data, err := json.Marshal(map[string]interface{}{"kind": "Secret", "type": sec.Type, "name": sec.Name, "data": sec.Data})
 	if err != nil {
@@ -102,22 +102,22 @@ func encodeSecret(sec *v1.Secret) (string, error) {
 	return string(data), nil
 }
 
-func unstructuredToConfigmap(u unstructured.Unstructured) (*v1.ConfigMap, error) {
+func unstructuredToConfigmap(u unstructured.Unstructured) (*corev1.ConfigMap, error) {
 	marshaled, err := json.Marshal(u.Object)
 	if err != nil {
 		return nil, err
 	}
-	var out v1.ConfigMap
+	var out corev1.ConfigMap
 	err = json.Unmarshal(marshaled, &out)
 	return &out, err
 }
 
-func unstructuredToSecret(u unstructured.Unstructured) (*v1.Secret, error) {
+func unstructuredToSecret(u unstructured.Unstructured) (*corev1.Secret, error) {
 	marshaled, err := json.Marshal(u.Object)
 	if err != nil {
 		return nil, err
 	}
-	var out v1.Secret
+	var out corev1.Secret
 	err = json.Unmarshal(marshaled, &out)
 	return &out, err
 }

--- a/api/k8sdeps/kunstruct/hasher_test.go
+++ b/api/k8sdeps/kunstruct/hasher_test.go
@@ -8,30 +8,30 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
+	corev1 "sigs.k8s.io/kustomize/pseudo/k8s/api/core/v1"
 )
 
 func TestConfigMapHash(t *testing.T) {
 	cases := []struct {
 		desc string
-		cm   *v1.ConfigMap
+		cm   *corev1.ConfigMap
 		hash string
 		err  string
 	}{
 		// empty map
-		{"empty data", &v1.ConfigMap{Data: map[string]string{}, BinaryData: map[string][]byte{}}, "42745tchd9", ""},
+		{"empty data", &corev1.ConfigMap{Data: map[string]string{}, BinaryData: map[string][]byte{}}, "42745tchd9", ""},
 		// one key
-		{"one key", &v1.ConfigMap{Data: map[string]string{"one": ""}}, "9g67k2htb6", ""},
+		{"one key", &corev1.ConfigMap{Data: map[string]string{"one": ""}}, "9g67k2htb6", ""},
 		// three keys (tests sorting order)
-		{"three keys", &v1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}}, "f5h7t85m9b", ""},
+		{"three keys", &corev1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}}, "f5h7t85m9b", ""},
 		// empty binary data map
-		{"empty binary data", &v1.ConfigMap{BinaryData: map[string][]byte{}}, "dk855m5d49", ""},
+		{"empty binary data", &corev1.ConfigMap{BinaryData: map[string][]byte{}}, "dk855m5d49", ""},
 		// one key with binary data
-		{"one key with binary data", &v1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}}, "mk79584b8c", ""},
+		{"one key with binary data", &corev1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}}, "mk79584b8c", ""},
 		// three keys with binary data (tests sorting order)
-		{"three keys with binary data", &v1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, "t458mc6db2", ""},
+		{"three keys with binary data", &corev1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, "t458mc6db2", ""},
 		// two keys, one with string and another with binary data
-		{"two keys with one each", &v1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}}, "698h7c7t9m", ""},
+		{"two keys with one each", &corev1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}}, "698h7c7t9m", ""},
 	}
 
 	for _, c := range cases {
@@ -48,16 +48,16 @@ func TestConfigMapHash(t *testing.T) {
 func TestSecretHash(t *testing.T) {
 	cases := []struct {
 		desc   string
-		secret *v1.Secret
+		secret *corev1.Secret
 		hash   string
 		err    string
 	}{
 		// empty map
-		{"empty data", &v1.Secret{Type: "my-type", Data: map[string][]byte{}}, "t75bgf6ctb", ""},
+		{"empty data", &corev1.Secret{Type: "my-type", Data: map[string][]byte{}}, "t75bgf6ctb", ""},
 		// one key
-		{"one key", &v1.Secret{Type: "my-type", Data: map[string][]byte{"one": []byte("")}}, "74bd68bm66", ""},
+		{"one key", &corev1.Secret{Type: "my-type", Data: map[string][]byte{"one": []byte("")}}, "74bd68bm66", ""},
 		// three keys (tests sorting order)
-		{"three keys", &v1.Secret{Type: "my-type", Data: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, "dgcb6h9tmk", ""},
+		{"three keys", &corev1.Secret{Type: "my-type", Data: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}}, "dgcb6h9tmk", ""},
 	}
 
 	for _, c := range cases {
@@ -74,27 +74,27 @@ func TestSecretHash(t *testing.T) {
 func TestEncodeConfigMap(t *testing.T) {
 	cases := []struct {
 		desc   string
-		cm     *v1.ConfigMap
+		cm     *corev1.ConfigMap
 		expect string
 		err    string
 	}{
 		// empty map
-		{"empty data", &v1.ConfigMap{Data: map[string]string{}}, `{"data":{},"kind":"ConfigMap","name":""}`, ""},
+		{"empty data", &corev1.ConfigMap{Data: map[string]string{}}, `{"data":{},"kind":"ConfigMap","name":""}`, ""},
 		// one key
-		{"one key", &v1.ConfigMap{Data: map[string]string{"one": ""}}, `{"data":{"one":""},"kind":"ConfigMap","name":""}`, ""},
+		{"one key", &corev1.ConfigMap{Data: map[string]string{"one": ""}}, `{"data":{"one":""},"kind":"ConfigMap","name":""}`, ""},
 		// three keys (tests sorting order)
-		{"three keys", &v1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}},
+		{"three keys", &corev1.ConfigMap{Data: map[string]string{"two": "2", "one": "", "three": "3"}},
 			`{"data":{"one":"","three":"3","two":"2"},"kind":"ConfigMap","name":""}`, ""},
 		// empty binary map
-		{"empty data", &v1.ConfigMap{BinaryData: map[string][]byte{}}, `{"data":null,"kind":"ConfigMap","name":""}`, ""},
+		{"empty data", &corev1.ConfigMap{BinaryData: map[string][]byte{}}, `{"data":null,"kind":"ConfigMap","name":""}`, ""},
 		// one key with binary data
-		{"one key", &v1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}},
+		{"one key", &corev1.ConfigMap{BinaryData: map[string][]byte{"one": []byte("")}},
 			`{"binaryData":{"one":""},"data":null,"kind":"ConfigMap","name":""}`, ""},
 		// three keys with binary data (tests sorting order)
-		{"three keys", &v1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}},
+		{"three keys", &corev1.ConfigMap{BinaryData: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")}},
 			`{"binaryData":{"one":"","three":"Mw==","two":"Mg=="},"data":null,"kind":"ConfigMap","name":""}`, ""},
 		// two keys, one string and one binary values
-		{"two keys with one each", &v1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}},
+		{"two keys with one each", &corev1.ConfigMap{Data: map[string]string{"one": ""}, BinaryData: map[string][]byte{"two": []byte("")}},
 			`{"binaryData":{"two":""},"data":{"one":""},"kind":"ConfigMap","name":""}`, ""},
 	}
 	for _, c := range cases {
@@ -111,16 +111,16 @@ func TestEncodeConfigMap(t *testing.T) {
 func TestEncodeSecret(t *testing.T) {
 	cases := []struct {
 		desc   string
-		secret *v1.Secret
+		secret *corev1.Secret
 		expect string
 		err    string
 	}{
 		// empty map
-		{"empty data", &v1.Secret{Type: "my-type", Data: map[string][]byte{}}, `{"data":{},"kind":"Secret","name":"","type":"my-type"}`, ""},
+		{"empty data", &corev1.Secret{Type: "my-type", Data: map[string][]byte{}}, `{"data":{},"kind":"Secret","name":"","type":"my-type"}`, ""},
 		// one key
-		{"one key", &v1.Secret{Type: "my-type", Data: map[string][]byte{"one": []byte("")}}, `{"data":{"one":""},"kind":"Secret","name":"","type":"my-type"}`, ""},
+		{"one key", &corev1.Secret{Type: "my-type", Data: map[string][]byte{"one": []byte("")}}, `{"data":{"one":""},"kind":"Secret","name":"","type":"my-type"}`, ""},
 		// three keys (tests sorting order) - note json.Marshal base64 encodes the values because they come in as []byte
-		{"three keys", &v1.Secret{
+		{"three keys", &corev1.Secret{
 			Type: "my-type",
 			Data: map[string][]byte{"two": []byte("2"), "one": []byte(""), "three": []byte("3")},
 		},
@@ -150,8 +150,8 @@ not their metadata (e.g. the Data of a ConfigMap, but nothing in ObjectMeta).
 		obj      interface{}
 		expect   int
 	}{
-		{"ConfigMap", v1.ConfigMap{}, 4},
-		{"Secret", v1.Secret{}, 5},
+		{"ConfigMap", corev1.ConfigMap{}, 4},
+		{"Secret", corev1.Secret{}, 5},
 	}
 	for _, c := range cases {
 		val := reflect.ValueOf(c.obj)

--- a/api/krusty/kustomizer_test.go
+++ b/api/krusty/kustomizer_test.go
@@ -5,17 +5,11 @@
 package krusty_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/krusty"
-	"testing"
 )
-
-// TODO: make this more like kusttest_test.AssertActualEqualsExpected
-func assertOutput(t *testing.T, actual []byte, expected string) {
-	if string(actual) != expected {
-		t.Fatalf("Err: expected:\n%s\nbut got:\n%s\n", expected, actual)
-	}
-}
 
 func TestSomething1(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -9,7 +9,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/filesys"
 	ldr "sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 

--- a/api/main.go
+++ b/api/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+
 	"sigs.k8s.io/kustomize/api/provenance"
 )
 

--- a/api/resmap/factory_test.go
+++ b/api/resmap/factory_test.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
 	. "sigs.k8s.io/kustomize/api/resmap"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
-	"sigs.k8s.io/kustomize/api/testutils/valtest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 

--- a/api/resmap/resmap_test.go
+++ b/api/resmap/resmap_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resid"
 	. "sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -41,6 +41,7 @@ var testConfigMap = factory.FromMap(
 
 const genArgOptions = "{nsfx:false,beh:unspecified}"
 
+//nolint:gosec
 const configMapAsString = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"winnie","namespace":"hundred-acre-wood"}}`
 
 var testDeployment = factory.FromMap(

--- a/api/transform/maptransformer_test.go
+++ b/api/transform/maptransformer_test.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/resource"
-	"sigs.k8s.io/kustomize/api/testutils/resmaptest"
+	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 	. "sigs.k8s.io/kustomize/api/transform"
 )
 

--- a/api/types/erronlybuiltinpluginsallowed.go
+++ b/api/types/erronlybuiltinpluginsallowed.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
Possibly upgrading github.com/golangci/golangci-lint v1.19.1 to 1.21.0 will fix the panics.

This PR also jams a `set -e` into the inlined bash scripts in the Makefile to avoid swallowing failures (which was unfortunately happening for a few hours).