### PR TITLE
Add Cluster as not namespaceable kind

### DIFF
--- a/api/resid/gvk.go
+++ b/api/resid/gvk.go
@@ -167,6 +167,7 @@ var notNamespaceableKinds = []string{
 	"CSIDriver",
 	"CSINode",
 	"CertificateSigningRequest",
+	"Cluster",
 	"ClusterRole",
 	"ClusterRoleBinding",
 	"ComponentStatus",


### PR DESCRIPTION
The Cluster object from the clusterregistry api is always cluster scoped.