### PR TITLE
Trim white spaces in config map files lines

### DIFF
--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -154,7 +154,7 @@ LEGUME=chickpea
 `)
 	th.WriteF("/app/overlay/configmap/dummy.txt",
 		`Lorem ipsum dolor sit amet, consectetur  
-adipiscing elit, sed do eiusmod tempor  
+adipiscing elit, sed do eiusmod tempor		
 incididunt ut labore et dolore magna aliqua.   
 `)
 	th.WriteF("/app/overlay/deployment/deployment.yaml", `

--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -153,9 +153,9 @@ FRUIT=banana
 LEGUME=chickpea
 `)
 	th.WriteF("/app/overlay/configmap/dummy.txt",
-		`Lorem ipsum dolor sit amet, consectetur
-adipiscing elit, sed do eiusmod tempor
-incididunt ut labore et dolore magna aliqua. 
+		`Lorem ipsum dolor sit amet, consectetur  
+adipiscing elit, sed do eiusmod tempor  
+incididunt ut labore et dolore magna aliqua.   
 `)
 	th.WriteF("/app/overlay/deployment/deployment.yaml", `
 apiVersion: apps/v1
@@ -292,8 +292,10 @@ metadata:
 ---
 apiVersion: v1
 data:
-  nonsense: "Lorem ipsum dolor sit amet, consectetur\nadipiscing elit, sed do eiusmod
-    tempor\nincididunt ut labore et dolore magna aliqua. \n"
+  nonsense: |
+    Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit, sed do eiusmod tempor
+    incididunt ut labore et dolore magna aliqua.
 kind: ConfigMap
 metadata:
   annotations:
@@ -302,6 +304,6 @@ metadata:
     app: mungebot
     org: kubernetes
     repo: test-infra
-  name: test-infra-app-config-f462h769f9
+  name: test-infra-app-config-4mt28b5bg2
 `)
 }

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -91,9 +91,9 @@ func (kvl *loader) keyValuesFromFileSources(sources []string) ([]types.Pair, err
 	return kvs, nil
 }
 
-//Takes string with multiple lines and trims the trailing white spaces from each line
+// Takes string with multiple lines and trims the trailing white spaces from each line.
 func (kvl *loader) trimTrailingSpacesInLines(str string) string {
-	re := regexp.MustCompile(` *\n`)
+	re := regexp.MustCompile(`\s*\n`)
 	return re.ReplaceAllString(str, "\n")
 }
 

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -85,9 +86,15 @@ func (kvl *loader) keyValuesFromFileSources(sources []string) ([]types.Pair, err
 		if err != nil {
 			return nil, err
 		}
-		kvs = append(kvs, types.Pair{Key: k, Value: string(content)})
+		kvs = append(kvs, types.Pair{Key: k, Value: kvl.trimTrailingSpacesInLines(string(content))})
 	}
 	return kvs, nil
+}
+
+//Takes string with multiple lines and trims the trailing white spaces from each line
+func (kvl *loader) trimTrailingSpacesInLines(str string) string {
+	re := regexp.MustCompile(` *\n`)
+	return re.ReplaceAllString(str, "\n")
 }
 
 func (kvl *loader) keyValuesFromEnvFiles(paths []string) ([]types.Pair, error) {

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -98,10 +98,10 @@ func TestKeyValuesFromFileSources(t *testing.T) {
 
 func TestTrimTrailingSpacesInLines(t *testing.T) {
 	kvl := makeKvLoader(filesys.MakeFsInMemory())
-	input := "\"fooKey\": \"fooValue\"   \n\t\"barKey\": \"barValue\""
+	input := "\"fooKey\": \"fooValue\"   \t\n\t\"barKey\": \"barValue\""
 	expected := "\"fooKey\": \"fooValue\"\n\t\"barKey\": \"barValue\""
 	res := kvl.trimTrailingSpacesInLines(input)
 	if !reflect.DeepEqual(res, expected) {
-		t.Errorf("%s should succeed, got: %s exptected: %s", "trim trailing spaces in lines", res, expected)
+		t.Errorf("Trim trailing spaces in lines should succeed, got: %s exptected: %s", res, expected)
 	}
 }

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -95,3 +95,13 @@ func TestKeyValuesFromFileSources(t *testing.T) {
 		}
 	}
 }
+
+func TestTrimTrailingSpacesInLines(t *testing.T) {
+	kvl := makeKvLoader(filesys.MakeFsInMemory())
+	input := "\"fooKey\": \"fooValue\"   \n\t\"barKey\": \"barValue\""
+	expected := "\"fooKey\": \"fooValue\"\n\t\"barKey\": \"barValue\""
+	res := kvl.trimTrailingSpacesInLines(input)
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("%s should succeed, got: %s exptected: %s", "trim trailing spaces in lines", res, expected)
+	}
+}


### PR DESCRIPTION
*Why*
This PR is to solve the issue https://github.com/kubernetes-sigs/kustomize/issues/1868. Given a config map file, kustomize will trim the white spaces so that the output is as expected in pretty format.


