### PR TITLE
Using single quote style when setting annotations

### DIFF
--- a/cmd/config/internal/commands/cat_test.go
+++ b/cmd/config/internal/commands/cat_test.go
@@ -90,8 +90,8 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   replicas: 1
 ---
@@ -100,8 +100,8 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   selector:
     app: nginx
@@ -196,8 +196,8 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   replicas: 1
 ---
@@ -206,8 +206,8 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   selector:
     app: nginx
@@ -233,8 +233,8 @@ metadata:
   name: bar
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
 spec:
   replicas: 3
 `, b.String()) {
@@ -414,8 +414,8 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   replicas: 1
 ---
@@ -424,8 +424,8 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   selector:
     app: nginx
@@ -536,8 +536,8 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   replicas: 1
 ---
@@ -546,8 +546,8 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   selector:
     app: nginx

--- a/cmd/config/internal/commands/cmdwrap_test.go
+++ b/cmd/config/internal/commands/cmdwrap_test.go
@@ -78,7 +78,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_deployment.yaml
   spec:
     replicas: 11
@@ -109,7 +109,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_service.yaml
   spec:
     selector:
@@ -133,7 +133,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_deployment.yaml
   spec:
     replicas: 11
@@ -161,7 +161,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_service.yaml
   spec:
     selector:
@@ -185,7 +185,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_deployment.yaml
   spec:
     replicas: 11
@@ -216,7 +216,7 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: "0"
       config.kubernetes.io/path: config/test_service.yaml
   spec:
     selector:

--- a/cmd/config/internal/commands/grep_test.go
+++ b/cmd/config/internal/commands/grep_test.go
@@ -75,9 +75,9 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   replicas: 1
 ---
@@ -86,9 +86,9 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f1.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f1.yaml'
 spec:
   selector:
     app: nginx
@@ -145,7 +145,7 @@ metadata:
   name: foo
   annotations:
     app: nginx2
-    config.kubernetes.io/index: 0
+    config.kubernetes.io/index: '0'
 spec:
   replicas: 1
 ---
@@ -154,7 +154,7 @@ metadata:
   name: foo
   annotations:
     app: nginx
-    config.kubernetes.io/index: 1
+    config.kubernetes.io/index: '1'
 spec:
   selector:
     app: nginx

--- a/cmd/config/internal/generateddocs/api/docs.go
+++ b/cmd/config/internal/generateddocs/api/docs.go
@@ -292,16 +292,17 @@ Resource Configuration may be read / written from / to sources such as directori
 stdin|out or network. Tools may be composed using pipes such that the tools writing
 Resource Configuration may be a different tool from the one that read the configuration.
 In order for tools to be composed in this way, while preserving origin information --
-such as the original file, index, etc.
+such as the original file, index, etc.:
 
-Tools **SHOULD** write the following annotations when reading from sources,
-and **SHOULD** respect the annotations when writing to sinks.
+Tools **SHOULD** insert the following annotations when reading from sources,
+and **SHOULD** delete the annotations when writing to sinks.
 
 ### ` + "`" + `config.kubernetes.io/path` + "`" + `
 
 Records the slash-delimited, OS-agnostic, relative file path to a Resource.
 
 This annotation **SHOULD** be set when reading Resources from files.
+It **SHOULD** be unset when writing Resources to files.
 When writing Resources to a directory, the Resource **SHOULD** be written to the corresponding
 path relative to that directory.
 
@@ -313,10 +314,11 @@ Example:
 
 ### ` + "`" + `config.kubernetes.io/index` + "`" + `
 
-Records the index of a Resource in file. In a multi-object files YAML file, Resources are separated
+Records the index of a Resource in file. In a multi-object YAML file, Resources are separated
 by three dashes (` + "`" + `---` + "`" + `), and the index represents the positon of the Resource starting from zero.
 
 This annotation **SHOULD** be set when reading Resources from files.
+It **SHOULD** be unset when writing Resources to files.
 When writing multiple Resources to the same file, the Resource **SHOULD** be written in the
 relative order matching the index.
 

--- a/kyaml/fieldmeta/fieldmeta.go
+++ b/kyaml/fieldmeta/fieldmeta.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package fieldmeta
 
 import (

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -150,7 +150,7 @@ func TestByteReader_Read(t *testing.T) {
 c: d
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
+    config.kubernetes.io/index: '0'
 `,
 		`# second resource
 e: f
@@ -158,12 +158,12 @@ g:
 - h
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
+    config.kubernetes.io/index: '1'
 `,
 		`i: j
 metadata:
   annotations:
-    config.kubernetes.io/index: 2
+    config.kubernetes.io/index: '2'
 `,
 	}
 	for i := range nodes {
@@ -230,7 +230,7 @@ func TestByteReader_Read_setAnnotationsOmitReaderAnnotations(t *testing.T) {
 c: d
 metadata:
   annotations:
-    foo: bar
+    foo: 'bar'
 `,
 		`# second resource
 e: f
@@ -238,12 +238,12 @@ g:
 - h
 metadata:
   annotations:
-    foo: bar
+    foo: 'bar'
 `,
 		`i: j
 metadata:
   annotations:
-    foo: bar
+    foo: 'bar'
 `,
 	}
 	for i := range nodes {
@@ -278,8 +278,8 @@ func TestByteReader_Read_setAnnotations(t *testing.T) {
 c: d
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    foo: bar
+    config.kubernetes.io/index: '0'
+    foo: 'bar'
 `,
 		`# second resource
 e: f
@@ -287,14 +287,14 @@ g:
 - h
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    foo: bar
+    config.kubernetes.io/index: '1'
+    foo: 'bar'
 `,
 		`i: j
 metadata:
   annotations:
-    config.kubernetes.io/index: 2
-    foo: bar
+    config.kubernetes.io/index: '2'
+    foo: 'bar'
 `,
 	}
 	for i := range nodes {

--- a/kyaml/kio/example_test.go
+++ b/kyaml/kio/example_test.go
@@ -77,7 +77,7 @@ spec:
 	//   labels:
 	//     app: nginx
 	//   annotations:
-	//     foo: bar
+	//     foo: 'bar'
 	// spec:
 	//   replicas: 3
 	//   selector:
@@ -99,7 +99,7 @@ spec:
 	// metadata:
 	//   name: nginx
 	//   annotations:
-	//     foo: bar
+	//     foo: 'bar'
 	// spec:
 	//   selector:
 	//     app: nginx

--- a/kyaml/kio/filters/container_test.go
+++ b/kyaml/kio/filters/container_test.go
@@ -177,13 +177,13 @@ items:
   metadata:
     name: deployment-foo
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: '0'
 - apiVersion: v1
   kind: Service
   metadata:
     name: service-foo
     annotations:
-      config.kubernetes.io/index: 1
+      config.kubernetes.io/index: '1'
 functionConfig: {apiVersion: apps/v1, kind: Deployment, metadata: {name: foo}}
 `, s) {
 				t.FailNow()
@@ -208,14 +208,14 @@ kind: StatefulSet
 metadata:
   name: deployment-foo
   annotations:
-    config.kubernetes.io/index: 0
+    config.kubernetes.io/index: '0'
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: service-foo
   annotations:
-    config.kubernetes.io/index: 1
+    config.kubernetes.io/index: '1'
 `, b.String())
 }
 
