### PR TITLE
Fix typo in kustomization file resources field explanation

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -206,7 +206,7 @@ _file_, or a path (or URL) refering to another
 kustomization _directory_, e.g.
 
 ```
-resource:
+resources:
 - myNamespace.yaml
 - sub-dir/some-deployment.yaml
 - ../../commonbase


### PR DESCRIPTION
This commit fixes typo in explanation of `resources` field in kustomization file.