### PR TITLE
Better support for testing tranformers with kyaml support

### DIFF
--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -4,7 +4,6 @@
 package main_test
 
 import (
-	"fmt"
 	"testing"
 
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
@@ -19,7 +18,6 @@ metadata:
 annotations:
   app: myApp
   greeting/morning: a string with blanks
-yamlSupport: %v
 fieldSpecs:
   - path: metadata/annotations
     create: true
@@ -48,16 +46,9 @@ spec:
 )
 
 func TestAnnotationsTransformer(t *testing.T) {
-	for _, b := range []bool{true, false} {
-		t.Run(fmt.Sprintf("yaml-%v", b), func(t *testing.T) {
-			th := kusttest_test.MakeEnhancedHarness(t).
-				PrepBuiltin("AnnotationsTransformer")
-			defer th.Reset()
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
 
-			cfg := fmt.Sprintf(config, b)
-			rm := th.LoadAndRunTransformer(cfg, input)
-
-			th.AssertActualEqualsExpected(rm, expectedOutput)
-		})
-	}
+	th.RunTransformerAndCheckResult(config, input, expectedOutput)
 }


### PR DESCRIPTION
This change pulls the logic for testing transformers with both `yamlSupport: false` and `yamlSupport: true` into the test harness. This is to avoid having to reproduce this logic in every test for the transformers.

@pwittrock @monopole 