### PR TITLE
fix issues caused by dropping or overriding style

### DIFF
--- a/cmd/config/internal/commands/cat_test.go
+++ b/cmd/config/internal/commands/cat_test.go
@@ -114,8 +114,8 @@ metadata:
     app: nginx
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
 spec:
   replicas: 3
 `, b.String()) {
@@ -218,8 +218,8 @@ metadata:
   name: foo
   annotations:
     config.kubernetes.io/local-config: "true"
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
   configFn:
     container:
       image: gcr.io/example/image:version
@@ -314,8 +314,8 @@ metadata:
   name: foo
   annotations:
     config.kubernetes.io/local-config: "true"
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
   configFn:
     container:
       image: gcr.io/example/reconciler:v1
@@ -438,8 +438,8 @@ metadata:
     app: nginx
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
 spec:
   replicas: 3
 `, string(actual)) {
@@ -560,8 +560,8 @@ metadata:
     app: nginx
   annotations:
     app: nginx
-    config.kubernetes.io/package: .
-    config.kubernetes.io/path: f2.yaml
+    config.kubernetes.io/package: '.'
+    config.kubernetes.io/path: 'f2.yaml'
 spec:
   replicas: 3
 `, string(actual)) {

--- a/cmd/config/internal/commands/cmdwrap_test.go
+++ b/cmd/config/internal/commands/cmdwrap_test.go
@@ -78,8 +78,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_deployment.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_deployment.yaml'
   spec:
     replicas: 11
     selector:
@@ -109,8 +109,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_service.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_service.yaml'
   spec:
     selector:
       name: test
@@ -133,8 +133,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_deployment.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_deployment.yaml'
   spec:
     replicas: 11
     selector:
@@ -161,8 +161,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_service.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_service.yaml'
   spec:
     selector:
       name: test
@@ -185,8 +185,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_deployment.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_deployment.yaml'
   spec:
     replicas: 11
     selector:
@@ -216,8 +216,8 @@ items:
       name: test
       app: nginx
     annotations:
-      config.kubernetes.io/index: "0"
-      config.kubernetes.io/path: config/test_service.yaml
+      config.kubernetes.io/index: '0'
+      config.kubernetes.io/path: 'config/test_service.yaml'
   spec:
     selector:
       name: test

--- a/kyaml/kio/filters/fmtr.go
+++ b/kyaml/kio/filters/fmtr.go
@@ -90,7 +90,6 @@ type formatter struct {
 
 // fmtNode recursively formats the Document Contents.
 func (f *formatter) fmtNode(n *yaml.Node, path string) error {
-	n.Style = 0
 	// sort the order of mapping fields
 	if n.Kind == yaml.MappingNode {
 		sort.Sort(sortedMapContents(*n))

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -17,6 +17,35 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio/filters/testyaml"
 )
 
+func TestFormatInput_Style(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+spec:
+  notBoolean: "true"
+  notBoolean2: "on"
+  isBoolean: on
+  isBoolean2: true
+`
+
+	expected := `apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+spec:
+  isBoolean: on
+  isBoolean2: true
+  notBoolean: "true"
+  notBoolean2: "on"
+`
+
+	s, err := FormatInput(strings.NewReader(y))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, s.String())
+}
+
 // TestFormatInput_configMap verifies a ConfigMap yaml is formatted correctly
 func TestFormatInput_configMap(t *testing.T) {
 	y := `
@@ -229,7 +258,7 @@ webhooks:
     - CONNECT
     - CREATE
     - UPDATE # this list is indented by 2
-    scope: Namespaced
+    scope: "Namespaced"
   timeoutSeconds: 1
 `
 	s, err := FormatInput(strings.NewReader(y))
@@ -467,7 +496,7 @@ func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
 	// check the result is formatted as yaml
 	b, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
+	assert.Equal(t, string(testyaml.FormattedJSON1), string(b))
 }
 
 // TestFormatFileOrDirectory_partialKubernetesYamlFile verifies that if a yaml file contains both

--- a/kyaml/kio/filters/testyaml/testyaml.go
+++ b/kyaml/kio/filters/testyaml/testyaml.go
@@ -55,3 +55,7 @@ status2:
   - 1
   - 2
 `)
+
+var FormattedJSON1 = []byte(`{"apiVersion": "example.com/v1beta1", "kind": "MyType", "spec": "a", "status": {"conditions": [
+      3, 1, 2]}}
+`)

--- a/kyaml/kio/pkgio_writer_test.go
+++ b/kyaml/kio/pkgio_writer_test.go
@@ -68,13 +68,13 @@ func TestLocalPackageWriter_Write_keepReaderAnnotations(t *testing.T) {
 metadata:
   annotations:
     config.kubernetes.io/index: 0
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/path: "a/b/a_test.yaml"
 ---
 c: d # second
 metadata:
   annotations:
     config.kubernetes.io/index: 1
-    config.kubernetes.io/path: a/b/a_test.yaml
+    config.kubernetes.io/path: "a/b/a_test.yaml"
 `, string(b))
 
 	b, err = ioutil.ReadFile(filepath.Join(d, "a", "b", "b_test.yaml"))
@@ -89,7 +89,7 @@ g:
 metadata:
   annotations:
     config.kubernetes.io/index: 0
-    config.kubernetes.io/path: a/b/b_test.yaml
+    config.kubernetes.io/path: "a/b/b_test.yaml"
 `, string(b))
 }
 

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -646,6 +646,25 @@ metadata:
 `, assertNoErrorString(t)(r0.String()))
 }
 
