### PR TITLE
cmd/config: update naming of commands

### DIFF
--- a/cmd/config/README.md
+++ b/cmd/config/README.md
@@ -3,8 +3,12 @@
 This package exists to expose config filters directly as cli commands for the purposes
 of development of the kyaml package and as a reference implementation for using the libraries.
 
-## Docs:
+## Docs
 
+All documentation is also built directly into the `config` command group using 
+`kustomize help config`.
+
+- [tutorials](docs/tutorials)
 - [commands](docs/commands)
 - [api-conventions](docs/api-conventions)
 

--- a/cmd/config/cmd/cmdxargs.go
+++ b/cmd/config/cmd/cmdxargs.go
@@ -41,7 +41,7 @@ items:
 - 1
 
 # this command:
-$ kyaml cat pkg/ --function-config config.yaml --wrap-kind ResourceList | kyaml run-fns xargs -- app
+$ kyaml cat pkg/ --function-config config.yaml --wrap-kind ResourceList | kyaml run xargs -- app
 
 # is equivalent to this command:
 $ kyaml cat pkg/ --function-config config.yaml --wrap-kind ResourceList | app --flag1=value1 --flag2=value2 2 1

--- a/cmd/config/cmd/run-fns.go
+++ b/cmd/config/cmd/run-fns.go
@@ -13,8 +13,8 @@ import (
 func GetRunFnRunner(name string) *RunFnRunner {
 	r := &RunFnRunner{}
 	c := &cobra.Command{
-		Use:     "run-fns DIR",
-		Aliases: []string{"run"},
+		Use:     "run DIR",
+		Aliases: []string{"run-fns"},
 		Short:   commands.RunFnsShort,
 		Long:    commands.RunFnsLong,
 		Example: commands.RunFnsExamples,

--- a/cmd/config/cmd/util.go
+++ b/cmd/config/cmd/util.go
@@ -63,7 +63,7 @@ var ExitOnError bool
 // StackOnError if true, will print a stack trace on failure.
 var StackOnError bool
 
-const cmdName = "kyaml"
+const cmdName = "kustomize config"
 
 // FixDocs replaces instances of old with new in the docs for c
 func fixDocs(new string, c *cobra.Command) {

--- a/cmd/config/cmddocs/api/docs.go
+++ b/cmd/config/cmddocs/api/docs.go
@@ -59,7 +59,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
     generated Resources -- e.g. 1. the function generates a Deployment, but doesn't
     specify ` + "`" + `cpu` + "`" + `, 2. the user sets the ` + "`" + `cpu` + "`" + ` on the generated Resource, 3. the
     function should keep the ` + "`" + `cpu` + "`" + ` when regenerating the Resource a second time.
-  - Functions **SHOULD** be usable outside ` + "`" + `kyaml run-fns` + "`" + ` -- e.g. though pipeline
+  - Functions **SHOULD** be usable outside ` + "`" + `kustomize config run-fns` + "`" + ` -- e.g. though pipeline
     mechanisms such as Tekton.
 
 #### Input Format
@@ -126,7 +126,8 @@ var ConfigFnLong = `# Configuration Functions API Semantics
 
 #### Container Environment
 
-  When run by ` + "`" + `kyaml run-fns` + "`" + `, functions are run in containers with the following environment:
+  When run by ` + "`" + `kustomize config run-fns` + "`" + `, functions are run in containers with the
+  following environment:
 
   - Network: ` + "`" + `none` + "`" + `
   - User: ` + "`" + `nobody` + "`" + `
@@ -152,8 +153,8 @@ var ConfigFnLong = `# Configuration Functions API Semantics
   4. Format the output
 
     #!/bin/bash
-    # script must run wrapped by kyaml for parsing input
-    # the functionConfig into env vars
+    # script must run wrapped by ` + "`" + `kustomize config run-fns wrap` + "`" + `
+    # for parsing input the functionConfig into env vars
     if [ -z ${WRAPPED} ]; then
       export WRAPPED=true
       config run-fns wrap -- $0
@@ -205,7 +206,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
 
 #### ` + "`" + `Dockerfile` + "`" + `
 
-  ` + "`" + `Dockerfile` + "`" + ` installs ` + "`" + `kyaml` + "`" + ` and copies the script into the container image.    
+  ` + "`" + `Dockerfile` + "`" + ` installs ` + "`" + `kustomize config` + "`" + ` and copies the script into the container image.    
 
     FROM golang:1.13-stretch
     RUN go get sigs.k8s.io/kustomize/cmd/config
@@ -215,7 +216,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
 
 ### Example Function Usage
 
-Following is an example of running the ` + "`" + `kyaml run-fns` + "`" + ` using the preceding API.
+Following is an example of running the ` + "`" + `kustomize config run-fns` + "`" + ` using the preceding API.
 
 #### ` + "`" + `nginx.yaml` + "`" + ` (Input)
 
@@ -238,7 +239,7 @@ Following is an example of running the ` + "`" + `kyaml run-fns` + "`" + ` using
   - ` + "`" + `annotations[config.kubernetes.io/local-config]` + "`" + `: mark this as not a Resource that should
     be applied
     
-#### ` + "`" + `kyaml run-fns dir/` + "`" + ` (Output)
+#### ` + "`" + `kustomize config run-fns dir/` + "`" + ` (Output)
 
   ` + "`" + `dir/my-instance_deployment.yaml` + "`" + ` contains the Deployment:
     

--- a/cmd/config/cmddocs/api/docs.go
+++ b/cmd/config/cmddocs/api/docs.go
@@ -59,7 +59,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
     generated Resources -- e.g. 1. the function generates a Deployment, but doesn't
     specify ` + "`" + `cpu` + "`" + `, 2. the user sets the ` + "`" + `cpu` + "`" + ` on the generated Resource, 3. the
     function should keep the ` + "`" + `cpu` + "`" + ` when regenerating the Resource a second time.
-  - Functions **SHOULD** be usable outside ` + "`" + `kustomize config run-fns` + "`" + ` -- e.g. though pipeline
+  - Functions **SHOULD** be usable outside ` + "`" + `kustomize config run` + "`" + ` -- e.g. though pipeline
     mechanisms such as Tekton.
 
 #### Input Format
@@ -126,7 +126,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
 
 #### Container Environment
 
-  When run by ` + "`" + `kustomize config run-fns` + "`" + `, functions are run in containers with the
+  When run by ` + "`" + `kustomize config run` + "`" + `, functions are run in containers with the
   following environment:
 
   - Network: ` + "`" + `none` + "`" + `
@@ -144,7 +144,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
   ` + "`" + `nginx-template.sh` + "`" + ` is a simple bash script which uses a *heredoc* as a templating solution
   for generating Resources from the functionConfig input fields.
 
-  The script wraps itself using ` + "`" + `config run-fns wrap -- $0` + "`" + ` which will:
+  The script wraps itself using ` + "`" + `config run wrap -- $0` + "`" + ` which will:
 
   1. Parse the ` + "`" + `ResourceList.functionConfig` + "`" + ` (provided to the container stdin) into env vars
   2. Merge the stdout into the original list of Resources
@@ -153,11 +153,11 @@ var ConfigFnLong = `# Configuration Functions API Semantics
   4. Format the output
 
     #!/bin/bash
-    # script must run wrapped by ` + "`" + `kustomize config run-fns wrap` + "`" + `
+    # script must run wrapped by ` + "`" + `kustomize config run wrap` + "`" + `
     # for parsing input the functionConfig into env vars
     if [ -z ${WRAPPED} ]; then
       export WRAPPED=true
-      config run-fns wrap -- $0
+      config run wrap -- $0
       exit $?
     fi
 
@@ -216,7 +216,7 @@ var ConfigFnLong = `# Configuration Functions API Semantics
 
 ### Example Function Usage
 
-Following is an example of running the ` + "`" + `kustomize config run-fns` + "`" + ` using the preceding API.
+Following is an example of running the ` + "`" + `kustomize config run` + "`" + ` using the preceding API.
 
 #### ` + "`" + `nginx.yaml` + "`" + ` (Input)
 
@@ -239,7 +239,7 @@ Following is an example of running the ` + "`" + `kustomize config run-fns` + "`
   - ` + "`" + `annotations[config.kubernetes.io/local-config]` + "`" + `: mark this as not a Resource that should
     be applied
     
-#### ` + "`" + `kustomize config run-fns dir/` + "`" + ` (Output)
+#### ` + "`" + `kustomize config run dir/` + "`" + ` (Output)
 
   ` + "`" + `dir/my-instance_deployment.yaml` + "`" + ` contains the Deployment:
     

--- a/cmd/config/cmddocs/commands/docs.go
+++ b/cmd/config/cmddocs/commands/docs.go
@@ -13,13 +13,13 @@ var CatLong = `
 `
 var CatExamples = `
     # print Resource config from a directory
-    kyaml cat my-dir/
+    kustomize config cat my-dir/
     
     # wrap Resource config from a directory in an ResourceList
-    kyaml cat my-dir/ --wrap-kind ResourceList --wrap-version config.kubernetes.io/v1alpha1 --function-config fn.yaml
+    kustomize config cat my-dir/ --wrap-kind ResourceList --wrap-version config.kubernetes.io/v1alpha1 --function-config fn.yaml
     
     # unwrap Resource config from a directory in an ResourceList
-    ... | kyaml cat`
+    ... | kustomize config cat`
 
 var CountShort = `[Alpha] Count Resources Config from a local directory.`
 var CountLong = `
@@ -30,7 +30,7 @@ var CountLong = `
 `
 var CountExamples = `
     # print Resource counts from a directory
-    kyaml count my-dir/`
+    kustomize config count my-dir/`
 
 var FmtShort = `[Alpha] Format yaml configuration files.`
 var FmtLong = `
@@ -61,16 +61,16 @@ field paths.
 `
 var FmtExamples = `
 	# format file1.yaml and file2.yml
-	kyaml fmt file1.yaml file2.yml
+	kustomize config fmt file1.yaml file2.yml
 
 	# format all *.yaml and *.yml recursively traversing directories
-	kyaml fmt my-dir/
+	kustomize config fmt my-dir/
 
 	# format kubectl output
-	kubectl get -o yaml deployments | kyaml fmt
+	kubectl get -o yaml deployments | kustomize config fmt
 
 	# format kustomize output
-	kustomize build | kyaml fmt`
+	kustomize build | kustomize config fmt`
 
 var GrepShort = `[Alpha] Search for matching Resources in a directory or from stdin`
 var GrepLong = `
@@ -88,16 +88,16 @@ var GrepLong = `
 `
 var GrepExamples = `
     # find Deployment Resources
-    kyaml grep "kind=Deployment" my-dir/
+    kustomize config grep "kind=Deployment" my-dir/
     
     # find Resources named nginx
-    kyaml grep "metadata.name=nginx" my-dir/
+    kustomize config grep "metadata.name=nginx" my-dir/
     
     # use tree to display matching Resources
-    kyaml grep "metadata.name=nginx" my-dir/ | kyaml tree
+    kustomize config grep "metadata.name=nginx" my-dir/ | kustomize config tree
     
     # look for Resources matching a specific container image
-    kyaml grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" my-dir/ | kyaml tree`
+    kustomize config grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" my-dir/ | kustomize config tree`
 
 var MergeShort = `[Alpha] Merge Resource configuration files`
 var MergeLong = `
@@ -114,10 +114,10 @@ earlier are lower-precedence (the destination).
 
 For information on merge rules, run:
 
-	kyaml docs merge
+	kustomize config docs merge
 `
 var MergeExamples = `
-    cat resources_and_patches.yaml | kyaml merge > merged_resources.yaml`
+    cat resources_and_patches.yaml | kustomize config merge > merged_resources.yaml`
 
 var RunFnsShort = `[Alpha] Reoncile config functions to Resources.`
 var RunFnsLong = `
@@ -157,22 +157,22 @@ order they appear in the file).
 	spec:
 	  configField: configValue
 
-  In the preceding example, 'kyaml run-fns example/' would identify the function by
+  In the preceding example, 'kustomize config run-fns example/' would identify the function by
   the metadata.configFn field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then writer the container stdout back to example/, replacing the directory
   file contents.
 
-  See ` + "`" + `kyaml help docs-fn` + "`" + ` for more details on writing functions.
+  See ` + "`" + `kustomize config help docs-fn` + "`" + ` for more details on writing functions.
 `
 var RunFnsExamples = `
-kyaml run-fns example/`
+kustomize config run-fns example/`
 
 var TreeShort = `[Alpha] Display Resource structure from a directory or stdin.`
 var TreeLong = `
 [Alpha] Display Resource structure from a directory or stdin.
 
-kyaml tree may be used to print Resources in a directory or cluster, preserving structure
+kustomize config tree may be used to print Resources in a directory or cluster, preserving structure
 
 Args:
 
@@ -181,37 +181,37 @@ Args:
 
 Resource fields may be printed as part of the Resources by specifying the fields as flags.
 
-kyaml tree has build-in support for printing common fields, such as replicas, container images,
+kustomize config tree has build-in support for printing common fields, such as replicas, container images,
 container names, etc.
 
-kyaml tree supports printing arbitrary fields using the '--field' flag.
+kustomize config tree supports printing arbitrary fields using the '--field' flag.
 
-By default, kyaml tree uses the directory structure for the tree structure, however when printing
+By default, kustomize config tree uses the directory structure for the tree structure, however when printing
 from the cluster, the Resource graph structure may be used instead.
 `
 var TreeExamples = `
     # print Resources using directory structure
-    kyaml tree my-dir/
+    kustomize config tree my-dir/
     
     # print replicas, container name, and container image and fields for Resources
-    kyaml tree my-dir --replicas --image --name
+    kustomize config tree my-dir --replicas --image --name
     
     # print all common Resource fields
-    kyaml tree my-dir/ --all
+    kustomize config tree my-dir/ --all
     
     # print the "foo"" annotation
-    kyaml tree my-dir/ --field "metadata.annotations.foo" 
+    kustomize config tree my-dir/ --field "metadata.annotations.foo" 
     
     # print the "foo"" annotation
-    kubectl get all -o yaml | kyaml tree my-dir/ --structure=graph \
+    kubectl get all -o yaml | kustomize config tree my-dir/ --structure=graph \
       --field="status.conditions[type=Completed].status"
     
     # print live Resources from a cluster using graph for structure
-    kubectl get all -o yaml | kyaml tree --replicas --name --image --structure=graph
+    kubectl get all -o yaml | kustomize config tree --replicas --name --image --structure=graph
     
     
     # print live Resources using graph for structure
-    kubectl get all,applications,releasetracks -o yaml | kyaml tree --structure=graph \
+    kubectl get all,applications,releasetracks -o yaml | kustomize config tree --structure=graph \
       --name --image --replicas \
       --field="status.conditions[type=Completed].status" \
       --field="status.conditions[type=Complete].status" \

--- a/cmd/config/cmddocs/commands/docs.go
+++ b/cmd/config/cmddocs/commands/docs.go
@@ -123,7 +123,7 @@ var RunFnsShort = `[Alpha] Reoncile config functions to Resources.`
 var RunFnsLong = `
 [Alpha] Reconcile config functions to Resources.
 
-run-fns sequentially invokes all config functions in the directly, providing Resources
+run sequentially invokes all config functions in the directly, providing Resources
 in the directory as input to the first function, and writing the output of the last
 function back to the directory.
 
@@ -140,7 +140,7 @@ order they appear in the file).
 #### Config Functions:
 
   Config functions are specified as Kubernetes types containing a metadata.configFn.container.image
-  field.  This fields tells run-fns how to invoke the container.
+  field.  This fields tells run how to invoke the container.
 
   Example config function:
 
@@ -157,7 +157,7 @@ order they appear in the file).
 	spec:
 	  configField: configValue
 
-  In the preceding example, 'kustomize config run-fns example/' would identify the function by
+  In the preceding example, 'kustomize config run example/' would identify the function by
   the metadata.configFn field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then writer the container stdout back to example/, replacing the directory
@@ -166,7 +166,7 @@ order they appear in the file).
   See ` + "`" + `kustomize config help docs-fn` + "`" + ` for more details on writing functions.
 `
 var RunFnsExamples = `
