### PR TITLE
Fix validation for array setters

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -148,6 +148,21 @@ spec:
   - "a"
   - "b"
   - "c"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: myspace
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: sidecar
+        image: nginx:1.7.9
+      - name: nginx
+        image: otherspace/nginx:1.7.9
  `,
 			inputOpenAPI: `
 apiVersion: v1alpha1
@@ -190,6 +205,21 @@ spec:
   - "a"
   - "b"
   - "c"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: myspace
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: sidecar
+        image: nginx:1.7.9
+      - name: nginx
+        image: otherspace/nginx:1.7.9
  `,
 		},
 

--- a/kyaml/go.mod
+++ b/kyaml/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-errors/errors v1.0.1
-	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/spec v0.19.5
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/validate v0.19.8

--- a/kyaml/setters2/add.go
+++ b/kyaml/setters2/add.go
@@ -75,17 +75,16 @@ func (a *Add) visitMapping(object *yaml.RNode, p string, _ *openapi.ResourceSche
 			values = append(values, sc.Value)
 		}
 
-		// check if there are different values for field path
-		if len(a.ListValues) > 0 && !reflect.DeepEqual(values, a.ListValues) {
-			return errors.Errorf("setters can only be created for fields with same values, "+
-				"encountered different array values for specified field path: %s, %s", values, a.ListValues)
-		}
-		a.ListValues = values
-
 		// pathToKey refers to the path address of the key node ex: metadata.annotations
 		// p is the path till parent node, pathToKey is obtained by appending child key
 		pathToKey := p + "." + strings.Trim(key, "\n")
 		if a.FieldName != "" && strings.HasSuffix(pathToKey, a.FieldName) {
+			// check if there are different values for field path before adding ref to the field
+			if len(a.ListValues) > 0 && !reflect.DeepEqual(values, a.ListValues) {
+				return errors.Errorf("setters can only be created for fields with same values, "+
+					"encountered different array values for specified field path: %s, %s", values, a.ListValues)
+			}
+			a.ListValues = values
 			return a.addRef(node.Key)
 		}
 		return nil


### PR DESCRIPTION
@mortent 

This PR is to fix the validation for array setters. We should only check if there are different array values for the filed path if the path matches.