### PR TITLE
Respect value of disableNameSuffixHash when specifiying GeneratorOptions per resource.

### DIFF
--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -159,7 +159,7 @@ func (rf *Factory) MakeConfigMap(
 		u,
 		types.NewGenArgs(
 			&types.GeneratorArgs{Behavior: args.Behavior},
-			options)), nil
+			mergeGeneratorOptions(options, args.GeneratorOptions))), nil
 }
 
 // MakeSecret makes an instance of Resource for Secret
@@ -175,5 +175,20 @@ func (rf *Factory) MakeSecret(
 		u,
 		types.NewGenArgs(
 			&types.GeneratorArgs{Behavior: args.Behavior},
-			options)), nil
+			mergeGeneratorOptions(options, args.GeneratorOptions))), nil
+}
+
+func mergeGeneratorOptions(a, b *types.GeneratorOptions) *types.GeneratorOptions {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+
+	r := *a
+	if b.DisableNameSuffixHash {
+		r.DisableNameSuffixHash = true
+	}
+	return &r
 }


### PR DESCRIPTION
#2182 added the ability to specify GeneratorOptions per resource (instead of globally per kustomization), but it didn't take into account `disableNameSuffixHash`. It would use the value from the global options, ignoring the per-resource one.

This PR fixes this behavior, respecting both the global and per-resource `disableNameSuffixHash` flags. 