-kustomize config run-fns example/`
+kustomize config run example/`
 
 var TreeShort = `[Alpha] Display Resource structure from a directory or stdin.`
 var TreeLong = `

--- a/cmd/config/cmddocs/tutorials/docs.go
+++ b/cmd/config/cmddocs/tutorials/docs.go
@@ -282,7 +282,7 @@ var ConfigurationBasicsLong = `
 var FunctionBasicsShort = `### Synopsis`
 var FunctionBasicsLong = `
   ` + "`" + `kustomize config` + "`" + ` enables encapsulating function for manipulating Resource
-  configuration inside containers, which are run using ` + "`" + `run-fns` + "`" + `.
+  configuration inside containers, which are run using ` + "`" + `run` + "`" + `.
 
   First fetch the kustomize repository, which contains a collection of example
   functions
@@ -299,7 +299,7 @@ var FunctionBasicsLong = `
   #### 1: Generate the Resources
 
   ` + "`" + `cd` + "`" + ` into the ` + "`" + `kustomize/functions/examples/template-heredoc-cockroachdb/` + "`" + `
-  directory, and invoke ` + "`" + `run-fns` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
+  directory, and invoke ` + "`" + `run` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
 
     cd template-heredoc-cockroachdb/
     
@@ -307,12 +307,12 @@ var FunctionBasicsLong = `
     kustomize config tree local-resource/ --name --image --replicas
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # view the generated Resources 
     kustomize config tree local-resource/ --name --image --replicas
     
-  ` + "`" + `run-fns` + "`" + ` generated the directory ` + "`" + ` local-resource/config` + "`" + ` containing the generated
+  ` + "`" + `run` + "`" + ` generated the directory ` + "`" + ` local-resource/config` + "`" + ` containing the generated
   Resources.
   
   #### 2. Modify the Generated Resources
@@ -320,14 +320,14 @@ var FunctionBasicsLong = `
   - modify the generated Resources by adding an annotation, sidecar container, etc.
   - modify the ` + "`" + `local-resources/example-use.yaml` + "`" + ` by changing the replicas 
   
