### PR TITLE
fix empty var names + clean up cross platform tests

### DIFF
--- a/kyaml/copyutil/copyutil_test.go
+++ b/kyaml/copyutil/copyutil_test.go
@@ -4,6 +4,7 @@
 package copyutil_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -104,7 +105,9 @@ func TestDiff_srcDestContentsDiffer(t *testing.T) {
 
 	diff, err := Diff(s, d)
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, diff.List(), []string{"a1/f.yaml"})
+	assert.ElementsMatch(t, diff.List(), []string{
+		fmt.Sprintf("a1%sf.yaml", string(filepath.Separator)),
+	})
 }
 
 // TestDiff_srcDestContentsDifferInDirs verifies if identical files
@@ -130,7 +133,11 @@ func TestDiff_srcDestContentsDifferInDirs(t *testing.T) {
 	diff, err := Diff(s, d)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, diff.List(), []string{
-		"a1", "a1/f.yaml", "b1/f.yaml", "b1"})
+		"a1",
+		fmt.Sprintf("a1%sf.yaml", string(filepath.Separator)),
+		fmt.Sprintf("b1%sf.yaml", string(filepath.Separator)),
+		"b1",
+	})
 }
 
 // TestDiff_skipGitSrc verifies that .git directories in the source

--- a/kyaml/kio/filters/container.go
+++ b/kyaml/kio/filters/container.go
@@ -130,7 +130,11 @@ func (c *ContainerFilter) getArgs() []string {
 
 	// export the local environment vars to the container
 	for _, pair := range os.Environ() {
-		args = append(args, "-e", strings.Split(pair, "=")[0])
+		tokens := strings.Split(pair, "=")
+		if tokens[0] == "" {
+			continue
+		}
+		args = append(args, "-e", tokens[0])
 	}
 	return append(args, c.Image)
 }

--- a/kyaml/kio/filters/container_test.go
+++ b/kyaml/kio/filters/container_test.go
@@ -131,7 +131,11 @@ metadata:
 	}
 	for _, e := range os.Environ() {
 		// the process env
-		expected = append(expected, "-e", strings.Split(e, "=")[0])
+		tokens := strings.Split(e, "=")
+		if tokens[0] == "" {
+			continue
+		}
+		expected = append(expected, "-e", tokens[0])
 	}
 	expected = append(expected, "example.com:version")
 	assert.Equal(t, expected, cmd.Args)