@@ -259,13 +259,13 @@ items:
   metadata:
     name: deployment-foo
     annotations:
-      config.kubernetes.io/index: 0
+      config.kubernetes.io/index: '0'
 - apiVersion: v1
   kind: Service
   metadata:
     name: service-foo
     annotations:
-      config.kubernetes.io/index: 1
+      config.kubernetes.io/index: '1'
 functionConfig: {apiversion: apps/v1, kind: Deployment, metadata: {name: foo}}
 `, s) {
 				t.FailNow()
@@ -290,14 +290,14 @@ kind: Deployment
 metadata:
   name: deployment-foo
   annotations:
-    config.kubernetes.io/index: 0
+    config.kubernetes.io/index: '0'
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: service-foo
   annotations:
-    config.kubernetes.io/index: 1
+    config.kubernetes.io/index: '1'
 `, b.String())
 }
 

--- a/kyaml/kio/filters/filters_test.go
+++ b/kyaml/kio/filters/filters_test.go
@@ -53,21 +53,21 @@ metadata:
   name: foo1
   namespace: bar
   annotations:
-    config.kubernetes.io/path: foo1_deployment.yaml
+    config.kubernetes.io/path: 'foo1_deployment.yaml'
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: foo1
   annotations:
-    config.kubernetes.io/path: foo1_service.yaml
+    config.kubernetes.io/path: 'foo1_service.yaml'
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: foo2
   annotations:
-    config.kubernetes.io/path: foo2_deployment.yaml
+    config.kubernetes.io/path: 'foo2_deployment.yaml'
 ---
 apiVersion: v1
 kind: Service
@@ -75,7 +75,7 @@ metadata:
   name: foo2
   namespace: bar
   annotations:
-    config.kubernetes.io/path: foo2_service.yaml
+    config.kubernetes.io/path: 'foo2_service.yaml'
 `, out.String())
 }
 
@@ -97,7 +97,7 @@ kind: Service
 metadata:
   name: foo1
   annotations:
-    config.kubernetes.io/path: foo1__service.yaml
+    config.kubernetes.io/path: 'foo1__service.yaml'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -105,14 +105,14 @@ metadata:
   name: foo1
   namespace: bar
   annotations:
-    config.kubernetes.io/path: foo1_bar_deployment.yaml
+    config.kubernetes.io/path: 'foo1_bar_deployment.yaml'
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: foo2
   annotations:
-    config.kubernetes.io/path: foo2__deployment.yaml
+    config.kubernetes.io/path: 'foo2__deployment.yaml'
 ---
 apiVersion: v1
 kind: Service
@@ -120,7 +120,7 @@ metadata:
   name: foo2
   namespace: bar
   annotations:
-    config.kubernetes.io/path: foo2_bar_service.yaml
+    config.kubernetes.io/path: 'foo2_bar_service.yaml'
 `, out.String())
 }
 