-  re-run ` + "`" + `run-fns` + "`" + `.  this will apply the updated replicas to the generated Resources,
+  re-run ` + "`" + `run` + "`" + `.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
 
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
   
-  ` + "`" + `run-fns` + "`" + ` facilitates a non-destructive *smart templating* approach that allows templating
+  ` + "`" + `run` + "`" + ` facilitates a non-destructive *smart templating* approach that allows templating
   to be composed with manual modifications directly to the template output, as well as
   composition with other functions which may appy validation or injection of values.
 
@@ -345,7 +345,7 @@ var FunctionBasicsLong = `
   #### 1: Generate the Resources
 
   ` + "`" + `cd` + "`" + ` into the ` + "`" + `kustomize/functions/examples/template-go-nginx/` + "`" + `
-  directory, and invoke ` + "`" + `run-fns` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
+  directory, and invoke ` + "`" + `run` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
 
     cd template-go-nginx/
     
@@ -353,12 +353,12 @@ var FunctionBasicsLong = `
     kustomize config tree local-resource/ --name --image --replicas
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # view the generated Resources 
     kustomize config tree local-resource/ --name --image --replicas
     
-  ` + "`" + `run-fns` + "`" + ` generated the directory ` + "`" + ` local-resource/config` + "`" + ` containing the generated
+  ` + "`" + `run` + "`" + ` generated the directory ` + "`" + ` local-resource/config` + "`" + ` containing the generated
   Resources.  this time it put the configuration in a single file rather than multiple
   files.  The mapping of Resources to files is controlled by the function itself through
   annotations on the generated Resources.
@@ -368,11 +368,11 @@ var FunctionBasicsLong = `
   - modify the generated Resources by adding an annotation, sidecar container, etc.
   - modify the ` + "`" + `local-resources/example-use.yaml` + "`" + ` by changing the replicas
   
