### PR TITLE
Change the ResourceIdentifier used in kstatus to use only Group instead of GroupVersion

### DIFF
--- a/cmd/resource/status/cmd/events.go
+++ b/cmd/resource/status/cmd/events.go
@@ -10,14 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/resource/status/generateddocs/commands"
-	"sigs.k8s.io/kustomize/kstatus/wait"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 // GetEventsRunner returns a command EventsRunner.
 func GetEventsRunner() *EventsRunner {
 	r := &EventsRunner{
-		createClientFunc: createClient,
+		newResolverFunc: newResolver,
 	}
 	c := &cobra.Command{
 		Use:     "events DIR...",
@@ -49,18 +48,16 @@ type EventsRunner struct {
 	Timeout            time.Duration
 	Command            *cobra.Command
 
-	createClientFunc createClientFunc
+	newResolverFunc newResolverFunc
 }
 
 func (r *EventsRunner) runE(c *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Create a client and use it to set up a new resolver.
-	client, err := r.createClientFunc()
+	resolver, err := r.newResolverFunc(r.Interval)
 	if err != nil {
-		return errors.Wrap(err, "error creating client")
+		return errors.Wrap(err, "error creating resolver")
 	}
-	resolver := wait.NewResolver(client, r.Interval)
 
 	// Set up a CaptureIdentifierFilter and run all inputs through the
 	// filter with the pipeline to capture the inventory of resources

--- a/cmd/resource/status/cmd/events_test.go
+++ b/cmd/resource/status/cmd/events_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kstatus/status"
 	"sigs.k8s.io/kustomize/kstatus/wait"
 )
@@ -20,7 +22,7 @@ func TestEventsNoResources(t *testing.T) {
 	fakeClient := &FakeClient{}
 
 	r := GetEventsRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient)
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -64,7 +66,7 @@ metadata:
 	}
 
 	r := GetEventsRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, appsv1.SchemeGroupVersion.WithKind("Deployment"))
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -141,7 +143,8 @@ items:
 	}
 
 	r := GetEventsRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, corev1.SchemeGroupVersion.WithKind("Pod"),
+		corev1.SchemeGroupVersion.WithKind("Service"))
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)

--- a/cmd/resource/status/cmd/fetch_test.go
+++ b/cmd/resource/status/cmd/fetch_test.go
@@ -25,7 +25,7 @@ func TestEmptyManifest(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(scheme)
 
 	r := GetFetchRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient)
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -65,7 +65,7 @@ metadata:
 	fakeClient := fake.NewFakeClientWithScheme(scheme, deployment)
 
 	r := GetFetchRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, appsv1.SchemeGroupVersion.WithKind("Deployment"))
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -78,7 +78,7 @@ metadata:
 	tableOutput := parseTableOutput(t, cleanOutput)
 
 	expectedResource := ResourceIdentifier{
-		apiVersion: "apps/v1",
+		apiVersion: "apps",
 		kind:       "Deployment",
 		namespace:  "default",
 		name:       "bar",
@@ -139,7 +139,8 @@ metadata:
 	outBuffer := &bytes.Buffer{}
 
 	r := GetFetchRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, appsv1.SchemeGroupVersion.WithKind("Deployment"),
+		v1.SchemeGroupVersion.WithKind("Service"))
 	r.Command.SetArgs([]string{d})
 	r.Command.SetOut(outBuffer)
 
