### PR TITLE
Detect path to plugins from krusty tests.

### DIFF
--- a/api/internal/plugins/compiler/compiler.go
+++ b/api/internal/plugins/compiler/compiler.go
@@ -41,6 +41,16 @@ func DeterminePluginSrcRoot(fSys filesys.FileSystem) (string, error) {
 					return filepath.Clean(
 						filepath.Join(
 							os.Getenv("PWD"),
+							"..", "..",
+							konfig.RelPluginHome))
+				},
+			},
+			{
+				Note: "relative to unit test (internal pkg)",
+				F: func() string {
+					return filepath.Clean(
+						filepath.Join(
+							os.Getenv("PWD"),
 							"..", "..", "..", "..",
 							konfig.RelPluginHome))
 				},


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/1908