### PR TITLE
Simplify substitutions

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -29,8 +29,7 @@ func TestCreateSubstitutionCommand(t *testing.T) {
 		{
 			name: "substitution replicas",
 			args: []string{
-				"image", "nginx:1.7.9", "--pattern", "IMAGE:TAG",
-				"--value", "IMAGE=image", "--value", "TAG=tag"},
+				"my-image-subst", "--field-value", "nginx:1.7.9", "--pattern", "${my-image-setter}:${my-tag-setter}"},
 			input: `
 apiVersion: apps/v1
 kind: Deployment
@@ -51,15 +50,15 @@ apiVersion: v1alpha1
 kind: Example
 openAPI:
   definitions:
-    io.k8s.cli.setters.image:
+    io.k8s.cli.setters.my-image-setter:
       x-k8s-cli:
         setter:
-          name: image
+          name: my-image-setter
           value: "nginx"
-    io.k8s.cli.setters.tag:
+    io.k8s.cli.setters.my-tag-setter:
       x-k8s-cli:
         setter:
-          name: tag
+          name: my-tag-setter
           value: "1.7.9"
  `,
 			expectedOpenAPI: `
@@ -67,26 +66,26 @@ apiVersion: v1alpha1
 kind: Example
 openAPI:
   definitions:
-    io.k8s.cli.setters.image:
+    io.k8s.cli.setters.my-image-setter:
       x-k8s-cli:
         setter:
-          name: image
+          name: my-image-setter
           value: "nginx"
-    io.k8s.cli.setters.tag:
+    io.k8s.cli.setters.my-tag-setter:
       x-k8s-cli:
         setter:
-          name: tag
+          name: my-tag-setter
           value: "1.7.9"
-    io.k8s.cli.substitutions.image:
+    io.k8s.cli.substitutions.my-image-subst:
       x-k8s-cli:
         substitution:
-          name: image
-          pattern: IMAGE:TAG
+          name: my-image-subst
+          pattern: ${my-image-setter}:${my-tag-setter}
           values:
-          - marker: IMAGE
-            ref: '#/definitions/io.k8s.cli.setters.image'
-          - marker: TAG
-            ref: '#/definitions/io.k8s.cli.setters.tag'
+          - marker: ${my-image-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-image-setter'
+          - marker: ${my-tag-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -99,7 +98,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9 # {"$ref":"#/definitions/io.k8s.cli.substitutions.image"}
+        image: nginx:1.7.9 # {"$ref":"#/definitions/io.k8s.cli.substitutions.my-image-subst"}
       - name: sidecar
         image: sidecar:1.7.9
  `,
@@ -107,8 +106,7 @@ spec:
 		{
 			name: "substitution and create setters 1",
 			args: []string{
-				"image", "something/nginx::1.7.9/nginxotherthing", "--pattern", "something/IMAGE::TAG/nginxotherthing",
-				"--value", "IMAGE=image", "--value", "TAG=tag"},
+				"my-image-subst", "--field-value", "something/nginx::1.7.9/nginxotherthing", "--pattern", "something/${my-image-setter}::${my-tag-setter}/nginxotherthing"},
 			input: `
 apiVersion: apps/v1
 kind: Deployment
@@ -133,26 +131,26 @@ apiVersion: v1alpha1
 kind: Example
 openAPI:
   definitions:
-    io.k8s.cli.setters.image:
+    io.k8s.cli.setters.my-image-setter:
       x-k8s-cli:
         setter:
-          name: image
+          name: my-image-setter
           value: nginx
-    io.k8s.cli.setters.tag:
+    io.k8s.cli.setters.my-tag-setter:
       x-k8s-cli:
         setter:
-          name: tag
+          name: my-tag-setter
           value: 1.7.9
-    io.k8s.cli.substitutions.image:
+    io.k8s.cli.substitutions.my-image-subst:
       x-k8s-cli:
         substitution:
-          name: image
-          pattern: something/IMAGE::TAG/nginxotherthing
+          name: my-image-subst
+          pattern: something/${my-image-setter}::${my-tag-setter}/nginxotherthing
           values:
-          - marker: IMAGE
-            ref: '#/definitions/io.k8s.cli.setters.image'
-          - marker: TAG
-            ref: '#/definitions/io.k8s.cli.setters.tag'
+          - marker: ${my-image-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-image-setter'
+          - marker: ${my-tag-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -165,7 +163,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: something/nginx::1.7.9/nginxotherthing # {"$ref":"#/definitions/io.k8s.cli.substitutions.image"}
+        image: something/nginx::1.7.9/nginxotherthing # {"$ref":"#/definitions/io.k8s.cli.substitutions.my-image-subst"}
       - name: sidecar
         image: sidecar:1.7.9
  `,

--- a/kyaml/setters2/settersutil/substitutioncreator.go
+++ b/kyaml/setters2/settersutil/substitutioncreator.go
@@ -4,6 +4,7 @@
 package settersutil
 
 import (
+	"fmt"
 	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -98,11 +99,14 @@ func (c SubstitutionCreator) CreateSettersForSubstitution(openAPIPath string) er
 		}
 
 		if obj == nil {
+			name := strings.TrimPrefix(value.Ref, "#/definitions/io.k8s.cli.setters.")
+			value := m[value.Marker]
+			fmt.Printf("unable to find setter with name %s, creating new setter with value %s\n", name, value)
 			sd := setters2.SetterDefinition{
 				// get the setter name from ref. Ex: from #/definitions/io.k8s.cli.setters.image_setter
 				// extract image_setter
-				Name:  strings.TrimPrefix(value.Ref, "#/definitions/io.k8s.cli.setters."),
-				Value: m[value.Marker],
+				Name:  name,
+				Value: value,
 			}
 			err := sd.AddToFile(openAPIPath)
 			if err != nil {


### PR DESCRIPTION
This PR prints a message while creating each setter for substitutions if they don't exist already. Also simplifies create-subst command to take less number of inputs.

Before:
create-subst my-image-subst nginx:0.1.0 --pattern IMAGE:TAG --value IMAGE=my-image-setter --value TAG=my-tag-setter

After:
create-subst my-image-subst --field-value nginx:0.1.0 --pattern ${my-image-setter}:${my-tag-setter}