### PR TITLE
Add more labelling tests.

### DIFF
--- a/api/krusty/baseandoverlaysmall_test.go
+++ b/api/krusty/baseandoverlaysmall_test.go
@@ -216,6 +216,8 @@ func TestSmallOverlay(t *testing.T) {
 namePrefix: b-
 commonLabels:
   env: prod
+  quotedFruit: "peach"
+  quotedBoolean: "true"
 resources:
 - ../base
 patchesStrategicMerge:
@@ -249,6 +251,8 @@ metadata:
   labels:
     app: myApp
     env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
   name: b-a-myDeployment
 spec:
   replicas: 1000
@@ -256,12 +260,16 @@ spec:
     matchLabels:
       app: myApp
       env: prod
+      quotedBoolean: "true"
+      quotedFruit: peach
   template:
     metadata:
       labels:
         app: myApp
         backend: awesome
         env: prod
+        quotedBoolean: "true"
+        quotedFruit: peach
     spec:
       containers:
       - image: whatever:1.8.0
@@ -273,6 +281,8 @@ metadata:
   labels:
     app: myApp
     env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
   name: b-a-myService
 spec:
   ports:
@@ -281,6 +291,8 @@ spec:
     app: myApp
     backend: bungie
     env: prod
+    quotedBoolean: "true"
+    quotedFruit: peach
 `)
 }
 

--- a/plugin/builtin/labeltransformer/LabelTransformer_test.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer_test.go
@@ -21,6 +21,9 @@ metadata:
   name: notImportantHere
 labels:
   app: myApp
+  quotedBoolean: "true"
+  quotedFruit: "peach"
+  unquotedBoolean: true
   env: production
 fieldSpecs:
 - path: spec/selector
@@ -69,6 +72,9 @@ metadata:
   labels:
     app: myApp
     env: production
+    quotedBoolean: "true"
+    quotedFruit: peach
+    unquotedBoolean: "true"
   name: myService
 spec:
   ports:
@@ -76,6 +82,9 @@ spec:
   selector:
     app: myApp
     env: production
+    quotedBoolean: "true"
+    quotedFruit: peach
+    unquotedBoolean: "true"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -83,6 +92,9 @@ metadata:
   labels:
     app: myApp
     env: production
+    quotedBoolean: "true"
+    quotedFruit: peach
+    unquotedBoolean: "true"
   name: mungebot
 spec:
   replicas: 1
@@ -90,11 +102,17 @@ spec:
     matchLabels:
       app: myApp
       env: production
+      quotedBoolean: "true"
+      quotedFruit: peach
+      unquotedBoolean: "true"
   template:
     metadata:
       labels:
         app: myApp
         env: production
+        quotedBoolean: "true"
+        quotedFruit: peach
+        unquotedBoolean: "true"
     spec:
       containers:
       - image: nginx


### PR DESCRIPTION
Investigation of #2479 

Demonstrate (at this particular checksum anyway) that quotes are retained in the label pair
```
quotedBoolean: "true"
```