### PR TITLE
Print file difference like git diff

### DIFF
--- a/kyaml/copyutil/copyutil.go
+++ b/kyaml/copyutil/copyutil.go
@@ -121,15 +121,21 @@ func Diff(sourceDir, destDir string) (sets.String, error) {
 			return diff, err
 		}
 		if !bytes.Equal(b1, b2) {
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(string(b1), string(b2), false)
-			fmt.Println(dmp.DiffPrettyText(diffs))
+			fmt.Println(PrettyFileDiff(string(b1), string(b2)))
 			diff.Insert(f)
 		}
 	}
-
 	// return the differing files
 	return diff, nil
+}
+
+// PrettyFileDiff takes the content of two files and returns the pretty diff
+func PrettyFileDiff(s1, s2 string) string {
+	dmp := diffmatchpatch.New()
+	wSrc, wDst, warray := dmp.DiffLinesToRunes(s1, s2)
+	diffs := dmp.DiffMainRunes(wSrc, wDst, false)
+	diffs = dmp.DiffCharsToLines(diffs, warray)
+	return dmp.DiffPrettyText(diffs)
 }
 
 // SyncFile copies file from src file path to a dst file path by replacement

--- a/kyaml/copyutil/copyutil_test.go
+++ b/kyaml/copyutil/copyutil_test.go
@@ -261,3 +261,25 @@ func TestSyncFileNoSrcFile(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "no such file or directory"))
 }
+
+func TestPrettyFileDiff(t *testing.T) {
+	s1 := `apiVersion: someversion/v1alpha2
+kind: ContainerCluster
+metadata:
+  clusterName: "some_cluster"
+  name: asm-cluster
+  namespace: "PROJECT_ID" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}`
+
+	s2 := `apiVersion: someversion/v1alpha2
+kind: ContainerCluster
+metadata:
+  clusterName: "some_cluster"
+  name: asm-cluster
+  namespace: "some_project" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}`
+
+	expectedLine1 := `[31m  namespace: "PROJECT_ID" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}`
+	expectedLine2 := `[32m  namespace: "some_project" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}`
+
+	assert.Contains(t, PrettyFileDiff(s1, s2), expectedLine1)
+	assert.Contains(t, PrettyFileDiff(s1, s2), expectedLine2)
+}


### PR DESCRIPTION
@pwittrock 

This PR changes the way kyaml prints the diff. This aligns with git diff style

Before: 
![image](https://user-images.githubusercontent.com/58999035/79396102-0c50c880-7f30-11ea-9a55-43e1a2332836.png)

After this change:
![image](https://user-images.githubusercontent.com/58999035/79396137-1c68a800-7f30-11ea-8a9b-a17aaa3d5f41.png)

