### PR TITLE
Return an error if setting a value that is not legal for the type

### DIFF
--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -40,6 +40,8 @@ func NewSetRunner(parent string) *SetRunner {
 	c.Flags().StringVar(&setterVersion, "version", "",
 		"use this version of the setter format")
 	c.Flags().MarkHidden("version")
+	c.Flags().BoolVar(&r.Set.ForceStringType, "force-string-type", false,
+		"force the yaml type of the value to be string")
 
 	return r
 }

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -941,6 +941,140 @@ spec:
 `,
 			errMsg: "cyclic substitution detected with name my-nested-subst",
 		},
+		{
+			name: "new value has different type",
+			args: []string{"maxUnavailable", "3"},
+			out:  "set 1 fields\n",
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: 35%
+ `,
+			input: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: 35% # {"$openapi":"maxUnavailable"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: "3"
+          isSet: true
+ `,
+			expectedResources: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: 3 # {"$openapi":"maxUnavailable"}
+`,
+		},
+		{
+			name: "override type to be string",
+			args: []string{"maxUnavailable", "3", "--force-string-type"},
+			out:  "set 1 fields\n",
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: 35%
+ `,
+			input: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: 35% # {"$openapi":"maxUnavailable"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: "3"
+          isSet: true
+ `,
+			expectedResources: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: "3" # {"$openapi":"maxUnavailable"}
+`,
+		},
+		{
+			name: "type override in setter schema",
+			args: []string{"maxUnavailable", "3"},
+			out:  "set 1 fields\n",
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: 35%
+ `,
+			input: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: 35% # {"$openapi":"maxUnavailable"}
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.maxUnavailable:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: maxUnavailable
+          value: "3"
+          isSet: true
+ `,
+			expectedResources: `
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  maxUnavailable: "3" # {"$openapi":"maxUnavailable"}
+`,
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/kyaml/setters2/settersutil/fieldsetter.go
+++ b/kyaml/setters2/settersutil/fieldsetter.go
@@ -21,6 +21,10 @@ type FieldSetter struct {
 	// Value is the value to set
 	Value string
 
+	// ForceStringType defines whether the type of the new value should
+	// be forced to be string
+	ForceStringType bool
+
 	// ListValues contains a list of values to set on a Sequence
 	ListValues []string
 
@@ -75,11 +79,21 @@ func (fs FieldSetter) Set(openAPIPath, resourcesPath string) (int, error) {
 		return 0, err
 	}
 
+	// If ForceStringType is true, we need to set the Type field in the
+	// Set filter to force the yaml type of the value to be string.
+	var valueType string
+	if fs.ForceStringType {
+		valueType = yaml.StringTag
+	}
+
 	// Update the resources with the new value
 	// Set NoDeleteFiles to true as SetAll will return only the nodes of files which should be updated and
 	// hence, rest of the files should not be deleted
 	inout := &kio.LocalPackageReadWriter{PackagePath: resourcesPath, NoDeleteFiles: true}
-	s := &setters2.Set{Name: fs.Name}
+	s := &setters2.Set{
+		Name: fs.Name,
+		Type: valueType,
+	}
 	err = kio.Pipeline{
 		Inputs:  []kio.Reader{inout},
 		Filters: []kio.Filter{setters2.SetAll(s)},

--- a/kyaml/yaml/compatibility.go
+++ b/kyaml/yaml/compatibility.go
@@ -13,11 +13,11 @@ import (
 )
 
 // typeToTag maps OpenAPI schema types to yaml 1.2 tags
-var typeToTag = map[string]string{
+var openAPITypeToYAMLTag = map[string]string{
 	"string":  StringTag,
 	"integer": IntTag,
 	"boolean": BoolTag,
-	"number":  "!!float",
+	"number":  FloatTag,
 }
 
 // FormatNonStringStyle makes sure that values which parse as non-string values in yaml 1.1
@@ -45,7 +45,7 @@ func FormatNonStringStyle(node *Node, schema spec.Schema) {
 	default:
 		return
 	}
-	if tag, found := typeToTag[t]; found {
+	if tag, found := openAPITypeToYAMLTag[t]; found {
 		// make sure the right tag is set
 		node.Tag = tag
 	}
@@ -90,3 +90,17 @@ func IsValueNonString(value string) bool {
 }
 
 var stringType = reflect.TypeOf("string")
+
+func OpenAPITypeForYALMType(yamlType string) (string, bool) {
+	for openAPIType, yamlTag := range openAPITypeToYAMLTag {
+		if yamlType == yamlTag {
+			return openAPIType, true
+		}
+	}
+	return "", false
+}
+
+func YAMLTypeForOpenAPIType(openAPIType string) (string, bool) {
+	yamlTag, found := openAPITypeToYAMLTag[openAPIType]
+	return yamlTag, found
+}

--- a/kyaml/yaml/compatibility_test.go
+++ b/kyaml/yaml/compatibility_test.go
@@ -114,7 +114,7 @@ var valueToTagMap = func() map[string]string {
 	// https://yaml.org/type/null.html
 	values := []string{"~", "null", "Null", "NULL"}
 	for i := range values {
-		val[values[i]] = "!!null"
+		val[values[i]] = yaml.NullTag
 	}
 
 	// https://yaml.org/type/bool.html
@@ -122,7 +122,7 @@ var valueToTagMap = func() map[string]string {
 		"y", "Y", "yes", "Yes", "YES", "true", "True", "TRUE", "on", "On", "ON", "n", "N", "no",
 		"No", "NO", "false", "False", "FALSE", "off", "Off", "OFF"}
 	for i := range values {
-		val[values[i]] = "!!bool"
+		val[values[i]] = yaml.BoolTag
 	}
 
 	// https://yaml.org/type/float.html
@@ -130,7 +130,7 @@ var valueToTagMap = func() map[string]string {
 		".nan", ".NaN", ".NAN", ".inf", ".Inf", ".INF",
 		"+.inf", "+.Inf", "+.INF", "-.inf", "-.Inf", "-.INF"}
 	for i := range values {
-		val[values[i]] = "!!float"
+		val[values[i]] = yaml.FloatTag
 	}
 
 	return val

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -593,6 +593,8 @@ const (
 	StringTag = "!!str"
 	BoolTag   = "!!bool"
 	IntTag    = "!!int"
+	FloatTag  = "!!float"
+	NullTag   = "!!null"
 )
 
 // Elements returns the list of elements in the RNode.


### PR DESCRIPTION
Current it is possible to use a setter to update a node with a value that is not legal for the type of the node (as defined in the tag). 

If we have Kptfile:
```
apiVersion: kpt.dev/v1alpha1
kind: Kptfile
metadata:
  name: .
packageMetadata:
  shortDescription: sample description
openAPI:
  definitions:
    io.k8s.cli.setters.stringVal:
      x-k8s-cli:
        setter:
          name: stringVal
          value: "1234"
```
and a single resource:
```
apiVersion: test/alpha
kind: strValue
metadata:
  name: strValue
spec:
  stringVal: 1234 # {"$kpt-set":"stringVal"}
  subVal: prefix-1234
```

Setting the value of the setter to `foo` leads to the following result:
```
apiVersion: test/alpha
kind: strValue
metadata:
  name: strValue
spec:
  stringVal: !!int foo # {"$kpt-set":"stringVal"}
  subVal: prefix-1234
```
The cause is the the `stringVal` node has type `integer`, so just setting its value to a string that is not a valid value for integer doesn't work.

With this PR, the procedure for determining the type of a setter value will be the following:
- If the user has used the `--force-string-type` flag when setting the value, the type of the value will be string. In this case the type in the setter schema doesn't matter (as long as the value passes validation) and the value doesn't matter. We could make this more flexible by having a `--force-type=<type>` flag, but it get more complicated for the user and I don't think it is needed.
- If there is a type specified in the setter schema, we try to map that to a yaml type. We can do this for the basic scalar types, but since openapi allows mixed types, this will not always be possible. If we can't find a yaml type, we just set the tag of the new node to `""` which forces the yaml marshalling library to determine the type.
- If we don't have any type information, we determine the type based on the new value. This has two steps:
  - Use the yaml library to parse just the value as yaml, and look up the type in the resulting yaml node.
  - Find the openapi type that matches the yaml type found above, and verify that the value is valid for the given type in openapi. If it is, then return that type. Otherwise return string.

The two-step process two determine the type just based on the value is to avoid choosing a type for a value that is valid in yaml, but not in json/openapi. For example, yaml supports "truthy" values like `on`', `off`, `yes`, but openapi only allows `true` and `false` for boolean values.

We should also look at the openapi schema for the type if it is available. I will handle that in a follow-up PR.

@phanimarupaka @pwittrock 