### PR TITLE
Updated README to use 'bases' instead of 'resources' in overlays examples

### DIFF
--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -148,7 +148,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
-resources:
+bases:
 - ../../base
 patchesStrategicMerge:
 - map.yaml
@@ -189,7 +189,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
-resources:
+bases:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml


### PR DESCRIPTION
In kustomize v2 `kustomization.yaml` can only refer to files in the same directory as itself, or in subdirectories. Only `bases` can refer to outside paths.

Please refer to: https://github.com/kubernetes-sigs/kustomize/issues/776