### PR TITLE
Fix length checking for ResMap resources

### DIFF
--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -532,7 +532,7 @@ func (m *resWrangler) ErrorIfNotEqualSets(other ResMap) error {
 	for _, r1 := range m.rList {
 		id := r1.CurId()
 		others := m2.GetMatchingResourcesByCurrentId(id.Equals)
-		if len(others) < 0 {
+		if len(others) == 0 {
 			return fmt.Errorf(
 				"id in self missing from other; id: %s", id)
 		}

--- a/api/resmap/resmap_test.go
+++ b/api/resmap/resmap_test.go
@@ -669,7 +669,12 @@ func TestErrorIfNotEqualSets(t *testing.T) {
 		t.Fatalf("%v should not equal %v %v", m1, m2, err)
 	}
 
-	m3 := resmaptest_test.NewRmBuilder(t, rf).Add(
+	m3 := resmaptest_test.NewRmBuilder(t, rf).AddR(r2).ResMap()
+	if err := m2.ErrorIfNotEqualSets(m3); err == nil {
+		t.Fatalf("%v should not equal %v %v", m2, m3, err)
+	}
+
+	m3 = resmaptest_test.NewRmBuilder(t, rf).Add(
 		map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "ConfigMap",


### PR DESCRIPTION
This PR fix resource comparing function `ErrorIfNotEqualSets`.

`ErrorIfNotEqualSets` panics by `runtime error: index out of range [0] with length 0` when this function compare two `ResMap` with different `"metadata"` value.

I add a test case that causes this panic.

And I Fix length checking for ResMap resources to suppress panics. 