### PR TITLE
kyaml: enable errcheck & golint; fix gofmt

### DIFF
--- a/kyaml/.golangci.yml
+++ b/kyaml/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - depguard
     - dogsled
     - dupl
-#    - errcheck
+    - errcheck
 #    - funlen
 #    - gochecknoinits
 #    - goconst
@@ -22,7 +22,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-#    - golint
+    - golint
     - gosec
     - gosimple
     - govet

--- a/kyaml/kio/filters/container_test.go
+++ b/kyaml/kio/filters/container_test.go
@@ -109,9 +109,9 @@ metadata:
 		return
 	}
 	instance := &ContainerFilter{
-		Image:  "example.com:version",
+		Image:   "example.com:version",
 		Network: "test-net",
-		Config: cfg,
+		Config:  cfg,
 	}
 	cmd, err := instance.getCommand()
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Enables **errcheck** and **golint** since they do not produce any errors currently.

Also fix gofmt issue that I introduced in https://github.com/kubernetes-sigs/kustomize/pull/1785:

```
kio/filters/container_test.go:112: File is not `gofmt`-ed with `-s` (gofmt)
		Image:  "example.com:version",
```

Part of #1772