### PR TITLE
Fix issue with kyaml json unmarshalling

### DIFF
--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -697,7 +697,17 @@ func (rn *RNode) MarshalJSON() ([]byte, error) {
 }
 
 func (rn *RNode) UnmarshalJSON(b []byte) error {
-	r, err := Parse(string(b))
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+
+	c, err := Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	r, err := Parse(string(c))
 	if err != nil {
 		return err
 	}

--- a/kyaml/yaml/types_test.go
+++ b/kyaml/yaml/types_test.go
@@ -50,20 +50,57 @@ spec:
 }
 
 func TestRNode_UnmarshalJSON(t *testing.T) {
-	instance := &RNode{}
-	err := instance.UnmarshalJSON([]byte(`{"hello":"world"}`))
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	actual, err := instance.String()
-	if !assert.NoError(t, err) {
-		t.FailNow()
+	testCases := []struct {
+		testName string
+		input    string
+		output   string
+	}{
+		{
+			testName: "simple document",
+			input:    `{"hello":"world"}`,
+			output:   `hello: world`,
+		},
+		{
+			testName: "nested structure",
+			input: `
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "my-deployment",
+    "namespace": "default"
+  }
+}
+`,
+			output: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  namespace: default
+`,
+		},
 	}
 
-	expected := `{"hello": "world"}`
-	if !assert.Equal(t,
-		strings.TrimSpace(expected), strings.TrimSpace(actual)) {
-		t.FailNow()
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.testName, func(t *testing.T) {
+			instance := &RNode{}
+			err := instance.UnmarshalJSON([]byte(tc.input))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			actual, err := instance.String()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			if !assert.Equal(t,
+				strings.TrimSpace(tc.output), strings.TrimSpace(actual)) {
+				t.FailNow()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
`UnmarshalJSON` tries to parse json directly, but this doesn't work properly. With this change it will first parse the json into a map, then marshall that map into yaml, before finally parsing the yaml into an `RNode`. This also matches the implementation of `MarshalJSON`.

@pwittrock 