### PR TITLE
Remove format filter for merge

### DIFF
--- a/kyaml/kio/filters/merge3.go
+++ b/kyaml/kio/filters/merge3.go
@@ -59,7 +59,7 @@ func (m Merge3) Merge() error {
 
 	return kio.Pipeline{
 		Inputs:  inputs,
-		Filters: []kio.Filter{m, FormatFilter{}}, // format the merged output
+		Filters: []kio.Filter{m},
 		Outputs: []kio.Writer{dest},
 	}.Execute()
 }


### PR DESCRIPTION
@pwittrock 

This PR is to remove format filter for merge to preserve input fields ordering.