### PR TITLE
Clean up output format for status events command

### DIFF
--- a/kustomize/internal/commands/status/cmd/events.go
+++ b/kustomize/internal/commands/status/cmd/events.go
@@ -54,7 +54,7 @@ type EventsRunner struct {
 func (r *EventsRunner) runE(c *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	resolver, err := r.newResolverFunc(r.Interval)
+	resolver, mapper, err := r.newResolverFunc(r.Interval)
 	if err != nil {
 		return errors.Wrap(err, "error creating resolver")
 	}
@@ -62,7 +62,9 @@ func (r *EventsRunner) runE(c *cobra.Command, args []string) error {
 	// Set up a CaptureIdentifierFilter and run all inputs through the
 	// filter with the pipeline to capture the inventory of resources
 	// which we are interested in.
-	captureFilter := &CaptureIdentifiersFilter{}
+	captureFilter := &CaptureIdentifiersFilter{
+		Mapper: mapper,
+	}
 	filters := []kio.Filter{captureFilter}
 
 	var inputs []kio.Reader

--- a/kustomize/internal/commands/status/cmd/fetch.go
+++ b/kustomize/internal/commands/status/cmd/fetch.go
@@ -50,7 +50,7 @@ type FetchRunner struct {
 func (r *FetchRunner) runE(c *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	resolver, err := r.newResolverFunc(time.Minute)
+	resolver, mapper, err := r.newResolverFunc(time.Minute)
 	if err != nil {
 		return errors.Wrap(err, "error creating resolver")
 	}
@@ -58,7 +58,9 @@ func (r *FetchRunner) runE(c *cobra.Command, args []string) error {
 	// Set up a CaptureIdentifierFilter and run all inputs through the
 	// filter with the pipeline to capture the inventory of resources
 	// which we are interested in.
-	captureFilter := &CaptureIdentifiersFilter{}
+	captureFilter := &CaptureIdentifiersFilter{
+		Mapper: mapper,
+	}
 	filters := []kio.Filter{captureFilter}
 
 	var inputs []kio.Reader

--- a/kustomize/internal/commands/status/cmd/helpers_test.go
+++ b/kustomize/internal/commands/status/cmd/helpers_test.go
@@ -241,7 +241,7 @@ func (f *FakeClient) List(context.Context, runtime.Object, ...client.ListOption)
 }
 
 func fakeResolver(fakeClient client.Reader, mapperTypes ...schema.GroupVersionKind) newResolverFunc {
-	return func(pollInterval time.Duration) (*wait.Resolver, error) {
+	return func(pollInterval time.Duration) (*wait.Resolver, meta.RESTMapper, error) {
 		var groupVersions []schema.GroupVersion
 		for _, gvk := range mapperTypes {
 			groupVersions = append(groupVersions, gvk.GroupVersion())
@@ -251,7 +251,7 @@ func fakeResolver(fakeClient client.Reader, mapperTypes ...schema.GroupVersionKi
 			mapper.Add(gvk, meta.RESTScopeNamespace)
 		}
 
-		return wait.NewResolver(fakeClient, mapper, pollInterval), nil
+		return wait.NewResolver(fakeClient, mapper, pollInterval), mapper, nil
 	}
 }
 

--- a/kustomize/internal/commands/status/cmd/wait.go
+++ b/kustomize/internal/commands/status/cmd/wait.go
@@ -60,12 +60,14 @@ type WaitRunner struct {
 func (r *WaitRunner) runE(c *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	resolver, err := r.newResolverFunc(r.Interval)
+	resolver, mapper, err := r.newResolverFunc(r.Interval)
 	if err != nil {
 		return errors.Wrap(err, "errors creating resolver")
 	}
 
-	captureFilter := &CaptureIdentifiersFilter{}
+	captureFilter := &CaptureIdentifiersFilter{
+		Mapper: mapper,
+	}
 	filters := []kio.Filter{captureFilter}
 
 	var inputs []kio.Reader


### PR DESCRIPTION
This makes a few changes to the output format from the status events command:
- It sets the namespace to default in the kio pipeline filter if it is not specified. This means we will no longer have the empty namespace in the output for namespaced resources.
- It removes the EventType column. I don't think it was very useful.
- It adds more information to the last line printed when the command exists, either because it timed out or because all resources have become Current.
- It changes the output for the resource type to only print the Kind. I think this should be sufficient in 99.99% of all cases.
- Moves the namespace column to be the first one.

![Screen Shot 2020-01-22 at 8 42 28 PM](https://user-images.githubusercontent.com/8463/72957277-d6001480-3d57-11ea-8e34-c906035dfb83.png)

Fixes: #2123

@pwittrock 
