### PR TITLE
Tests for List setters should not alter resources

### DIFF
--- a/kyaml/setters2/list.go
+++ b/kyaml/setters2/list.go
@@ -181,6 +181,8 @@ func (l *List) listSubst(object *yaml.RNode) error {
 }
 
 // count returns the number of fields set by the setter with name
+// set filter is leveraged for this but the resources are not written
+// back to files as only LocalPackageReader is invoked and not writer
 func (l *List) count(path, name string) (int, error) {
 	s := &Set{Name: name}
 	err := kio.Pipeline{


### PR DESCRIPTION
@mortent 

This PR corresponds to issue https://github.com/GoogleContainerTools/kpt/issues/725. 

It is done by introducing DryRun field in Set type. It can be leveraged in future as well for other purposes.