### PR TITLE
Add test case when image tag is a number

### DIFF
--- a/kustomize/internal/commands/edit/set/setimage_test.go
+++ b/kustomize/internal/commands/edit/set/setimage_test.go
@@ -40,6 +40,30 @@ func TestSetImage(t *testing.T) {
 		},
 		{
 			given: given{
+				args: []string{"image1=my-image1:1234"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- name: image1",
+					"  newName: my-image1",
+					"  newTag: \"1234\"",
+				}},
+		},
+		{
+			given: given{
+				args: []string{"image1=my-image1:3.2e2"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- name: image1",
+					"  newName: my-image1",
+					"  newTag: \"3.2e2\"",
+				}},
+		},
+		{
+			given: given{
 				args: []string{"image1=my-image1@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
 			},
 			expected: expected{


### PR DESCRIPTION
# Description
- Added a test to make sure the quotes are added when the image tag is a number or exponent
    - ref. https://github.com/kubernetes-sigs/kustomize/issues/1303