### PR TITLE
Enable specifying GeneratorOptions per resource

### DIFF
--- a/api/internal/k8sdeps/configmapandsecret/configmapfactory.go
+++ b/api/internal/k8sdeps/configmapandsecret/configmapfactory.go
@@ -38,10 +38,7 @@ func (f *Factory) MakeConfigMap(
 			return nil, errors.Wrap(err, "trouble mapping")
 		}
 	}
-	if f.options != nil {
-		cm.SetLabels(f.options.Labels)
-		cm.SetAnnotations(f.options.Annotations)
-	}
+	f.setLabelsAndAnnnotations(cm, args.GeneratorOptions)
 	return cm, nil
 }
 

--- a/api/internal/k8sdeps/configmapandsecret/factory.go
+++ b/api/internal/k8sdeps/configmapandsecret/factory.go
@@ -4,6 +4,7 @@
 package configmapandsecret
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/types"
 )
@@ -18,6 +19,37 @@ type Factory struct {
 func NewFactory(
 	kvLdr ifc.KvLoader, o *types.GeneratorOptions) *Factory {
 	return &Factory{kvLdr: kvLdr, options: o}
+}
+
+// setLabelsAndAnnnotations will take the labels and annotations from
+// global GeneratorOptions and resource level GeneratorOptions and merge them
+// with the resource level taking precedence, and then set them on the provided
+// obj.
+func (f *Factory) setLabelsAndAnnnotations(obj metav1.Object, opts *types.GeneratorOptions) {
+	labels := make(map[string]string)
+	annotations := make(map[string]string)
+	if f.options != nil {
+		for k, v := range f.options.Labels {
+			labels[k] = v
+		}
+		for k, v := range f.options.Annotations {
+			annotations[k] = v
+		}
+	}
+	if opts != nil {
+		for k, v := range opts.Labels {
+			labels[k] = v
+		}
+		for k, v := range opts.Annotations {
+			annotations[k] = v
+		}
+	}
+	if len(labels) != 0 {
+		obj.SetLabels(labels)
+	}
+	if len(annotations) != 0 {
+		obj.SetAnnotations(annotations)
+	}
 }
 
 const keyExistsErrorMsg = "cannot add key %s, another key by that name already exists: %v"

--- a/api/internal/k8sdeps/configmapandsecret/secretfactory.go
+++ b/api/internal/k8sdeps/configmapandsecret/secretfactory.go
@@ -39,10 +39,7 @@ func (f *Factory) MakeSecret(
 			return nil, err
 		}
 	}
-	if f.options != nil {
-		s.SetLabels(f.options.Labels)
-		s.SetAnnotations(f.options.Annotations)
-	}
+	f.setLabelsAndAnnnotations(s, args.GeneratorOptions)
 	return s, nil
 }
 

--- a/api/types/generatorargs.go
+++ b/api/types/generatorargs.go
@@ -21,4 +21,7 @@ type GeneratorArgs struct {
 
 	// KvPairSources for the generator.
 	KvPairSources `json:",inline,omitempty" yaml:",inline,omitempty"`
+
+	// GeneratorOptions modify this generator
+	GeneratorOptions *GeneratorOptions `json:"generatorOptions,omitempty" yaml:"generatorOptions,omitempty"`
 }

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -131,6 +131,10 @@ crds:
 Modifies behavior of all [ConfigMap](#configmapgenerator)
 and [Secret](#secretgenerator) generators.
 
+Additionally, generatorOptions can be set on a per resource level within each
+generator. For details on per-resource generatorOptions usage see
+[field-name-configMapGenerator] and See [field-name-secretGenerator].
+
 ```
 generatorOptions:
   # labels to add to all generated resources

--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -90,9 +90,9 @@ commonAnnotations:
 Each entry in this list results in the creation of
 one ConfigMap resource (it's a generator of n maps).
 
-The example below creates two ConfigMaps. One with the
-names and contents of the given files, the other with
-key/value as data.
+The example below creates three ConfigMaps. One with the names and contents of
+the given files, one with key/value as data, and a third which sets an
+annotation and label via generatorOptions for that single ConfigMap.
 
 Each configMapGenerator item accepts a parameter of
 `behavior: [create|replace|merge]`.
@@ -109,6 +109,14 @@ configMapGenerator:
   literals:	
   - JAVA_HOME=/opt/java/jdk
   - JAVA_TOOL_OPTIONS=-agentlib:hprof
+- name: dashboards
+  files:
+  - mydashboard.json
+  generatorOptions:
+    annotations:
+      dashboard: "1"
+    labels:
+      app.kubernetes.io/name: "app1"
 ```
 
 It is also possible to
@@ -651,6 +659,15 @@ secretGenerator:
   envs:
   - env.txt
   type: Opaque
+- name: secret-with-annotation
+  files:
+  - app-config.yaml
+  type: Opaque
+  generatorOptions:
+    annotations:
+      app_config: "true"
+    labels:
+      app.kubernetes.io/name: "app2"
 ```
 
 ### Usage via plugin


### PR DESCRIPTION
In addition to specifying GeneratorOptions globally within a
kustomization, also allow users to set GeneratorOptions on a
per-resource level.

Fixes #2179