### PR TITLE
Indent preformatted text in kstatus doc.go

### DIFF
--- a/kstatus/status/doc.go
+++ b/kstatus/status/doc.go
@@ -4,7 +4,7 @@
 // Package kstatus contains functionality for computing the status
 // of Kubernetes resources.
 //
-// The statuses defined in this package is:
+// The statuses defined in this package are:
 //  * InProgress
 //  * Current
 //  * Failed
@@ -13,11 +13,12 @@
 //
 // Computing the status of a resources can be done by calling the
 // Compute function in the status package.
-// import (
-//     "sigs.k8s.io/kustomize/kstatus/status"
-// )
-// res, err := status.Compute(resource)
 //
+//   import (
+//     "sigs.k8s.io/kustomize/kstatus/status"
+//   )
+//
+//   res, err := status.Compute(resource)
 //
 // The package also defines a set of new conditions:
 //  * InProgress
@@ -31,8 +32,10 @@
 // the standard conditions described above. The values of
 // these conditions are decided based on other status information
 // available in the resources.
-// import (
+//
+//   import (
 //     "sigs.k8s.io/kustomize/kstatus/status
-// )
-// err := status.Augment(resource)
+//   )
+//
+//   err := status.Augment(resource)
 package status

--- a/kstatus/wait/doc.go
+++ b/kstatus/wait/doc.go
@@ -15,24 +15,24 @@
 // only requires functions for getting the apiVersion, kind, name
 // and namespace of a resource.
 //
-// import (
-//   "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-//   "k8s.io/apimachinery/pkg/types"
-//   "sigs.k8s.io/kustomize/kstatus/wait"
-// )
+//   import (
+//     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+//     "k8s.io/apimachinery/pkg/types"
+//     "sigs.k8s.io/kustomize/kstatus/wait"
+//   )
 //
-// key := types.NamespacedName{Name: "name", Namespace: "namespace"}
-// deployment := &unstructured.Unstructured{
-//   Object: map[string]interface{}{
-//     "apiVersion": "apps/v1",
-//     "kind":       "Deployment",
-//   },
-// }
-// client.Get(context.Background(), key, deployment)
-// resourceIdentifiers := []wait.ResourceIdentifier{deployment}
+//   key := types.NamespacedName{Name: "name", Namespace: "namespace"}
+//   deployment := &unstructured.Unstructured{
+//     Object: map[string]interface{}{
+//       "apiVersion": "apps/v1",
+//       "kind":       "Deployment",
+//     },
+//   }
+//   client.Get(context.Background(), key, deployment)
+//   resourceIdentifiers := []wait.ResourceIdentifier{deployment}
 //
-// resolver := wait.NewResolver(client)
-// results := resolver.FetchAndResolve(context.Background(), resourceIdentifiers)
+//   resolver := wait.NewResolver(client)
+//   results := resolver.FetchAndResolve(context.Background(), resourceIdentifiers)
 //
 // WaitForStatus also looks up status for a list of resources, but it will
 // block until all the provided resources has reached the Current status or
@@ -40,18 +40,19 @@
 // a channel that will provide updates as the status of the different
 // resources change.
 //
-// import (
-//   "sigs.k8s.io/kustomize/kstatus/wait"
-// )
-// resolver := wait.NewResolver(client)
-// eventsChan := resolver.WaitForStatus(context.Background(), resourceIdentifiers, 2 * time.Second)
-// for {
-//   select {
-//   case event, ok := <-eventsChan:
-//     if !ok {
-//       return
+//   import (
+//     "sigs.k8s.io/kustomize/kstatus/wait"
+//   )
+//
+//   resolver := wait.NewResolver(client)
+//   eventsChan := resolver.WaitForStatus(context.Background(), resourceIdentifiers, 2 * time.Second)
+//   for {
+//     select {
+//     case event, ok := <-eventsChan:
+//       if !ok {
+//         return
+//       }
+//       fmt.Printf(event) // do something useful here.
 //     }
-//     fmt.Printf(event) // do something useful here.
 //   }
-// }
 package wait


### PR DESCRIPTION
This indents the code examples in the kstatus doc.go files so that they'll be placed inside `<pre>` blocks by godoc. Without this change only the coincidentally indented lines are marked as preformatted in godoc HTML output.