### PR TITLE
Allow braces in image tag name (api)

### DIFF
--- a/api/builtins/ImageTagTransformer.go
+++ b/api/builtins/ImageTagTransformer.go
@@ -144,8 +144,10 @@ func (p *ImageTagTransformerPlugin) findContainers(obj map[string]interface{}) e
 }
 
 func isImageMatched(s, t string) bool {
-	// Tag values are limited to [a-zA-Z0-9_.-].
-	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.-]*)?$")
+	// Tag values are limited to [a-zA-Z0-9_.{}-].
+	// Some tools like Bazel rules_k8s allow tag patterns with {} characters.
+	// More info: https://github.com/bazelbuild/rules_k8s/pull/423
+	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.{}-]*)?$")
 	return pattern.MatchString(s)
 }
 

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -148,8 +148,10 @@ func (p *plugin) findContainers(obj map[string]interface{}) error {
 }
 
 func isImageMatched(s, t string) bool {
-	// Tag values are limited to [a-zA-Z0-9_.-].
-	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.-]*)?$")
+	// Tag values are limited to [a-zA-Z0-9_.{}-].
+	// Some tools like Bazel rules_k8s allow tag patterns with {} characters.
+	// More info: https://github.com/bazelbuild/rules_k8s/pull/423
+	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.{}-]*)?$")
 	return pattern.MatchString(s)
 }
 


### PR DESCRIPTION
Related PR with context: https://github.com/kubernetes-sigs/kustomize/pull/2137

This adds only the API change for supporting `{}` characters in an image tag name.