### PR TITLE
Update link to travis pre-commit hook in docs

### DIFF
--- a/api/internal/plugins/doc.go
+++ b/api/internal/plugins/doc.go
@@ -94,7 +94,7 @@ TO GENERATE CODE
   cd $repo/plugin/builtin
   go generate ./...
 
-See travis/pre-commit.sh for canonical way
+See travis/kyaml-pre-commit.sh for canonical way
 to execute the above.
 
 This creates

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ English | [简体中文](zh/README.md)
 To run these examples, your `$PATH` must contain `kustomize`.
 See the [installation instructions](../docs/INSTALL.md).
 
-These examples are [tested](../travis/pre-commit.sh)
+These examples are [tested](../travis/kyaml-pre-commit.sh)
 to work with the latest _released_ version of kustomize.
 
 Basic Usage

--- a/examples/zh/README.md
+++ b/examples/zh/README.md
@@ -4,7 +4,7 @@
 
 这些示例默认 `kustomize` 在您的 `$PATH` 中。
 
-这些示例通过了 [pre-commit](../../travis/pre-commit.sh) 测试，并且应该与 HEAD 一起使用。
+这些示例通过了 [pre-commit](../../travis/kyaml-pre-commit.sh) 测试，并且应该与 HEAD 一起使用。
 
 ```
 go get sigs.k8s.io/kustomize/v3/cmd/kustomize


### PR DESCRIPTION
This is my first contribution, be gentle please.

### Changelog 
- Fixed broken link in docs to travis pre-commit hook
- This files appears to have been renamed `kyaml-pre-commit.sh`