-  re-run ` + "`" + `run-fns` + "`" + `.  this will apply the updated replicas to the generated Resources,
+  re-run ` + "`" + `run` + "`" + `.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
   
   Just like in the preceding section, the function is implemented using a non-destructive
   approach which merges the generated Resources into previously generated instances.
@@ -384,15 +384,15 @@ var FunctionBasicsLong = `
 
 ### Validation -- resource reservations
 
-  This section uses ` + "`" + `run-fns` + "`" + ` to perform validation rather than generate Resources.
+  This section uses ` + "`" + `run` + "`" + ` to perform validation rather than generate Resources.
   
   #### 1: Run the Validator
 
   ` + "`" + `cd` + "`" + ` into the ` + "`" + `kustomize/functions/examples/validator-resource-requests` + "`" + `
-  directory, and invoke ` + "`" + `run-fns` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
+  directory, and invoke ` + "`" + `run` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
 
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     cpu-requests missing for a container in Deployment nginx (example-use.yaml [1])
     Error: exit status 1
     Usage:
@@ -404,19 +404,19 @@ var FunctionBasicsLong = `
   and print the name of the file + Resource index.  Edit the file and uncomment the resources,
   then re-run the functions.
   
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
 
   The validation now passes.
 
 ### Injection -- resource reservations
 
-  This section uses ` + "`" + `run-fns` + "`" + ` to perform injection of field values based off annotations
+  This section uses ` + "`" + `run` + "`" + ` to perform injection of field values based off annotations
   on the Resource.
   
   #### 1: Run the Injector
 
   ` + "`" + `cd` + "`" + ` into the ` + "`" + `kustomize/functions/examples/inject-tshirt-sizes` + "`" + `
-  directory, and invoke ` + "`" + `run-fns` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
+  directory, and invoke ` + "`" + `run` + "`" + ` on the ` + "`" + `local-resource/` + "`" + ` directory.
 
     # print the resources
     kustomize config tree local-resource --resources --name
@@ -428,7 +428,7 @@ var FunctionBasicsLong = `
                 └── name: nginx
 
     # run the functions
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # print the new resources
     kustomize config tree local-resource --resources --name    
@@ -443,7 +443,7 @@ var FunctionBasicsLong = `
   
   Change the ` + "`" + `tshirt-size` + "`" + ` annotation from ` + "`" + `medium` + "`" + ` to ` + "`" + `small` + "`" + ` and re-run the functions.
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     kustomize config tree local-resource/
     local-resource
     ├── [example-use.yaml]  Validator 
@@ -459,5 +459,5 @@ var FunctionBasicsLong = `
 
 Functions may be composed together.  Try putting the Injection (tshirt-size) and 
 Validation functions together in the same .yaml file (separated by ` + "`" + `---` + "`" + `).  Run
-` + "`" + `run-fns` + "`" + ` and observe that the first function in the file is applied to the Resources,
+` + "`" + `run` + "`" + ` and observe that the first function in the file is applied to the Resources,
 and then the second function in the file is applied.`

--- a/cmd/config/docs/api-conventions/config-fn.md
+++ b/cmd/config/docs/api-conventions/config-fn.md
@@ -53,7 +53,7 @@
     generated Resources -- e.g. 1. the function generates a Deployment, but doesn't
     specify `cpu`, 2. the user sets the `cpu` on the generated Resource, 3. the
     function should keep the `cpu` when regenerating the Resource a second time.
