### PR TITLE
End to End tests framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ verify-kustomize: \
 	test-examples-kustomize-against-HEAD \
 	test-examples-kustomize-against-latest
 
+.PHONY: verify-kustomize-e2e
+verify-kustomize-e2e: test-examples-e2e-kustomize-against-HEAD
+
 # Other builds in this repo might want a different linter version.
 # Without one Makefile to rule them all, the different makes
 # cannot assume that golanci-lint is at the version they want
@@ -47,6 +50,11 @@ $(MYGOBIN)/stringer:
 $(MYGOBIN)/goimports:
 	cd api; \
 	go install golang.org/x/tools/cmd/goimports
+
+# Install resource from whatever is checked out.
+$(MYGOBIN)/resource:
+	cd cmd/resource; \
+	go install .
 
 # To pin pluginator, use this recipe instead:
 #   cd api;
@@ -192,6 +200,10 @@ test-unit-kustomize-all: \
 .PHONY:
 test-examples-kustomize-against-HEAD: $(MYGOBIN)/kustomize $(MYGOBIN)/mdrip
 	./hack/testExamplesAgainstKustomize.sh HEAD
+
+.PHONY:
+test-examples-e2e-kustomize-against-HEAD: $(MYGOBIN)/kustomize $(MYGOBIN)/mdrip $(MYGOBIN)/resource
+	./hack/testExamplesE2EAgainstKustomize.sh HEAD
 
 .PHONY:
 test-examples-kustomize-against-latest: $(MYGOBIN)/mdrip

--- a/hack/testExamplesE2EAgainstKustomize.sh
+++ b/hack/testExamplesE2EAgainstKustomize.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+mdrip --blockTimeOut 60m0s --mode test \
+    --label testE2EAgainstLatestRelease examples
+
+echo "Example e2e tests passed against ${version}."


### PR DESCRIPTION
*Why*
This PR sets the end to end test framework for kustomize. Real kubernetes clusters are spun on local using kind, all the commands are tested and cleaned.