### PR TITLE
Fix 'config run' by removing default mount.

### DIFF
--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -92,8 +92,6 @@ func (r *RunFns) init() {
 	// if containerFilterProvider hasn't been set, use the default
 	if r.containerFilterProvider == nil {
 		r.containerFilterProvider = func(image, path string, api *yaml.RNode) kio.Filter {
-			defaultMount := filters.StorageMount{}
-			r.StorageMounts = append(r.StorageMounts, defaultMount)
 			cf := &filters.ContainerFilter{Image: image, Config: api, StorageMounts: r.StorageMounts}
 			return cf
 		}

--- a/kyaml/runfn/runfn_test.go
+++ b/kyaml/runfn/runfn_test.go
@@ -40,10 +40,7 @@ kind:
 		return
 	}
 	filter := instance.containerFilterProvider("example.com:version", "", api)
-	defaultMount := filters.StorageMount{}
-	mounts := []filters.StorageMount{}
-	mounts = append(mounts, defaultMount)
-	assert.Equal(t, &filters.ContainerFilter{Image: "example.com:version", Config: api, StorageMounts: mounts}, filter)
+	assert.Equal(t, &filters.ContainerFilter{Image: "example.com:version", Config: api}, filter)
 }
 
 func TestCmd_Execute(t *testing.T) {


### PR DESCRIPTION
In, pull #1822 mount logic was refactored where the default
mount using zero-value no longer makes sense and leads to
this failure:

"invalid argument "type=,src=,dst=:ro" for "--mount" flag: type is
required"

I think the intent here was to remove default mount.

Tested this by:
1. (cd kyaml; make test); (cd cmd/config; make test)
2. Running a function locally using 'config run'