### PR TITLE
Migrate label transformer

### DIFF
--- a/api/filters/fsslice/fsslice_test.go
+++ b/api/filters/fsslice/fsslice_test.go
@@ -302,8 +302,6 @@ kind: Bar
 		expected: `
 apiVersion: v1
 kind: Bar
-a:
-  b: e
 `,
 		filter: fsslice.Filter{
 			SetValue:   fsslice.SetScalar("e"),
@@ -326,6 +324,8 @@ kind: Bar
 		expected: `
 apiVersion: v1
 kind: Bar
+a:
+  b: e
 `,
 		filter: fsslice.Filter{
 			SetValue:   fsslice.SetScalar("e"),

--- a/api/filters/fsslice/gvk.go
+++ b/api/filters/fsslice/gvk.go
@@ -9,6 +9,18 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+// Return true for 'v' followed by a 1 or 2, and don't look at rest.
+// I.e. 'v1', 'v1beta1', 'v2', would return true.
+func looksLikeACoreApiVersion(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	if s[0:1] != "v" {
+		return false
+	}
+	return s[1:2] == "1" || s[1:2] == "2"
+}
+
 // parseGV parses apiVersion field into group and version.
 func parseGV(apiVersion string) (group, version string) {
 	// parse the group and version from the apiVersion field
@@ -17,12 +29,12 @@ func parseGV(apiVersion string) (group, version string) {
 	if len(parts) > 1 {
 		version = parts[1]
 	}
-	// TODO: Special case the original "apiVersion" of what
-	//       we now call the "core" (empty) group.
-	//if group == "v1" && version == "" {
-	//	version = "v1"
-	//	group = ""
-	//}
+	// Special case the original "apiVersion" of what
+	// we now call the "core" (empty) group.
+	if version == "" && looksLikeACoreApiVersion(group) {
+		version = group
+		group = ""
+	}
 	return
 }
 

--- a/api/filters/fsslice/gvk_test.go
+++ b/api/filters/fsslice/gvk_test.go
@@ -44,18 +44,18 @@ func TestParseGV(t *testing.T) {
 		},
 		"coreV1": {
 			input:           "v1",
-			expectedGroup:   "v1",
-			expectedVersion: "",
+			expectedGroup:   "",
+			expectedVersion: "v1",
 		},
 		"coreV2": {
 			input:           "v2",
-			expectedGroup:   "v2",
-			expectedVersion: "",
+			expectedGroup:   "",
+			expectedVersion: "v2",
 		},
 		"coreV2Beta1": {
 			input:           "v2beta1",
-			expectedGroup:   "v2beta1",
-			expectedVersion: "",
+			expectedGroup:   "",
+			expectedVersion: "v2beta1",
 		},
 	}
 
@@ -103,12 +103,6 @@ apiVersion: apps/v1
 `,
 			expected: resid.Gvk{Group: "apps", Version: "v1", Kind: ""},
 		},
-		// When apiVersion is just "v1" (not, say, "apps/v1"), that
-		// could be interpreted as Group="", Version="v1"
-		// (implying the original "core" api group) or the other way around
-		// (Group="v1", Version="").
-		// At the time of writing, fsslice.go does the latter -
-		// might have to change that.
 		"apiVersionOnlyNoSlash1": {
 			input: `
 apiVersion: apps
@@ -119,7 +113,7 @@ apiVersion: apps
 			input: `
 apiVersion: v1
 `,
-			expected: resid.Gvk{Group: "v1", Version: "", Kind: ""},
+			expected: resid.Gvk{Group: "", Version: "v1", Kind: ""},
 		},
 	}
 

--- a/api/filters/labels/labels_test.go
+++ b/api/filters/labels/labels_test.go
@@ -283,7 +283,7 @@ metadata:
 					},
 					{
 						Gvk: resid.Gvk{
-							Group: "v1",
+							Version: "v1",
 						},
 						Path:               "a/b",
 						CreateIfNotPresent: true,

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -5,9 +5,10 @@
 package main
 
 import (
+	"sigs.k8s.io/kustomize/api/filters/labels"
 	"sigs.k8s.io/kustomize/api/resmap"
-	"sigs.k8s.io/kustomize/api/transform"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filtersutil"
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,12 +29,14 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
-	t, err := transform.NewMapTransformer(
-		p.FieldSpecs,
-		p.Labels,
-	)
-	if err != nil {
-		return err
+	for _, r := range m.Resources() {
+		err := filtersutil.ApplyToJSON(labels.Filter{
+			Labels:  p.Labels,
+			FsSlice: p.FieldSpecs,
+		}, r.Kunstructured)
+		if err != nil {
+			return err
+		}
 	}
-	return t.Transform(m)
+	return nil
 }

--- a/plugin/builtin/labeltransformer/go.mod
+++ b/plugin/builtin/labeltransformer/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	sigs.k8s.io/kustomize/api v0.3.1
+	sigs.k8s.io/kustomize/kyaml v0.1.5
 	sigs.k8s.io/yaml v1.1.0
 )
 


### PR DESCRIPTION
Two commits.

The first fixes the GVK selector in the filters package to work the way kustomize works.

The second uses this to migrate the LabelsTransformer.