@@ -143,14 +143,14 @@ metadata:
   name: foo1
   namespace: bar
   annotations:
-    config.kubernetes.io/path: resource.yaml
+    config.kubernetes.io/path: 'resource.yaml'
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: foo2
   annotations:
-    config.kubernetes.io/path: resource.yaml
+    config.kubernetes.io/path: 'resource.yaml'
 ---
 apiVersion: v1
 kind: Service
@@ -158,13 +158,13 @@ metadata:
   name: foo2
   namespace: bar
   annotations:
-    config.kubernetes.io/path: resource.yaml
+    config.kubernetes.io/path: 'resource.yaml'
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: foo1
   annotations:
-    config.kubernetes.io/path: resource.yaml
+    config.kubernetes.io/path: 'resource.yaml'
 `, out.String())
 }

--- a/kyaml/kio/pkgio_reader_test.go
+++ b/kyaml/kio/pkgio_reader_test.go
@@ -107,16 +107,16 @@ func TestLocalPackageReader_Read_pkg(t *testing.T) {
 			`a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'a_test.yaml'
 `,
 			`c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'a_test.yaml'
 `,
 			`# second thing
 e: f
@@ -126,9 +126,9 @@ g:
   - j
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: b_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'b_test.yaml'
 `,
 		}
 		for i := range nodes {
@@ -169,16 +169,16 @@ func TestLocalPackageReader_Read_file(t *testing.T) {
 			`a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'a_test.yaml'
 `,
 			`c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'a_test.yaml'
 `,
 		}
 		for i := range nodes {
@@ -268,16 +268,16 @@ func TestLocalPackageReader_Read_nestedDirs(t *testing.T) {
 			`a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `,
 			`c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `,
 			`# second thing
 e: f
@@ -287,9 +287,9 @@ g:
   - j
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/b_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/b_test.yaml'
 `,
 		}
 		for i := range nodes {
@@ -326,9 +326,9 @@ func TestLocalPackageReader_Read_matchRegex(t *testing.T) {
 	assert.Equal(t, `a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 
 	val, err = nodes[1].String()
@@ -336,9 +336,9 @@ metadata:
 	assert.Equal(t, `c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 }
 
@@ -365,9 +365,9 @@ func TestLocalPackageReader_Read_skipSubpackage(t *testing.T) {
 	assert.Equal(t, `a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 
 	val, err = nodes[1].String()
@@ -375,9 +375,9 @@ metadata:
 	assert.Equal(t, `c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 }
 
@@ -403,9 +403,9 @@ func TestLocalPackageReader_Read_includeSubpackage(t *testing.T) {
 	assert.Equal(t, `a: b #first
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 
 	val, err = nodes[1].String()
@@ -413,9 +413,9 @@ metadata:
 	assert.Equal(t, `c: d # second
 metadata:
   annotations:
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/package: a/b
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/index: '1'
+    config.kubernetes.io/package: 'a/b'
+    config.kubernetes.io/path: 'a/b/a_test.yaml'
 `, val)
 
 	val, err = nodes[2].String()
@@ -428,9 +428,9 @@ g:
   - j
 metadata:
   annotations:
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/package: a/c
-    config.kubernetes.io/path: a/c/c_test.yaml
+    config.kubernetes.io/index: '0'
+    config.kubernetes.io/package: 'a/c'
+    config.kubernetes.io/path: 'a/c/c_test.yaml'
 `, val)
 }
 

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -637,12 +637,12 @@ func TestSetAnnotation_Fn(t *testing.T) {
 kind: Deployment`))
 
 	rn := assertNoError(t)(r0.Pipe(SetAnnotation("a.b.c", "d.e.f")))
-	assert.Equal(t, "d.e.f\n", assertNoErrorString(t)(rn.String()))
+	assert.Equal(t, "'d.e.f'\n", assertNoErrorString(t)(rn.String()))
 	assert.Equal(t, `apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    a.b.c: d.e.f
+    a.b.c: 'd.e.f'
 `, assertNoErrorString(t)(r0.String()))
 }
 

--- a/kyaml/yaml/kfns.go
+++ b/kyaml/yaml/kfns.go
@@ -31,9 +31,13 @@ type AnnotationSetter struct {
 }
 
 func (s AnnotationSetter) Filter(rn *RNode) (*RNode, error) {
+	// some tools get confused about the type if annotations are not quoted
+	v := NewScalarRNode(s.Value)
+	v.YNode().Tag = "!!str"
+	v.YNode().Style = yaml.SingleQuotedStyle
 	return rn.Pipe(
 		PathGetter{Path: []string{"metadata", "annotations"}, Create: yaml.MappingNode},
-		FieldSetter{Name: s.Key, Value: NewScalarRNode(s.Value)})
+		FieldSetter{Name: s.Key, Value: v})
 }
 
 func SetAnnotation(key, value string) AnnotationSetter {


### PR DESCRIPTION
Annotations must be strings.  Use single-quote style so tools don't get confused about the type.

Fixes: #1975