### PR TITLE
Implement new rules for status for PDBs

### DIFF
--- a/kstatus/status/status.go
+++ b/kstatus/status/status.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	Statuses = []Status{InProgressStatus, FailedStatus, CurrentStatus, TerminatingStatus, UnknownStatus}
+	Statuses       = []Status{InProgressStatus, FailedStatus, CurrentStatus, TerminatingStatus, UnknownStatus}
 	ConditionTypes = []ConditionType{ConditionFailed, ConditionInProgress}
 )
 

--- a/kstatus/status/status_compute_test.go
+++ b/kstatus/status/status_compute_test.go
@@ -822,92 +822,49 @@ func TestReplicasetStatus(t *testing.T) {
 	}
 }
 
-var pdbNoStatus = `
-apiVersion: policy/v1
+var pdbNotObserved = `
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-   generation: 1
+   generation: 2
    name: test
+   namespace: qual
+status:
+   observedGeneration: 1
 `
 
-var pdbOK1 = `
-apiVersion: policy/v1
+var pdbObserved = `
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
    generation: 1
    name: test
    namespace: qual
 status:
-   currentHealthy: 2
-   desiredHealthy: 2
-`
-
-var pdbMoreHealthy = `
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-   generation: 1
-   name: test
-   namespace: qual
-status:
-   currentHealthy: 4
-   desiredHealthy: 2
-`
-
-var pdbLessHealthy = `
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-   generation: 1
-   name: test
-   namespace: qual
-status:
-   currentHealthy: 2
-   desiredHealthy: 4
+   observedGeneration: 1
 `
 
 func TestPDBStatus(t *testing.T) {
 	testCases := map[string]testSpec{
-		"pdbNoStatus": {
-			spec:           pdbNoStatus,
+		"pdbNotObserved": {
+			spec:           pdbNotObserved,
 			expectedStatus: InProgressStatus,
 			expectedConditions: []Condition{{
 				Type:   ConditionInProgress,
 				Status: corev1.ConditionTrue,
-				Reason: "ZeroDesiredHealthy",
+				Reason: "LatestGenerationNotObserved",
 			}},
 			absentConditionTypes: []ConditionType{
 				ConditionFailed,
 			},
 		},
-		"pdbOK1": {
-			spec:               pdbOK1,
+		"pdbObserved": {
+			spec:               pdbObserved,
 			expectedStatus:     CurrentStatus,
 			expectedConditions: []Condition{},
 			absentConditionTypes: []ConditionType{
 				ConditionFailed,
 				ConditionInProgress,
-			},
-		},
-		"pdbMoreHealthy": {
-			spec:               pdbMoreHealthy,
-			expectedStatus:     CurrentStatus,
-			expectedConditions: []Condition{},
-			absentConditionTypes: []ConditionType{
-				ConditionFailed,
-				ConditionInProgress,
-			},
-		},
-		"pdbLessHealthy": {
-			spec:           pdbLessHealthy,
-			expectedStatus: InProgressStatus,
-			expectedConditions: []Condition{{
-				Type:   ConditionInProgress,
-				Status: corev1.ConditionTrue,
-				Reason: "BudgetNotMet",
-			}},
-			absentConditionTypes: []ConditionType{
-				ConditionFailed,
 			},
 		},
 	}


### PR DESCRIPTION
Changes the status rule for PDBs. Instead of focusing on whether a certain number of pods have become ready, it decides status on whether the controller has observed it and computed `AllowedDisruptions`. As long as this has happened, the workload(s) covered by the PDB will be protected from disruption through the Evictions API.

@pwittrock @seans3 @KnVerey