### PR TITLE
Finalize helm v3 support

### DIFF
--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -28,10 +28,6 @@
 # Example execution:
 # ./plugin/someteam.example.com/v1/ChartInflator configFile.yaml
 
-# TODO: allow specification of a specific chart VERSION
-# so this test doesn't break every time minecraft is upgraded :P
-# See https://github.com/helm/helm/issues/4008
-
 set -e
 
 # Yaml parsing is a ridiculous thing to do in bash,

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator
@@ -145,8 +145,13 @@ function v2PullChart {
 }
 
 function v3PullChart {
-  # TODO implement
-  echo "?? helmV3 pull --repo https://hub.helm.sh/charts/ stable/minecraft  --destination /tmp/junk"
+  if [ ! -d "$chartHome/$chartName" ]; then
+    v3RunHelm pull $chartVersionArg \
+        $chartRepoArg \
+        --untar \
+        --untardir $chartHome \
+        $chartNameArg
+  fi
 }
 
 function v2InflateChart {
@@ -158,8 +163,12 @@ function v2InflateChart {
 }
 
 function v3InflateChart {
-  # TODO implement
-  true
+    v3RunHelm template \
+      --release-name $releaseName \
+      --namespace $releaseNamespace \
+      --values $valuesFile \
+      $chartHome/$chartName
+
 }
 
 HELM_VERSION=$($helmBin version -c --short)

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -8,13 +8,14 @@
 package main_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-const expectedResources = `
+const expectedResourcesTemplate = `
 apiVersion: v1
 data:
   rcon-password: Q0hBTkdFTUUh
@@ -23,7 +24,7 @@ metadata:
   labels:
     app: release-name-minecraft
     chart: minecraft-SOMEVERSION
-    heritage: Tiller
+    heritage: %s
     release: release-name
   name: release-name-minecraft
 type: Opaque
@@ -36,7 +37,7 @@ metadata:
   labels:
     app: release-name-minecraft
     chart: minecraft-SOMEVERSION
-    heritage: Tiller
+    heritage: %s
     release: release-name
   name: release-name-minecraft-datadir
 spec:
@@ -52,7 +53,7 @@ metadata:
   labels:
     app: release-name-minecraft
     chart: minecraft-SOMEVERSION
-    heritage: Tiller
+    heritage: %s
     release: release-name
   name: release-name-minecraft
 spec:
@@ -66,9 +67,13 @@ spec:
   type: LoadBalancer
 `
 
+func expectedResources(serviceName string) string {
+	return fmt.Sprintf(expectedResourcesTemplate, serviceName, serviceName, serviceName)
+}
+
 // This test requires having "helmV2" (presumably helm V2 series) on the PATH.
 //
-// TODO: Download and inflate the chart, and check that
+// Download and inflate the chart, and check that
 // in for the test.
 func TestHelmV2ChartInflator(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
@@ -81,6 +86,7 @@ kind: ChartInflator
 metadata:
   name: notImportantHere
 chartName: minecraft
+chartVersion: 1.2.0
 helmBin: helmV2
 `)
 
@@ -88,12 +94,12 @@ helmBin: helmV2
 	th.AssertActualEqualsExpectedWithTweak(m,
 		func(x []byte) []byte {
 			return chartName.ReplaceAll(x, []byte("chart: minecraft-SOMEVERSION"))
-		}, expectedResources)
+		}, expectedResources("Tiller"))
 }
 
 // This test requires having "helmV3" (presumably helm V3 series) on the PATH.
 //
-func disabled_TestHelmV3ChartInflator(t *testing.T) {
+func TestHelmV3ChartInflator(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
 		PrepExecPlugin("someteam.example.com", "v1", "ChartInflator")
 	defer th.Reset()
@@ -105,6 +111,7 @@ metadata:
   name: notImportantHere
 chartRepo: https://kubernetes-charts.storage.googleapis.com/
 chartName: minecraft
+chartVersion: 1.2.0
 helmBin: helmV3
 `)
 
@@ -112,5 +119,5 @@ helmBin: helmV3
 	th.AssertActualEqualsExpectedWithTweak(m,
 		func(x []byte) []byte {
 			return chartName.ReplaceAll(x, []byte("chart: minecraft-SOMEVERSION"))
-		}, expectedResources)
+		}, expectedResources("Helm"))
 }

--- a/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
+++ b/plugin/someteam.example.com/v1/chartinflator/ChartInflator_test.go
@@ -103,6 +103,7 @@ apiVersion: someteam.example.com/v1
 kind: ChartInflator
 metadata:
   name: notImportantHere
+chartRepo: https://kubernetes-charts.storage.googleapis.com/
 chartName: minecraft
 helmBin: helmV3
 `)


### PR DESCRIPTION
Support helm v3 in the chartinflator plugin

1. - Added necessary wrapper functions to call HelmV3,
2. - Made sure the UT works for both HelmV2 and HelmV3,
3. - Pinned ChartVersion for UT to ensure that in future they won't break,
4. - Removed TODO notes related to accomplished tasks.

Closes: https://github.com/kubernetes-sigs/kustomize/issues/2396