### PR TITLE
Feat(execPlugin): Allow execution of exec plugins using multiple shells

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -244,6 +244,28 @@ kustomize uses an exec plugin adapter to provide
 marshalled resources on `stdin` and capture
 `stdout` for further processing.
 
+#### Targeting multiple operatings systems
+
+An exec plugin allows an exec configuration to configure usage on multiple operatings systems. 
+Simply add a configuration file allongside the `execPlugin`.
+
+Create a yaml file in the plugin folder: 
+```
+$XDG_CONFIG_HOME/kustomize/plugin
+    /${apiVersion}/LOWERCASE(${kind})/${kind}.yaml 
+```
+This configuration file contains a list of exec options, which are tried in order of appearance: 
+```
+execOptions:
+  - cmd: "pwsh" # Allow execution of powershell core on linux and windows
+    args: ["-NoProfile","-File","{{.Script}}"]
+  - cmd: "powershell.exe"
+    args: ["-NoProfile","-File","{{.Script}}.ps1"]    
+```  
+The plugin will check if the cmd is on the path, and if so it will use that exec option. 
+Each `arg` is a go template, which will be parsed with a single value data map that contains the script to be executed. 
+If no command or exec config is found, the default execution will be used (`sh`).
+
 #### Generator Options
 
 A generator exec plugin can adjust the generator options for the resources it emits by setting one of the following internal annotations. 

--- a/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap.ps1
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap.ps1
@@ -1,0 +1,11 @@
+Write-Output "
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: example-configmap-test
+  annotations:
+    kustomize.config.k8s.io/needs-hash: `"true`"
+data:
+  username: `"$($args[1])`"
+  password: `"$($args[2])`"
+"

--- a/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap.yaml
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/BashedConfigMap.yaml
@@ -1,0 +1,9 @@
+# This is the execPlugin configuration file for executing a command 
+# Each cmd is tested on the path and if found, the command is used
+# Each arg is handled as a template and each template will receive the "Script" which 
+# contains the file that needs to be executed
+execOptions:
+  - cmd: "powershell.exe" # Powershell < 6  
+    args: ["-NoProfile","-File","{{.Script}}.ps1"]    
+  - cmd: "pwsh" # Can run on Windows and Linux (Powershell core)
+    args: ["-NoProfile","-File","{{.Script}}.ps1"]


### PR DESCRIPTION
I really like the `execPlugin` generator, but as usual the windows developers are discriminated upon (pun intended!). 
So I've tweaked the `execPlugin` code a bit. Actually life does not change if you're not using it. This PR allows the creation of a `<api>/<kind>/<Kind>.yaml` execution configuration file. If this file exists, `execPlugin` checks all the variants contained if there's a fiable candidate on the `$path` and uses this command to execute this, or a `shell` specific script. I've included a short description and added an example to the `BashedConfigMap`, so it runs on `Powershell` and `pwsh` shells as well. 

Please review and let me know if I can do anything to allow this change.  