-  - Functions **SHOULD** be usable outside `kustomize config run-fns` -- e.g. though pipeline
+  - Functions **SHOULD** be usable outside `kustomize config run` -- e.g. though pipeline
     mechanisms such as Tekton.
 
 #### Input Format
@@ -120,7 +120,7 @@
 
 #### Container Environment
 
-  When run by `kustomize config run-fns`, functions are run in containers with the
+  When run by `kustomize config run`, functions are run in containers with the
   following environment:
 
   - Network: `none`
@@ -138,7 +138,7 @@
   `nginx-template.sh` is a simple bash script which uses a *heredoc* as a templating solution
   for generating Resources from the functionConfig input fields.
 
-  The script wraps itself using `config run-fns wrap -- $0` which will:
+  The script wraps itself using `config run wrap -- $0` which will:
 
   1. Parse the `ResourceList.functionConfig` (provided to the container stdin) into env vars
   2. Merge the stdout into the original list of Resources
@@ -147,11 +147,11 @@
   4. Format the output
 
     #!/bin/bash
-    # script must run wrapped by `kustomize config run-fns wrap`
+    # script must run wrapped by `kustomize config run wrap`
     # for parsing input the functionConfig into env vars
     if [ -z ${WRAPPED} ]; then
       export WRAPPED=true
-      config run-fns wrap -- $0
+      config run wrap -- $0
       exit $?
     fi
 
@@ -210,7 +210,7 @@
 
 ### Example Function Usage
 
-Following is an example of running the `kustomize config run-fns` using the preceding API.
+Following is an example of running the `kustomize config run` using the preceding API.
 
 #### `nginx.yaml` (Input)
 
@@ -233,7 +233,7 @@ Following is an example of running the `kustomize config run-fns` using the prec
   - `annotations[config.kubernetes.io/local-config]`: mark this as not a Resource that should
     be applied
     
-#### `kustomize config run-fns dir/` (Output)
+#### `kustomize config run dir/` (Output)
 
   `dir/my-instance_deployment.yaml` contains the Deployment:
     

--- a/cmd/config/docs/api-conventions/config-fn.md
+++ b/cmd/config/docs/api-conventions/config-fn.md
@@ -53,7 +53,7 @@
     generated Resources -- e.g. 1. the function generates a Deployment, but doesn't
     specify `cpu`, 2. the user sets the `cpu` on the generated Resource, 3. the
     function should keep the `cpu` when regenerating the Resource a second time.
-  - Functions **SHOULD** be usable outside `kyaml run-fns` -- e.g. though pipeline
+  - Functions **SHOULD** be usable outside `kustomize config run-fns` -- e.g. though pipeline
     mechanisms such as Tekton.
 
 #### Input Format
@@ -120,7 +120,8 @@
 
 #### Container Environment
 
-  When run by `kyaml run-fns`, functions are run in containers with the following environment:
+  When run by `kustomize config run-fns`, functions are run in containers with the
+  following environment:
 
   - Network: `none`
   - User: `nobody`
@@ -146,8 +147,8 @@
   4. Format the output
 
     #!/bin/bash
-    # script must run wrapped by kyaml for parsing input
-    # the functionConfig into env vars
+    # script must run wrapped by `kustomize config run-fns wrap`
+    # for parsing input the functionConfig into env vars
     if [ -z ${WRAPPED} ]; then
       export WRAPPED=true
       config run-fns wrap -- $0
@@ -199,7 +200,7 @@
 
 #### `Dockerfile`
 
-  `Dockerfile` installs `kyaml` and copies the script into the container image.    
+  `Dockerfile` installs `kustomize config` and copies the script into the container image.    
 
     FROM golang:1.13-stretch
     RUN go get sigs.k8s.io/kustomize/cmd/config
@@ -209,7 +210,7 @@
 
 ### Example Function Usage
 
-Following is an example of running the `kyaml run-fns` using the preceding API.
+Following is an example of running the `kustomize config run-fns` using the preceding API.
 
 #### `nginx.yaml` (Input)
 
@@ -232,7 +233,7 @@ Following is an example of running the `kyaml run-fns` using the preceding API.
   - `annotations[config.kubernetes.io/local-config]`: mark this as not a Resource that should
     be applied
     
-#### `kyaml run-fns dir/` (Output)
+#### `kustomize config run-fns dir/` (Output)
 
   `dir/my-instance_deployment.yaml` contains the Deployment:
     

--- a/cmd/config/docs/commands/cat.md
+++ b/cmd/config/docs/commands/cat.md
@@ -12,10 +12,10 @@
 ### Examples
 
     # print Resource config from a directory
-    kyaml cat my-dir/
+    kustomize config cat my-dir/
     
     # wrap Resource config from a directory in an ResourceList
-    kyaml cat my-dir/ --wrap-kind ResourceList --wrap-version config.kubernetes.io/v1alpha1 --function-config fn.yaml
+    kustomize config cat my-dir/ --wrap-kind ResourceList --wrap-version config.kubernetes.io/v1alpha1 --function-config fn.yaml
     
     # unwrap Resource config from a directory in an ResourceList
-    ... | kyaml cat
+    ... | kustomize config cat

--- a/cmd/config/docs/commands/count.md
+++ b/cmd/config/docs/commands/count.md
@@ -12,4 +12,4 @@
 ### Examples
 
     # print Resource counts from a directory
-    kyaml count my-dir/
+    kustomize config count my-dir/

--- a/cmd/config/docs/commands/fmt.md
+++ b/cmd/config/docs/commands/fmt.md
@@ -32,13 +32,13 @@ field paths.
 ### Examples
 
 	# format file1.yaml and file2.yml
-	kyaml fmt file1.yaml file2.yml
+	kustomize config fmt file1.yaml file2.yml
 
 	# format all *.yaml and *.yml recursively traversing directories
-	kyaml fmt my-dir/
+	kustomize config fmt my-dir/
 
 	# format kubectl output
-	kubectl get -o yaml deployments | kyaml fmt
+	kubectl get -o yaml deployments | kustomize config fmt
 
 	# format kustomize output
