### PR TITLE
Handle variables in annotations

### DIFF
--- a/api/konfig/builtinpluginconsts/varreference.go
+++ b/api/konfig/builtinpluginconsts/varreference.go
@@ -190,5 +190,7 @@ varReference:
   kind: StatefulSet
 
 - path: metadata/labels
+
+- path: metadata/annotations
 `
 )

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -1157,6 +1157,8 @@ vars:
     name: my-deployment
     labels:
       my-label: $(NAMESPACE)
+    annotations:
+      my-annotation: $(NAMESPACE)
   spec:
     template:
       spec:
@@ -1176,6 +1178,8 @@ vars:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    my-annotation: my-namespace
   labels:
     my-label: my-namespace
   name: my-deployment


### PR DESCRIPTION
To accompany #782 which adds support for variables to be substituted in labels, this one additionally promotes this feature for annotation fields.

Annotations are used everywhere (service, ingress), and it's often necessary to provide custom values for them. I've found it useful to specify tags for AWS load balancers defined by the following annotations:

- [service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/)
- [alb.ingress.kubernetes.io/tags](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/)
