### PR TITLE
Fix install_kustomize.sh so that it works on alpine linux

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -26,9 +26,9 @@ trap cleanup EXIT
 pushd $tmpDir >& /dev/null
 
 opsys=windows
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
+if [[ "$OSTYPE" == linux* ]]; then
   opsys=linux
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
 fi
 


### PR DESCRIPTION
The install script fails and thinks that alpine linux is in windows. This is because 
`$OSTYPE` in alpine linux is linux-musl, not linux-gnu as this script assumes.

I tested these changes with this script:
```
#!/bin/bash

set -euo pipefail

opsys=""
function check {
    opsys=windows
    if [[ "$OSTYPE" == linux* ]]; then
      opsys=linux
    elif [[ "$OSTYPE" == darwin* ]]; then
      opsys=darwin
    fi
}

OSTYPE="linux-gnu"
check
test "$opsys" == "linux" || echo $OSTYPE test failed

OSTYPE="linuxsomething"
check
test "$opsys" == "linux" || echo $OSTYPE test failed

OSTYPE="darwinsomething"
check
test "$opsys" == "darwin" || echo $OSTYPE test failed

OSTYPE="either"
check
test "$opsys" == "windows" || echo $OSTYPE test failed
```

closes: #2146