### PR TITLE
WIP: #2476 Make fails with '.../transformers/setProject/setProject.yaml: No such file or directory

### DIFF
--- a/examples/valueAdd.md
+++ b/examples/valueAdd.md
@@ -171,9 +171,9 @@ resources:
 EOF
 ```
 
-Make a transformer configration file.
+Make a transformer configuration file.
 
-The transformer used is called `AddValueTransformer`.  It's
+The transformer used is called `ValueAddTransformer`.  It's
 intended to implement the 'add' operation of
 [IETF RFC 6902 JSON].   The add operation is simple declaration
 of what value to add, and a powerful syntax for specifying where
@@ -191,6 +191,7 @@ the config must live in its own file:
 
 <!-- @defineSetProjectTransformer @testAgainstLatestRelease -->
 ```
+mkdir -p $DEMO_HOME/transformers/setProject
 cat <<'EOF' >$DEMO_HOME/transformers/setProject/setProject.yaml
 apiVersion: builtin
 kind: ValueAddTransformer


### PR DESCRIPTION
Fixes #2476 

Created the parent directory for `setProject.yaml` (and fixed a couple of typos).

Build now fails with `Error: unable to load builtin ~G_builtin_ValueAddTransformer`, and I'm not sure how to fix that!

<details><summary>Full log</summary>
<p>

```
./hack/testExamplesAgainstKustomize.sh HEAD
Example tests passed against HEAD.
( \
		set -e; \
		/bin/rm -f /Users/paul/Dev/opensource/kustomize/bin/kustomize; \
		echo "Installing kustomize from latest."; \
		GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4; \
		./hack/testExamplesAgainstKustomize.sh latest; \
		echo "Reinstalling kustomize from HEAD."; \
		cd kustomize; go install .; \
	)
Installing kustomize from latest.
go: finding sigs.k8s.io v3.5.4
go: finding sigs.k8s.io/kustomize/kustomize v3.5.4
go: finding sigs.k8s.io/kustomize v3.5.4
----------------------------------------------------------------------
echo "Error @runIt (block #14 in testAgainstLatestRelease) of /Users/paul/Dev/opensource/kustomize/src/sigs.k8s.io/kustomize/examples/valueAdd.md"

kustomize build $DEMO_HOME/projects/dog-222 >$DEMO_HOME/out_actual.yaml
----------------------------------------------------------------------

stdOut capture:
----------------------------------------------------------------------

----------------------------------------------------------------------

stdErr capture:
----------------------------------------------------------------------
Error: unable to load builtin ~G_builtin_ValueAddTransformer
----------------------------------------------------------------------
F0514 19:58:54.627051   95512 main.go:45] exit status 1
```
</details>