### PR TITLE
Fix a wrong path in example documentation

### DIFF
--- a/functions/examples/validator-resource-requests/README.md
+++ b/functions/examples/validator-resource-requests/README.md
@@ -17,7 +17,7 @@ Resource configuration, and looks for invalid configuration.
 The function is invoked by authoring a [local Resource](local-resource)
 with `metadata.configFn` and running:
 
-    kustomize config run local-resources/
+    kustomize config run local-resource/
     
 This exists non-zero if there is an error.
 


### PR DESCRIPTION
I encountered an error below.
```
$ kustomize config run local-resources/
Error: lstat /Users/naoki/go/src/sigs.k8s.io/kustomize/functions/examples/validator-resource-requests/local-resources: no such file or directory
```