### PR TITLE
Migrate setters from v1 to v2

### DIFF
--- a/cmd/config/configcobra/cmds.go
+++ b/cmd/config/configcobra/cmds.go
@@ -53,6 +53,7 @@ var (
 	Fmt                = commands.FmtCommand
 	Grep               = commands.GrepCommand
 	ListSetters        = commands.ListSettersCommand
+	MigrateSetters     = commands.MigrateSettersCommand
 	Merge              = commands.MergeCommand
 	Merge3             = commands.Merge3Command
 	RunFn              = commands.RunFnCommand
@@ -107,6 +108,7 @@ func NewConfigCommand(name string) *cobra.Command {
 
 	root.AddCommand(commands.SetCommand(name))
 	root.AddCommand(commands.ListSettersCommand(name))
+	root.AddCommand(commands.MigrateSettersCommand(name))
 	root.AddCommand(commands.CreateSetterCommand(name))
 	root.AddCommand(commands.CreateSubstitutionCommand(name))
 	root.AddCommand(commands.SinkCommand(name))

--- a/cmd/config/docs/commands/migrate-setters.md
+++ b/cmd/config/docs/commands/migrate-setters.md
@@ -1,0 +1,19 @@
+## set
+
+Migrate setters for Resources.
+
+### Synopsis
+
+Migrate setters for Resources.
+
+  DIR
+
+    A directory containing Resource configuration.
+
+### Examples
+
+  Migrate setters:
+
+    # migrate setters from v1 to v2 with openAPI
+    $ kustomize cfg migrate-setters hello-world/
+    migrated 2 setters

--- a/cmd/config/go.mod
+++ b/cmd/config/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	k8s.io/apimachinery v0.17.0
-	sigs.k8s.io/kustomize/kyaml v0.0.0
+	sigs.k8s.io/kustomize/kyaml v0.1.4
 )
 
-replace sigs.k8s.io/kustomize/kyaml v0.0.0 => ../../kyaml
+replace sigs.k8s.io/kustomize/kyaml v0.1.4 => ../../kyaml

--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -42,7 +42,7 @@ func ListSettersCommand(parent string) *cobra.Command {
 
 type ListSettersRunner struct {
 	Command  *cobra.Command
-	Lookup   setters.LookupSetters
+	Lookup   setters.LookupDeleteSetters
 	List     setters2.List
 	Markdown bool
 }

--- a/cmd/config/internal/commands/cmdmigratesetters.go
+++ b/cmd/config/internal/commands/cmdmigratesetters.go
@@ -1,0 +1,95 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/cmd/config/ext"
+	"sigs.k8s.io/kustomize/cmd/config/internal/generateddocs/commands"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/setters"
+	"sigs.k8s.io/kustomize/kyaml/setters2/settersutil"
+)
+
+// NewMigrateSettersRunner returns a command runner.
+func NewMigrateSettersRunner(parent string) *MigrateSettersRunner {
+	r := &MigrateSettersRunner{}
+	c := &cobra.Command{
+		Use:     "migrate-setters DIR",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   commands.MigrateSettersShort,
+		Long:    commands.MigrateSettersLong,
+		Example: commands.MigrateSettersExamples,
+		RunE:    r.runE,
+	}
+	fixDocs(parent, c)
+	r.Command = c
+	return r
+}
+
+func MigrateSettersCommand(parent string) *cobra.Command {
+	return NewMigrateSettersRunner(parent).Command
+}
+
+type MigrateSettersRunner struct {
+	Command *cobra.Command
+	Lookup  setters.LookupDeleteSetters
+}
+
+func (r *MigrateSettersRunner) runE(c *cobra.Command, args []string) error {
+	// list v1 setters and delete them from resource files
+	r.Lookup.Delete = true
+	rw := &kio.LocalPackageReadWriter{
+		PackagePath: args[0],
+	}
+	err := kio.Pipeline{
+		Inputs:  []kio.Reader{rw},
+		Filters: []kio.Filter{&r.Lookup},
+		Outputs: []kio.Writer{rw},
+	}.Execute()
+	if err != nil {
+		return err
+	}
+
+	openAPIPath, err := ext.GetOpenAPIFile(args)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(openAPIPath)
+	if err != nil {
+		return err
+	}
+
+	// for each v1 setter, create the equivalent in v2 partial setters
+	// can't be converted to substitutions due to not enough information,
+	// they should be manually created by user
+	migratedCount := 0
+	for _, setter := range r.Lookup.SetterCounts {
+		sc := settersutil.SetterCreator{
+			Name:          setter.Name,
+			FieldValue:    setter.Value,
+			Description:   setter.Description,
+			SetBy:         setter.SetBy,
+			Type:          setter.Type,
+			ResourcesPath: args[0],
+			OpenAPIPath:   openAPIPath,
+		}
+		err = kio.Pipeline{
+			Inputs:  []kio.Reader{rw},
+			Filters: []kio.Filter{&sc},
+			Outputs: []kio.Writer{rw},
+		}.Execute()
+		if err != nil {
+			fmt.Fprintf(c.OutOrStdout(), "encountered error: %s while migrating setter %s\n", err.Error(), setter.Name)
+		} else {
+			migratedCount++
+		}
+	}
+	fmt.Fprintf(c.OutOrStdout(), "migrated %d setters\n", migratedCount)
+	return nil
+}

--- a/cmd/config/internal/commands/cmdmigratesetters_test.go
+++ b/cmd/config/internal/commands/cmdmigratesetters_test.go
@@ -1,0 +1,252 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/cmd/config/internal/commands"
+)
+
+func TestMigrateSettersCommand(t *testing.T) {
+	var tests = []struct {
+		name            string
+		input           string
+		err             string
+		openAPIFile     string
+		expectedOutput  string
+		expectedOpenAPI string
+	}{
+		{
+			name: "migrate-setters-delete-partial-setters",
+			input: `
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"cluster-name","value":"cluster-name"},{"name":"gcloud.compute.zone","value":"us-east1-d"}]}}
+spec:
+  profile: asm # {"type":"string","x-kustomize":{"setter":{"name":"profilesetter","value":"asm"}}}
+  hub:
+  - --gcr.io/asm-testing # {"type":"string","x-kustomize":{"setter":{"name":"hubsetter","value":"--gcr.io/asm-testing"}}}
+  - --gcr.io/asm-testing2
+ `,
+
+			openAPIFile: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization`,
+
+			expectedOutput: `apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"$ref":"#/definitions/io.k8s.cli.setters.profilesetter"}
+  hub:
+  - --gcr.io/asm-testing # {"$ref":"#/definitions/io.k8s.cli.setters.hubsetter"}
+  - --gcr.io/asm-testing2
+`,
+
+			expectedOpenAPI: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization
+openAPI:
+  definitions:
+    io.k8s.cli.setters.cluster-name:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: cluster-name
+          value: cluster-name
+    io.k8s.cli.setters.gcloud.compute.zone:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.compute.zone
+          value: us-east1-d
+    io.k8s.cli.setters.gcloud.core.project:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.core.project
+          value: project-id
+    io.k8s.cli.setters.hubsetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: hubsetter
+          value: --gcr.io/asm-testing
+    io.k8s.cli.setters.profilesetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: profilesetter
+          value: asm
+`,
+		},
+		{
+			name: "migrate-setters-with-both-versions",
+
+			input: `
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"type":"string","x-kustomize":{"setter":{"name":"profilesetter","value":"asm"}}}
+  hub: gcr.io/asm-testing # {"$ref":"#/definitions/io.k8s.cli.setters.hubsetter"}
+ `,
+
+			openAPIFile: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization
+openAPI:
+  definitions:
+    io.k8s.cli.setters.hubsetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: hubsetter
+          value: gcr.io/asm-testing`,
+
+			expectedOutput: `apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"$ref":"#/definitions/io.k8s.cli.setters.profilesetter"}
+  hub: gcr.io/asm-testing # {"$ref":"#/definitions/io.k8s.cli.setters.hubsetter"}
+`,
+
+			expectedOpenAPI: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization
+openAPI:
+  definitions:
+    io.k8s.cli.setters.hubsetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: hubsetter
+          value: gcr.io/asm-testing
+    io.k8s.cli.setters.profilesetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: profilesetter
+          value: asm
+`,
+		},
+		{
+			name: "setter-already-exists",
+
+			input: `
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"type":"string","x-kustomize":{"setter":{"name":"profilesetter","value":"asm"}}}
+  hub: gcr.io/asm-testing
+ `,
+
+			openAPIFile: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization
+openAPI:
+  definitions:
+    io.k8s.cli.setters.profilesetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: profilesetter
+          value: asm
+`,
+
+			expectedOutput: `apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"$ref":"#/definitions/io.k8s.cli.setters.profilesetter"}
+  hub: gcr.io/asm-testing
+`,
+
+			expectedOpenAPI: `apiVersion: kustomization.dev/v1alpha1
+kind: Kustomization
+openAPI:
+  definitions:
+    io.k8s.cli.setters.profilesetter:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: profilesetter
+          value: asm
+`,
+		},
+		{
+			name: "no-openAPI-file-error",
+			input: `
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  clusterName: "project-id/us-east1-d/cluster-name"
+spec:
+  profile: asm # {"type":"string","x-kustomize":{"setter":{"name":"profilesetter","value":"asm"}}}
+  hub: gcr.io/asm-testing
+ `,
+
+			err: "kustomization: no such file or directory",
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			openAPIFileName := "kustomization"
+
+			dir, err := ioutil.TempDir("", "")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			defer os.RemoveAll(dir)
+
+			err = ioutil.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(test.input), 0600)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			if test.openAPIFile != "" {
+				err = ioutil.WriteFile(filepath.Join(dir, openAPIFileName), []byte(test.openAPIFile), 0600)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			}
+
+			runner := commands.NewMigrateSettersRunner("")
+			runner.Command.SetArgs([]string{dir})
+			err = runner.Command.Execute()
+			if test.err == "" {
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			} else {
+				if !assert.Contains(t, err.Error(), test.err) {
+					t.FailNow()
+				}
+				return
+			}
+
+			actualOutput, err := ioutil.ReadFile(filepath.Join(dir, "deploy.yaml"))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			actualOpenAPI, err := ioutil.ReadFile(filepath.Join(dir, openAPIFileName))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, test.expectedOutput, string(actualOutput))
+			assert.Equal(t, test.expectedOpenAPI, string(actualOpenAPI))
+		})
+	}
+}

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -49,7 +49,7 @@ func SetCommand(parent string) *cobra.Command {
 
 type SetRunner struct {
 	Command     *cobra.Command
-	Lookup      setters.LookupSetters
+	Lookup      setters.LookupDeleteSetters
 	Perform     setters.PerformSetters
 	Set         settersutil.FieldSetter
 	OpenAPIFile string
@@ -57,7 +57,7 @@ type SetRunner struct {
 
 func initSetterVersion(c *cobra.Command, args []string) error {
 	setterVersion = "v2"
-	l := setters.LookupSetters{}
+	l := setters.LookupDeleteSetters{}
 
 	// backwards compatibility for resources with setter v1
 	err := kio.Pipeline{
@@ -122,7 +122,7 @@ func (r *SetRunner) runE(c *cobra.Command, args []string) error {
 	return handleError(c, lookup(r.Lookup, c, args))
 }
 
-func lookup(l setters.LookupSetters, c *cobra.Command, args []string) error {
+func lookup(l setters.LookupDeleteSetters, c *cobra.Command, args []string) error {
 	// lookup the setters
 	err := kio.Pipeline{
 		Inputs:  []kio.Reader{&kio.LocalPackageReader{PackagePath: args[0]}},

--- a/cmd/config/internal/generateddocs/commands/docs.go
+++ b/cmd/config/internal/generateddocs/commands/docs.go
@@ -214,6 +214,21 @@ For information on merge rules, run:
 var Merge3Examples = `
     kustomize config merge3 --ancestor a/ --from b/ --to c/`
 
+var MigrateSettersShort = `Migrate setters for Resources.`
+var MigrateSettersLong = `
+Migrate setters for Resources.
+
+  DIR
+
+    A directory containing Resource configuration.
+`
+var MigrateSettersExamples = `
+  Migrate setters:
+
+    # migrate setters from v1 to v2 with openAPI
+    $ kustomize cfg migrate-setters hello-world/
+    migrated 2 setters`
+
 var RunFnsShort = `[Alpha] Reoncile config functions to Resources.`
 var RunFnsLong = `
 [Alpha] Reconcile config functions to Resources.

