### PR TITLE
Improve tests for AnnotationsTransformer

### DIFF
--- a/api/builtins/AnnotationsTransformer.go
+++ b/api/builtins/AnnotationsTransformer.go
@@ -19,7 +19,7 @@ type AnnotationsTransformerPlugin struct {
 
 	// YAMLSupport can be set to true to use the kyaml filter instead of the
 	// kunstruct transformer
-	YAMLSupport bool
+	YAMLSupport bool `json:"yamlSupport,omitempty" yaml:"yamlSupport,omitempty"`
 }
 
 func (p *AnnotationsTransformerPlugin) Config(

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
@@ -20,7 +20,7 @@ type plugin struct {
 
 	// YAMLSupport can be set to true to use the kyaml filter instead of the
 	// kunstruct transformer
-	YAMLSupport bool
+	YAMLSupport bool `json:"yamlSupport,omitempty" yaml:"yamlSupport,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -4,17 +4,14 @@
 package main_test
 
 import (
+	"fmt"
 	"testing"
 
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-func TestAnnotationsTransformer(t *testing.T) {
-	th := kusttest_test.MakeEnhancedHarness(t).
-		PrepBuiltin("AnnotationsTransformer")
-	defer th.Reset()
-
-	rm := th.LoadAndRunTransformer(`
+var (
+	config = `
 apiVersion: builtin
 kind: AnnotationsTransformer
 metadata:
@@ -22,10 +19,12 @@ metadata:
 annotations:
   app: myApp
   greeting/morning: a string with blanks
+yamlSupport: %v
 fieldSpecs:
   - path: metadata/annotations
     create: true
-`, `
+`
+	input = `
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,9 +32,8 @@ metadata:
 spec:
   ports:
   - port: 7002
-`)
-
-	th.AssertActualEqualsExpected(rm, `
+`
+	expectedOutput = `
 apiVersion: v1
 kind: Service
 metadata:
@@ -46,5 +44,20 @@ metadata:
 spec:
   ports:
   - port: 7002
-`)
+`
+)
+
+func TestAnnotationsTransformer(t *testing.T) {
+	for _, b := range []bool{true, false} {
+		t.Run(fmt.Sprintf("yaml-%v", b), func(t *testing.T) {
+			th := kusttest_test.MakeEnhancedHarness(t).
+				PrepBuiltin("AnnotationsTransformer")
+			defer th.Reset()
+
+			cfg := fmt.Sprintf(config, b)
+			rm := th.LoadAndRunTransformer(cfg, input)
+
+			th.AssertActualEqualsExpected(rm, expectedOutput)
+		})
+	}
 }


### PR DESCRIPTION
Run the tests for both the legacy and the kyaml implementation of the transformer.

@pwittrock @monopole 