### PR TITLE
Changes in Kubernetes v2.x breaks this example

### DIFF
--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -148,7 +148,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
-resources:
+bases:
 - ../../base
 patchesStrategicMerge:
 - map.yaml
@@ -189,7 +189,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
-resources:
+bases:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml


### PR DESCRIPTION
Only `bases` can be accessed in higher directories. https://github.com/kubernetes-sigs/kustomize/pull/700 https://github.com/kubernetes-sigs/kustomize/issues/766