### PR TITLE
Remove dependency on curse library

### DIFF
--- a/cmd/resource/go.mod
+++ b/cmd/resource/go.mod
@@ -3,11 +3,8 @@ module sigs.k8s.io/kustomize/cmd/resource
 go 1.12
 
 require (
-	github.com/kless/term v0.0.0-20161130133337-e551c64f56c0 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/sethgrid/curse v0.0.0-20181231162520-d4ee583ebf0f
 	github.com/spf13/cobra v0.0.5
-	github.com/tredoe/term v0.0.0-20161130133337-e551c64f56c0 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90

--- a/cmd/resource/go.sum
+++ b/cmd/resource/go.sum
@@ -155,8 +155,6 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kless/term v0.0.0-20161130133337-e551c64f56c0 h1:urSxQgTe6jlMLp7SBqS9kScNOFrkumkEPd5wkEqR4zo=
-github.com/kless/term v0.0.0-20161130133337-e551c64f56c0/go.mod h1:QHlPrsvQ38EZ3avQaGw+V049LEqMXGn/Q7///G4rlPw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -213,8 +211,6 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nL
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/sethgrid/curse v0.0.0-20181231162520-d4ee583ebf0f h1:5sRN2QRb4WELQTjDA0RxH6fDHsqU8DvmSxOVQrFE5EU=
-github.com/sethgrid/curse v0.0.0-20181231162520-d4ee583ebf0f/go.mod h1:AcGQtZEPLvE/ypI3mXUA5nzST17BmzYJJy/n5HXoFTA=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.3/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -237,8 +233,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tredoe/term v0.0.0-20161130133337-e551c64f56c0 h1:62GgUset6v9/OOwgp6G9G0T85xd1tSrxuJb6B32wfC0=
-github.com/tredoe/term v0.0.0-20161130133337-e551c64f56c0/go.mod h1:KgcOI1tnP8CSXsT+9RJU/CYuGBjeJAXbhyG8ufn21jQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=


### PR DESCRIPTION
The curse library use ANSI escape sequences to read back the cursor position from the terminal. Since we are allowing users to redirect StdIn, it doesn't work here. The printer never actually needed the coordinates, so this removes the library and relies only on a small number of escape sequences that doesn't need the coordinates. I'm working on tests for all the status commands in a separate PR.