### PR TITLE
Fixed a wrong path and run `make all`

### DIFF
--- a/cmd/config/docs/tutorials/function-basics.md
+++ b/cmd/config/docs/tutorials/function-basics.md
@@ -39,7 +39,7 @@
   #### 2. Modify the Generated Resources
 
   - modify the generated Resources by adding an annotation, sidecar container, etc.
-  - modify the `local-resources/example-use.yaml` by changing the replicas
+  - modify the `local-resource/example-use.yaml` by changing the replicas
 
   re-run `run`.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
@@ -86,7 +86,7 @@
   #### 2. Modify the Generated Resources
 
   - modify the generated Resources by adding an annotation, sidecar container, etc.
-  - modify the `local-resources/example-use.yaml` by changing the replicas
+  - modify the `local-resource/example-use.yaml` by changing the replicas
 
   re-run `run`.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.

--- a/cmd/config/internal/generateddocs/api/docs.go
+++ b/cmd/config/internal/generateddocs/api/docs.go
@@ -292,16 +292,17 @@ Resource Configuration may be read / written from / to sources such as directori
 stdin|out or network. Tools may be composed using pipes such that the tools writing
 Resource Configuration may be a different tool from the one that read the configuration.
 In order for tools to be composed in this way, while preserving origin information --
-such as the original file, index, etc.
+such as the original file, index, etc.:
 
-Tools **SHOULD** write the following annotations when reading from sources,
-and **SHOULD** respect the annotations when writing to sinks.
+Tools **SHOULD** insert the following annotations when reading from sources,
+and **SHOULD** delete the annotations when writing to sinks.
 
 ### ` + "`" + `config.kubernetes.io/path` + "`" + `
 
 Records the slash-delimited, OS-agnostic, relative file path to a Resource.
 
 This annotation **SHOULD** be set when reading Resources from files.
+It **SHOULD** be unset when writing Resources to files.
 When writing Resources to a directory, the Resource **SHOULD** be written to the corresponding
 path relative to that directory.
 
@@ -313,10 +314,11 @@ Example:
 
 ### ` + "`" + `config.kubernetes.io/index` + "`" + `
 
-Records the index of a Resource in file. In a multi-object files YAML file, Resources are separated
+Records the index of a Resource in file. In a multi-object YAML file, Resources are separated
 by three dashes (` + "`" + `---` + "`" + `), and the index represents the positon of the Resource starting from zero.
 
 This annotation **SHOULD** be set when reading Resources from files.
+It **SHOULD** be unset when writing Resources to files.
 When writing multiple Resources to the same file, the Resource **SHOULD** be written in the
 relative order matching the index.
 

--- a/cmd/config/internal/generateddocs/tutorials/docs.go
+++ b/cmd/config/internal/generateddocs/tutorials/docs.go
@@ -316,7 +316,7 @@ var FunctionBasicsLong = `
   #### 2. Modify the Generated Resources
 
   - modify the generated Resources by adding an annotation, sidecar container, etc.
-  - modify the ` + "`" + `local-resources/example-use.yaml` + "`" + ` by changing the replicas
+  - modify the ` + "`" + `local-resource/example-use.yaml` + "`" + ` by changing the replicas
 
   re-run ` + "`" + `run` + "`" + `.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.
@@ -363,7 +363,7 @@ var FunctionBasicsLong = `
   #### 2. Modify the Generated Resources
 
   - modify the generated Resources by adding an annotation, sidecar container, etc.
-  - modify the ` + "`" + `local-resources/example-use.yaml` + "`" + ` by changing the replicas
+  - modify the ` + "`" + `local-resource/example-use.yaml` + "`" + ` by changing the replicas
 
   re-run ` + "`" + `run` + "`" + `.  this will apply the updated replicas to the generated Resources,
   but keep the fields that you manually added to the generated Resource configuration.

--- a/functions/examples/template-go-nginx/README.md
+++ b/functions/examples/template-go-nginx/README.md
@@ -29,7 +29,7 @@ with `metadata.configFn` and running:
 
     kustomize config run local-resource/
 
-This generates the `local-resources/config` directory containing the template output.
+This generates the `local-resource/config` directory containing the template output.
 
 - the template output may be modified by adding fields -- such as initContainers,
   sidecarConatiners, cpu resource limits, etc -- and these fields will be retained

--- a/functions/examples/template-heredoc-cockroachdb/README.md
+++ b/functions/examples/template-heredoc-cockroachdb/README.md
@@ -24,7 +24,7 @@ with `metadata.configFn` and running:
 
     kustomize config run local-resource/
 
-This generates the `local-resources/config` directory containing the template output.
+This generates the `local-resource/config` directory containing the template output.
 
 - the template output may be modified by adding fields -- such as initContainers,
   sidecarConatiners, cpu resource limits, etc -- and these fields will be retained


### PR DESCRIPTION
I manually modified local-resources to local-resource in these 3 files.

- cmd/config/docs/tutorials/function-basics.md
- functions/examples/template-go-nginx/README.md
- functions/examples/template-heredoc-cockroachdb/README.md

Then, I executed `make all` in `cmd/config` directory.

ref #1970 #1971