### PR TITLE
Add install command for MacPorts user

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -66,8 +66,16 @@ git checkout kustomize/v3.2.3
 
 #### macOS
 
+For [Homebrew](https://brew.sh) users:
+
 ```
 brew install kustomize
+```
+
+For [MacPorts](https://www.macports.org) users:
+
+```
+sudo port install kustomize
 ```
 
 #### windows


### PR DESCRIPTION
I recently started maintaining `kustomize` for [MacPorts](https://www.macports.org) and this change adds the `kustomize` installation command for MacPorts users to the install docs.