### PR TITLE
Accept all values as string type in validation

### DIFF
--- a/kyaml/go.mod
+++ b/kyaml/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-errors/errors v1.0.1
+	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/spec v0.19.5
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/validate v0.19.8

--- a/kyaml/setters2/set.go
+++ b/kyaml/setters2/set.go
@@ -244,8 +244,23 @@ func validateAgainstSchema(ext *CliExtension, sch *spec.Schema) error {
 
 	var inputYAML string
 	if len(ext.Setter.ListValues) > 0 {
-		tmpl, err := template.New("validator").
-			Parse(`{{.key}}:{{block "list" .values}}{{"\n"}}{{range .}}{{println "-" .}}{{end}}{{end}}`)
+		// tmplText contains the template we will use to produce a yaml
+		// document that we can use for validation.
+		var tmplText string
+		if sch.Items != nil && sch.Items.Schema != nil &&
+			sch.Items.Schema.Type.Contains("string") {
+			// If string is one of the legal types for the value, we
+			// output it with quotes in the yaml document to make sure it
+			// is later parsed as a string.
+			tmplText = `{{.key}}:{{block "list" .values}}{{"\n"}}{{range .}}{{printf "- %q\n" .}}{{end}}{{end}}`
+		} else {
+			// If string is not specifically set as the type, we just
+			// let the yaml unmarshaller detect the correct type. Thus, we
+			// do not add quotes around the value.
+			tmplText = `{{.key}}:{{block "list" .values}}{{"\n"}}{{range .}}{{println "-" .}}{{end}}{{end}}`
+		}
+
+		tmpl, err := template.New("validator").Parse(tmplText)
 		if err != nil {
 			return err
 		}
@@ -259,7 +274,15 @@ func validateAgainstSchema(ext *CliExtension, sch *spec.Schema) error {
 		}
 		inputYAML = builder.String()
 	} else {
-		inputYAML = fmt.Sprintf("%s: %s", ext.Setter.Name, ext.Setter.Value)
+		var format string
+		// Only add quotes around the value is string is one of the
+		// types in the schema.
+		if sch.Type.Contains("string") {
+			format = "%s: \"%s\""
+		} else {
+			format = "%s: %s"
+		}
+		inputYAML = fmt.Sprintf(format, ext.Setter.Name, ext.Setter.Value)
 	}
 
 	input := map[string]interface{}{}

--- a/kyaml/yaml/compatibility_test.go
+++ b/kyaml/yaml/compatibility_test.go
@@ -23,7 +23,7 @@ func TestIsYaml1_1NonString(t *testing.T) {
 		{val: "2", expected: true},
 		{val: "true", expected: true},
 		{val: "1.0\nhello", expected: false}, // multiline strings should always be false
-		{val: "", expected: false}, // empty string should be considered a string
+		{val: "", expected: false},           // empty string should be considered a string
 	}
 
 	for k := range valueToTagMap {


### PR DESCRIPTION
If a user specifies a type when creating a setter, the validation logic will use this type during validation (which unfortunately also runs as part of `list-setters`). But the input value to the setter have been unmarshalled from yaml to a go type by the time we do validation, which means that validation happens against a go type. So values such as `1234` will have been turned into a go int and therefore does not pass validation if the required type is `string`. 

Since all values that can be used as setter values will be valid strings, we should never fail validation when the type is string. This PR looks at the result after validation, and removes any errors caused by a value not being of type string. The advantage of this approach over removing the type constraint before validation, is that this also captures situations where the value list must be string.

Ref: #713

@phanimarupaka @pwittrock 