### PR TITLE
Nested substitutions

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -149,16 +149,6 @@ apiVersion: v1alpha1
 kind: Example
 openAPI:
   definitions:
-    io.k8s.cli.setters.my-image-setter:
-      x-k8s-cli:
-        setter:
-          name: my-image-setter
-          value: nginx
-    io.k8s.cli.setters.my-tag-setter:
-      x-k8s-cli:
-        setter:
-          name: my-tag-setter
-          value: 1.7.9
     io.k8s.cli.substitutions.my-image-subst:
       x-k8s-cli:
         substitution:
@@ -169,6 +159,16 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.my-image-setter'
           - marker: ${my-tag-setter}
             ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
+    io.k8s.cli.setters.my-image-setter:
+      x-k8s-cli:
+        setter:
+          name: my-image-setter
+          value: nginx
+    io.k8s.cli.setters.my-tag-setter:
+      x-k8s-cli:
+        setter:
+          name: my-tag-setter
+          value: 1.7.9
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -189,7 +189,8 @@ spec:
 		{
 			name: "nested substitution",
 			args: []string{
-				"my-nested-subst", "--field-value", "something/nginx::1.7.9/nginxotherthing", "--pattern", "something/${my-image-subst}/${my-other-setter}"},
+				"my-nested-subst", "--field-value", "something/nginx::1.7.9/nginxotherthing",
+				"--pattern", "something/${my-image-subst}/${my-other-setter}"},
 			input: `
 apiVersion: apps/v1
 kind: Deployment
@@ -256,11 +257,6 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.my-image-setter'
           - marker: ${my-tag-setter}
             ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
-    io.k8s.cli.setters.my-other-setter:
-      x-k8s-cli:
-        setter:
-          name: my-other-setter
-          value: nginxotherthing
     io.k8s.cli.substitutions.my-nested-subst:
       x-k8s-cli:
         substitution:
@@ -271,6 +267,11 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.substitutions.my-image-subst'
           - marker: ${my-other-setter}
             ref: '#/definitions/io.k8s.cli.setters.my-other-setter'
+    io.k8s.cli.setters.my-other-setter:
+      x-k8s-cli:
+        setter:
+          name: my-other-setter
+          value: nginxotherthing
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -287,6 +288,125 @@ spec:
       - name: sidecar
         image: nginx::1.7.9 # {"$openapi":"my-image-subst"}
  `,
