### PR TITLE
Docs and examples use config.k8s.io/function annotation

### DIFF
--- a/cmd/config/docs/api-conventions/config-fn.md
+++ b/cmd/config/docs/api-conventions/config-fn.md
@@ -222,15 +222,15 @@ Following is an example of running the `kustomize config run` using the precedin
     metadata:
       name: my-instance
       annotations:
+        config.k8s.io/function: |
+          container:
+            image: gcr.io/example-functions/nginx-template:v1.0.0
         config.kubernetes.io/local-config: "true"
-      configFn:
-        container:
-          image: gcr.io/example-functions/nginx-template:v1.0.0
     spec:
       replicas: 5
 
-  - `configFn.container.image`: the image to use for this API
-  - `annotations[config.kubernetes.io/local-config]`: mark this as not a Resource that should
+  - `annotations.[config.k8s.io/function]`: the image to use for this API
+  - `annotations.[config.kubernetes.io/local-config]`: mark this as not a Resource that should
     be applied
 
 #### `kustomize config run dir/` (Output)

--- a/cmd/config/docs/api-conventions/config-fn.md
+++ b/cmd/config/docs/api-conventions/config-fn.md
@@ -229,7 +229,7 @@ Following is an example of running the `kustomize config run` using the precedin
     spec:
       replicas: 5
 
-  - `annotations.[config.k8s.io/function]`: the image to use for this API
+  - `annotations.[config.k8s.io/function]`: the specification of how to run the function
   - `annotations.[config.kubernetes.io/local-config]`: mark this as not a Resource that should
     be applied
 

--- a/cmd/config/docs/commands/run-fns.md
+++ b/cmd/config/docs/commands/run-fns.md
@@ -22,8 +22,8 @@ order they appear in the file).
 
 #### Config Functions:
 
-  Config functions are specified as Kubernetes types containing a metadata.configFn.container.image
-  field.  This field tells run how to invoke the container.
+  Config functions are specified as Kubernetes types containing a metadata.annotations.[config.k8s.io/function]
+  field specifying an image for the container to run.  This image tells run how to invoke the container.
 
   Example config function:
 
@@ -31,17 +31,17 @@ order they appear in the file).
 	apiVersion: fn.example.com/v1beta1
 	kind: ExampleFunctionKind
 	metadata:
-	  configFn:
-	    container:
-	      # function is invoked as a container running this image
-	      image: gcr.io/example/examplefunction:v1.0.1
 	  annotations:
+	    config.k8s.io/function: |
+	      container:
+	        # function is invoked as a container running this image
+	        image: gcr.io/example/examplefunction:v1.0.1
 	    config.kubernetes.io/local-config: "true" # tools should ignore this
 	spec:
 	  configField: configValue
 
   In the preceding example, 'kustomize config run example/' would identify the function by
-  the metadata.configFn field.  It would then write all Resources in the directory to
+  the metadata.annotations.[config.k8s.io/function] field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then write the container stdout back to example/, replacing the directory
   file contents.

--- a/cmd/config/internal/generateddocs/api/docs.go
+++ b/cmd/config/internal/generateddocs/api/docs.go
@@ -228,15 +228,15 @@ Following is an example of running the ` + "`" + `kustomize config run` + "`" + 
     metadata:
       name: my-instance
       annotations:
+        config.k8s.io/function: |
+          container:
+            image: gcr.io/example-functions/nginx-template:v1.0.0
         config.kubernetes.io/local-config: "true"
-      configFn:
-        container:
-          image: gcr.io/example-functions/nginx-template:v1.0.0
     spec:
       replicas: 5
 
-  - ` + "`" + `configFn.container.image` + "`" + `: the image to use for this API
-  - ` + "`" + `annotations[config.kubernetes.io/local-config]` + "`" + `: mark this as not a Resource that should
+  - ` + "`" + `annotations.[config.k8s.io/function]` + "`" + `: the image to use for this API
+  - ` + "`" + `annotations.[config.kubernetes.io/local-config]` + "`" + `: mark this as not a Resource that should
     be applied
 
 #### ` + "`" + `kustomize config run dir/` + "`" + ` (Output)

--- a/cmd/config/internal/generateddocs/api/docs.go
+++ b/cmd/config/internal/generateddocs/api/docs.go
@@ -235,7 +235,7 @@ Following is an example of running the ` + "`" + `kustomize config run` + "`" + 
     spec:
       replicas: 5
 
-  - ` + "`" + `annotations.[config.k8s.io/function]` + "`" + `: the image to use for this API
+  - ` + "`" + `annotations.[config.k8s.io/function]` + "`" + `: the specification of how to run the function
   - ` + "`" + `annotations.[config.kubernetes.io/local-config]` + "`" + `: mark this as not a Resource that should
     be applied
 

--- a/cmd/config/internal/generateddocs/commands/docs.go
+++ b/cmd/config/internal/generateddocs/commands/docs.go
@@ -201,8 +201,8 @@ order they appear in the file).
 
 #### Config Functions:
 
-  Config functions are specified as Kubernetes types containing a metadata.configFn.container.image
-  field.  This field tells run how to invoke the container.
+  Config functions are specified as Kubernetes types containing a metadata.annotations.[config.k8s.io/function]
+  field specifying an image for the container to run.  This image tells run how to invoke the container.
 
   Example config function:
 
@@ -210,17 +210,17 @@ order they appear in the file).
 	apiVersion: fn.example.com/v1beta1
 	kind: ExampleFunctionKind
 	metadata:
