### PR TITLE
Fix docs broken files links as Github relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Since [v1.14][kubectl announcement] the kustomize build system has been included
 
 | kubectl version | kustomize version |
 |---------|--------|
-| v1.16.0 | [v2.0.3](https://github.com/kubernetes-sigs/kustomize/tree/v2.0.3) |
-| v1.15.x | [v2.0.3](https://github.com/kubernetes-sigs/kustomize/tree/v2.0.3) |
-| v1.14.x | [v2.0.3](https://github.com/kubernetes-sigs/kustomize/tree/v2.0.3) |
+| v1.16.0 | [v2.0.3](/../../tree/v2.0.3) |
+| v1.15.x | [v2.0.3](/../../tree/v2.0.3) |
+| v1.14.x | [v2.0.3](/../../tree/v2.0.3) |
 
 For examples and guides for using the kubectl integration please see the [kubectl book] or the [kubernetes documentation].
 
@@ -167,7 +167,7 @@ is governed by the [Kubernetes Code of Conduct].
 [eschewed feature list]: docs/eschewedFeatures.md
 [imageBase]: docs/images/base.jpg
 [imageOverlay]: docs/images/overlay.jpg
-[kind/feature]: https://github.com/kubernetes-sigs/kustomize/labels/kind%2Ffeature
+[kind/feature]: /../../labels/kind%2Ffeature
 [kubectl announcement]: https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement
 [kubectl book]: https://kubectl.docs.kubernetes.io/pages/app_customization/introduction.html
 [kubernetes documentation]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
@@ -175,12 +175,12 @@ is governed by the [Kubernetes Code of Conduct].
 [kustomization]: docs/glossary.md#kustomization
 [overlay]: docs/glossary.md#overlay
 [overlays]: docs/glossary.md#overlay
-[release page]: https://github.com/kubernetes-sigs/kustomize/releases
+[release page]: /../../releases
 [resource]: docs/glossary.md#resource
 [resources]: docs/glossary.md#resource
 [sig-cli]: https://github.com/kubernetes/community/blob/master/sig-cli/README.md
 [variant]: docs/glossary.md#variant
 [variants]: docs/glossary.md#variant
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
-[v2.1.0]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.1.0
+[v2.0.3]: /../../releases/tag/v2.0.3
+[v2.1.0]: /../../releases/tag/v2.1.0
 [workflows]: docs/workflows.md

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,10 +10,10 @@ This was meant to help protect the person inclined to
 download kustomization directories from the web and use
 them without inspection to control their production
 cluster
-(see [#693](https://github.com/kubernetes-sigs/kustomize/issues/693),
-[#700](https://github.com/kubernetes-sigs/kustomize/pull/700),
-[#995](https://github.com/kubernetes-sigs/kustomize/pull/995) and
-[#998](https://github.com/kubernetes-sigs/kustomize/pull/998))
+(see [#693](/../../issues/693),
+[#700](/../../pull/700),
+[#995](/../../pull/995) and
+[#998](/../../pull/998))
 
 Resources (including configmap and secret generators)
 can _still be shared_ via the recommended best practice
@@ -31,9 +31,9 @@ kustomize build --load_restrictor none $target
 
 ## Some field is not transformed by kustomize
 
-Example: [#1319](https://github.com/kubernetes-sigs/kustomize/issues/1319), [#1322](https://github.com/kubernetes-sigs/kustomize/issues/1322), [#1347](https://github.com/kubernetes-sigs/kustomize/issues/1347) and etc.
+Example: [#1319](/../../issues/1319), [#1322](/../../issues/1322), [#1347](/../../issues/1347) and etc.
 
-The fields transformed by kustomize is configured explicitly in [defaultconfig](https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/transformers/config/defaultconfig). The configuration itself can be customized by including `configurations` in `kustomization.yaml`, e.g.
+The fields transformed by kustomize is configured explicitly in [defaultconfig](/api/konfig/builtinpluginconsts/defaultconfig.go). The configuration itself can be customized by including `configurations` in `kustomization.yaml`, e.g. 
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -55,4 +55,4 @@ images: []
 replicas: []
 ```
 
-To persist the changes to default configuration, submit a PR like [#1338](https://github.com/kubernetes-sigs/kustomize/pull/1338), [#1348](https://github.com/kubernetes-sigs/kustomize/pull/1348) and etc.
+To persist the changes to default configuration, submit a PR like [#1338](/../../pull/1338), [#1348](/../../pull/1348) and etc.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,4 @@
-[release page]: https://github.com/kubernetes-sigs/kustomize/releases
+[release page]: /../../releases
 [Go]: https://golang.org
 
 # Installation

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,14 +23,14 @@ English | [简体中文](zh/README.md)
 
 ## Release notes
 
- * [kustomize/3.2.2](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.2) - kustomize CLI
+ * [kustomize/3.2.2](/../../releases/tag/kustomize%2Fv3.2.2) - kustomize CLI
    moved to depend on kustomize Go API [3.3.0](v3.3.0.md).
 
  * [API 3.3.0](v3.3.0.md) - First release of the kustomize Go API
    in a module excluding the `kustomize` CLI.  From here on,
    the CLI and API will release independently.
  
- * [kustomize/3.2.1](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.1) - Patch release
+ * [kustomize/3.2.1](/../../releases/tag/kustomize%2Fv3.2.1) - Patch release
    of `kustomize` CLI in its own module,
    depending on Go API release [3.2.0](v3.2.0.md).
 
@@ -64,6 +64,6 @@ English | [简体中文](zh/README.md)
 
  * [Code of conduct](../code-of-conduct.md)
 
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
+[v2.0.3]: /../../releases/tag/v2.0.3
 [kubectl]: https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement
 [kubectl repository]: https://github.com/kubernetes/kubectl

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,7 +1,7 @@
 # Filing bugs
 
-[target package]: https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/target
-[example of a target test]: https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/target/baseandoverlaysmall_test.go
+[target package]: /api/internal/target
+[example of a target test]: /api/internal/target/baseandoverlaysmall_test.go
 
 File issues as desired, but
 if you've found a problem with how
@@ -22,7 +22,7 @@ kustomize has a simple test harness in the
 input and the expected output.
 
 See this [example of a target test], and contribution
-[#971](https://github.com/kubernetes-sigs/kustomize/pull/971),
+[#971](/../../pull/971),
 which does exactly the right thing.
 
 The pattern is

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -211,9 +211,9 @@ resource:
 - myNamespace.yaml
 - sub-dir/some-deployment.yaml
 - ../../commonbase
-- github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
+- github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6
 - deployment.yaml
-- github.com/kubernets-sigs/kustomize//examples/helloWorld?ref=test-branch
+- github.com/kubernets-sigs/kustomize/examples/helloWorld?ref=test-branch
 ```
 
 Resources will be read and processed in
@@ -301,8 +301,7 @@ can only be placed in particular fields of
 particular objects as specified by kustomize's
 configuration data.
 
-The default config data for vars is at
-https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/transformers/config/defaultconfig/varreference.go
+The default config data for vars is at [/api/konfig/builtinpluginconsts/varreference.go](/api/konfig/builtinpluginconsts/varreference.go)
 Long story short, the default targets are all
 container command args and env value fields.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -26,7 +26,7 @@
 [patch]: #patch
 [patches]: #patch
 [patchJson6902]: #patchjson6902
-[patchExampleJson6902]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/jsonpatch.md
+[patchExampleJson6902]: /examples/jsonpatch.md
 [patchesJson6902]: #patchjson6902
 [proposal]: https://github.com/kubernetes/community/pull/1629
 [rebase]: https://git-scm.com/docs/git-rebase

--- a/docs/plugins/goPluginGuidedExample.md
+++ b/docs/plugins/goPluginGuidedExample.md
@@ -167,7 +167,7 @@ This step may succeed, but kustomize might
 ultimately fail to load the plugin because of
 dependency [skew].
 
-[skew]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/plugins/README.md#caveats
+[skew]: /docs/plugins/README.md#caveats
 [used in this demo]: #install-kustomize
 
 On load failure

--- a/docs/v2.1.0.md
+++ b/docs/v2.1.0.md
@@ -16,9 +16,9 @@
 [kustomize plugin documentation]: plugins
 [root]: glossary.md#kustomization-root
 [transformer configs]: ../examples/transformerconfigs
-[v1.0.9]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v1.0.9
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
-[v2.1.0]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.1.0
+[v1.0.9]: /../../releases/tag/v1.0.9
+[v2.0.3]: /../../releases/tag/v2.0.3
+[v2.1.0]: /../../releases/tag/v2.1.0
 [versioning policy]: versioningPolicy.md
 
 Go modules, resource ordering respected, generator and transformer plugins, eased

--- a/docs/v3.0.0.md
+++ b/docs/v3.0.0.md
@@ -4,7 +4,7 @@ This release is basically [v2.1.0](v2.1.0.md),
 with many post-v2.1.0 bugs fixed (in about 150
 commits) and a `v3` in Go package paths.
 
-[plugin]: https://github.com/kubernetes-sigs/kustomize/tree/master/docs/plugins
+[plugin]: /docs/plugins
 
 The major version increment to `v3` puts a new
 floor on a stable API for [plugin] developers

--- a/docs/v3.3.0.md
+++ b/docs/v3.3.0.md
@@ -1,7 +1,7 @@
 # kustomize 3.3.0
  
-[versioning policy documentation]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/versioningPolicy.md
-[release process documentation]: https://github.com/kubernetes-sigs/kustomize/tree/master/releasing
+[versioning policy documentation]: /docs/versioningPolicy.md
+[release process documentation]: /releasing
  
 ## Summary of changes
 

--- a/docs/versioningPolicy.md
+++ b/docs/versioningPolicy.md
@@ -255,11 +255,11 @@ If missing, the value of `apiVersion` defaults to
 [proposal]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresources-versioning.md
 [beta-level rules]: https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md#alpha-beta-and-stable-versions
 [changes]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md
-[adapt]: https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/types/kustomization.go#L166
+[adapt]: /api/types/kustomization.go#L166
 [special]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources
 [k8s API]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
 [conventions]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
-[release page]: https://github.com/kubernetes-sigs/kustomize/releases
+[release page]: /../../releases
 [release process]: ../releasing/README.md
 [kustomization]: glossary.md#kustomization
 [`kind`]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/docs/zh/INSTALL.md
+++ b/docs/zh/INSTALL.md
@@ -1,4 +1,4 @@
-[release 页面]: https://github.com/kubernetes-sigs/kustomize/releases
+[release 页面]: /../../releases
 [Go]: https://golang.org
 [golang.org]: https://golang.org
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -45,6 +45,6 @@
 
 >声明：部分文档可能稍微滞后于英文版本，同步工作持续进行中
 
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
+[v2.0.3]: /../../releases/tag/v2.0.3
 [kubectl]: https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement
 [kubectl repository]: https://github.com/kubernetes/kubectl

--- a/docs/zh/fields.md
+++ b/docs/zh/fields.md
@@ -428,7 +428,7 @@ var 是包含该对象的变量名、对象引用和字段引用的元组。
 变量引用，即字符串 '$(FOO)' ，只能放在 kustomize 配置指定的特定对象的特定字段中。
 
 关于 vars 的默认配置数据可以查看：
-https://github.com/kubernetes-sigs/kustomize/blob/master/pkg/transformers/config/defaultconfig/varreference.go
+[/api/konfig/builtinpluginconsts/varreference.go](/api/konfig/builtinpluginconsts/varreference.go)
 
 默认目标是所有容器 command args 和 env 字段。
 

--- a/docs/zh/glossary.md
+++ b/docs/zh/glossary.md
@@ -27,7 +27,7 @@
 [patch]: #patch
 [patches]: #patch
 [patchJson6902]: #patchjson6902
-[patchExampleJson6902]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/jsonpatch.md
+[patchExampleJson6902]: /examples/jsonpatch.md
 [patchesJson6902]: #patchjson6902
 [proposal]: https://github.com/kubernetes/community/pull/1629
 [rebase]: https://git-scm.com/docs/git-rebase

--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -113,7 +113,7 @@ configuration is to
 This latter change initiates rolling update to the pods
 in the deployment.  The older configMap, when no longer
 referenced by any other resource, is eventually [garbage
-collected](https://github.com/kubernetes-sigs/kustomize/issues/242).
+collected](/../../issues/242).
 
 ### How this works with kustomize
 

--- a/examples/goGetterGeneratorPlugin.md
+++ b/examples/goGetterGeneratorPlugin.md
@@ -4,9 +4,9 @@ Kustomize supports building a [remote target], but the URLs are limited to commo
 
 To extend the supported format, Kustomize has a [plugin] system that allows one to integrate third-party tools such as [hashicorp/go-getter] to "download things from a string URL using a variety of protocols", extract the content and generated resources as part of kustomize build.
 
-[remote target]: https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md
-[Git repository specs]: https://github.com/kubernetes-sigs/kustomize/blob/master/api/internal/git/repospec_test.go
-[plugin]: ../docs/plugins
+[remote target]: /examples/remoteBuild.md
+[Git repository specs]: /api/internal/git/repospec_test.go
+[plugin]: /docs/plugins
 [hashicorp/go-getter]: https://github.com/hashicorp/go-getter
 
 ## Make a place to work

--- a/examples/remoteBuild.md
+++ b/examples/remoteBuild.md
@@ -14,7 +14,7 @@ one pod in the output:
 <!-- @remoteOverlayBuild @testAgainstLatestRelease -->
 
 ```
-target="github.com/kubernetes-sigs/kustomize//examples/multibases/dev/?ref=v1.0.6"
+target="github.com/kubernetes-sigs/kustomize/examples/multibases/dev/?ref=v1.0.6"
 test 1 == \
   $(kustomize build $target | grep dev-myapp-pod | wc -l); \
   echo $?
@@ -26,7 +26,7 @@ someone who wants to send them all at the same time):
 
 <!-- @remoteBuild @testAgainstLatestRelease -->
 ```
-target="https://github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6"
+target="https://github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6"
 test 3 == \
   $(kustomize build $target | grep cluster-a-.*-myapp-pod | wc -l); \
   echo $?
@@ -40,7 +40,7 @@ DEMO_HOME=$(mktemp -d)
 
 cat <<EOF >$DEMO_HOME/kustomization.yaml
 resources:
-- github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
+- github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6
 namePrefix: remote-
 EOF
 ```
@@ -69,10 +69,10 @@ Here are some example urls pointing to Github repos following this convention.
   `github.com/Liujingfang1/mysql?ref=test`
 - a subdirectory in a repo on version v1.0.6
 
-  `github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6`
+  `github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6`
 - a subdirectory in a repo on branch repoUrl2
 
-  `github.com/Liujingfang1/kustomize//examples/helloWorld?ref=repoUrl2`
+  `github.com/Liujingfang1/kustomize/examples/helloWorld?ref=repoUrl2`
 - a subdirectory in a repo on commit `7050a45134e9848fca214ad7e7007e96e5042c03`
 
-  `github.com/Liujingfang1/kustomize//examples/helloWorld?ref=7050a45134e9848fca214ad7e7007e96e5042c03`
+  `github.com/Liujingfang1/kustomize/examples/helloWorld?ref=7050a45134e9848fca214ad7e7007e96e5042c03`

--- a/examples/secretGeneratorPlugin.md
+++ b/examples/secretGeneratorPlugin.md
@@ -5,8 +5,8 @@
 [base64]: https://tools.ietf.org/html/rfc4648#section-4
 [configuration directory]: https://wiki.archlinux.org/index.php/XDG_Base_Directory#Specification
 [grpc]: https://grpc.io
-[tag]: https://github.com/kubernetes-sigs/kustomize/releases
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
+[tag]: /../../releases
+[v2.0.3]: /../../releases/tag/v2.0.3
 [`exec.Command`]: https://golang.org/pkg/os/exec/#Command
 
 # Generating Secrets

--- a/examples/zh/configGeneration.md
+++ b/examples/zh/configGeneration.md
@@ -105,7 +105,7 @@ grep -C 2 configMapKeyRef $BASE/deployment.yaml
  1. 使用新名称创建一个新的 configMap
  2. 为_deployment_ 添加 patch，修改相应 `configMapKeyRef` 字段的名称值。
 
-后一种更改会启动对 deployment 中的 pod 的滚动更新。旧的 configMap 在不再被任何其他资源引用时最终会被[垃圾回收](https://github.com/kubernetes-sigs/kustomize/issues/242)。
+后一种更改会启动对 deployment 中的 pod 的滚动更新。旧的 configMap 在不再被任何其他资源引用时最终会被[垃圾回收](/../../issues/242)。
 
 ### 如何使用 kustomize 
 

--- a/examples/zh/remoteBuild.md
+++ b/examples/zh/remoteBuild.md
@@ -9,7 +9,7 @@
 <!-- @remoteOverlayBuild @test -->
 
 ```bash
-target="github.com/kubernetes-sigs/kustomize//examples/multibases/dev/?ref=v1.0.6"
+target="github.com/kubernetes-sigs/kustomize/examples/multibases/dev/?ref=v1.0.6"
 test 1 == \
   $(kustomize build $target | grep dev-myapp-pod | wc -l); \
   echo $?
@@ -19,7 +19,7 @@ test 1 == \
 
 <!-- @remoteBuild @test -->
 ```bash
-target="https://github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6"
+target="https://github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6"
 test 3 == \
   $(kustomize build $target | grep cluster-a-.*-myapp-pod | wc -l); \
   echo $?
@@ -33,7 +33,7 @@ DEMO_HOME=$(mktemp -d)
 
 cat <<EOF >$DEMO_HOME/kustomization.yaml
 resources:
-- github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
+- github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6
 namePrefix: remote-
 EOF
 ```
@@ -59,10 +59,10 @@ URL 需要遵循 [hashicorp/go-getter URL 格式](https://github.com/hashicorp/g
   `github.com/Liujingfang1/mysql?ref=test`
 - kustomization.yaml 在 v1.0.6 版本的子目录
 
-  `github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6`
+  `github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6`
 - kustomization.yaml repoUrl2 分支的子目录
 
-  `github.com/Liujingfang1/kustomize//examples/helloWorld?ref=repoUrl2`
+  `github.com/Liujingfang1/kustomize/examples/helloWorld?ref=repoUrl2`
 - kustomization.yaml commit `7050a45134e9848fca214ad7e7007e96e5042c03` 的子目录
 
-  `github.com/Liujingfang1/kustomize//examples/helloWorld?ref=7050a45134e9848fca214ad7e7007e96e5042c03`
+  `github.com/Liujingfang1/kustomize/examples/helloWorld?ref=7050a45134e9848fca214ad7e7007e96e5042c03`

--- a/examples/zh/secretGeneratorPlugin.md
+++ b/examples/zh/secretGeneratorPlugin.md
@@ -5,8 +5,8 @@
 [base64]: https://tools.ietf.org/html/rfc4648#section-4
 [configuration directory]: https://wiki.archlinux.org/index.php/XDG_Base_Directory#Specification
 [grpc]: https://grpc.io
-[tag]: https://github.com/kubernetes-sigs/kustomize/releases
-[v2.0.3]: https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3
+[tag]: /../../releases
+[v2.0.3]: /../../releases/tag/v2.0.3
 [`exec.Command`]: https://golang.org/pkg/os/exec/#Command
 
 # 生成 Secrets

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -1,6 +1,6 @@
 # Releasing
 
-[release page]: https://github.com/kubernetes-sigs/kustomize/releases
+[release page]: /../../releases
 [`cloud-build-local`]: https://github.com/GoogleCloudPlatform/cloud-build-local
 [Google Cloud Build]: https://cloud.google.com/cloud-build
 [semver]: https://semver.org
@@ -21,8 +21,8 @@ for an explanation of the `foo/v2.3.0` tags applied below.
 [`sigs.k8s.io/kustomize/api`]: #sigsk8siokustomizeapi
 [`sigs.k8s.io/kustomize/pluginator`]: #sigsk8siokustomizepluginator
 [`sigs.k8s.io/kustomize/pseudo/k8s`]: #sigsk8siokustomizepseudok8s
-[kustomize/v3.2.1]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.1
-[pluginator/v1.0.0]: https://github.com/kubernetes-sigs/kustomize/releases/tag/pluginator%2Fv1.0.0
+[kustomize/v3.2.1]: /../../releases/tag/kustomize%2Fv3.2.1
+[pluginator/v1.0.0]: /../../releases/tag/pluginator%2Fv1.0.0
 
 | Module Description | Module Prefix | Ex. Tag  | Ex. Branch Name |
 | ---                | ------        | --- | ---         |


### PR DESCRIPTION
I've came across multiple broken file links in the documentation I suppose due to recent refactoring in the code away from /pkg. 
* Fixing URLs to files to their new location 
* Updating documentation URLs to relative paths