+		},
+		{
+			name: "nested cyclic substitution",
+			args: []string{"my-nested-subst", "--field-value", "something/nginx::1.7.9/nginxotherthing",
+				"--pattern", "something/${my-image-subst}/${my-other-setter}"},
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.my-image-setter:
+      x-k8s-cli:
+        setter:
+          name: my-image-setter
+          value: nginx
+    io.k8s.cli.setters.my-tag-setter:
+      x-k8s-cli:
+        setter:
+          name: my-tag-setter
+          value: 1.7.9
+    io.k8s.cli.substitutions.my-image-subst:
+      x-k8s-cli:
+        substitution:
+          name: my-image-subst
+          pattern: ${my-nested-subst}::${my-tag-setter}
+          values:
+          - marker: ${my-nested-subst}
+            ref: '#/definitions/io.k8s.cli.substitutions.my-nested-subst'
+          - marker: ${my-tag-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
+    io.k8s.cli.setters.my-other-setter:
+      x-k8s-cli:
+        setter:
+          name: my-other-setter
+          value: nginxotherthing
+    io.k8s.cli.substitutions.my-nested-subst:
+      x-k8s-cli:
+        substitution:
+          name: my-nested-subst
+          pattern: something/${my-image-subst}/${my-other-setter}
+          values:
+          - marker: ${my-image-subst}
+            ref: '#/definitions/io.k8s.cli.substitutions.my-image-subst'
+          - marker: ${my-other-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-other-setter'
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: something/nginx::1.7.9/nginxotherthing # {"$openapi":"my-nested-subst"}
+      - name: sidecar
+        image: nginx::1.7.9 # {"$openapi":"my-image-subst"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.my-image-setter:
+      x-k8s-cli:
+        setter:
+          name: my-image-setter
+          value: nginx
+    io.k8s.cli.setters.my-tag-setter:
+      x-k8s-cli:
+        setter:
+          name: my-tag-setter
+          value: 1.7.9
+    io.k8s.cli.substitutions.my-image-subst:
+      x-k8s-cli:
+        substitution:
+          name: my-image-subst
+          pattern: ${my-nested-subst}::${my-tag-setter}
+          values:
+          - marker: ${my-nested-subst}
+            ref: '#/definitions/io.k8s.cli.substitutions.my-nested-subst'
+          - marker: ${my-tag-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
+    io.k8s.cli.setters.my-other-setter:
+      x-k8s-cli:
+        setter:
+          name: my-other-setter
+          value: nginxotherthing
+    io.k8s.cli.substitutions.my-nested-subst:
+      x-k8s-cli:
+        substitution:
+          name: my-nested-subst
+          pattern: something/${my-image-subst}/${my-other-setter}
+          values:
+          - marker: ${my-image-subst}
+            ref: '#/definitions/io.k8s.cli.substitutions.my-image-subst'
+          - marker: ${my-other-setter}
+            ref: '#/definitions/io.k8s.cli.setters.my-other-setter'
+
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: something/nginx::1.7.9/nginxotherthing # {"$openapi":"my-nested-subst"}
+      - name: sidecar
+        image: nginx::1.7.9 # {"$openapi":"my-image-subst"}
+`,
+			err: "cyclic substitution detected with name my-nested-subst",
 		},
 	}
 	for i := range tests {

--- a/kyaml/setters2/types.go
+++ b/kyaml/setters2/types.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 )
 
-type cliExtension struct {
+type CliExtension struct {
 	Setter       *setter       `yaml:"setter,omitempty" json:"setter,omitempty"`
 	Substitution *substitution `yaml:"substitution,omitempty" json:"substitution,omitempty"`
 }
@@ -37,8 +37,8 @@ type substitutionSetterReference struct {
 //K8sCliExtensionKey is the name of the OpenAPI field containing the setter extensions
 const K8sCliExtensionKey = "x-k8s-cli"
 
-// getExtFromSchema returns the cliExtension openAPI extension if it is present in schema
-func getExtFromSchema(schema *spec.Schema) (*cliExtension, error) {
+// GetExtFromSchema returns the cliExtension openAPI extension if it is present in schema
+func GetExtFromSchema(schema *spec.Schema) (*CliExtension, error) {
 	cep := schema.VendorExtensible.Extensions[K8sCliExtensionKey]
 	if cep == nil {
 		return nil, nil
@@ -47,7 +47,7 @@ func getExtFromSchema(schema *spec.Schema) (*cliExtension, error) {
 	if err != nil {
 		return nil, err
 	}
-	val := &cliExtension{}
+	val := &CliExtension{}
 	if err := json.Unmarshal(b, val); err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func getExtFromSchema(schema *spec.Schema) (*cliExtension, error) {
 
 // getExtFromComment returns the cliExtension openAPI extension if it is present as
 // a comment on the field.
-func getExtFromComment(schema *openapi.ResourceSchema) (*cliExtension, error) {
+func getExtFromComment(schema *openapi.ResourceSchema) (*CliExtension, error) {
 	if schema == nil {
 		// no schema found
 		// TODO(pwittrock): should this be an error if it doesn't resolve?
@@ -64,7 +64,7 @@ func getExtFromComment(schema *openapi.ResourceSchema) (*cliExtension, error) {
 	}
 
 	// get the cli extension from the openapi (contains setter information)
-	ext, err := getExtFromSchema(schema.Schema)
+	ext, err := GetExtFromSchema(schema.Schema)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}


### PR DESCRIPTION
@mortent @pwittrock 

This PR adds support for nested substitutions. A substitution can point to another substitution to better organize them. Here are the related issues/requests

https://github.com/GoogleContainerTools/kpt/issues/321
https://github.com/GoogleContainerTools/kpt/issues/551

@yuwenma FYI