### PR TITLE
Re-introduce shallow git clones for git based remote resources

### DIFF
--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -50,7 +50,7 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"fetch",
 		"--depth=1",
 		"origin",
-		"FETCH_HEAD")
+		repoSpec.Ref)
 	cmd.Dir = repoSpec.Dir.String()
 	out, err = cmd.CombinedOutput()
 	if err != nil {
@@ -61,7 +61,7 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 	cmd = exec.Command(
 		gitProgram,
 		"checkout",
-		repoSpec.Ref)
+		"FETCH_HEAD")
 	cmd.Dir = repoSpec.Dir.String()
 	out, err = cmd.CombinedOutput()
 	if err != nil {

--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -50,7 +50,7 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"fetch",
 		"--depth=1",
 		"origin",
-		repoSpec.Ref)
+		"FETCH_HEAD")
 	cmd.Dir = repoSpec.Dir.String()
 	out, err = cmd.CombinedOutput()
 	if err != nil {

--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -4,6 +4,7 @@
 package git
 
 import (
+	"log"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -35,8 +36,9 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"--depth=1",
 		repoSpec.CloneSpec(),
 		repoSpec.Dir.String())
-	_, err = cmd.CombinedOutput()
+	out, err = cmd.CombinedOutput()
 	if err != nil {
+		log.Printf("Error cloning git repo: %s", out)
 		return errors.Wrapf(
 			err,
 			"trouble cloning git repo %v in %s",
@@ -50,8 +52,9 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"origin",
 		repoSpec.Ref)
 	cmd.Dir = repoSpec.Dir.String()
-	_, err = cmd.CombinedOutput()
+	out, err = cmd.CombinedOutput()
 	if err != nil {
+		log.Printf("Error fetching ref: %s", out)
 		return errors.Wrapf(err, "trouble fetching %s", repoSpec.Ref)
 	}
 
@@ -60,8 +63,9 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"checkout",
 		repoSpec.Ref)
 	cmd.Dir = repoSpec.Dir.String()
-	_, err = cmd.CombinedOutput()
+	out, err = cmd.CombinedOutput()
 	if err != nil {
+		log.Printf("Error checking out ref: %s", out)
 		return errors.Wrapf(err, "trouble checking out %s", repoSpec.Ref)
 	}
 
@@ -72,8 +76,9 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"--init",
 		"--recursive")
 	cmd.Dir = repoSpec.Dir.String()
-	_, err = cmd.CombinedOutput()
+	out, err = cmd.CombinedOutput()
 	if err != nil {
+		log.Printf("Error fetching submodules: %s", out)
 		return errors.Wrapf(err, "trouble fetching submodules for %s", repoSpec.CloneSpec())
 	}
 

--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -4,7 +4,6 @@
 package git
 
 import (
-	"log"
 	"os/exec"
 
 	"github.com/pkg/errors"
@@ -33,11 +32,11 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 	cmd := exec.Command(
 		gitProgram,
 		"clone",
+		"--depth=1",
 		repoSpec.CloneSpec(),
 		repoSpec.Dir.String())
-	out, err := cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Error cloning git repo: %s", out)
 		return errors.Wrapf(
 			err,
 			"trouble cloning git repo %v in %s",
@@ -46,12 +45,23 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 
 	cmd = exec.Command(
 		gitProgram,
+		"fetch",
+		"--depth=1",
+		"origin",
+		repoSpec.Ref)
+	cmd.Dir = repoSpec.Dir.String()
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "trouble fetching %s", repoSpec.Ref)
+	}
+
+	cmd = exec.Command(
+		gitProgram,
 		"checkout",
 		repoSpec.Ref)
 	cmd.Dir = repoSpec.Dir.String()
-	out, err = cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Error checking out ref: %s", out)
 		return errors.Wrapf(err, "trouble checking out %s", repoSpec.Ref)
 	}
 
@@ -62,9 +72,8 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"--init",
 		"--recursive")
 	cmd.Dir = repoSpec.Dir.String()
-	out, err = cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
-		log.Printf("Error fetching submodules: %s", out)
 		return errors.Wrapf(err, "trouble fetching submodules for %s", repoSpec.CloneSpec())
 	}
 

--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -36,7 +36,7 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 		"--depth=1",
 		repoSpec.CloneSpec(),
 		repoSpec.Dir.String())
-	out, err = cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error cloning git repo: %s", out)
 		return errors.Wrapf(


### PR DESCRIPTION
Removing the shallow clone significantly increased the build time for kustomize builds that included remote large remote git repositories. By re-introducing this, the build times for these builds can go down significantly. 