### PR TITLE
Generate network config

### DIFF
--- a/cmd/config/internal/commands/run-fns.go
+++ b/cmd/config/internal/commands/run-fns.go
@@ -89,6 +89,14 @@ func (r *RunFnRunner) getFunctions(c *cobra.Command, args, dataItems []string) (
 	if err != nil {
 		return nil, err
 	}
+	if r.Network {
+		err = fn.PipeE(
+			yaml.LookupCreate(yaml.MappingNode, "container", "network"),
+			yaml.SetField("required", yaml.NewScalarRNode("true")))
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// create the function config
 	rc, err := yaml.Parse(`

--- a/cmd/config/internal/commands/run_test.go
+++ b/cmd/config/internal/commands/run_test.go
@@ -101,7 +101,7 @@ metadata:
   name: function-input
   annotations:
     config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
+      container: {image: 'foo:bar', network: {required: true}}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -118,7 +118,7 @@ metadata:
   name: function-input
   annotations:
     config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
+      container: {image: 'foo:bar', network: {required: true}}
 data: {}
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
@pwittrock 

This PR is to fix the issue https://github.com/GoogleContainerTools/kpt/issues/334. By this, the declarative network config is generated when the --network flag is set.