### PR TITLE
Correct explanation of ApendAll method in ResMap interface

### DIFF
--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -114,7 +114,7 @@ type ResMap interface {
 	Append(*resource.Resource) error
 
 	// AppendAll appends another ResMap to self,
-	// failing on any OrgId collision.
+	// failing on any CurId collision.
 	AppendAll(ResMap) error
 
 	// AbsorbAll appends, replaces or merges the contents


### PR DESCRIPTION
This commit corrects expalation of `ApendAll` method in `ResMap` interface. `AppendAll` method should fail on **CurId** collision, not **OrgId** collision.