### PR TITLE
Set the ElasticSearch index creation configuration

### DIFF
--- a/api/internal/crawl/index/kustomize.go
+++ b/api/internal/crawl/index/kustomize.go
@@ -96,6 +96,24 @@ func NewKustomizeIndex(ctx context.Context) (*KustomizeIndex, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	indicesExistsOp := idx.client.Indices.Exists
+	resp, err := indicesExistsOp([]string{"kustomize"},
+		indicesExistsOp.WithContext(idx.ctx),
+		indicesExistsOp.WithPretty())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == 200 {
+		fmt.Printf("The kustomize index already exists\n")
+	} else {
+		fmt.Printf("Creating the kustomize index\n")
+		if err := idx.CreateIndex([]byte(IndexConfig)); err != nil {
+			return nil, err
+		}
+	}
+
 	return &KustomizeIndex{idx}, nil
 }
 


### PR DESCRIPTION
Currently, the `kustomize` index in ElasticSearch is using dynamic
mapping, which sets the types of all the fields to `text`. However,
`text` field type is good for full-text value matching, and not good for
exact-value matching.  For exact-value matching, the `keyword` filed
type should be used.