### PR TITLE
Fix copy comments for Folded style scalar nodes

### DIFF
--- a/kyaml/comments/comments.go
+++ b/kyaml/comments/comments.go
@@ -30,7 +30,16 @@ func (c *copier) VisitMap(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.RNod
 }
 
 func (c *copier) VisitScalar(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.RNode, error) {
-	copy(s.Dest(), s.Origin())
+	to := s.Origin()
+	// TODO: File a bug with upstream yaml to handle comments for FoldedStyle scalar nodes
+	// Hack: convert FoldedStyle scalar node to DoubleQuotedStyle as the line comments are
+	// being serialized without space
+	// https://github.com/GoogleContainerTools/kpt/issues/766
+	if to != nil && to.Document().Style == yaml.FoldedStyle {
+		to.Document().Style = yaml.DoubleQuotedStyle
+	}
+
+	copy(s.Dest(), to)
 	return s.Dest(), nil
 }
 

--- a/kyaml/comments/comments_test.go
+++ b/kyaml/comments/comments_test.go
@@ -288,6 +288,29 @@ items:
 - a # comment
 `,
 		},
+
+		{
+			name: "copy_comments_folded_style",
+			from: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
+`,
+			to: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: >-
+    012345678901234567890123456789012345678901234567890123456789012345678901234
+`,
+			expected: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
+`,
+		},
 	}
 
 	for i := range testCases {


### PR DESCRIPTION
@frankfarzan @pwittrock @prachirp 

This PR is to fix the issue https://github.com/GoogleContainerTools/kpt/issues/766. The approach here is to convert the FoldedStyle scalar nodes to DoubleQuotedStyle so that the comments are serialized correctly by upstream yaml. 