### PR TITLE
Do not remove empty lines in configmap/secret

### DIFF
--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -153,7 +153,8 @@ FRUIT=banana
 LEGUME=chickpea
 `)
 	th.WriteF("/app/overlay/configmap/dummy.txt",
-		`Lorem ipsum dolor sit amet, consectetur  
+		`Lorem ipsum dolor sit amet, consectetur
+ 		 
 adipiscing elit, sed do eiusmod tempor		
 incididunt ut labore et dolore magna aliqua.   
 `)
@@ -294,6 +295,7 @@ apiVersion: v1
 data:
   nonsense: |
     Lorem ipsum dolor sit amet, consectetur
+
     adipiscing elit, sed do eiusmod tempor
     incididunt ut labore et dolore magna aliqua.
 kind: ConfigMap
@@ -304,6 +306,6 @@ metadata:
     app: mungebot
     org: kubernetes
     repo: test-infra
-  name: test-infra-app-config-4mt28b5bg2
+  name: test-infra-app-config-hh272bg5d4
 `)
 }

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -93,7 +93,7 @@ func (kvl *loader) keyValuesFromFileSources(sources []string) ([]types.Pair, err
 
 // trimTrailingSpacesInLines takes string with multiple lines and trims the trailing white spaces and tabs from each line.
 func trimTrailingSpacesInLines(str string) string {
-	re := regexp.MustCompile(`\s*\n`)
+	re := regexp.MustCompile(`[ \t]*\n`)
 	return re.ReplaceAllString(str, "\n")
 }
 

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -97,8 +97,8 @@ func TestKeyValuesFromFileSources(t *testing.T) {
 }
 
 func TestTrimTrailingSpacesInLines(t *testing.T) {
-	input := "\"fooKey\": \"fooValue\"   \t\n\t\"barKey\": \"barValue\""
-	expected := "\"fooKey\": \"fooValue\"\n\t\"barKey\": \"barValue\""
+	input := "\"fooKey\": \"fooValue\"   \t\n \t\t  \n\t\"barKey\": \"barValue\""
+	expected := "\"fooKey\": \"fooValue\"\n\n\t\"barKey\": \"barValue\""
 	res := trimTrailingSpacesInLines(input)
 	if !reflect.DeepEqual(res, expected) {
 		t.Errorf("Trim trailing spaces in lines should succeed, got: %s exptected: %s", res, expected)

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -20,6 +20,7 @@ exclude (
 )
 
 replace (
+	sigs.k8s.io/kustomize/api v0.3.2 => ../api
 	sigs.k8s.io/kustomize/cmd/kubectl v0.0.3 => ../cmd/kubectl
 	sigs.k8s.io/kustomize/kstatus v0.0.1 => ../kstatus
 )


### PR DESCRIPTION
*Why*

This PR is to make sure that only trailing tabs and spaces are trimmed but not new lines from configMap and secret.