### PR TITLE
Treat empty strings as string type instead of null type

### DIFF
--- a/kyaml/yaml/compatibility.go
+++ b/kyaml/yaml/compatibility.go
@@ -70,6 +70,9 @@ func IsYaml1_1NonString(node *Node) bool {
 }
 
 func IsValueNonString(value string) bool {
+	if value == "" {
+		return false
+	}
 	if strings.Contains(value, "\n") {
 		// multi-line strings will fail to unmarshal
 		return false

--- a/kyaml/yaml/compatibility_test.go
+++ b/kyaml/yaml/compatibility_test.go
@@ -23,6 +23,7 @@ func TestIsYaml1_1NonString(t *testing.T) {
 		{val: "2", expected: true},
 		{val: "true", expected: true},
 		{val: "1.0\nhello", expected: false}, // multiline strings should always be false
+		{val: "", expected: false}, // empty string should be considered a string
 	}
 
 	for k := range valueToTagMap {
@@ -111,7 +112,7 @@ var valueToTagMap = func() map[string]string {
 	val := map[string]string{}
 
 	// https://yaml.org/type/null.html
-	values := []string{"", "~", "null", "Null", "NULL"}
+	values := []string{"~", "null", "Null", "NULL"}
 	for i := range values {
 		val[values[i]] = "!!null"
 	}


### PR DESCRIPTION
Kyaml currently treats an empty string as a non-string type. This does not seems to be in line with the [spec](https://yaml.org/type/null.html) which says

> Note that a null is different from an empty string and that a mapping entry with some key and a null value is valid and different from not having that key in the mapping.

This causes issues when users have empty strings in their manifests, ref https://github.com/GoogleContainerTools/kpt/issues/693.

This changes this behavior so an empty string is considered to be of type string.

@phanimarupaka @pwittrock 