### PR TITLE
Plugin flow doc improvements and a new option for the plugin loader

### DIFF
--- a/api/internal/plugins/compiler/compiler.go
+++ b/api/internal/plugins/compiler/compiler.go
@@ -119,7 +119,7 @@ func (b *Compiler) Compile(g, v, k string) error {
 	lowK := strings.ToLower(k)
 	objDir := filepath.Join(b.objRoot, g, v, lowK)
 	objFile := filepath.Join(objDir, k) + ".so"
-	if RecentFileExists(objFile) {
+	if FileYoungerThan(objFile, time.Minute) {
 		// Skip rebuilding it.
 		return nil
 	}
@@ -134,7 +134,6 @@ func (b *Compiler) Compile(g, v, k string) error {
 		if !FileExists(s) {
 			return fmt.Errorf(
 				"cannot find source at '%s' or '%s'", srcFile, s)
-
 		}
 		srcFile = s
 	}
@@ -160,17 +159,15 @@ func (b *Compiler) Compile(g, v, k string) error {
 	return nil
 }
 
-// True if file less than 3 minutes old, i.e. not
-// accidentally left over from some earlier build.
-func RecentFileExists(path string) bool {
+// FileYoungerThan returns true if the file age is <= the Duration argument.
+func FileYoungerThan(path string, d time.Duration) bool {
 	fi, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false
 		}
 	}
-	age := time.Since(fi.ModTime())
-	return age.Minutes() < 3
+	return time.Since(fi.ModTime()) <= d
 }
 
 func FileExists(name string) bool {

--- a/api/internal/plugins/compiler/compiler_test.go
+++ b/api/internal/plugins/compiler/compiler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/kustomize/api/filesys"
 	. "sigs.k8s.io/kustomize/api/internal/plugins/compiler"
@@ -38,7 +39,7 @@ func TestCompiler(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !RecentFileExists(expectObj) {
+	if !FileYoungerThan(expectObj, time.Second) {
 		t.Errorf("didn't find expected obj file %s", expectObj)
 	}
 
@@ -52,7 +53,7 @@ func TestCompiler(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !RecentFileExists(expectObj) {
+	if !FileYoungerThan(expectObj, time.Second) {
 		t.Errorf("didn't find expected obj file %s", expectObj)
 	}
 

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -19,8 +18,7 @@ import (
 // high level tests.
 
 func TestMakeCustomizedResMap(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
-	th := kusttest_test.MakeHarnessWithFs(t, fSys)
+	th := kusttest_test.MakeHarness(t)
 	th.WriteK("/whatever", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -168,7 +166,7 @@ metadata:
 	}
 
 	actual, err := makeKustTargetWithRf(
-		t, fSys, "/whatever", resFactory).MakeCustomizedResMap()
+		t, th.GetFSys(), "/whatever", resFactory).MakeCustomizedResMap()
 	if err != nil {
 		t.Fatalf("unexpected Resources error %v", err)
 	}

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -70,7 +70,8 @@ func (th Harness) MakeOptionsPluginsDisabled() krusty.Options {
 
 // Enables use of non-builtin plugins.
 func (th Harness) MakeOptionsPluginsEnabled() krusty.Options {
-	c, err := konfig.EnabledPluginConfig()
+	// TODO: Change to types.BploLoadFromFileSys to enable debugging.
+	c, err := konfig.EnabledPluginConfig(types.BploUseStaticallyLinked)
 	if err != nil {
 		if strings.Contains(err.Error(), "unable to find plugin root") {
 			th.t.Log(

--- a/api/testutils/kusttest/plugintestenv.go
+++ b/api/testutils/kusttest/plugintestenv.go
@@ -16,10 +16,10 @@ import (
 	"sigs.k8s.io/kustomize/api/konfig"
 )
 
-// pluginTestEnv manages plugins for tests.
+// pluginTestEnv manages compiling plugins for tests.
 // It manages a Go plugin compiler,
-// makes and removes a temporary working directory,
-// and sets/resets shell env vars as needed.
+// maybe makes and removes a temporary working directory,
+// maybe sets/resets shell env vars as needed.
 type pluginTestEnv struct {
 	t        *testing.T
 	compiler *compiler.Compiler
@@ -56,19 +56,19 @@ func (x *pluginTestEnv) reset() {
 	x.removeWorkDir()
 }
 
-// buildGoPlugin compiles a Go plugin, leaving the newly
+// prepareGoPlugin compiles a Go plugin, leaving the newly
 // created object code in the right place - a temporary
-// working  directory pointed to by KustomizePluginHomeEnv.
+// working directory pointed to by KustomizePluginHomeEnv.
 // This avoids overwriting anything the user/developer has
 // otherwise created.
-func (x *pluginTestEnv) buildGoPlugin(g, v, k string) {
+func (x *pluginTestEnv) prepareGoPlugin(g, v, k string) {
 	err := x.compiler.Compile(g, v, k)
 	if err != nil {
 		x.t.Errorf("compile failed: %v", err)
 	}
 }
 
-// prepExecPlugin copies an exec plugin from it's
+// prepareExecPlugin copies an exec plugin from it's
 // home in the discovered srcRoot to the same temp
 // directory where Go plugin object code is placed.
 // Kustomize (and its tests) expect to find plugins
@@ -76,7 +76,7 @@ func (x *pluginTestEnv) buildGoPlugin(g, v, k string) {
 // framework is compiling Go plugins to a temp dir,
 // it must likewise copy Exec plugins to that same
 // temp dir.
-func (x *pluginTestEnv) prepExecPlugin(g, v, k string) {
+func (x *pluginTestEnv) prepareExecPlugin(g, v, k string) {
 	lowK := strings.ToLower(k)
 	src := filepath.Join(x.srcRoot, g, v, lowK, k)
 	tmp := filepath.Join(x.workDir, g, v, lowK, k)

--- a/api/types/pluginconfig.go
+++ b/api/types/pluginconfig.go
@@ -10,22 +10,23 @@ type PluginConfig struct {
 	// containing the fields 'apiVersion' and 'kind', e.g.
 	//   apiVersion: apps/v1
 	//   kind: Deployment
-	// When kustomize reads a plugin configuration file (as as result
-	// of seeing the file name in the 'generators:' or 'transformers:'
-	// field in a kustomization file), it must then locate the plugin
-	// code (Go plugin or exec plugin).
-	// Every kustomize plugin (its code, its tests, supporting data
+	// kustomize reads plugin configuration data from a file path
+	// specified in the 'generators:' or 'transformers:' field of a
+	// kustomization file.  kustomize must then use this data to both
+	// locate the plugin and configure it.
+	// Every kustomize plugin (its code, its tests, its supporting data
 	// files, etc.) must be housed in its own directory at
 	//   ${AbsPluginHome}/${pluginApiVersion}/LOWERCASE(${pluginKind})
 	// where
 	//   - ${AbsPluginHome} is an absolute path, defined below.
 	//   - ${pluginApiVersion} is taken from the plugin config file.
 	//   - ${pluginKind} is taken from the plugin config file.
-	// The value of AbsPluginHome can be any absolute path, but might
-	// default to $XDG_CONFIG_HOME/kustomize/plugin.
+	// The value of AbsPluginHome can be any absolute path.
 	AbsPluginHome string
 
-	// PluginRestrictions defines the plugin restriction state.
-	// See type for more information.
+	// PluginRestrictions distinguishes plugin restrictions.
 	PluginRestrictions PluginRestrictions
+
+	// BpLoadingOptions distinguishes builtin plugin behaviors.
+	BpLoadingOptions BuiltinPluginLoadingOptions
 }

--- a/api/types/pluginrestrictions.go
+++ b/api/types/pluginrestrictions.go
@@ -26,3 +26,18 @@ const (
 	// No restrictions, do whatever you want.
 	PluginRestrictionsNone
 )
+
+// BuiltinPluginLoadingOptions distinguish ways in which builtin plugins are used.
+//go:generate stringer -type=BuiltinPluginLoadingOptions
+type BuiltinPluginLoadingOptions int
+
+const (
+	BploUndefined BuiltinPluginLoadingOptions = iota
+
+	// Desired in production use for performance.
+	BploUseStaticallyLinked
+
+	// Desired in testing and development cycles where it's undesirable
+	// to generate static code.
+	BploLoadFromFileSys
+)

--- a/hack/buildExternalGoPlugins.sh
+++ b/hack/buildExternalGoPlugins.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 set -e
 
 # Builds or removes Go plugin object code.
@@ -40,8 +40,8 @@ function removePlugin {
 }
 
 goPlugins=$(
-  find $root -name "*.go" | 
-  grep -v builtin/ | 
+  find $root -name "*.go" |
+  grep -v builtin/ |
   xargs grep -l "var KustomizePlugin")
 
 for p in $goPlugins; do

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 )
 
@@ -107,7 +108,7 @@ func (o *Options) makeOptions() *krusty.Options {
 		DoPrune:              false,
 	}
 	if isFlagEnablePluginsSet() {
-		c, err := konfig.EnabledPluginConfig()
+		c, err := konfig.EnabledPluginConfig(types.BploUseStaticallyLinked)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Fix (or provide) some API comments and add a new plugin loader option to 
load builtins from disk instead of always using the statically linked version.

This PR leaves execution alone, but a subsequent change will use the new
option in tests to improve plugin development flow.