-	kustomize build | kyaml fmt
+	kustomize build | kustomize config fmt

--- a/cmd/config/docs/commands/grep.md
+++ b/cmd/config/docs/commands/grep.md
@@ -19,13 +19,13 @@
 ### Examples
 
     # find Deployment Resources
-    kyaml grep "kind=Deployment" my-dir/
+    kustomize config grep "kind=Deployment" my-dir/
     
     # find Resources named nginx
-    kyaml grep "metadata.name=nginx" my-dir/
+    kustomize config grep "metadata.name=nginx" my-dir/
     
     # use tree to display matching Resources
-    kyaml grep "metadata.name=nginx" my-dir/ | kyaml tree
+    kustomize config grep "metadata.name=nginx" my-dir/ | kustomize config tree
     
     # look for Resources matching a specific container image
-    kyaml grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" my-dir/ | kyaml tree
+    kustomize config grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" my-dir/ | kustomize config tree

--- a/cmd/config/docs/commands/merge.md
+++ b/cmd/config/docs/commands/merge.md
@@ -17,8 +17,8 @@ earlier are lower-precedence (the destination).
 
 For information on merge rules, run:
 
-	kyaml docs merge
+	kustomize config docs merge
 
 ### Examples
 
-    cat resources_and_patches.yaml | kyaml merge > merged_resources.yaml
+    cat resources_and_patches.yaml | kustomize config merge > merged_resources.yaml

--- a/cmd/config/docs/commands/run-fns.md
+++ b/cmd/config/docs/commands/run-fns.md
@@ -1,4 +1,4 @@
-## run-fns
+## run
 
 [Alpha] Reoncile config functions to Resources.
 
@@ -6,7 +6,7 @@
 
 [Alpha] Reconcile config functions to Resources.
 
-run-fns sequentially invokes all config functions in the directly, providing Resources
+run sequentially invokes all config functions in the directly, providing Resources
 in the directory as input to the first function, and writing the output of the last
 function back to the directory.
 
@@ -23,7 +23,7 @@ order they appear in the file).
 #### Config Functions:
 
   Config functions are specified as Kubernetes types containing a metadata.configFn.container.image
-  field.  This fields tells run-fns how to invoke the container.
+  field.  This fields tells run how to invoke the container.
 
   Example config function:
 
@@ -40,7 +40,7 @@ order they appear in the file).
 	spec:
 	  configField: configValue
 
-  In the preceding example, 'kustomize config run-fns example/' would identify the function by
+  In the preceding example, 'kustomize config run example/' would identify the function by
   the metadata.configFn field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then writer the container stdout back to example/, replacing the directory
@@ -50,4 +50,4 @@ order they appear in the file).
 
 ### Examples
 
-kustomize config run-fns example/
+kustomize config run example/

--- a/cmd/config/docs/commands/run-fns.md
+++ b/cmd/config/docs/commands/run-fns.md
@@ -40,14 +40,14 @@ order they appear in the file).
 	spec:
 	  configField: configValue
 
-  In the preceding example, 'kyaml run-fns example/' would identify the function by
+  In the preceding example, 'kustomize config run-fns example/' would identify the function by
   the metadata.configFn field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then writer the container stdout back to example/, replacing the directory
   file contents.
 
-  See `kyaml help docs-fn` for more details on writing functions.
+  See `kustomize config help docs-fn` for more details on writing functions.
 
 ### Examples
 
-kyaml run-fns example/
+kustomize config run-fns example/

--- a/cmd/config/docs/commands/tree.md
+++ b/cmd/config/docs/commands/tree.md
@@ -6,7 +6,7 @@
 
 [Alpha] Display Resource structure from a directory or stdin.
 
-kyaml tree may be used to print Resources in a directory or cluster, preserving structure
+kustomize config tree may be used to print Resources in a directory or cluster, preserving structure
 
 Args:
 
@@ -15,38 +15,38 @@ Args:
 
 Resource fields may be printed as part of the Resources by specifying the fields as flags.
 
-kyaml tree has build-in support for printing common fields, such as replicas, container images,
+kustomize config tree has build-in support for printing common fields, such as replicas, container images,
 container names, etc.
 
-kyaml tree supports printing arbitrary fields using the '--field' flag.
+kustomize config tree supports printing arbitrary fields using the '--field' flag.
 
-By default, kyaml tree uses the directory structure for the tree structure, however when printing
+By default, kustomize config tree uses the directory structure for the tree structure, however when printing
 from the cluster, the Resource graph structure may be used instead.
 
 ### Examples
 
     # print Resources using directory structure
-    kyaml tree my-dir/
+    kustomize config tree my-dir/
     
     # print replicas, container name, and container image and fields for Resources
-    kyaml tree my-dir --replicas --image --name
+    kustomize config tree my-dir --replicas --image --name
     
     # print all common Resource fields
-    kyaml tree my-dir/ --all
+    kustomize config tree my-dir/ --all
     
     # print the "foo"" annotation
-    kyaml tree my-dir/ --field "metadata.annotations.foo" 
+    kustomize config tree my-dir/ --field "metadata.annotations.foo" 
     
     # print the "foo"" annotation
-    kubectl get all -o yaml | kyaml tree my-dir/ --structure=graph \
+    kubectl get all -o yaml | kustomize config tree my-dir/ --structure=graph \
       --field="status.conditions[type=Completed].status"
     
     # print live Resources from a cluster using graph for structure
-    kubectl get all -o yaml | kyaml tree --replicas --name --image --structure=graph
+    kubectl get all -o yaml | kustomize config tree --replicas --name --image --structure=graph
     
     
     # print live Resources using graph for structure
-    kubectl get all,applications,releasetracks -o yaml | kyaml tree --structure=graph \
+    kubectl get all,applications,releasetracks -o yaml | kustomize config tree --structure=graph \
       --name --image --replicas \
       --field="status.conditions[type=Completed].status" \
       --field="status.conditions[type=Complete].status" \

