### PR TITLE
Isolate apiVersion parsing.

### DIFF
--- a/api/filters/fsslice/fieldspec_filter.go
+++ b/api/filters/fsslice/fieldspec_filter.go
@@ -124,12 +124,7 @@ func isMatchGVK(fs types.FieldSpec, obj *yaml.RNode) (bool, error) {
 	}
 
 	// parse the group and version from the apiVersion field
-	var group, version string
-	parts := strings.SplitN(meta.APIVersion, "/", 2)
-	group = parts[0]
-	if len(parts) > 1 {
-		version = parts[1]
-	}
+	group, version := parseGV(meta.APIVersion)
 
 	if fs.Group != "" && fs.Group != group {
 		// group doesn't match

--- a/api/filters/fsslice/fsslice.go
+++ b/api/filters/fsslice/fsslice.go
@@ -4,9 +4,6 @@
 package fsslice
 
 import (
-	"strings"
-
-	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -58,21 +55,4 @@ func (fltr Filter) Filter(obj *yaml.RNode) (*yaml.RNode, error) {
 		}
 	}
 	return obj, nil
-}
-
-// GetGVK parses the metadata into a GVK
-func GetGVK(meta yaml.ResourceMeta) resid.Gvk {
-	// parse the group and version from the apiVersion field
-	var group, version string
-	parts := strings.SplitN(meta.APIVersion, "/", 2)
-	group = parts[0]
-	if len(parts) > 1 {
-		version = parts[1]
-	}
-
-	return resid.Gvk{
-		Group:   group,
-		Version: version,
-		Kind:    meta.Kind,
-	}
 }

--- a/api/filters/fsslice/gvk.go
+++ b/api/filters/fsslice/gvk.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+package fsslice
+
+import (
+	"strings"
+
+	"sigs.k8s.io/kustomize/api/resid"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// parseGV parses apiVersion field into group and version.
+func parseGV(apiVersion string) (group, version string) {
+	// parse the group and version from the apiVersion field
+	parts := strings.SplitN(apiVersion, "/", 2)
+	group = parts[0]
+	if len(parts) > 1 {
+		version = parts[1]
+	}
+	// TODO: Special case the original "apiVersion" of what
+	//       we now call the "core" (empty) group.
+	//if group == "v1" && version == "" {
+	//	version = "v1"
+	//	group = ""
+	//}
+	return
+}
+
+// GetGVK parses the metadata into a GVK
+func GetGVK(meta yaml.ResourceMeta) resid.Gvk {
+	group, version := parseGV(meta.APIVersion)
+	return resid.Gvk{
+		Group:   group,
+		Version: version,
+		Kind:    meta.Kind,
+	}
+}

--- a/api/filters/fsslice/gvk_test.go
+++ b/api/filters/fsslice/gvk_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+package fsslice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/resid"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestGetGVK(t *testing.T) {
+	testCases := map[string]struct {
+		input      string
+		expected   resid.Gvk
+		parseError string
+		metaError  string
+	}{
+		"empty": {
+			input: `
+`,
+			parseError: "EOF",
+		},
+		"junk": {
+			input: `
+congress: effective
+`,
+			metaError: "missing Resource metadata",
+		},
+		"normal": {
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+`,
+			expected: resid.Gvk{Group: "apps", Version: "v1", Kind: "Deployment"},
+		},
+		"apiVersionOnlyWithSlash": {
+			input: `
+apiVersion: apps/v1
+`,
+			expected: resid.Gvk{Group: "apps", Version: "v1", Kind: ""},
+		},
+		// When apiVersion is just "v1" (not, say, "apps/v1"), that
+		// could be interpreted as Group="", Version="v1"
+		// (implying the original "core" api group) or the other way around
+		// (Group="v1", Version="").
+		// At the time of writing, fsslice.go does the latter -
+		// might have to change that.
+		"apiVersionOnlyNoSlash1": {
+			input: `
+apiVersion: apps
+`,
+			expected: resid.Gvk{Group: "apps", Version: "", Kind: ""},
+		},
+		"apiVersionOnlyNoSlash2": {
+			input: `
+apiVersion: v1
+`,
+			expected: resid.Gvk{Group: "v1", Version: "", Kind: ""},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			obj, err := yaml.Parse(tc.input)
+			if len(tc.parseError) != 0 {
+				if err == nil {
+					t.Error("expected parse error")
+					return
+				}
+				if !strings.Contains(err.Error(), tc.parseError) {
+					t.Errorf("expected parse err '%s', got '%v'", tc.parseError, err)
+				}
+				return
+			}
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			meta, err := obj.GetMeta()
+			if len(tc.metaError) != 0 {
+				if err == nil {
+					t.Error("expected meta error")
+					return
+				}
+				if !strings.Contains(err.Error(), tc.metaError) {
+					t.Errorf("expected meta err '%s', got '%v'", tc.metaError, err)
+				}
+				return
+			}
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			gvk := GetGVK(meta)
+			if !assert.Equal(t, tc.expected, gvk) {
+				t.FailNow()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Move GV parsing to it's own file, and remove duplication
(`strings.SplitN(meta.APIVersion, "/", 2)` happened twice).