### PR TITLE
Adds inventory hash to grouping object.

### DIFF
--- a/cmd/kubectl/go.mod
+++ b/cmd/kubectl/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/spf13/cobra v0.0.5
+	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/cli-runtime v0.17.0
 	k8s.io/client-go v0.17.0


### PR DESCRIPTION
* Adds a hash of the inventory strings into an annotation of the grouping object.
* Adds three helper functions (`calcInventoryHash`, `retrieveInventoryHash`, and `mapsKeysToSlice`) to implement the previously stated functionality.
* Updates unit tests to test this functionality.

/sig cli
/priority important-soon

```release-note
NONE
```