@@ -152,7 +153,7 @@ metadata:
 	tableOutput := parseTableOutput(t, cleanOutput)
 
 	expectedDeploymentResource := ResourceIdentifier{
-		apiVersion: "apps/v1",
+		apiVersion: "apps",
 		kind:       "Deployment",
 		namespace:  "default",
 		name:       "foo",
@@ -162,7 +163,7 @@ metadata:
 	verifyOutputContains(t, tableOutput, expectedDeploymentResource, expectedDeploymentStatus, expectedDeploymentMessage)
 
 	expectedServiceResource := ResourceIdentifier{
-		apiVersion: "v1",
+		apiVersion: "",
 		kind:       "Service",
 		namespace:  "default",
 		name:       "foo",

--- a/cmd/resource/status/cmd/print.go
+++ b/cmd/resource/status/cmd/print.go
@@ -61,8 +61,7 @@ var (
 			width:     25,
 			colorFunc: defaultColorFunc,
 			contentFunc: func(data ResourceStatusData) string {
-				return fmt.Sprintf("%s/%s", data.Identifier.GetAPIVersion(),
-					data.Identifier.GetKind())
+				return fmt.Sprintf("%s/%s", data.Identifier.GroupKind.Group, data.Identifier.GroupKind.Kind)
 			},
 		},
 		namespaceColumn: {
@@ -70,7 +69,7 @@ var (
 			width:     15,
 			colorFunc: defaultColorFunc,
 			contentFunc: func(data ResourceStatusData) string {
-				return data.Identifier.GetNamespace()
+				return data.Identifier.Namespace
 			},
 		},
 		nameColumn: {
@@ -78,7 +77,7 @@ var (
 			width:     20,
 			colorFunc: defaultColorFunc,
 			contentFunc: func(data ResourceStatusData) string {
-				return data.Identifier.GetName()
+				return data.Identifier.Name
 			},
 		},
 		statusColumn: {
@@ -255,8 +254,8 @@ var (
 			width:                      20,
 			requireResourceUpdateEvent: true,
 			contentFunc: func(event wait.Event) string {
-				return fmt.Sprintf("%s/%s", event.EventResource.Identifier.GetAPIVersion(),
-					event.EventResource.Identifier.GetKind())
+				return fmt.Sprintf("%s/%s", event.EventResource.ResourceIdentifier.GroupKind.Group,
+					event.EventResource.ResourceIdentifier.GroupKind.Kind)
 			},
 		},
 		{
@@ -264,7 +263,7 @@ var (
 			width:                      15,
 			requireResourceUpdateEvent: true,
 			contentFunc: func(event wait.Event) string {
-				return event.EventResource.Identifier.GetNamespace()
+				return event.EventResource.ResourceIdentifier.Namespace
 			},
 		},
 		{
@@ -272,7 +271,7 @@ var (
 			width:                      20,
 			requireResourceUpdateEvent: true,
 			contentFunc: func(event wait.Event) string {
-				return event.EventResource.Identifier.GetName()
+				return event.EventResource.ResourceIdentifier.Name
 			},
 		},
 		{

--- a/cmd/resource/status/cmd/wait_test.go
+++ b/cmd/resource/status/cmd/wait_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/acarl005/stripansi"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kstatus/status"
 )
 
@@ -18,7 +20,7 @@ func TestWaitNoResources(t *testing.T) {
 	fakeClient := &FakeClient{}
 
 	r := GetWaitRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient)
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -72,7 +74,7 @@ metadata:
 	}
 
 	r := GetWaitRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, appsv1.SchemeGroupVersion.WithKind("Deployment"))
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)
@@ -144,7 +146,8 @@ items:
 	}
 
 	r := GetWaitRunner()
-	r.createClientFunc = newClientFunc(fakeClient)
+	r.newResolverFunc = fakeResolver(fakeClient, corev1.SchemeGroupVersion.WithKind("Pod"),
+		corev1.SchemeGroupVersion.WithKind("Service"))
 	r.Command.SetArgs([]string{})
 	r.Command.SetIn(inBuffer)
 	r.Command.SetOut(outBuffer)

--- a/kstatus/wait/util.go
+++ b/kstatus/wait/util.go
@@ -5,24 +5,28 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// keyFromResourceIdentifier creates a resourceKey from a ResourceIdentifier.
-func keyFromResourceIdentifier(i ResourceIdentifier) resourceKey {
-	return resourceKey{
-		apiVersion: i.GetAPIVersion(),
-		kind:       i.GetKind(),
-		name:       i.GetName(),
-		namespace:  i.GetNamespace(),
+func resourceIdentifierFromObject(object KubernetesObject) ResourceIdentifier {
+	return ResourceIdentifier{
+		Name:      object.GetName(),
+		Namespace: object.GetNamespace(),
+		GroupKind: object.GroupVersionKind().GroupKind(),
 	}
 }
 
-// keyFromObject creates a resourceKey from an Object.
-func keyFromObject(obj runtime.Object) resourceKey {
-	gvk := obj.GetObjectKind().GroupVersionKind()
-	r := obj.(metav1.Object)
-	return resourceKey{
-		apiVersion: gvk.GroupVersion().String(),
-		kind:       gvk.Kind,
-		name:       r.GetName(),
-		namespace:  r.GetNamespace(),
+func resourceIdentifiersFromObjects(objects []KubernetesObject) []ResourceIdentifier {
+	var resourceIdentifiers []ResourceIdentifier
+	for _, object := range objects {
+		resourceIdentifiers = append(resourceIdentifiers, resourceIdentifierFromObject(object))
+	}
+	return resourceIdentifiers
+}
+
+func resourceIdentifierFromRuntimeObject(object runtime.Object) ResourceIdentifier {
+	gvk := object.GetObjectKind().GroupVersionKind()
+	r := object.(metav1.Object)
+	return ResourceIdentifier{
+		GroupKind: gvk.GroupKind(),
+		Name:      r.GetName(),
+		Namespace: r.GetNamespace(),
 	}
 }


### PR DESCRIPTION
The previous version of the ResourceIdentifier included the resource version. This is not necessary, so with this change only group, kind, namespace and name are needed. In order to look up a resource from a cluster, we resolve the resource version with the RESTMapper. 

This also addresses a problem where resources that didn't include the namespace in the manifest was not handled correctly. 