--- a/cmd/config/docs/tutorials/function-basics.md
+++ b/cmd/config/docs/tutorials/function-basics.md
@@ -3,7 +3,7 @@
 ### Synopsis
 
   `kustomize config` enables encapsulating function for manipulating Resource
-  configuration inside containers, which are run using `run-fns`.
+  configuration inside containers, which are run using `run`.
 
   First fetch the kustomize repository, which contains a collection of example
   functions
@@ -20,7 +20,7 @@
   #### 1: Generate the Resources
 
   `cd` into the `kustomize/functions/examples/template-heredoc-cockroachdb/`
-  directory, and invoke `run-fns` on the `local-resource/` directory.
+  directory, and invoke `run` on the `local-resource/` directory.
 
     cd template-heredoc-cockroachdb/
     
@@ -28,12 +28,12 @@
     kustomize config tree local-resource/ --name --image --replicas
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # view the generated Resources 
     kustomize config tree local-resource/ --name --image --replicas
     
-  `run-fns` generated the directory ` local-resource/config` containing the generated
+  `run` generated the directory ` local-resource/config` containing the generated
   Resources.
   
   #### 2. Modify the Generated Resources
@@ -41,14 +41,14 @@
   - modify the generated Resources by adding an annotation, sidecar container, etc.
   - modify the `local-resources/example-use.yaml` by changing the replicas 
   
-  re-run `run-fns`.  this will apply the updated replicas to the generated Resources,
+  re-run `run`.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
 
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
   
-  `run-fns` facilitates a non-destructive *smart templating* approach that allows templating
+  `run` facilitates a non-destructive *smart templating* approach that allows templating
   to be composed with manual modifications directly to the template output, as well as
   composition with other functions which may appy validation or injection of values.
 
@@ -66,7 +66,7 @@
   #### 1: Generate the Resources
 
   `cd` into the `kustomize/functions/examples/template-go-nginx/`
-  directory, and invoke `run-fns` on the `local-resource/` directory.
+  directory, and invoke `run` on the `local-resource/` directory.
 
     cd template-go-nginx/
     
@@ -74,12 +74,12 @@
     kustomize config tree local-resource/ --name --image --replicas
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # view the generated Resources 
     kustomize config tree local-resource/ --name --image --replicas
     
-  `run-fns` generated the directory ` local-resource/config` containing the generated
+  `run` generated the directory ` local-resource/config` containing the generated
   Resources.  this time it put the configuration in a single file rather than multiple
   files.  The mapping of Resources to files is controlled by the function itself through
   annotations on the generated Resources.
@@ -89,11 +89,11 @@
   - modify the generated Resources by adding an annotation, sidecar container, etc.
   - modify the `local-resources/example-use.yaml` by changing the replicas
   
-  re-run `run-fns`.  this will apply the updated replicas to the generated Resources,
+  re-run `run`.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
     
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
   
   Just like in the preceding section, the function is implemented using a non-destructive
   approach which merges the generated Resources into previously generated instances.
@@ -105,15 +105,15 @@
 
 ### Validation -- resource reservations
 
-  This section uses `run-fns` to perform validation rather than generate Resources.
+  This section uses `run` to perform validation rather than generate Resources.
   
   #### 1: Run the Validator
 
   `cd` into the `kustomize/functions/examples/validator-resource-requests`
-  directory, and invoke `run-fns` on the `local-resource/` directory.
+  directory, and invoke `run` on the `local-resource/` directory.
 
     # run the function
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     cpu-requests missing for a container in Deployment nginx (example-use.yaml [1])
     Error: exit status 1
     Usage:
@@ -125,19 +125,19 @@
   and print the name of the file + Resource index.  Edit the file and uncomment the resources,
   then re-run the functions.
   
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
 
   The validation now passes.
 
 ### Injection -- resource reservations
 
-  This section uses `run-fns` to perform injection of field values based off annotations
+  This section uses `run` to perform injection of field values based off annotations
   on the Resource.
   
   #### 1: Run the Injector
 
   `cd` into the `kustomize/functions/examples/inject-tshirt-sizes`
-  directory, and invoke `run-fns` on the `local-resource/` directory.
+  directory, and invoke `run` on the `local-resource/` directory.
 
     # print the resources
     kustomize config tree local-resource --resources --name
@@ -149,7 +149,7 @@
                 └── name: nginx
 
     # run the functions
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
     # print the new resources
     kustomize config tree local-resource --resources --name    
@@ -164,7 +164,7 @@
   
   Change the `tshirt-size` annotation from `medium` to `small` and re-run the functions.
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     kustomize config tree local-resource/
     local-resource
     ├── [example-use.yaml]  Validator 
@@ -180,5 +180,5 @@
 
 Functions may be composed together.  Try putting the Injection (tshirt-size) and 
 Validation functions together in the same .yaml file (separated by `---`).  Run
-`run-fns` and observe that the first function in the file is applied to the Resources,
+`run` and observe that the first function in the file is applied to the Resources,
 and then the second function in the file is applied.

--- a/functions/examples/injection-tshirt-sizes/README.md
+++ b/functions/examples/injection-tshirt-sizes/README.md
@@ -17,7 +17,7 @@ Resource configuration, and looks for invalid configuration.
 The function is invoked by authoring a [local Resource](local-resource)
 with `metadata.configFn` and running:
 
-    kustomize config run-fns local-resources/
+    kustomize config run local-resources/
     
 This exists non-zero if there is an error.
 
@@ -25,11 +25,11 @@ This exists non-zero if there is an error.
 
 Run the validator with:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
 This will add resource reservations to the Deployment.  Change the `tshirt-size`
 annotation from `medium` to `small` and rerun:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
 
 Observe that the reservations have changed.

