### PR TITLE
Avoid processing the nil pointer returned by kustomizationResultAdapter

### DIFF
--- a/api/internal/crawl/crawler/github/crawler.go
+++ b/api/internal/crawl/crawler/github/crawler.go
@@ -193,7 +193,9 @@ func processQuery(ctx context.Context, gcl GhClient, query string,
 				errs = append(errs, err)
 				errorCnt++
 			}
-			output <- k
+			if k != nil {
+				output <- k
+			}
 			totalCnt++
 		}
 


### PR DESCRIPTION
Currently, the crawler job panics whenever a nil pointer is returned by
kustomizationResultAdapter.