### PR TITLE
Start adding helm3 to ChartInflator and its coverage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,18 +261,31 @@ $(MYGOBIN)/kubeval:
 	)
 
 # linux only.
-# This is for testing an example plugin that
-# uses helm to inflate a chart for subsequent kustomization.
-# Don't want to add a hard dependence in go.mod file
-# to helm.
-# Instead, download the binary.
-$(MYGOBIN)/helm:
+# This is for testing an example plugin that uses helm to inflate a chart
+# for subsequent kustomization.
+# Don't want to add a hard dependence in go.mod file to helm.
+# Instead, download the binaries.
+$(MYGOBIN)/helmV2:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		wget https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz; \
-		tar -xvzf helm-v2.13.1-linux-amd64.tar.gz; \
-		mv linux-amd64/helm $(MYGOBIN); \
+		tgzFile=helm-v2.13.1-linux-amd64.tar.gz; \
+		wget https://storage.googleapis.com/kubernetes-helm/$$tgzFile; \
+		tar -xvzf $$tgzFile; \
+		mv linux-amd64/helm $(MYGOBIN)/helmV2; \
+		rm -rf $$d \
+	)
+
+# Helm V3 differs from helm V2; downloading it to provide coverage for the
+# chart inflator plugin under helm v3.
+$(MYGOBIN)/helmV3:
+	( \
+		set -e; \
+		d=$(shell mktemp -d); cd $$d; \
+		tgzFile=helm-v3.2.0-rc.1-linux-amd64.tar.gz; \
+		wget https://get.helm.sh/$$tgzFile; \
+		tar -xvzf $$tgzFile; \
+		mv linux-amd64/helm $(MYGOBIN)/helmV3; \
 		rm -rf $$d \
 	)
 

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -115,25 +115,69 @@ if [ -z "$releaseNamespace" ]; then
   releaseNamespace=default
 fi
 
-function doHelm {
-  $helmBin --home $helmHome $@
+function v2RunHelm {
+  $helmBin --home $helmHome "$@"
 }
 
-# The init command is extremely chatty
-doHelm init --client-only >& /dev/null
+function v3RunHelm {
+  XDG_CONFIG_DIR=$helmHome
+  $helmBin "$@"
+}
 
-if [ ! -d "$chartHome/$chartName" ]; then
-  doHelm fetch $chartVersionArg \
-      $chartRepoArg \
-      --untar \
-      --untardir $chartHome \
-      $chartNameArg
-fi
+function v2InitHelm {
+  # The init command is extremely chatty
+  v2RunHelm init --client-only >& /dev/null
+}
 
-doHelm template \
-    --name $releaseName \
-    --namespace $releaseNamespace \
-    --values $valuesFile \
-    $chartHome/$chartName
+function v3InitHelm {
+  # Do nothing - there's no init command in helm v3
+  true
+}
+
+function v2PullChart {
+  if [ ! -d "$chartHome/$chartName" ]; then
+    v2RunHelm fetch $chartVersionArg \
+        $chartRepoArg \
+        --untar \
+        --untardir $chartHome \
+        $chartNameArg
+  fi
+}
+
+function v3PullChart {
+  # TODO implement
+  echo "?? helmV3 pull --repo https://hub.helm.sh/charts/ stable/minecraft  --destination /tmp/junk"
+}
+
+function v2InflateChart {
+  v2RunHelm template \
+      --name $releaseName \
+      --namespace $releaseNamespace \
+      --values $valuesFile \
+      $chartHome/$chartName
+}
+
+function v3InflateChart {
+  # TODO implement
+  true
+}
+
+HELM_VERSION=$($helmBin version -c --short)
+
+case $HELM_VERSION in
+  'Client: v2'*)
+    v2InitHelm
+    v2PullChart
+    v2InflateChart
+  ;;
+  v3*)
+    v3InitHelm
+    v3PullChart
+    v3InflateChart
+  ;;
+  *)
+    echo "[!] Unsupported 'helm' version '${HELM_VERSION}'" 1>&2 && exit 1
+  ;;
+esac
 
 /bin/rm -rf $TMP_DIR


### PR DESCRIPTION
Took a pass at the work started in #2321 (which might be covid19-abandoned?)

@rcmorano Can you sign off on this, then continue it, filling in the unimplemented bash functions?

I timeboxed it but ran out of time, so this PR just add the make target to get helmv3 and sets up a test for it, and a bash skeleton.

To run the test

go test -v -run TestHelmV3ChartInflator \
   ./plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go

after removing "disabled_" from the test name.