--- a/functions/examples/injection-tshirt-sizes/image/main.go
+++ b/functions/examples/injection-tshirt-sizes/image/main.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main implements an injection function for resource reservations and
-// is run with `kustomize config run-fns -- DIR/`.
+// is run with `kustomize config run -- DIR/`.
 package main
 
 import (

--- a/functions/examples/template-go-nginx/README.md
+++ b/functions/examples/template-go-nginx/README.md
@@ -27,21 +27,21 @@ function input, and writing the function output.
 The function is invoked by authoring a [local Resource](local-resource)
 with `metadata.configFn` and running:
 
-    kustomize config run-fns local-resources/
+    kustomize config run local-resources/
     
 This generates the `local-resources/config` directory containing the template output.
 
 - the template output may be modified by adding fields -- such as initContainers,
   sidecarConatiners, cpu resource limits, etc -- and these fields will be retained 
-  when re-running `run-fns`
-- the function input `example-use.yaml` may be changed and rerunning `run-fns` will update
+  when re-running `run`
+- the function input `example-use.yaml` may be changed and rerunning `run` will update
   only the parts changed in the template output.
 
 ## Running the Example
 
 Run the config with:
 
-     kustomize config run-fns local-resource/
+     kustomize config run local-resource/
      
 This will create the directory
 
@@ -50,6 +50,6 @@ This will create the directory
 Add an annotation to the StatefulSet Resource and change the replica count of the
 `kind: Nginx` Resource in `example-use.yaml`.  Rerun the template:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
 The replica count should be updated, but your annotation should remain.

--- a/functions/examples/template-go-nginx/local-resource/example-use.yaml
+++ b/functions/examples/template-go-nginx/local-resource/example-use.yaml
@@ -1,7 +1,7 @@
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: examples.config.kubernetes.io/v1beta1 # call `kustomize config run-fns` on a directory containing this file
+apiVersion: examples.config.kubernetes.io/v1beta1 # call `kustomize config run` on a directory containing this file
 kind: Nginx
 metadata:
   name: demo

--- a/functions/examples/template-heredoc-cockroachdb/README.md
+++ b/functions/examples/template-heredoc-cockroachdb/README.md
@@ -11,7 +11,7 @@ The function is implemented as an [image](image), and built using `make image`.
 The template is implemented as a heredoc, which substitutes environment variables
 into a static string.
 
-This simple implementation uses `kustomize config run-fns wrap --` to perform the
+This simple implementation uses `kustomize config run wrap --` to perform the
 heavy lifting of implementing the function interface.
 
 - parse functionConfig from stdin into environment variables
@@ -22,21 +22,21 @@ heavy lifting of implementing the function interface.
 The function is invoked by authoring a [local Resource](local-resource)
 with `metadata.configFn` and running:
 
-    kustomize config run-fns local-resources/
+    kustomize config run local-resources/
     
 This generates the `local-resources/config` directory containing the template output.
 
 - the template output may be modified by adding fields -- such as initContainers,
   sidecarConatiners, cpu resource limits, etc -- and these fields will be retained 
-  when re-running `run-fns`
-- the function input `example-use.yaml` may be changed and rerunning `run-fns` will update
+  when re-running `run`
+- the function input `example-use.yaml` may be changed and rerunning `run` will update
   only the parts changed in the template output.
 
 ## Running the Example
 
 Run the config with:
 
-     kustomize config run-fns local-resource/
+     kustomize config run local-resource/
      
 This will create the directory
 
@@ -45,6 +45,6 @@ This will create the directory
 Add an annotation to the StatefulSet Resource and change the replica count of the
 `kind: CockroachDB` Resource in `example-use.yaml`.  Rerun the template:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
 The replica count should be updated, but your annotation should remain.

--- a/functions/examples/template-heredoc-cockroachdb/image/cockroachdb-template.sh
+++ b/functions/examples/template-heredoc-cockroachdb/image/cockroachdb-template.sh
@@ -3,18 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-# use `kustomize config run-fns wrap` to parse the container stdin into
+# use `kustomize config run wrap` to parse the container stdin into
 # environment variables, and to merge the template output into the
 # input Resources.
 if [ -z ${WRAPPED} ]; then
   export WRAPPED=true
-  kustomize config run-fns wrap -- $0
+  kustomize config run wrap -- $0
   exit $?
 fi
 
 # this is the template for a cockroachdb instance
 # environment variables are parsed from the input functionConfig by
-# `kustomize config run-fns wrap`
+# `kustomize config run wrap`
 cat <<End-of-message
 apiVersion: v1
 kind: Service

--- a/functions/examples/template-heredoc-cockroachdb/local-resource/example-use.yaml
+++ b/functions/examples/template-heredoc-cockroachdb/local-resource/example-use.yaml
@@ -1,7 +1,7 @@
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-# call `kustomize config run-fns` on a directory containing this file
+# call `kustomize config run` on a directory containing this file
 apiVersion: examples.config.kubernetes.io/v1beta1
 kind: CockroachDB
 metadata:

--- a/functions/examples/validator-resource-requests/README.md
+++ b/functions/examples/validator-resource-requests/README.md
@@ -17,7 +17,7 @@ Resource configuration, and looks for invalid configuration.
 The function is invoked by authoring a [local Resource](local-resource)
 with `metadata.configFn` and running:
 
-    kustomize config run-fns local-resources/
+    kustomize config run local-resources/
     
 This exists non-zero if there is an error.
 
@@ -25,7 +25,7 @@ This exists non-zero if there is an error.
 
 Run the validator with:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
 This will return an error:
 
@@ -33,6 +33,6 @@ This will return an error:
 
 Now uncomment the resource reservations and run again:
 
-    kustomize config run-fns local-resource/
+    kustomize config run local-resource/
     
 This will return success

--- a/functions/examples/validator-resource-requests/image/main.go
+++ b/functions/examples/validator-resource-requests/image/main.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package main implements a validator function run by `kustomize config run-fns`
+// Package main implements a validator function run by `kustomize config run`
 package main
 
 import (


### PR DESCRIPTION
- update docs to show `kustomize config` instead of `kyaml` for commands
- rename `kustomize config run-fns` command to `kustomize config run`
  - keep an alias to `run-fns` for backwards compatibility