### PR TITLE
Mulitple improvements of the crawler

### DIFF
--- a/api/internal/crawl/config/crawler/cronjob/cronjob.yaml
+++ b/api/internal/crawl/config/crawler/cronjob/cronjob.yaml
@@ -12,6 +12,7 @@ spec:
           containers:
           - name: crawler
             image: gcr.io/kustomize-search/crawler:latest
+            imagePullPolicy: Always
             env:
             - name: GITHUB_ACCESS_TOKEN
               valueFrom:

--- a/api/internal/crawl/config/crawler/job/job.yaml
+++ b/api/internal/crawl/config/crawler/job/job.yaml
@@ -9,6 +9,7 @@ spec:
       containers:
       - name: crawler
         image: gcr.io/kustomize-search/crawler:latest
+        imagePullPolicy: Always
         env:
         - name: GITHUB_ACCESS_TOKEN
           valueFrom:

--- a/api/internal/crawl/config/webapp/backend/deployment.yaml
+++ b/api/internal/crawl/config/webapp/backend/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: kustomize-search
         image: gcr.io/kustomize-search/backend:latest
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /liveness

--- a/api/internal/crawl/config/webapp/frontend/deployment.yaml
+++ b/api/internal/crawl/config/webapp/frontend/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: frontend
         image: gcr.io/kustomize-search/frontend:latest
+        imagePullPolicy: Always
         ports:
         - name: frontend-port
           containerPort: 80

--- a/api/internal/crawl/crawler/crawler_test.go
+++ b/api/internal/crawl/crawler/crawler_test.go
@@ -29,7 +29,7 @@ type testCrawler struct {
 }
 
 func (c testCrawler) Match(d *doc.Document) bool {
-	return d != nil && strings.HasPrefix(d.ID(), c.matchPrefix)
+	return d != nil
 }
 
 func (c testCrawler) FetchDocument(_ context.Context, d *doc.Document) error {

--- a/api/internal/crawl/crawler/github/queries.go
+++ b/api/internal/crawl/crawler/github/queries.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	perPageArg     = "per_page"
+	perPageArg = "per_page"
 )
 
 const githubMaxPageSize = 100

--- a/api/internal/crawl/crawler/github/queries_test.go
+++ b/api/internal/crawl/crawler/github/queries_test.go
@@ -68,7 +68,7 @@ func TestQueryType(t *testing.T) {
 
 func TestGithubSearchQuery(t *testing.T) {
 	const (
-		perPage     = 100
+		perPage = 100
 	)
 
 	testCases := []struct {
@@ -82,7 +82,7 @@ func TestGithubSearchQuery(t *testing.T) {
 	}{
 		{
 			rc: RequestConfig{
-				perPage:     perPage,
+				perPage: perPage,
 			},
 			codeQuery: Query{
 				Filename("kustomization.yaml"),

--- a/api/internal/crawl/doc/doc.go
+++ b/api/internal/crawl/doc/doc.go
@@ -44,9 +44,9 @@ type KustomizationDocument struct {
 type set map[string]struct{}
 
 func (doc *KustomizationDocument) String() string {
-	return fmt.Sprintf("%s %s %s %v %v %v %v %v", doc.RepositoryURL, doc.FilePath,
-		doc.DefaultBranch, doc.CreationTime, doc.IsSame,
-		doc.Kinds, doc.Identifiers, doc.Values)
+	return fmt.Sprintf("%s %s %s %v %v %v len(identifiers):%v  len(values):%v",
+		doc.RepositoryURL, doc.FilePath, doc.DefaultBranch, doc.CreationTime,
+		doc.IsSame,	doc.Kinds, len(doc.Identifiers), len(doc.Values))
 }
 
 // Implements the CrawlerDocument interface.

--- a/api/internal/crawl/doc/docname_test.go
+++ b/api/internal/crawl/doc/docname_test.go
@@ -62,3 +62,44 @@ func TestFromRelativePath(t *testing.T) {
 		}
 	}
 }
+
+func TestDocument_RepositoryFullName(t *testing.T) {
+	testCases := []struct {
+		doc Document
+		expectedRepositoryFullName string
+	}{
+		{
+			doc: Document{
+				RepositoryURL: "https://github.com/user/repo",
+			},
+			expectedRepositoryFullName: "user/repo",
+		},
+		{
+			doc: Document{
+				RepositoryURL: "https://github.com//user/repo////",
+			},
+			expectedRepositoryFullName: "user/repo",
+		},
+		{
+			doc: Document{
+				RepositoryURL: "repo/",
+			},
+			expectedRepositoryFullName: "repo",
+		},
+		{
+			doc: Document{
+				RepositoryURL: "",
+			},
+			expectedRepositoryFullName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		returnedRepositoryFullName := tc.doc.RepositoryFullName()
+		if returnedRepositoryFullName != tc.expectedRepositoryFullName {
+			t.Errorf("RepositoryFullName expected %s, got %s",
+				tc.expectedRepositoryFullName,
+				returnedRepositoryFullName)
+		}
+	}
+}


### PR DESCRIPTION
1) Set document IDs to avoid duplicating documents;
2) Set the `creationTime` field of each document in the index;
3) set the `values`, `kinds` and `identifiers` fields for all documents;
4) Add a `Copy` method into the `Document` struct: this fixes the issue
where all the documents existing in the index point to the same Document
object;
5) Avoid using keystore redis;
6) Set imagePullPolicy to `Always` for crawler jobs.