### PR TITLE
Adding env variable containing the mode for exec plugins

### DIFF
--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -159,10 +159,14 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 		return nil, errors.Wrap(
 			err, "closing plugin config file "+f.Name())
 	}
+	mode := "generate"
+	if input != nil {
+		mode = "transform"
+	}
 	//nolint:gosec
 	cmd := exec.Command(
 		p.path, append([]string{f.Name()}, p.args...)...)
-	cmd.Env = p.getEnv()
+	cmd.Env = p.getEnv(mode)
 	cmd.Stdin = bytes.NewReader(input)
 	cmd.Stderr = os.Stderr
 	if _, err := os.Stat(p.h.Loader().Root()); err == nil {
@@ -177,11 +181,12 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 	return result, os.Remove(f.Name())
 }
 
-func (p *ExecPlugin) getEnv() []string {
+func (p *ExecPlugin) getEnv(mode string) []string {
 	env := os.Environ()
 	env = append(env,
 		"KUSTOMIZE_PLUGIN_CONFIG_STRING="+string(p.cfg),
-		"KUSTOMIZE_PLUGIN_CONFIG_ROOT="+p.h.Loader().Root())
+		"KUSTOMIZE_PLUGIN_CONFIG_ROOT="+p.h.Loader().Root(),
+		"KUSTOMIZE_PLUGIN_MODE="+mode)
 	return env
 }
 


### PR DESCRIPTION
It was mentioned in the exec-plugin documentation [1]
that there were plans to allow the same exec plugin
to be targeted by both the generators and transformers.
The proposal was - to add some additional arguments, but
the consequences would be - it would affect all currently
existing plugins. This change proposal won't break anything,
because it adds this as a new env variable 
KUSTOMIZE_PLUGIN_MODE in addition to the previously 
existing env variables. 
KUSTOMIZE_PLUGIN_MODE can have the following values:
'generate' or 'transform'.

[1] https://github.com/kubernetes-sigs/kustomize/tree/master/docs/plugins#exec-plugins