+func TestUpdateAnnotation_Fn(t *testing.T) {
+	// create metadata.annotations field
+	r0 := assertNoError(t)(Parse(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    a.b.c: "h.i.j"
+`))
+
+	rn := assertNoError(t)(r0.Pipe(SetAnnotation("a.b.c", "d.e.f")))
+	assert.Equal(t, "\"d.e.f\"\n", assertNoErrorString(t)(rn.String()))
+	assert.Equal(t, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    a.b.c: "d.e.f"
+`, assertNoErrorString(t)(r0.String()))
+}
+
 func TestRNode_GetMeta(t *testing.T) {
 	s := `apiVersion: v1/apps
 kind: Deployment

--- a/kyaml/yaml/merge2/element_test.go
+++ b/kyaml/yaml/merge2/element_test.go
@@ -23,8 +23,7 @@ kind: Deployment
 items:
 - name: foo
   image: foo:v1
-  command:
-  - run.sh
+  command: ['run.sh']
 `,
 	},
 
@@ -47,8 +46,7 @@ kind: Deployment
 items:
 - name: foo
   image: foo:v1
-  command:
-  - run.sh
+  command: ['run.sh']
 `,
 	},
 
@@ -62,15 +60,14 @@ items:
 `,
 		`
 kind: Deployment
-items: {}
+items: []
 `,
 		`
 kind: Deployment
 items:
 - name: foo
   image: foo:v1
-  command:
-  - run.sh
+  command: ['run.sh']
 `,
 	},
 
@@ -90,8 +87,7 @@ kind: Deployment
 items:
 - name: foo
   image: foo:v1
-  command:
-  - run.sh
+  command: ['run.sh']
 `,
 	},
 
@@ -118,8 +114,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 	},
 
@@ -146,8 +141,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 	},
 
@@ -174,8 +168,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 	},
 
@@ -205,8 +198,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 	},
 
@@ -225,8 +217,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 		`
 kind: Deployment
@@ -235,8 +226,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 	},
 
@@ -255,8 +245,7 @@ items:
   image: foo:v1
 - name: bar
   image: bar:v1
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `,
 		`
 kind: Deployment

--- a/kyaml/yaml/merge2/merge2_old_test.go
+++ b/kyaml/yaml/merge2/merge2_old_test.go
@@ -83,10 +83,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.7.9
-        args:
-        - c
-        - a
-        - b
+        args: ['c', 'a', 'b']
         env:
         - name: DEMO_GREETING
           value: "Hello from the environment"
@@ -139,10 +136,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.7.9
-        args:
-        - c
-        - a
-        - b
+        args: ['c', 'a', 'b']
         env:
         - name: DEMO_GREETING
           value: "Hello from the environment"
@@ -208,10 +202,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.7.9
-        args:
-        - c
-        - a
-        - b
+        args: ['c', 'a', 'b']
         env:
         - name: DEMO_GREETING
           value: "Hello from the environment"
@@ -276,10 +267,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.7.9
-        args:
-        - c
-        - a
-        - b
+        args: ['c', 'a', 'b']
         env:
         - name: DEMO_GREETING
           value: "New Demo Greeting"
@@ -343,10 +331,7 @@ spec:
       containers:
       - name: nginx
         image: nginx:1.7.9
-        args:
-        - e
-        - d
-        - f
+        args: ['e', 'd', 'f']
         env:
         - name: DEMO_GREETING
           value: "Hello from the environment"

--- a/kyaml/yaml/merge3/element_test.go
+++ b/kyaml/yaml/merge3/element_test.go
@@ -174,8 +174,7 @@ kind: Deployment
 containers:
 - name: foo
   image: foo:bar
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `, nil},
 
 	//
@@ -206,8 +205,7 @@ kind: Deployment
 containers:
 - name: foo
   image: foo:bar
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `, nil},
 
 	//
@@ -239,8 +237,7 @@ kind: Deployment
 containers:
 - name: foo
   image: foo:bar
-  command:
-  - run2.sh
+  command: ['run2.sh']
 `, nil},
 
 	//
@@ -367,8 +364,7 @@ kind: Deployment
 containers:
 - name: foo
   image: foo:bar
-  command:
-  - run.sh
+  command: ['run.sh']
 `, nil},
 
 	//

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -146,9 +146,6 @@ func NewListRNode(values ...string) *RNode {
 
 // NewRNode returns a new RNode pointer containing the provided Node.
 func NewRNode(value *yaml.Node) *RNode {
-	if value != nil {
-		value.Style = 0
-	}
 	return &RNode{value: value}
 }
 
@@ -389,7 +386,7 @@ const (
 	Flow = "Flow"
 )
 
-// String returns a string valuer for a Node, applying the supplied formatting options
+// String returns a string value for a Node, applying the supplied formatting options
 func String(node *yaml.Node, opts ...string) (string, error) {
 	if node == nil {
 		return "", nil


### PR DESCRIPTION
dropping the node style creates a compatibility issue where quotes around "on" are dropped
because yaml.v3 interprets it as a string.
    
other yaml parsers interpret on as a bool value, and parse it as a bool rather than string.
    
fix: retain the original style so it is kept as quoted.
    
- fmt: don't drop the styles
- merge2: keep the style when merging elements
- setting a field: if changing the value of a scalar field, retain its style by default
