### PR TITLE
Merge Resources after `config run`.

### DIFF
--- a/cmd/config/internal/commands/run-fns.go
+++ b/cmd/config/internal/commands/run-fns.go
@@ -34,6 +34,8 @@ func GetRunFnRunner(name string) *RunFnRunner {
 		&r.DryRun, "dry-run", false, "print results to stdout")
 	r.Command.Flags().BoolVar(
 		&r.GlobalScope, "global-scope", false, "set global scope for functions.")
+	r.Command.Flags().BoolVar(
+		&r.NoMerge, "no-merge", false, "do not merge resources after functions run.")
 	r.Command.Flags().StringSliceVar(
 		&r.FnPaths, "fn-path", []string{},
 		"read functions from these directories instead of the configuration directory.")
@@ -53,6 +55,7 @@ type RunFnRunner struct {
 	Command            *cobra.Command
 	DryRun             bool
 	GlobalScope        bool
+	NoMerge            bool
 	FnPaths            []string
 	Image              string
 	RunFns             runfn.RunFns
@@ -184,6 +187,7 @@ func (r *RunFnRunner) preRunE(c *cobra.Command, args []string) error {
 	r.RunFns = runfn.RunFns{
 		FunctionPaths: r.FnPaths,
 		GlobalScope:   r.GlobalScope,
+		NoMerge:       r.NoMerge,
 		Functions:     fns,
 		Output:        output,
 		Input:         input,

--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -47,6 +47,9 @@ type RunFns struct {
 	// Output can be set to write the result to Output rather than back to the directory
 	Output io.Writer
 
+	// NoMerge disables merging of Resources after functions are ran.
+	NoMerge bool
+
 	// NoFunctionsFromInput if set to true will not read any functions from the input,
 	// and only use explicit sources
 	NoFunctionsFromInput *bool
@@ -70,6 +73,11 @@ func (r RunFns) Execute() error {
 	if err != nil {
 		return err
 	}
+
+	if !r.NoMerge {
+		fltrs = append(fltrs, filters.MergeFilter{})
+	}
+
 	return r.runFunctions(nodes, output, fltrs)
 }
 


### PR DESCRIPTION
Fixes #2118

TODO
- [X] cmd/config tests
- [x] cmd/config doc updates

Tested the `--no-merge` flag with the following:
```sh
DEMO=$(mktemp -d)

cat <<EOF >$DEMO/my-cm1.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
data:
  key: value1
EOF

cat $DEMO/my-cm1.yaml | sed 's/value1/value2/' >$DEMO/my-cm2.yaml

# No merge
config run $DEMO --image=gcr.io/config-functions/noop:v0.0.1 --no-merge

EXPECTED='apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
data:
  key: value1
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
data:
  key: value2'

TEST="$(config cat $DEMO)"
[ "$TEST" = "$EXPECTED" ]

# Merge
config run $DEMO --image=gcr.io/config-functions/noop:v0.0.1

EXPECTED='apiVersion: v1
kind: ConfigMap
metadata:
  name: my-configmap
data:
  key: value2'

TEST="$(config cat $DEMO)"
[ "$TEST" = "$EXPECTED" ]
```