### PR TITLE
Simplify test framework

### DIFF
--- a/api/internal/loadertest/fakeloader.go
+++ b/api/internal/loadertest/fakeloader.go
@@ -20,10 +20,10 @@ type FakeLoader struct {
 
 // NewFakeLoader returns a Loader that uses a fake filesystem.
 // The loader will be restricted to root only.
-// The initialDir argument should be an absolute file path.
-func NewFakeLoader(initialDir string) FakeLoader {
+// The root argument should be an absolute file path.
+func NewFakeLoader(root string) FakeLoader {
 	return NewFakeLoaderWithRestrictor(
-		loader.RestrictionRootOnly, filesys.MakeFsInMemory(), initialDir)
+		loader.RestrictionRootOnly, filesys.MakeFsInMemory(), root)
 }
 
 // NewFakeLoaderWithRestrictor returns a Loader that

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -45,13 +45,10 @@ port: "12345"
 )
 
 func TestLoader(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "SecretGenerator")
-	tc.BuildGoPlugin(
-		"someteam.example.com", "v1", "SomeServiceGenerator")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		BuildGoPlugin("builtin", "", "SecretGenerator").
+		BuildGoPlugin("someteam.example.com", "v1", "SomeServiceGenerator")
+	defer th.Reset()
 
 	rmF := resmap.NewFactory(resource.NewFactory(
 		kunstruct.NewKunstructuredFactoryImpl()), nil)

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -21,21 +21,23 @@ import (
 
 func makeKustTarget(
 	t *testing.T,
-	fSys filesys.FileSystem, path string) *target.KustTarget {
+	fSys filesys.FileSystem,
+	root string) *target.KustTarget {
 	return makeKustTargetWithRf(
-		t, fSys, path,
+		t, fSys, root,
 		resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
 }
 
 func makeKustTargetWithRf(
 	t *testing.T,
-	fSys filesys.FileSystem, path string,
+	fSys filesys.FileSystem,
+	root string,
 	resFact *resource.Factory) *target.KustTarget {
 	rf := resmap.NewFactory(resFact, transformer.NewFactoryImpl())
 	pc := konfig.DisabledPluginConfig()
 	kt := target.NewKustTarget(
 		loadertest.NewFakeLoaderWithRestrictor(
-			loader.RestrictionRootOnly, fSys, path),
+			loader.RestrictionRootOnly, fSys, root),
 		valtest_test.MakeFakeValidator(),
 		rf,
 		transformer.NewFactoryImpl(),

--- a/api/krusty/chartinflatorplugin_test.go
+++ b/api/krusty/chartinflatorplugin_test.go
@@ -28,13 +28,10 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflatorPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "ChartInflator")
+	defer th.Reset()
 
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "ChartInflator")
-
-	th := kusttest_test.MakeHarness(t)
 	th.WriteK("/app", `
 generators:
 - chartInflator.yaml

--- a/api/krusty/customconfigofbuiltinplugin_test.go
+++ b/api/krusty/customconfigofbuiltinplugin_test.go
@@ -13,13 +13,10 @@ import (
 // This is a NamePrefixer that touches Deployments
 // and Services exclusively.
 func TestCustomNamePrefixer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixSuffixTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PrefixSuffixTransformer")
-
-	th := kusttest_test.MakeHarness(t)
 	th.WriteK("/app", `
 resources:
 - deployment.yaml

--- a/api/krusty/customconfigreusable_test.go
+++ b/api/krusty/customconfigreusable_test.go
@@ -14,17 +14,11 @@ import (
 // in a base, allowing them to be reused in any number of
 // kustomizations.
 func TestReusableCustomTransformers(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PrefixSuffixTransformer")
-	tc.BuildGoPlugin(
-		"builtin", "", "AnnotationsTransformer")
-	tc.BuildGoPlugin(
-		"builtin", "", "LabelTransformer")
-
-	th := kusttest_test.MakeHarness(t)
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixSuffixTransformer").
+		PrepBuiltin("AnnotationsTransformer").
+		PrepBuiltin("LabelTransformer")
+	defer th.Reset()
 
 	// First write three custom configurations for builtin plugins.
 

--- a/api/krusty/diamondcomposition_test.go
+++ b/api/krusty/diamondcomposition_test.go
@@ -331,13 +331,10 @@ patchesStrategicMerge:
 }
 
 func TestIssue1251_Plugins_ProdVsDev(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarness(t)
 	defineTransformerDirStructure(th)
 	th.WriteK("/app/prod", `
 resources:
@@ -364,14 +361,11 @@ transformers:
 }
 
 func TestIssue1251_Plugins_Local(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarness(t)
-	writeDeploymentBase(th)
+	writeDeploymentBase(th.Harness)
 
 	writeJsonTransformerPluginConfig(
 		th, "/app/composite", "addDnsPolicy", patchJsonDnsPolicy)
@@ -393,7 +387,7 @@ transformers:
 }
 
 func writeJsonTransformerPluginConfig(
-	th kusttest_test.Harness, path, name, patch string) {
+	th *kusttest_test.HarnessEnhanced, path, name, patch string) {
 	th.WriteF(filepath.Join(path, name+"Config.yaml"),
 		fmt.Sprintf(`
 apiVersion: builtin
@@ -411,14 +405,10 @@ jsonOp: '%s'
 
 // Remote in the sense that they are bundled in a different kustomization.
 func TestIssue1251_Plugins_Bundled(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarness(t)
-	writeDeploymentBase(th)
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
+	writeDeploymentBase(th.Harness)
 
 	th.WriteK("/app/patches", `
 resources:
@@ -443,8 +433,8 @@ transformers:
 	th.AssertActualEqualsExpected(m, expectedPatchedDeployment)
 }
 
-func defineTransformerDirStructure(th kusttest_test.Harness) {
-	writeDeploymentBase(th)
+func defineTransformerDirStructure(th *kusttest_test.HarnessEnhanced) {
+	writeDeploymentBase(th.Harness)
 
 	th.WriteK("/app/patches/addDnsPolicy", `
 resources:

--- a/api/krusty/pluginenv_test.go
+++ b/api/krusty/pluginenv_test.go
@@ -18,11 +18,10 @@ import (
 // its working directory and some environment variables,
 // to add regression protection to plugin loading logic.
 func TestPluginEnvironment(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "PrintPluginEnv")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin(
+			"someteam.example.com", "v1", "PrintPluginEnv")
+	defer th.Reset()
 
 	confirmBehavior(
 		kusttest_test.MakeHarnessWithFs(t, filesys.MakeFsInMemory()),

--- a/api/krusty/resourceconflict_test.go
+++ b/api/krusty/resourceconflict_test.go
@@ -90,7 +90,6 @@ resources:
 }
 
 func TestBase(t *testing.T) {
-	//th := kusttest_test.NewKustTestHarness(t, "/app/base")
 	th := kusttest_test.MakeHarness(t)
 	writeBase(th)
 	m := th.Run("/app/base", th.MakeDefaultOptions())
@@ -339,7 +338,6 @@ rules:
 
 func TestMultibasesWithConflict(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	//th := kusttest_test.NewKustTestHarness(t, "/app/combined")
 	writeBase(th)
 	writeMidOverlays(th)
 	writeTopOverlay(th)

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -75,7 +75,7 @@ func (th Harness) MakeOptionsPluginsEnabled() krusty.Options {
 		if strings.Contains(err.Error(), "unable to find plugin root") {
 			th.t.Log(
 				"Tests that want to run with plugins enabled must be " +
-					"bookended by calls to NewPluginTestEnv.Set(), Reset().")
+					"bookended by calls to newPluginTestEnv.Set(), Reset().")
 		}
 		th.t.Fatal(err)
 	}

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestAnnotationsTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "AnnotationsTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator_test.go
@@ -6,22 +6,18 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestConfigMapGenerator(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ConfigMapGenerator")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "ConfigMapGenerator")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/devops.env", `
+	th.WriteF("devops.env", `
 SERVICE_PORT=32
 `)
-	th.WriteF("/app/uxteam.env", `
+	th.WriteF("uxteam.env", `
 COLOR=red
 `)
 

--- a/plugin/builtin/hashtransformer/HashTransformer_test.go
+++ b/plugin/builtin/hashtransformer/HashTransformer_test.go
@@ -10,13 +10,9 @@ import (
 )
 
 func TestHashTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "HashTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("HashTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestImageTagTransformerNewTag(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -81,13 +77,9 @@ spec:
 `)
 }
 func TestImageTagTransformerNewImage(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -153,13 +145,9 @@ spec:
 }
 
 func TestImageTagTransformerNewImageAndTag(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -226,13 +214,9 @@ spec:
 }
 
 func TestImageTagTransformerNewDigest(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -298,13 +282,9 @@ spec:
 }
 
 func TestImageTagTransformerNewImageAndDigest(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -369,14 +349,11 @@ spec:
         name: init-alpine
 `)
 }
+
 func TestImageTagTransformerEmptyContainers(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ImageTagTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
+++ b/plugin/builtin/inventorytransformer/InventoryTransformer_test.go
@@ -6,7 +6,7 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const (
@@ -58,13 +58,9 @@ metadata:
 )
 
 func TestInventoryTransformerCollect(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "InventoryTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("InventoryTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -79,13 +75,9 @@ policy: GarbageCollect
 }
 
 func TestInventoryTransformerIgnore(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "InventoryTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("InventoryTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -100,13 +92,9 @@ policy: GarbageIgnore
 }
 
 func TestInventoryTransformerDefaultPolicy(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "InventoryTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("InventoryTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/labeltransformer/LabelTransformer_test.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer_test.go
@@ -10,13 +10,9 @@ import (
 )
 
 func TestLabelTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "LabelTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("LabelTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
@@ -4,19 +4,15 @@
 package main_test
 
 import (
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 	"testing"
-
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestLegacyOrderTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("LegacyOrderTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "LegacyOrderTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
 kind: LegacyOrderTransformer

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -7,17 +7,13 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestNamespaceTransformer1(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "NamespaceTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -189,13 +185,9 @@ metadata:
 }
 
 func TestNamespaceTransformerClusterLevelKinds(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "NamespaceTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
 
 	const noChangeExpected = `
 apiVersion: v1
@@ -240,13 +232,9 @@ fieldSpecs:
 }
 
 func TestNamespaceTransformerObjectConflict(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "NamespaceTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
 
 	err := th.ErrorFromLoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const target = `
@@ -28,13 +28,9 @@ spec:
 `
 
 func TestPatchJson6902TransformerMissingFile(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -51,19 +47,15 @@ path: jsonpatch.json
 	if err == nil {
 		t.Fatalf("expected error")
 	}
-	if !strings.Contains(err.Error(), "'/app/jsonpatch.json' doesn't exist") {
+	if !strings.Contains(err.Error(), "'/jsonpatch.json' doesn't exist") {
 		t.Fatalf("unexpected err: %v", err)
 	}
 }
 
 func TestBadPatchJson6902Transformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -86,13 +78,9 @@ jsonOp: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyJson6902Transformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -114,13 +102,9 @@ target:
 }
 
 func TestBothSpecifiedJson6902Transformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	th.WriteF("/app/jsonpatch.json", `[
 {"op": "replace", "path": "/spec/template/spec/containers/0/name", "value": "my-nginx"},
@@ -150,15 +134,11 @@ jsonOp: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Clust
 }
 
 func TestPatchJson6902TransformerFromJsonFile(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/jsonpatch.json", `[
+	th.WriteF("jsonpatch.json", `[
 {"op": "replace", "path": "/spec/template/spec/containers/0/name", "value": "my-nginx"},
 {"op": "add", "path": "/spec/replica", "value": "999"},
 {"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["arg1", "arg2", "arg3"]}
@@ -200,15 +180,11 @@ spec:
 }
 
 func TestPatchJson6902TransformerFromYamlFile(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/jsonpatch.json", `
+	th.WriteF("jsonpatch.json", `
 - op: add
   path: /spec/template/spec/containers/0/command
   value: ["arg1", "arg2", "arg3"]
@@ -250,13 +226,9 @@ spec:
 }
 
 func TestPatchJson6902TransformerWithInlineJSON(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -291,13 +263,9 @@ spec:
 }
 
 func TestPatchJson6902TransformerWithInlineYAML(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchJson6902Transformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchJson6902Transformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const (
@@ -58,12 +58,9 @@ spec:
 )
 
 func TestPatchStrategicMergeTransformerMissingFile(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -77,7 +74,7 @@ paths:
 		t.Fatalf("expected error")
 	}
 	if !strings.Contains(err.Error(),
-		"'/app/patch.yaml' doesn't exist") &&
+		"'/patch.yaml' doesn't exist") &&
 		!strings.Contains(err.Error(),
 			"cannot unmarshal string") {
 		t.Fatalf("unexpected err: %v", err)
@@ -85,13 +82,9 @@ paths:
 }
 
 func TestBadPatchStrategicMergeTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -110,13 +103,9 @@ patches: 'thisIsNotAPatch'
 }
 
 func TestBothEmptyPatchStrategicMergeTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -133,15 +122,11 @@ metadata:
 }
 
 func TestPatchStrategicMergeTransformerFromFiles(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch.yaml", `
+	th.WriteF("/patch.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -183,13 +168,9 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerWithInlineJSON(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -218,13 +199,9 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerWithInlineYAML(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -270,15 +247,11 @@ spec:
 }
 
 func TestPatchStrategicMergeTransformerMultiplePatches(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch1.yaml", `
+	th.WriteF("patch1.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -294,7 +267,7 @@ spec:
           value: BAR
 `)
 
-	th.WriteF("/app/patch2.yaml", `
+	th.WriteF("patch2.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -347,15 +320,11 @@ spec:
 }
 
 func TestStrategicMergeTransformerMultiplePatchesWithConflicts(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch1.yaml", `
+	th.WriteF("patch1.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -371,7 +340,7 @@ spec:
           value: BAR
 `)
 
-	th.WriteF("/app/patch2.yaml", `
+	th.WriteF("patch2.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -408,15 +377,11 @@ paths:
 }
 
 func TestStrategicMergeTransformerWrongNamespace(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch.yaml", `
+	th.WriteF("patch.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy
@@ -451,15 +416,11 @@ paths:
 }
 
 func TestStrategicMergeTransformerNoSchema(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch.yaml", `
+	th.WriteF("patch.yaml", `
 apiVersion: example.com/v1
 kind: Foo
 metadata:
@@ -491,15 +452,11 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatches(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch1.yaml", `
+	th.WriteF("patch1.yaml", `
 apiVersion: example.com/v1
 kind: Foo
 metadata:
@@ -509,7 +466,7 @@ spec:
     B:
     C: Z
 `)
-	th.WriteF("/app/patch2.yaml", `
+	th.WriteF("patch2.yaml", `
 apiVersion: example.com/v1
 kind: Foo
 metadata:
@@ -547,15 +504,11 @@ spec:
 }
 
 func TestStrategicMergeTransformerNoSchemaMultiPatchesWithConflict(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch1.yaml", `
+	th.WriteF("patch1.yaml", `
 apiVersion: example.com/v1
 kind: Foo
 metadata:
@@ -564,7 +517,7 @@ spec:
   bar:
     C: Z
 `)
-	th.WriteF("/app/patch2.yaml", `
+	th.WriteF("patch2.yaml", `
 apiVersion: example.com/v1
 kind: Foo
 metadata:
@@ -883,15 +836,13 @@ func TestSinglePatch(t *testing.T) {
 		},
 	}
 
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	for _, test := range tests {
-		th := kusttest_test.MakeHarnessEnhanced(t, fmt.Sprintf("/%s", test.name))
+		th.ResetLoaderRoot(fmt.Sprintf("/%s", test.name))
 		th.WriteF(fmt.Sprintf("/%s/patch%d.yaml", test.name, 0), test.patch)
-
 		if test.errorExpected {
 			err := th.ErrorFromLoadAndRunTransformer(toConfig(test.patch), test.base)
 			compareExpectedError(t, test.name, err, test.errorMsg)
@@ -986,13 +937,12 @@ func TestMultiplePatches(t *testing.T) {
 		},
 	}
 
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	for _, test := range tests {
-		th := kusttest_test.MakeHarnessEnhanced(t, fmt.Sprintf("/%s", test.name))
+		th.ResetLoaderRoot(fmt.Sprintf("/%s", test.name))
 		for idx, patch := range test.patch {
 			th.WriteF(fmt.Sprintf("/%s/patch%d.yaml", test.name, idx), patch)
 		}
@@ -1117,13 +1067,12 @@ func TestMultiplePatchesWithConflict(t *testing.T) {
 		},
 	}
 
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	for _, test := range tests {
-		th := kusttest_test.MakeHarnessEnhanced(t, fmt.Sprintf("/%s", test.name))
+		th.ResetLoaderRoot(fmt.Sprintf("/%s", test.name))
 		for idx, patch := range test.patch {
 			th.WriteF(fmt.Sprintf("/%s/patch%d.yaml", test.name, idx), patch)
 		}
@@ -1226,13 +1175,12 @@ func TestMultipleNamespaces(t *testing.T) {
 		},
 	}
 
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
 	for _, test := range tests {
-		th := kusttest_test.MakeHarnessEnhanced(t, fmt.Sprintf("/%s", test.name))
+		th.ResetLoaderRoot(fmt.Sprintf("/%s", test.name))
 		for idx, patch := range test.patch {
 			th.WriteF(fmt.Sprintf("/%s/patch%d.yaml", test.name, idx), patch)
 		}
@@ -1248,15 +1196,11 @@ func TestMultipleNamespaces(t *testing.T) {
 }
 
 func TestPatchStrategicMergeTransformerPatchDelete(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchStrategicMergeTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchStrategicMergeTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch.yaml", `
+	th.WriteF("patch.yaml", `
 apiVersion: apps/v1
 metadata:
   name: myDeploy

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 const (
@@ -65,12 +65,9 @@ spec:
 )
 
 func TestPatchTransformerMissingFile(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -83,18 +80,15 @@ path: patch.yaml
 		t.Fatalf("expected error")
 	}
 	if !strings.Contains(err.Error(),
-		"'/app/patch.yaml' doesn't exist") {
+		"'/patch.yaml' doesn't exist") {
 		t.Fatalf("unexpected err: %v", err)
 	}
 }
 
 func TestPatchTransformerBadPatch(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -113,12 +107,9 @@ patch: "thisIsNotAPatch"
 }
 
 func TestPatchTransformerMissingSelector(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -137,13 +128,9 @@ patch: '[{"op": "add", "path": "/spec/template/spec/dnsPolicy", "value": "Cluste
 }
 
 func TestPatchTransformerBothEmptyPathAndPatch(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -160,13 +147,9 @@ metadata:
 }
 
 func TestPatchTransformerBothNonEmptyPathAndPatch(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	_, err := th.RunTransformer(`
 apiVersion: builtin
@@ -185,15 +168,11 @@ Patch: "something"
 }
 
 func TestPatchTransformerFromFiles(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/patch.yaml", `
+	th.WriteF("patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -267,13 +246,9 @@ spec:
 }
 
 func TestPatchTransformerWithInline(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "PatchTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -6,17 +6,14 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestPrefixSuffixTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixSuffixTransformer")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "PrefixSuffixTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
 kind: PrefixSuffixTransformer

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestReplicaCountTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"builtin", "", "ReplicaCountTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -152,13 +148,10 @@ spec:
 }
 
 func TestMatchesCurrentID(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin("builtin", "", "PrefixSuffixTransformer")
-	tc.BuildGoPlugin("builtin", "", "ReplicaCountTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixSuffixTransformer").
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: builtin
@@ -198,12 +191,9 @@ spec:
 }
 
 func TestNoMatch(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin("builtin", "", "ReplicaCountTransformer")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
 
 	err := th.ErrorFromLoadAndRunTransformer(`
 apiVersion: builtin

--- a/plugin/builtin/secretgenerator/SecretGenerator_test.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator_test.go
@@ -6,25 +6,21 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSecretGenerator(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("SecretGenerator")
+	defer th.Reset()
 
-	tc.BuildGoPlugin(
-		"builtin", "", "SecretGenerator")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/a.env", `
+	th.WriteF("a.env", `
 ROUTER_PASSWORD=admin
 `)
-	th.WriteF("/app/b.env", `
+	th.WriteF("b.env", `
 DB_PASSWORD=iloveyou
 `)
-	th.WriteF("/app/longsecret.txt", `
+	th.WriteF("longsecret.txt", `
 Lorem ipsum dolor sit amet,
 consectetur adipiscing elit.
 `)

--- a/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestBashedConfigMapPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "BashedConfigMap")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "BashedConfigMap")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // This test requires having the helm binary on the PATH.
@@ -19,13 +19,9 @@ import (
 // TODO: Download and inflate the chart, and check that
 // in for the test.
 func TestChartInflator(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "ChartInflator")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "ChartInflator")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
@@ -6,16 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestDatePrefixerPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"someteam.example.com", "v1", "DatePrefixer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		BuildGoPlugin("someteam.example.com", "v1", "DatePrefixer")
+	defer th.Reset()
 
 	m := th.LoadAndRunTransformer(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/gogetter/GoGetter_test.go
+++ b/plugin/someteam.example.com/v1/gogetter/GoGetter_test.go
@@ -10,19 +10,14 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 // This test requires having the go-getter binary on the PATH.
-//
 func TestGoGetter(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "GoGetter")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "GoGetter")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1
@@ -44,13 +39,9 @@ metadata:
 }
 
 func TestGoGetterUrl(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "GoGetter")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "GoGetter")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1
@@ -73,13 +64,9 @@ metadata:
 }
 
 func TestGoGetterCommand(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "GoGetter")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "GoGetter")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1
@@ -102,13 +89,9 @@ metadata:
 }
 
 func TestGoGetterSubPath(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "GoGetter")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "GoGetter")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/printpluginenv/PrintPluginEnv_test.go
+++ b/plugin/someteam.example.com/v1/printpluginenv/PrintPluginEnv_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func shouldContain(t *testing.T, s []byte, x string) {
@@ -17,13 +17,11 @@ func shouldContain(t *testing.T, s []byte, x string) {
 }
 
 func TestPrintPluginEnvPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin(
-		"someteam.example.com", "v1", "PrintPluginEnv")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/theAppRoot")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "PrintPluginEnv")
+	// Just to be clear.
+	th.ResetLoaderRoot("/theAppRoot")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSecretsFromDatabasePlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"someteam.example.com", "v1", "SecretsFromDatabase")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		BuildGoPlugin("someteam.example.com", "v1", "SecretsFromDatabase")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
+++ b/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
@@ -6,17 +6,15 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSedTransformer(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "SedTransformer")
+	defer th.Reset()
 
-	tc.PrepExecPlugin("someteam.example.com", "v1", "SedTransformer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
-
-	th.WriteF("/app/sed-input.txt", `
+	th.WriteF("sed-input.txt", `
 s/$FRUIT/orange/g
 s/$VEGGIE/tomato/g
 `)

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator_test.go
@@ -6,17 +6,13 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestSomeServiceGeneratorPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
+	th := kusttest_test.MakeEnhancedHarness(t).BuildGoPlugin(
 		"someteam.example.com", "v1", "SomeServiceGenerator")
-
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	defer th.Reset()
 
 	m := th.LoadAndRunGenerator(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
@@ -6,16 +6,14 @@ package main_test
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestStringPrefixerPlugin(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.BuildGoPlugin(
-		"someteam.example.com", "v1", "StringPrefixer")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		BuildGoPlugin(
+			"someteam.example.com", "v1", "StringPrefixer")
+	defer th.Reset()
 
 	m := th.LoadAndRunTransformer(`
 apiVersion: someteam.example.com/v1

--- a/plugin/someteam.example.com/v1/validator/validator_test.go
+++ b/plugin/someteam.example.com/v1/validator/validator_test.go
@@ -9,15 +9,13 @@ import (
 	"strings"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
 func TestValidatorHappy(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin("someteam.example.com", "v1", "Validator")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "Validator")
+	defer th.Reset()
 
 	rm := th.LoadAndRunTransformer(`
 apiVersion: someteam.example.com/v1
@@ -48,11 +46,9 @@ metadata:
 }
 
 func TestValidatorUnHappy(t *testing.T) {
-	tc := kusttest_test.NewPluginTestEnv(t).Set()
-	defer tc.Reset()
-
-	tc.PrepExecPlugin("someteam.example.com", "v1", "Validator")
-	th := kusttest_test.MakeHarnessEnhanced(t, "/app")
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepExecPlugin("someteam.example.com", "v1", "Validator")
+	defer th.Reset()
 
 	err := th.ErrorFromLoadAndRunTransformer(`
 apiVersion: someteam.example.com/v1


### PR DESCRIPTION
Delete ~250 loc, take many methods private and generally make it harder to make a mistake when setting up a test.

This only impacts the test framework.