--- a/kyaml/fieldmeta/fieldmeta.go
+++ b/kyaml/fieldmeta/fieldmeta.go
@@ -19,6 +19,8 @@ type FieldMeta struct {
 	Schema spec.Schema
 
 	Extensions XKustomize
+
+	Delete bool
 }
 
 type XKustomize struct {
@@ -70,6 +72,12 @@ func (fm *FieldMeta) Read(n *yaml.RNode) error {
 		b, err := json.Marshal(fe)
 		if err != nil {
 			return errors.Wrap(err)
+		}
+		// removes setters and substitutions from comments if Delete flag is set
+		// this version of setters are deprecated and migrate-setters use this flag
+		if fm.Delete {
+			n.YNode().HeadComment = ""
+			n.YNode().LineComment = ""
 		}
 		return json.Unmarshal(b, &fm.Extensions)
 	}

--- a/kyaml/setters/lookupkio.go
+++ b/kyaml/setters/lookupkio.go
@@ -10,15 +10,18 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-var _ kio.Filter = &LookupSetters{}
+var _ kio.Filter = &LookupDeleteSetters{}
 
-// LookupSetters identifies setters for a collection of Resources
-type LookupSetters struct {
+// LookupDeleteSetters identifies setters for a collection of Resources
+type LookupDeleteSetters struct {
 	// Name is the name of the setter to match.  Optional.
 	Name string
 
 	// SetterCounts is populated by Filter and contains the count of fields matching each setter.
 	SetterCounts []setterCount
+
+	// Delete if set deletes the setter after lookup
+	Delete bool
 }
 
 // setterCount records the identified setters and number of fields matching those setters
@@ -31,12 +34,12 @@ type setterCount struct {
 }
 
 // Filter implements kio.Filter
-func (l *LookupSetters) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
+func (l *LookupDeleteSetters) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
 	setters := map[string]*setterCount{}
 
 	for i := range input {
 		// lookup substitutions for this object
-		ls := &lookupSetters{Name: l.Name}
+		ls := &lookupDeleteSetters{Name: l.Name, Delete: l.Delete}
 		if err := input[i].PipeE(ls); err != nil {
 			return nil, err
 		}

--- a/kyaml/setters/lookupyaml.go
+++ b/kyaml/setters/lookupyaml.go
@@ -8,15 +8,18 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-var _ yaml.Filter = &lookupSetters{}
+var _ yaml.Filter = &lookupDeleteSetters{}
 
-// lookupSetters looks up setters for a Resource
-type lookupSetters struct {
+// lookupDeleteSetters looks up setters for a Resource
+type lookupDeleteSetters struct {
 	// Name of the setter to lookup.  Optional
 	Name string
 
 	// Setters is a list of setters that were found
 	Setters []setter
+
+	// Delete if set deletes the setter after lookup
+	Delete bool
 }
 
 type setter struct {
@@ -26,7 +29,7 @@ type setter struct {
 	SetBy       string
 }
 
-func (ls *lookupSetters) Filter(object *yaml.RNode) (*yaml.RNode, error) {
+func (ls *lookupDeleteSetters) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 	switch object.YNode().Kind {
 	case yaml.DocumentNode:
 		// skip the document node
@@ -47,9 +50,9 @@ func (ls *lookupSetters) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 }
 
 // lookup finds any setters for a field
-func (ls *lookupSetters) lookup(field *yaml.RNode) error {
+func (ls *lookupDeleteSetters) lookup(field *yaml.RNode) error {
 	// check if there is a substitution for this field
-	var fm = &fieldmeta.FieldMeta{}
+	var fm = &fieldmeta.FieldMeta{Delete: ls.Delete}
 	if err := fm.Read(field); err != nil {
 		return err
 	}

--- a/kyaml/setters2/settersutil/fieldsetter.go
+++ b/kyaml/setters2/settersutil/fieldsetter.go
@@ -47,6 +47,7 @@ func (fs FieldSetter) Set(openAPIPath, resourcesPath string) (int, error) {
 		Description: fs.Description,
 		SetBy:       fs.SetBy,
 	}
+
 	if err := soa.UpdateFile(openAPIPath); err != nil {
 		return 0, err
 	}

--- a/kyaml/setters2/settersutil/settercreator.go
+++ b/kyaml/setters2/settersutil/settercreator.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/setters2"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // SetterCreator creates or updates a setter in the OpenAPI definitions, and inserts references
@@ -32,6 +33,14 @@ type SetterCreator struct {
 	// FieldValue if set will add the OpenAPI reference to fields if they have this value.
 	// Optional.  If unspecified match all field values.
 	FieldValue string
+
+	OpenAPIPath string
+
+	ResourcesPath string
+}
+
+func (c *SetterCreator) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
+	return nil, c.Create(c.OpenAPIPath, c.ResourcesPath)
 }
 
 func (c SetterCreator) Create(openAPIPath, resourcesPath string) error {


### PR DESCRIPTION
This PR introduces `cfg migrate-setters` command to migrate setters from v1 to v2 with openAPIDefinitions.