-	  configFn:
-	    container:
-	      # function is invoked as a container running this image
-	      image: gcr.io/example/examplefunction:v1.0.1
 	  annotations:
+	    config.k8s.io/function: |
+	      container:
+	        # function is invoked as a container running this image
+	        image: gcr.io/example/examplefunction:v1.0.1
 	    config.kubernetes.io/local-config: "true" # tools should ignore this
 	spec:
 	  configField: configValue
 
   In the preceding example, 'kustomize config run example/' would identify the function by
-  the metadata.configFn field.  It would then write all Resources in the directory to
+  the metadata.annotations.[config.k8s.io/function] field.  It would then write all Resources in the directory to
   a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
   would then write the container stdout back to example/, replacing the directory
   file contents.

--- a/functions/examples/injection-tshirt-sizes/README.md
+++ b/functions/examples/injection-tshirt-sizes/README.md
@@ -15,7 +15,7 @@ Resource configuration, and looks for invalid configuration.
 ## Function invocation
 
 The function is invoked by authoring a [local Resource](local-resource)
-with `metadata.configFn` and running:
+with `metadata.annotations.[config.k8s.io/function]` and running:
 
     kustomize config run local-resource/
 

--- a/functions/examples/injection-tshirt-sizes/local-resource/example-use.yaml
+++ b/functions/examples/injection-tshirt-sizes/local-resource/example-use.yaml
@@ -4,9 +4,10 @@
 apiVersion: examples.config.kubernetes.io/v1beta1
 kind: Validator
 metadata:
-  configFn:
-    container:
-      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/functions/examples/template-go-nginx/README.md
+++ b/functions/examples/template-go-nginx/README.md
@@ -25,7 +25,7 @@ function input, and writing the function output.
 ## Function invocation
 
 The function is invoked by authoring a [local Resource](local-resource)
-with `metadata.configFn` and running:
+with `metadata.annotations.[config.k8s.io/function]` and running:
 
     kustomize config run local-resource/
 

--- a/functions/examples/template-go-nginx/local-resource/example-use.yaml
+++ b/functions/examples/template-go-nginx/local-resource/example-use.yaml
@@ -5,8 +5,9 @@ apiVersion: examples.config.kubernetes.io/v1beta1 # call `kustomize config run` 
 kind: Nginx
 metadata:
   name: demo
-  configFn:
-    container:
-      image: gcr.io/kustomize-functions/example-nginx:v0.1.0
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-nginx:v0.1.0
 spec:
   replicas: 4

--- a/functions/examples/template-heredoc-cockroachdb/README.md
+++ b/functions/examples/template-heredoc-cockroachdb/README.md
@@ -20,7 +20,7 @@ heavy lifting of implementing the function interface.
 ## Function invocation
 
 The function is invoked by authoring a [local Resource](local-resource)
-with `metadata.configFn` and running:
+with `metadata.annotations.[config.k8s.io/function]` and running:
 
     kustomize config run local-resource/
 

--- a/functions/examples/template-heredoc-cockroachdb/local-resource/example-use.yaml
+++ b/functions/examples/template-heredoc-cockroachdb/local-resource/example-use.yaml
@@ -6,8 +6,9 @@ apiVersion: examples.config.kubernetes.io/v1beta1
 kind: CockroachDB
 metadata:
   name: demo
-  configFn:
-    container:
-      image: gcr.io/kustomize-functions/example-cockroachdb:v0.1.0
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-cockroachdb:v0.1.0
 spec:
   replicas: 3

--- a/functions/examples/validator-kubeval/README.md
+++ b/functions/examples/validator-kubeval/README.md
@@ -18,7 +18,7 @@ the `API` struct definition in [main.go](image/main.go) for documentation.
 ## Function invocation
 
 The function is invoked by authoring a [local Resource](local-resource)
-with `metadata.configFn` and running:
+with `metadata.annotations.[config.k8s.io/function]` and running:
 
     kustomize config run local-resource/
 

--- a/functions/examples/validator-kubeval/local-resource/example-use.yaml
+++ b/functions/examples/validator-kubeval/local-resource/example-use.yaml
@@ -4,9 +4,10 @@
 apiVersion: examples.config.kubernetes.io/v1beta1
 kind: Kubeval
 metadata:
-  configFn:
-    container:
-      image: gcr.io/kustomize-functions/example-validator-kubeval:v0.1.0
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-validator-kubeval:v0.1.0
 spec:
   strict: true
   ignoreMissingSchemas: true

--- a/functions/examples/validator-resource-requests/README.md
+++ b/functions/examples/validator-resource-requests/README.md
@@ -15,7 +15,7 @@ Resource configuration, and looks for invalid configuration.
 ## Function invocation
 
 The function is invoked by authoring a [local Resource](local-resource)
-with `metadata.configFn` and running:
+with `metadata.annotations.[config.k8s.io/function]` and running:
 
     kustomize config run local-resource/
 

--- a/functions/examples/validator-resource-requests/local-resource/example-use.yaml
+++ b/functions/examples/validator-resource-requests/local-resource/example-use.yaml
@@ -4,9 +4,10 @@
 apiVersion: examples.config.kubernetes.io/v1beta1
 kind: Validator
 metadata:
-  configFn:
-    container:
-      image: gcr.io/kustomize-functions/example-validator:v0.1.0
+  annotations:
+    config.k8s.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-validator:v0.1.0
 ---
 apiVersion: apps/v1 # this should fail validation
 kind: Deployment


### PR DESCRIPTION
- Update function docs to recommend new annotation
- Update examples to use config.k8s.io/function annotation