### PR TITLE
Added support for helm v3 to ChartInflator plugin

### DIFF
--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -68,6 +68,7 @@ function parseYaml {
 }
 
 TMP_DIR=$(mktemp -d)
+HELM_VERSION=$(helm version --short)
 
 parseYaml $1
 
@@ -115,25 +116,18 @@ if [ -z "$releaseNamespace" ]; then
   releaseNamespace=default
 fi
 
-function doHelm {
-  $helmBin --home $helmHome $@
-}
+case $HELM_VERSION in
+  v2*)
+    source $(dirname ${BASH_SOURCE[0]})/ChartInflator.v2.functions
+  ;;
+  v1*)
+    source $(dirname ${BASH_SOURCE[0]})/ChartInflator.v3.functions
+  ;;
+  *)
+    echo "[!] Unsupported 'helm' version '${HELM_VERSION}'" && exit 1
+  ;;
+esac
 
-# The init command is extremely chatty
-doHelm init --client-only >& /dev/null
-
-if [ ! -d "$chartHome/$chartName" ]; then
-  doHelm fetch $chartVersionArg \
-      $chartRepoArg \
-      --untar \
-      --untardir $chartHome \
-      $chartNameArg
-fi
-
-doHelm template \
-    --name $releaseName \
-    --namespace $releaseNamespace \
-    --values $valuesFile \
-    $chartHome/$chartName
+doHelmChartInflation
 
 /bin/rm -rf $TMP_DIR

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -120,7 +120,7 @@ case $HELM_VERSION in
   v2*)
     source $(dirname ${BASH_SOURCE[0]})/ChartInflator.v2.functions
   ;;
-  v1*)
+  v3*)
     source $(dirname ${BASH_SOURCE[0]})/ChartInflator.v3.functions
   ;;
   *)

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator.v2.functions
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator.v2.functions
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# helm-v2 compatible functions
+
+function doHelm {
+  $helmBin --home $helmHome $@
+}
+
+function doHelmChartInflation {
+  # The init command is extremely chatty
+  doHelm init --client-only >& /dev/null
+  
+  if [ ! -d "$chartHome/$chartName" ]; then
+    doHelm fetch $chartVersionArg \
+        $chartRepoArg \
+        --untar \
+        --untardir $chartHome \
+        $chartNameArg
+  fi
+  
+  doHelm template \
+      --name $releaseName \
+      --namespace $releaseNamespace \
+      --values $valuesFile \
+      $chartHome/$chartName
+  
+}

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator.v3.functions
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator.v3.functions
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# helm-v3 compatible functions
+
+function doHelm {
+  XDG_CONFIG_DIR=$helmHome
+  $helmBin $@
+}
+
+function doHelmChartInflation {
+  
+  if [ ! -d "$chartHome/$chartName" ]; then
+    doHelm fetch $chartVersionArg \
+        $chartRepoArg \
+        --untar \
+        --untardir $chartHome \
+        $chartNameArg
+  fi
+  
+  doHelm template \
+      --name-template $releaseName \
+      --namespace $releaseNamespace \
+      --values $valuesFile \
+      $chartHome/$chartName
+  
+}


### PR DESCRIPTION
Some `helm` syntax has changed from [v2 to v3 [0]](https://helm.sh/docs/topics/v2_v3_migration/) so `helm` invocations from the script needed to be adapted.
In order to support both versions, I have splitted the plugin in 2 different functions files for the affected invocations. I hope it looks good :)

[0] https://helm.sh/docs/topics/v2_v3_migration/