### PR TITLE
Print the initial unknown status for all resources before looking at events

### DIFF
--- a/cmd/resource/status/cmd/print.go
+++ b/cmd/resource/status/cmd/print.go
@@ -138,10 +138,10 @@ func (s *TablePrinter) Print() {
 
 func (s *TablePrinter) PrintUntil(stop <-chan struct{}, interval time.Duration) <-chan struct{} {
 	completed := make(chan struct{})
+	setColor(s.out, WHITE)
+	s.printTable(s.statusInfo.CurrentStatus(), false)
 	go func() {
 		defer close(completed)
-		setColor(s.out, WHITE)
-		s.printTable(s.statusInfo.CurrentStatus(), false)
 		ticker := time.NewTicker(interval)
 		for {
 			select {

--- a/cmd/resource/status/cmd/wait_test.go
+++ b/cmd/resource/status/cmd/wait_test.go
@@ -36,7 +36,7 @@ func TestWaitNoResources(t *testing.T) {
 
 	aggStatuses := tableOutput.allAggStatuses()
 	expectedAggStatuses := []status.Status{
-		status.CurrentStatus,
+		status.UnknownStatus,
 		status.CurrentStatus,
 	}
 	if !reflect.DeepEqual(aggStatuses, expectedAggStatuses) {


### PR DESCRIPTION
Currently there is a race when printing the statuses for all the resources the first time. Depending on how long it takes to compute the resource statuses, the output might include the statuses for resources instead of just the Unknown for all resources. This is not really a problem in normal usage, but it makes the tests flaky. This change makes sure that the printer prints the list of all resources with the Unknown status before it starts listening for resource updates on the channel.