--- a/kyaml/kio/pkgio_reader_test.go
+++ b/kyaml/kio/pkgio_reader_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -269,15 +270,15 @@ func TestLocalPackageReader_Read_nestedDirs(t *testing.T) {
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
 `,
 			`c: d # second
 metadata:
   annotations:
     config.kubernetes.io/index: '1'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
 `,
 			`# second thing
 e: f
@@ -288,8 +289,8 @@ g:
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/b_test.yaml'
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}b_test.yaml'
 `,
 		}
 		for i := range nodes {
@@ -297,7 +298,8 @@ metadata:
 			if !assert.NoError(t, err) {
 				return
 			}
-			if !assert.Equal(t, expected[i], val) {
+			want := strings.ReplaceAll(expected[i], "${SEP}", string(filepath.Separator))
+			if !assert.Equal(t, want, val) {
 				return
 			}
 		}
@@ -321,25 +323,29 @@ func TestLocalPackageReader_Read_matchRegex(t *testing.T) {
 		assert.FailNow(t, "wrong number items")
 	}
 
-	val, err := nodes[0].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `a: b #first
+	expected := []string{
+		`a: b #first
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
-
-	val, err = nodes[1].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `c: d # second
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+		`c: d # second
 metadata:
   annotations:
     config.kubernetes.io/index: '1'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+	}
+
+	for i, node := range nodes {
+		val, err := node.String()
+		assert.NoError(t, err)
+		want := strings.ReplaceAll(expected[i], "${SEP}", string(filepath.Separator))
+		assert.Equal(t, want, val)
+	}
 }
 
 func TestLocalPackageReader_Read_skipSubpackage(t *testing.T) {
@@ -360,25 +366,29 @@ func TestLocalPackageReader_Read_skipSubpackage(t *testing.T) {
 		assert.FailNow(t, "wrong number items")
 	}
 
-	val, err := nodes[0].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `a: b #first
+	expected := []string{
+		`a: b #first
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
-
-	val, err = nodes[1].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `c: d # second
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+		`c: d # second
 metadata:
   annotations:
     config.kubernetes.io/index: '1'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+	}
+
+	for i, node := range nodes {
+		val, err := node.String()
+		assert.NoError(t, err)
+		want := strings.ReplaceAll(expected[i], "${SEP}", string(filepath.Separator))
+		assert.Equal(t, want, val)
+	}
 }
 
 func TestLocalPackageReader_Read_includeSubpackage(t *testing.T) {
@@ -398,29 +408,23 @@ func TestLocalPackageReader_Read_includeSubpackage(t *testing.T) {
 	if !assert.Len(t, nodes, 3) {
 		assert.FailNow(t, "wrong number items")
 	}
-	val, err := nodes[0].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `a: b #first
+
+	expected := []string{
+		`a: b #first
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
-
-	val, err = nodes[1].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `c: d # second
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+		`c: d # second
 metadata:
   annotations:
     config.kubernetes.io/index: '1'
-    config.kubernetes.io/package: 'a/b'
-    config.kubernetes.io/path: 'a/b/a_test.yaml'
-`, val)
-
-	val, err = nodes[2].String()
-	assert.NoError(t, err)
-	assert.Equal(t, `# second thing
+    config.kubernetes.io/package: 'a${SEP}b'
+    config.kubernetes.io/path: 'a${SEP}b${SEP}a_test.yaml'
+`,
+		`# second thing
 e: f
 g:
   h:
@@ -429,9 +433,17 @@ g:
 metadata:
   annotations:
     config.kubernetes.io/index: '0'
-    config.kubernetes.io/package: 'a/c'
-    config.kubernetes.io/path: 'a/c/c_test.yaml'
-`, val)
+    config.kubernetes.io/package: 'a${SEP}c'
+    config.kubernetes.io/path: 'a${SEP}c${SEP}c_test.yaml'
+`,
+	}
+
+	for i, node := range nodes {
+		val, err := node.String()
+		assert.NoError(t, err)
+		want := strings.ReplaceAll(expected[i], "${SEP}", string(filepath.Separator))
+		assert.Equal(t, want, val)
+	}
 }
 
 // func TestLocalPackageReaderWriter_DeleteFiles(t *testing.T) {


### PR DESCRIPTION
While testing out kyaml functions on a Windows machine, I noticed that ranging over `os.Environ` produces a strange variable which looks like `=::=::\`. I'm not totally sure what is causing this, but it's picked up by e.g. `printenv` (or similar, in this case via Cygwin) so I'm inclined to believe it's some OS weirdness from Windows:
```powershell
> printenv
!::=::\ # note, printenv does not include leading equal sign unlike os.Environ()
ALLUSERSPROFILE=C:\ProgramData
...
```

Passing the value `=::=::\` to `strings.Split(val, "=")` returns three tokens, where the first is empty due to the leading `=`. This breaks invocations of kyaml, since docker won't recognize the empty string as a valid variable name to run the container.

Fix seems simple enough, don't pass empty strings to docker `-e`.

You can see this in action with `TestFilter_command_network` on a Windows machine:
```powershell
--- FAIL: TestFilter_command_StorageMount (0.00s)
    container_test.go:102:
                Error Trace:    container_test.go:102
                Error:          Not equal:
                                expected: []string{"docker", "run", "--rm", "-i", "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR", "--network", "none", "--user", "nobody", "--security-opt=no-new-privileges", "--mount", "type=bind,src=/mount/path,dst=/local/:ro", "--mount", "type=volume,src=myvol,dst=/local/:ro", "--mount", "type=tmpfs,src=,dst=/local/:ro", "-e", "", "-e", "ALLUSERSPROFILE", "-e", "APPDATA", "-e", "CommonProgramFiles", "-e", "CommonProgramFiles(x86)", "-e", "CommonProgramW6432", "-e", "COMPUTERNAME", "-e", "ComSpec", "-e", "DriverData", "-e", "FPS_BROWSER_APP_PROFILE_STRING", "-e", "FPS_BROWSER_USER_PROFILE_STRING", "-e", "GO111MODULE", "-e", "GOPATH", "-e", "HOMEDRIVE", "-e", "HOMEPATH", "-e", "KUSTOMIZE_ENABLE_ALPHA_COMMANDS", "-e", "KYAML_TEST", "-e", "LOCALAPPDATA", "-e", "LOGONSERVER", "-e", "NUMBER_OF_PROCESSORS", "-e", "OneDrive", "-e", "OneDriveConsumer", "-e", "OS", "-e", "Path", "-e", "PATHEXT", "-e", "PROCESSOR_ARCHITECTURE", "-e", "PROCESSOR_IDENTIFIER", "-e", "PROCESSOR_LEVEL", "-e", "PROCESSOR_REVISION", "-e", "ProgramData", "-e", "ProgramFiles", "-e", "ProgramFiles(x86)", "-e", "ProgramW6432", "-e", "PSModulePath", "-e", "PUBLIC", "-e", "SESSIONNAME", "-e", "SystemDrive", "-e", "SystemRoot", "-e", "TEMP", "-e", "TMP", "-e", "USERDOMAIN", "-e", "USERDOMAIN_ROAMINGPROFILE", "-e", "USERNAME", "-e", "USERPROFILE", "-e", "windir", "-e", "PWD", "example.com:version"}
                                actual  : []string{"docker", "run", "--rm", "-i", "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR", "--network", "none", "--user", "nobody", "--security-opt=no-new-privileges", "--mount", "type=bind,src=/mount/path,dst=/local/:ro", "--mount", "type=volume,src=myvol,dst=/local/:ro", "--mount", "type=tmpfs,src=,dst=/local/:ro", "-e", "ALLUSERSPROFILE", "-e", "APPDATA", "-e", "CommonProgramFiles", "-e", "CommonProgramFiles(x86)", "-e", "CommonProgramW6432", "-e", "COMPUTERNAME", "-e", "ComSpec", "-e", "DriverData", "-e", "FPS_BROWSER_APP_PROFILE_STRING", "-e", "FPS_BROWSER_USER_PROFILE_STRING", "-e", "GO111MODULE", "-e", "GOPATH", "-e", "HOMEDRIVE", "-e", "HOMEPATH", "-e", "KUSTOMIZE_ENABLE_ALPHA_COMMANDS", "-e", "KYAML_TEST", "-e", "LOCALAPPDATA", "-e", "LOGONSERVER", "-e", "NUMBER_OF_PROCESSORS", "-e", "OneDrive", "-e", "OneDriveConsumer", "-e", "OS", "-e", "Path", "-e", "PATHEXT", "-e", "PROCESSOR_ARCHITECTURE", "-e", "PROCESSOR_IDENTIFIER", "-e", "PROCESSOR_LEVEL", "-e", "PROCESSOR_REVISION", "-e", "ProgramData", "-e", "ProgramFiles", "-e", "ProgramFiles(x86)", "-e", "ProgramW6432", "-e", "PSModulePath", "-e", "PUBLIC", "-e", "SESSIONNAME", "-e", "SystemDrive", "-e", "SystemRoot", "-e", "TEMP", "-e", "TMP", "-e", "USERDOMAIN", "-e", "USERDOMAIN_ROAMINGPROFILE", "-e", "USERNAME", "-e", "USERPROFILE", "-e", "windir", "-e", "PWD", "example.com:version"}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,2 +1,2 @@
                                -([]string) (len=114) {
                                +([]string) (len=112) {
                                  (string) (len=6) "docker",
                                @@ -22,4 +22,2 @@
                                  (string) (len=30) "type=tmpfs,src=,dst=/local/:ro",
                                - (string) (len=2) "-e",
#EMPTY HERE                     - (string) "",
                                  (string) (len=2) "-e",
                Test:           TestFilter_command_StorageMount
```
