### PR TITLE
Show prow build instead of deprecated travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ and it's like [`sed`], in that it emits edited text.
 This tool is sponsored by [sig-cli] ([KEP]), and
 inspired by [DAM].
 
-
-[![Build Status](https://travis-ci.org/kubernetes-sigs/kustomize.svg?branch=master)](https://travis-ci.org/kubernetes-sigs/kustomize)
+[![Build Status](https://prow.k8s.io/badge.svg?jobs=kustomize-presubmit-master)](https://prow.k8s.io/job-history/kubernetes-jenkins/pr-logs/directory/kustomize-presubmit-master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/kustomize)](https://goreportcard.com/report/github.com/kubernetes-sigs/kustomize)
 
 Download a binary from the [release page], or see


### PR DESCRIPTION
Oops.  Should have changed this when we deprecated travis builds.