### PR TITLE
Allow Exec plugins to be generators and transformers without need to register 2 GVK

### DIFF
--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -106,7 +106,7 @@ func (p *ExecPlugin) processOptionalArgsFields() error {
 }
 
 func (p *ExecPlugin) Generate() (resmap.ResMap, error) {
-	output, err := p.invokePlugin(nil)
+	output, err := p.invokePlugin(nil, "generate")
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (p *ExecPlugin) Transform(rm resmap.ResMap) error {
 	}
 
 	// invoke the plugin with resources as the input
-	output, err := p.invokePlugin(resources)
+	output, err := p.invokePlugin(resources, "transform")
 	if err != nil {
 		return fmt.Errorf("%v %s", err, string(output))
 	}
@@ -143,7 +143,7 @@ func (p *ExecPlugin) Transform(rm resmap.ResMap) error {
 // invokePlugin writes plugin config to a temp file, then
 // passes the full temp file path as the first arg to a process
 // running the plugin binary.  Process output is returned.
-func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
+func (p *ExecPlugin) invokePlugin(input []byte, mode string) ([]byte, error) {
 	f, err := ioutil.TempFile("", tmpConfigFilePrefix)
 	if err != nil {
 		return nil, errors.Wrap(
@@ -158,10 +158,6 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(
 			err, "closing plugin config file "+f.Name())
-	}
-	mode := "generate"
-	if input != nil {
-		mode = "transform"
 	}
 	//nolint:gosec
 	cmd := exec.Command(

--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -159,10 +159,14 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 		return nil, errors.Wrap(
 			err, "closing plugin config file "+f.Name())
 	}
+	mode := "generate"
+	if input != nil {
+		mode = "transform"
+	}
 	//nolint:gosec
 	cmd := exec.Command(
 		p.path, append([]string{f.Name()}, p.args...)...)
-	cmd.Env = p.getEnv()
+	cmd.Env = p.getEnv(mode)
 	cmd.Stdin = bytes.NewReader(input)
 	cmd.Stderr = os.Stderr
 	if _, err := os.Stat(p.h.Loader().Root()); err == nil {
@@ -177,11 +181,12 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 	return result, os.Remove(f.Name())
 }
 
-func (p *ExecPlugin) getEnv() []string {
+func (p *ExecPlugin) getEnv(mode string) []string {
 	env := os.Environ()
 	env = append(env,
 		"KUSTOMIZE_PLUGIN_CONFIG_STRING="+string(p.cfg),
-		"KUSTOMIZE_PLUGIN_CONFIG_ROOT="+p.h.Loader().Root())
+		"KUSTOMIZE_PLUGIN_CONFIG_ROOT="+p.h.Loader().Root(),
+		"KUSTOMIZE_PLUGIN_MODE="+mode)
 	return env
 }
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -208,17 +208,13 @@ single argument on its command line - the name of
 a YAML file containing its configuration (the file name
 provided in the kustomization file).
 
-> TODO: restrictions on plugin to allow the _same exec
-> plugin_ to be targeted by both the
-> `generators` and `transformers` fields.
+> NOTE: the same exec plugin is allowd to be used as
+> `generators` and `transformers`.
 >
-> - first arg could be the fixed string
->   `generate` or `transform`,
->   (the name of the configuration file moves to
->   the 2nd arg), or
-> - or by default an exec plugin behaves as a tranformer
->   unless a flag `-g` is provided, switching the
->   exec plugin to behave as a generator.
+> The special environment variable KUSTOMIZE_PLUGIN_MODE
+> is passed to the plugin and can take the following values:
+> - `generate` if the plugin is called as `generator`, or
+> - `transform` if the plugin is called as `transformer`.
 
 [helm chart inflator]: ../../plugin/someteam.example.com/v1/chartinflator
 [bashed config map]: ../../plugin/someteam.example.com/v1/bashedconfigmap


### PR DESCRIPTION
It was mentioned in the exec-plugin documentation [1]
that there were plans to allow the same exec plugin
to be targeted by both the generators and transformers.
The proposal was - to add some additional arguments, but
the consequences would be - it would affect all currently
existing plugins. This change proposal won't break anything,
because it adds this as a new env variable
KUSTOMIZE_PLUGIN_MODE in addition to the previously
existing env variables.
KUSTOMIZE_PLUGIN_MODE can have the following values:
'generate' or 'transform'.

[1] https://github.com/kubernetes-sigs/kustomize/tree/master/docs/plugins#exec-plugins