### PR TITLE
Add schema-path flag to input openAPI for setters

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -48,6 +48,9 @@ func NewCreateSetterRunner(parent string) *CreateSetterRunner {
 	set.Flags().MarkHidden("partial")
 	set.Flags().StringVar(&setterVersion, "version", "",
 		"use this version of the setter format")
+	set.Flags().StringVar(&r.CreateSetter.SchemaPath, "schema-path", "",
+		`openAPI schema file path for setter constraints -- file content `+
+			`e.g. {"type": "string", "maxLength": 15, "enum": ["allowedValue1", "allowedValue2"]}`)
 	set.Flags().MarkHidden("version")
 	fixDocs(parent, set)
 	r.Command = set

--- a/kyaml/testutil/testutil.go
+++ b/kyaml/testutil/testutil.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package testutil_test
 
 import (

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -722,6 +722,24 @@ func (rn *RNode) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// ConvertJSONToYamlNode parses input json string and returns equivalent yaml node
+func ConvertJSONToYamlNode(jsonStr string) (*RNode, error) {
+	var body map[string]interface{}
+	err := json.Unmarshal([]byte(jsonStr), &body)
+	if err != nil {
+		return nil, err
+	}
+	yml, err := yaml.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	node, err := Parse(string(yml))
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
 // checkKey returns true if all elems have the key
 func checkKey(key string, elems []*Node) bool {
 	count := 0

--- a/kyaml/yaml/types_test.go
+++ b/kyaml/yaml/types_test.go
@@ -146,3 +146,23 @@ hello: world
 		})
 	}
 }
+
+func TestConvertJSONToYamlNode(t *testing.T) {
+	inputJSON := `{"type": "string", "maxLength": 15, "enum": ["allowedValue1", "allowedValue2"]}`
+	expected := `enum:
+- allowedValue1
+- allowedValue2
+maxLength: 15
+type: string
+`
+
+	node, err := ConvertJSONToYamlNode(inputJSON)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	actual, err := node.String()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
@mortent This PR adds a flag --schema-path for users to input openAPI validations schema.