### PR TITLE
Adjust scripts to allow either Go v.13 or Go v1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,6 @@ test-go-mod:
 	./travis/check-go-mod.sh
 
 .PHONY:
-test-examples-kustomize-against-HEAD: $(MYGOBIN)/kustomize $(MYGOBIN)/mdrip
-	./hack/testExamplesAgainstKustomize.sh HEAD
-
-.PHONY:
 test-examples-e2e-kustomize: $(MYGOBIN)/mdrip $(MYGOBIN)/kind
 	( \
 		set -e; \
@@ -233,12 +229,16 @@ test-examples-e2e-kustomize: $(MYGOBIN)/mdrip $(MYGOBIN)/kind
 	)
 
 .PHONY:
+test-examples-kustomize-against-HEAD: $(MYGOBIN)/kustomize $(MYGOBIN)/mdrip
+	./hack/testExamplesAgainstKustomize.sh HEAD
+
+.PHONY:
 test-examples-kustomize-against-latest: $(MYGOBIN)/mdrip
 	( \
 		set -e; \
 		/bin/rm -f $(MYGOBIN)/kustomize; \
 		echo "Installing kustomize from latest."; \
-		GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v3; \
+		GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4; \
 		./hack/testExamplesAgainstKustomize.sh latest; \
 		echo "Reinstalling kustomize from HEAD."; \
 		cd kustomize; go install .; \
@@ -288,6 +288,10 @@ $(MYGOBIN)/helmV3:
 		mv linux-amd64/helm $(MYGOBIN)/helmV3; \
 		rm -rf $$d \
 	)
+
+# Default version of helm is v2 for the time being.
+$(MYGOBIN)/helm: $(MYGOBIN)/helmV2
+	ln -s $(MYGOBIN)/helmV2 $(MYGOBIN)/helm
 
 $(MYGOBIN)/kind:
 	( \

--- a/hack/shellHelpers.sh
+++ b/hack/shellHelpers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO: Make the code ignorant of the CI environment "brand name".
+# We used to run CI tests on travis, and disabled certain tests
+# when running there.  Now we run on Prow, so look for that.
+# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md
+# Might be useful to eschew using the brand name of the CI environment
+# (replace "travis" with "RemoteCI" or something - not just switch to "prow").
+
+function onLinuxAndNotOnRemoteCI {
+  [[ ("linux" == "$(go env GOOS)") && (-z ${PROW_JOB_ID+x}) ]] && return
+  false
+}

--- a/hack/testExamplesAgainstKustomize.sh
+++ b/hack/testExamplesAgainstKustomize.sh
@@ -9,10 +9,8 @@ set -o pipefail
 
 version=$1
 
-function onLinuxAndNotOnTravis {
-  [[ ("linux" == "$(go env GOOS)") && (-z ${TRAVIS+x}) ]] && return
-  false
-}
+# All hack scripts should run from top level.
+. hack/shellHelpers.sh
 
 # TODO: change the label?
 # We test against the latest release, and HEAD, and presumably
@@ -22,13 +20,12 @@ mdrip --mode test \
     --label testAgainstLatestRelease examples
 
 # TODO: make work for non-linux
-if onLinuxAndNotOnTravis; then
-  echo "On linux, and not on travis, so running the notravis example tests."
+if onLinuxAndNotOnRemoteCI; then
+  echo "On linux, and not on remote CI.  Running expensive tests."
 
   # Requires helm.
   make $(go env GOPATH)/bin/helm
-  mdrip --mode test \
-      --label helmtest examples/chart.md
+  mdrip --mode test --label helmtest examples/chart.md
 fi
 
 echo "Example tests passed against ${version}."


### PR DESCRIPTION
The Makefile target  `test-examples-kustomize-against-latest`
fails under go v1.14.2 but works under v.13.6

This change allows the test to work under either Go 1.13 or 1.14.

Not changing go.mod files in this PR.

Go 1.13 still fine.
