### PR TITLE
configMapGenerator docs content addition for `envs` option

### DIFF
--- a/docs/api-reference/glossary/index.html
+++ b/docs/api-reference/glossary/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -911,8 +911,8 @@ absolute path, or by relative path.</p>
 <li><strong>B</strong> may not <em>depend on</em> <strong>A</strong>, even transitively.</li>
 </ul>
 <p><strong>A</strong> may contain <strong>B</strong>, but in this case it might be
-simplest to have <strong>A</strong> directly depend on <strong>B</strong>&lsquo;s
-resources and eliminate <strong>B</strong>&lsquo;s kustomization.yaml file
+simplest to have <strong>A</strong> directly depend on <strong>B</strong>&rsquo;s
+resources and eliminate <strong>B</strong>&rsquo;s kustomization.yaml file
 (i.e. absorb <strong>B</strong> into <strong>A</strong>).</p>
 <p>Conventionally, <strong>B</strong> is in a directory that&rsquo;s sibling
 to <strong>A</strong>, or <strong>B</strong> is off in a completely independent

--- a/docs/api-reference/index.html
+++ b/docs/api-reference/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/bases/index.html
+++ b/docs/api-reference/kustomization/bases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/commonannotations/index.html
+++ b/docs/api-reference/kustomization/commonannotations/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/commonlabels/index.html
+++ b/docs/api-reference/kustomization/commonlabels/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/components/index.html
+++ b/docs/api-reference/kustomization/components/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/configmapgenerator/index.html
+++ b/docs/api-reference/kustomization/configmapgenerator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -748,9 +748,13 @@
 	<div class="lead">Generate ConfigMap resources.</div>
 	<p>Each entry in this list results in the creation of
 one ConfigMap resource (it&rsquo;s a generator of n maps).</p>
-<p>The example below creates three ConfigMaps. One with the names and contents of
-the given files, one with key/value as data, and a third which sets an
-annotation and label via <code>options</code> for that single ConfigMap.</p>
+<p>The example below creates four ConfigMaps:</p>
+<ul>
+<li>first, with the names and contents of the given files</li>
+<li>second, with key/value as data using key/value pairs from files</li>
+<li>third, also with key/value as data, directly specified using <code>literals</code></li>
+<li>and a fourth, which sets an annotation and label via <code>options</code> for that single ConfigMap</li>
+</ul>
 <p>Each configMapGenerator item accepts a parameter of
 <code>behavior: [create|replace|merge]</code>.
 This allows an overlay to modify or
@@ -780,8 +784,12 @@ trump any attempt to locally override it.</p>
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">files</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- application.properties<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- more.properties<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline"></span>- <span style="color:#204a87;font-weight:bold">name</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline"> </span>my-java-server-env-file-vars<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">envs</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span>- my-server-env.properties<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span>- more-server-props.env<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline"></span>- <span style="color:#204a87;font-weight:bold">name</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline"> </span>my-java-server-env-vars<span style="color:#f8f8f8;text-decoration:underline">
-</span><span style="color:#f8f8f8;text-decoration:underline">  </span>literals<span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">	
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">literals</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- JAVA_HOME=/opt/java/jdk<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- JAVA_TOOL_OPTIONS=-agentlib<span style="color:#000;font-weight:bold">:</span>hprof<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">options</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">

--- a/docs/api-reference/kustomization/crds/index.html
+++ b/docs/api-reference/kustomization/crds/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/generatoroptions/index.html
+++ b/docs/api-reference/kustomization/generatoroptions/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/images/index.html
+++ b/docs/api-reference/kustomization/images/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/index.html
+++ b/docs/api-reference/kustomization/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/index.xml
+++ b/docs/api-reference/kustomization/index.xml
@@ -199,9 +199,13 @@ resource has been applied to a cluster.&lt;/p&gt;
         
         &lt;p&gt;Each entry in this list results in the creation of
 one ConfigMap resource (it&amp;rsquo;s a generator of n maps).&lt;/p&gt;
-&lt;p&gt;The example below creates three ConfigMaps. One with the names and contents of
-the given files, one with key/value as data, and a third which sets an
-annotation and label via &lt;code&gt;options&lt;/code&gt; for that single ConfigMap.&lt;/p&gt;
+&lt;p&gt;The example below creates four ConfigMaps:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;first, with the names and contents of the given files&lt;/li&gt;
+&lt;li&gt;second, with key/value as data using key/value pairs from files&lt;/li&gt;
+&lt;li&gt;third, also with key/value as data, directly specified using &lt;code&gt;literals&lt;/code&gt;&lt;/li&gt;
+&lt;li&gt;and a fourth, which sets an annotation and label via &lt;code&gt;options&lt;/code&gt; for that single ConfigMap&lt;/li&gt;
+&lt;/ul&gt;
 &lt;p&gt;Each configMapGenerator item accepts a parameter of
 &lt;code&gt;behavior: [create|replace|merge]&lt;/code&gt;.
 This allows an overlay to modify or
@@ -231,8 +235,12 @@ trump any attempt to locally override it.&lt;/p&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;files&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- application.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- more.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;my-java-server-env-file-vars&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;envs&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- my-server-env.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- more-server-props.env&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;my-java-server-env-vars&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;literals&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;	
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;literals&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- JAVA_HOME=/opt/java/jdk&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- JAVA_TOOL_OPTIONS=-agentlib&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;hprof&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;options&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
@@ -774,7 +782,7 @@ resources.&lt;/p&gt;
 supported.  No ints, bools, arrays etc.  It&amp;rsquo;s not
 possible to, say, extract the name of the image in
 container number 2 of some pod template.&lt;/p&gt;
-&lt;p&gt;A variable reference, i.e. the string &amp;lsquo;$(FOO)&#39;,
+&lt;p&gt;A variable reference, i.e. the string &amp;lsquo;$(FOO)&amp;rsquo;,
 can only be placed in particular fields of
 particular objects as specified by kustomize&amp;rsquo;s
 configuration data.&lt;/p&gt;

--- a/docs/api-reference/kustomization/nameprefix/index.html
+++ b/docs/api-reference/kustomization/nameprefix/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/namespace/index.html
+++ b/docs/api-reference/kustomization/namespace/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/namesuffix/index.html
+++ b/docs/api-reference/kustomization/namesuffix/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/patches/index.html
+++ b/docs/api-reference/kustomization/patches/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -506,10 +506,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/api-reference/kustomization/patchesjson6902/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patchesJson6902</a>
+    <a  href="/kustomize/api-reference/kustomization/patchesjson6902/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patchesJson6902</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizeapi-referencekustomizationpatchesjson6902">
+    <li class="collapse " id="kustomizeapi-referencekustomizationpatchesjson6902">
       
       
       
@@ -529,10 +529,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/api-reference/kustomization/patchesstrategicmerge/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patchesStrategicMerge</a>
+    <a  href="/kustomize/api-reference/kustomization/patchesstrategicmerge/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patchesStrategicMerge</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizeapi-referencekustomizationpatchesstrategicmerge">
+    <li class="collapse " id="kustomizeapi-referencekustomizationpatchesstrategicmerge">
       
       
       

--- a/docs/api-reference/kustomization/patchesjson6902/index.html
+++ b/docs/api-reference/kustomization/patchesjson6902/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -483,10 +483,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patches</a>
+    <a  href="/kustomize/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patches</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizeapi-referencekustomizationpatches">
+    <li class="collapse " id="kustomizeapi-referencekustomizationpatches">
       
       
       

--- a/docs/api-reference/kustomization/patchesstrategicmerge/index.html
+++ b/docs/api-reference/kustomization/patchesstrategicmerge/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -483,10 +483,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patches</a>
+    <a  href="/kustomize/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patches</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizeapi-referencekustomizationpatches">
+    <li class="collapse " id="kustomizeapi-referencekustomizationpatches">
       
       
       

--- a/docs/api-reference/kustomization/replicas/index.html
+++ b/docs/api-reference/kustomization/replicas/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/resources/index.html
+++ b/docs/api-reference/kustomization/resources/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/secretegenerator/index.html
+++ b/docs/api-reference/kustomization/secretegenerator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/api-reference/kustomization/vars/index.html
+++ b/docs/api-reference/kustomization/vars/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -794,7 +794,7 @@ resources.</p>
 supported.  No ints, bools, arrays etc.  It&rsquo;s not
 possible to, say, extract the name of the image in
 container number 2 of some pod template.</p>
-<p>A variable reference, i.e. the string &lsquo;$(FOO)',
+<p>A variable reference, i.e. the string &lsquo;$(FOO)&rsquo;,
 can only be placed in particular fields of
 particular objects as specified by kustomize&rsquo;s
 configuration data.</p>

--- a/docs/blog/2018/05/21/v1.0.1/index.html
+++ b/docs/blog/2018/05/21/v1.0.1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/02/05/v2.0.0/index.html
+++ b/docs/blog/2019/02/05/v2.0.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/06/18/v2.1.0/index.html
+++ b/docs/blog/2019/06/18/v2.1.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/07/03/v3.0.0/index.html
+++ b/docs/blog/2019/07/03/v3.0.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/07/26/v3.1.0/index.html
+++ b/docs/blog/2019/07/26/v3.1.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/09/17/v3.2.0/index.html
+++ b/docs/blog/2019/09/17/v3.2.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/09/26/v3.2.1/index.html
+++ b/docs/blog/2019/09/26/v3.2.1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/2019/10/24/v3.3.0/index.html
+++ b/docs/blog/2019/10/24/v3.3.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/blog/releases/index.html
+++ b/docs/blog/releases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/bugs/index.html
+++ b/docs/contributing/bugs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/community/index.html
+++ b/docs/contributing/community/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/docs/index.html
+++ b/docs/contributing/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/features/index.html
+++ b/docs/contributing/features/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/howitworks/index.html
+++ b/docs/contributing/howitworks/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/index.html
+++ b/docs/contributing/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/mac/index.html
+++ b/docs/contributing/mac/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/contributing/windows/index.html
+++ b/docs/contributing/windows/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/en/sitemap.xml
+++ b/docs/en/sitemap.xml
@@ -64,7 +64,7 @@
   
   <url>
     <loc>https://kubernetes-sigs.github.io/kustomize/installation/binaries/</loc>
-    <lastmod>2020-06-07T21:07:46-07:00</lastmod>
+    <lastmod>2020-06-22T15:59:38+05:00</lastmod>
     <xhtml:link
                 rel="alternate"
                 hreflang="zh"
@@ -274,7 +274,7 @@
   
   <url>
     <loc>https://kubernetes-sigs.github.io/kustomize/guides/plugins/</loc>
-    <lastmod>2020-06-07T21:07:46-07:00</lastmod>
+    <lastmod>2020-06-15T14:22:31-07:00</lastmod>
     <xhtml:link
                 rel="alternate"
                 hreflang="zh"

--- a/docs/faq/eschewedfeatures/index.html
+++ b/docs/faq/eschewedfeatures/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/faq/versioningpolicy/index.html
+++ b/docs/faq/versioningpolicy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/bespoke/index.html
+++ b/docs/guides/bespoke/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/offtheshelf/index.html
+++ b/docs/guides/offtheshelf/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/plugins/builtins/index.html
+++ b/docs/guides/plugins/builtins/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/plugins/execpluginguidedexample/index.html
+++ b/docs/guides/plugins/execpluginguidedexample/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/plugins/goplugincaveats/index.html
+++ b/docs/guides/plugins/goplugincaveats/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/plugins/gopluginguidedexample/index.html
+++ b/docs/guides/plugins/gopluginguidedexample/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/guides/plugins/index.html
+++ b/docs/guides/plugins/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -598,7 +598,6 @@ attached functions implement the <code>Configurable</code>,
 <pre><code>package main
 
 import (
-  &quot;sigs.k8s.io/kustomize/api/ifc&quot;
   &quot;sigs.k8s.io/kustomize/api/resmap&quot;
   ...
 )
@@ -608,8 +607,7 @@ type plugin struct {...}
 var KustomizePlugin plugin
 
 func (p *plugin) Config(
-   ldr ifc.Loader,
-   rf *resmap.Factory,
+   h *resmap.PluginHelpers,
    c []byte) error {...}
 
 func (p *plugin) Generate() (resmap.ResMap, error) {...}
@@ -708,7 +706,7 @@ go build -buildmode plugin \
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified June 7, 2020: <a  href="https://github.com/kubernetes-sigs/kustomize/commit/42497c664f619a36cc86156e366b53099bd633cb">Convert docs to docsy (42497c66)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 15, 2020: <a  href="https://github.com/kubernetes-sigs/kustomize/commit/36165d28437ac350db61d301c032c0c661ee684b">Update GO plugin doc (36165d28)</a>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/installation/binaries/index.html
+++ b/docs/installation/binaries/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -369,7 +369,7 @@
 	<h1>Binaries</h1>
 	<div class="lead">Install Kustomize by downloading precompiled binaries.</div>
 	<p>Binaries at various versions for linux, MacOs and Windows are published on the [release page].</p>
-<p>The follow <a href="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh">script</a> detects your OS and downloads the appropriate kustomize binary to your
+<p>The following <a href="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh">script</a> detects your OS and downloads the appropriate kustomize binary to your
 current working directory.</p>
 <pre><code>curl -s &quot;https://raw.githubusercontent.com/\
 kubernetes-sigs/kustomize/master/hack/install_kustomize.sh&quot;  | bash
@@ -396,7 +396,7 @@ kubernetes-sigs/kustomize/master/hack/install_kustomize.sh&quot;  | bash
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified June 7, 2020: <a  href="https://github.com/kubernetes-sigs/kustomize/commit/42497c664f619a36cc86156e366b53099bd633cb">Convert docs to docsy (42497c66)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 22, 2020: <a  href="https://github.com/kubernetes-sigs/kustomize/commit/94101fb7cc22e73c63e6e9fa80a2297d9367732c">fix typo (94101fb7)</a>
 </div>
 </div>
 

--- a/docs/installation/chocolatey/index.html
+++ b/docs/installation/chocolatey/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/installation/homebrew/index.html
+++ b/docs/installation/homebrew/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/installation/source/index.html
+++ b/docs/installation/source/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
 	<sitemap>
 	   	<loc>https://kubernetes-sigs.github.io/kustomize/en/sitemap.xml</loc>
 		
-	   	<lastmod>2020-06-15T13:39:13+08:00</lastmod>
+	   	<lastmod>2020-06-22T15:59:38+05:00</lastmod>
 		
 	</sitemap>
 	

--- a/docs/zh/api-reference/glossary/index.html
+++ b/docs/zh/api-reference/glossary/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/index.html
+++ b/docs/zh/api-reference/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/bases/index.html
+++ b/docs/zh/api-reference/kustomization/bases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/commonannotations/index.html
+++ b/docs/zh/api-reference/kustomization/commonannotations/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/commonlabels/index.html
+++ b/docs/zh/api-reference/kustomization/commonlabels/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/components/index.html
+++ b/docs/zh/api-reference/kustomization/components/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/configmapgenerator/index.html
+++ b/docs/zh/api-reference/kustomization/configmapgenerator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -747,7 +747,13 @@
 	<h1>configMapGenerator</h1>
 	<div class="lead">生成 ConfigMap 资源.</div>
 	<p>列表中的每个条目都将生成一个 ConfigMap （合计可以生成 n 个 ConfigMap）。</p>
-<p>下面的示例会生成 3 个ConfigMap：第一个带有给定文件的名称和内容，第二个将在 data 中添加 key/value，第三个通过 <code>options</code> 为单个 ConfigMap 设置注释和标签。</p>
+<p>以下示例创建四个 ConfigMap：</p>
+<ul>
+<li>第一个使用给定文件的名称和内容创建数据</li>
+<li>第二个使用文件中的键/值对将数据创建为键/值</li>
+<li>第三个使用 <code>literals</code> 中的键/值对创建数据作为键/值</li>
+<li>第四个通过 <code>options</code> 设置单个 ConfigMap 的注释和标签</li>
+</ul>
 <p>每个 configMapGenerator 项均接受的参数 <code>behavior: [create|replace|merge]</code>，这个参数允许修改或替换父级现有的 configMap。</p>
 <p>此外，每个条目都有一个 <code>options</code> 字段，该字段具有与 kustomization 文件的 <code>generatorOptions</code> 字段相同的子字段。</p>
 <p><code>options</code> 字段允许用户为生成的实例添加标签和（或）注释，或者分别禁用该实例名称的哈希后缀。此处添加的标签和注释不会被 kustomization 文件 <code>generatorOptions</code> 字段关联的全局选项覆盖。但是如果全局 <code>generatorOptions</code> 字段指定 <code>disableNameSuffixHash: true</code>，其他 <code>options</code> 的设置将无法将其覆盖。</p>
@@ -765,8 +771,12 @@
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">files</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- application.properties<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- more.properties<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline"></span>- <span style="color:#204a87;font-weight:bold">name</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline"> </span>my-java-server-env-file-vars<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">envs</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span>- my-server-env.properties<span style="color:#f8f8f8;text-decoration:underline">
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span>- more-server-props.env<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline"></span>- <span style="color:#204a87;font-weight:bold">name</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline"> </span>my-java-server-env-vars<span style="color:#f8f8f8;text-decoration:underline">
-</span><span style="color:#f8f8f8;text-decoration:underline">  </span>literals<span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">	
+</span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">literals</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- JAVA_HOME=/opt/java/jdk<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span>- JAVA_TOOL_OPTIONS=-agentlib<span style="color:#000;font-weight:bold">:</span>hprof<span style="color:#f8f8f8;text-decoration:underline">
 </span><span style="color:#f8f8f8;text-decoration:underline">  </span><span style="color:#204a87;font-weight:bold">options</span><span style="color:#000;font-weight:bold">:</span><span style="color:#f8f8f8;text-decoration:underline">

--- a/docs/zh/api-reference/kustomization/crds/index.html
+++ b/docs/zh/api-reference/kustomization/crds/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/generatoroptions/index.html
+++ b/docs/zh/api-reference/kustomization/generatoroptions/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/images/index.html
+++ b/docs/zh/api-reference/kustomization/images/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/index.html
+++ b/docs/zh/api-reference/kustomization/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/index.xml
+++ b/docs/zh/api-reference/kustomization/index.xml
@@ -192,7 +192,13 @@
         
         
         &lt;p&gt;列表中的每个条目都将生成一个 ConfigMap （合计可以生成 n 个 ConfigMap）。&lt;/p&gt;
-&lt;p&gt;下面的示例会生成 3 个ConfigMap：第一个带有给定文件的名称和内容，第二个将在 data 中添加 key/value，第三个通过 &lt;code&gt;options&lt;/code&gt; 为单个 ConfigMap 设置注释和标签。&lt;/p&gt;
+&lt;p&gt;以下示例创建四个 ConfigMap：&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;第一个使用给定文件的名称和内容创建数据&lt;/li&gt;
+&lt;li&gt;第二个使用文件中的键/值对将数据创建为键/值&lt;/li&gt;
+&lt;li&gt;第三个使用 &lt;code&gt;literals&lt;/code&gt; 中的键/值对创建数据作为键/值&lt;/li&gt;
+&lt;li&gt;第四个通过 &lt;code&gt;options&lt;/code&gt; 设置单个 ConfigMap 的注释和标签&lt;/li&gt;
+&lt;/ul&gt;
 &lt;p&gt;每个 configMapGenerator 项均接受的参数 &lt;code&gt;behavior: [create|replace|merge]&lt;/code&gt;，这个参数允许修改或替换父级现有的 configMap。&lt;/p&gt;
 &lt;p&gt;此外，每个条目都有一个 &lt;code&gt;options&lt;/code&gt; 字段，该字段具有与 kustomization 文件的 &lt;code&gt;generatorOptions&lt;/code&gt; 字段相同的子字段。&lt;/p&gt;
 &lt;p&gt;&lt;code&gt;options&lt;/code&gt; 字段允许用户为生成的实例添加标签和（或）注释，或者分别禁用该实例名称的哈希后缀。此处添加的标签和注释不会被 kustomization 文件 &lt;code&gt;generatorOptions&lt;/code&gt; 字段关联的全局选项覆盖。但是如果全局 &lt;code&gt;generatorOptions&lt;/code&gt; 字段指定 &lt;code&gt;disableNameSuffixHash: true&lt;/code&gt;，其他 &lt;code&gt;options&lt;/code&gt; 的设置将无法将其覆盖。&lt;/p&gt;
@@ -210,8 +216,12 @@
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;files&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- application.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- more.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;my-java-server-env-file-vars&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;envs&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- my-server-env.properties&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- more-server-props.env&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;my-java-server-env-vars&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;literals&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;	
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;literals&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- JAVA_HOME=/opt/java/jdk&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;- JAVA_TOOL_OPTIONS=-agentlib&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;hprof&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
 &lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;  &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;options&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;

--- a/docs/zh/api-reference/kustomization/nameprefix/index.html
+++ b/docs/zh/api-reference/kustomization/nameprefix/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/namespace/index.html
+++ b/docs/zh/api-reference/kustomization/namespace/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/namesuffix/index.html
+++ b/docs/zh/api-reference/kustomization/namesuffix/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/patches/index.html
+++ b/docs/zh/api-reference/kustomization/patches/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -506,10 +506,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/zh/api-reference/kustomization/patchesjson6902/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patchesJson6902</a>
+    <a  href="/kustomize/zh/api-reference/kustomization/patchesjson6902/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patchesJson6902</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizezhapi-referencekustomizationpatchesjson6902">
+    <li class="collapse " id="kustomizezhapi-referencekustomizationpatchesjson6902">
       
       
       
@@ -529,10 +529,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/zh/api-reference/kustomization/patchesstrategicmerge/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patchesStrategicMerge</a>
+    <a  href="/kustomize/zh/api-reference/kustomization/patchesstrategicmerge/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patchesStrategicMerge</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizezhapi-referencekustomizationpatchesstrategicmerge">
+    <li class="collapse " id="kustomizezhapi-referencekustomizationpatchesstrategicmerge">
       
       
       

--- a/docs/zh/api-reference/kustomization/patchesjson6902/index.html
+++ b/docs/zh/api-reference/kustomization/patchesjson6902/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -483,10 +483,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/zh/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patches</a>
+    <a  href="/kustomize/zh/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patches</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizezhapi-referencekustomizationpatches">
+    <li class="collapse " id="kustomizezhapi-referencekustomizationpatches">
       
       
       

--- a/docs/zh/api-reference/kustomization/patchesstrategicmerge/index.html
+++ b/docs/zh/api-reference/kustomization/patchesstrategicmerge/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 
@@ -483,10 +483,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kustomize/zh/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">patches</a>
+    <a  href="/kustomize/zh/api-reference/kustomization/patches/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">patches</a>
   </li>
   <ul>
-    <li class="collapse show" id="kustomizezhapi-referencekustomizationpatches">
+    <li class="collapse " id="kustomizezhapi-referencekustomizationpatches">
       
       
       

--- a/docs/zh/api-reference/kustomization/replicas/index.html
+++ b/docs/zh/api-reference/kustomization/replicas/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/resources/index.html
+++ b/docs/zh/api-reference/kustomization/resources/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/secretegenerator/index.html
+++ b/docs/zh/api-reference/kustomization/secretegenerator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/api-reference/kustomization/vars/index.html
+++ b/docs/zh/api-reference/kustomization/vars/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2018/05/21/v1.0.1/index.html
+++ b/docs/zh/blog/2018/05/21/v1.0.1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/02/05/v2.0.0/index.html
+++ b/docs/zh/blog/2019/02/05/v2.0.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/06/18/v2.1.0/index.html
+++ b/docs/zh/blog/2019/06/18/v2.1.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/07/03/v3.0.0/index.html
+++ b/docs/zh/blog/2019/07/03/v3.0.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/07/26/v3.1.0/index.html
+++ b/docs/zh/blog/2019/07/26/v3.1.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/09/17/v3.2.0/index.html
+++ b/docs/zh/blog/2019/09/17/v3.2.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/09/26/v3.2.1/index.html
+++ b/docs/zh/blog/2019/09/26/v3.2.1/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/2019/10/24/v3.3.0/index.html
+++ b/docs/zh/blog/2019/10/24/v3.3.0/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/index.html
+++ b/docs/zh/blog/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/blog/releases/index.html
+++ b/docs/zh/blog/releases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/bugs/index.html
+++ b/docs/zh/contributing/bugs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/community/index.html
+++ b/docs/zh/contributing/community/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/docs/index.html
+++ b/docs/zh/contributing/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/features/index.html
+++ b/docs/zh/contributing/features/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/howitworks/index.html
+++ b/docs/zh/contributing/howitworks/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/index.html
+++ b/docs/zh/contributing/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/mac/index.html
+++ b/docs/zh/contributing/mac/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/contributing/windows/index.html
+++ b/docs/zh/contributing/windows/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/faq/eschewedfeatures/index.html
+++ b/docs/zh/faq/eschewedfeatures/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/faq/index.html
+++ b/docs/zh/faq/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/faq/versioningpolicy/index.html
+++ b/docs/zh/faq/versioningpolicy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/bespoke/index.html
+++ b/docs/zh/guides/bespoke/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/index.html
+++ b/docs/zh/guides/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/offtheshelf/index.html
+++ b/docs/zh/guides/offtheshelf/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/plugins/builtins/index.html
+++ b/docs/zh/guides/plugins/builtins/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/plugins/execpluginguidedexample/index.html
+++ b/docs/zh/guides/plugins/execpluginguidedexample/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/plugins/goplugincaveats/index.html
+++ b/docs/zh/guides/plugins/goplugincaveats/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/plugins/gopluginguidedexample/index.html
+++ b/docs/zh/guides/plugins/gopluginguidedexample/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/guides/plugins/index.html
+++ b/docs/zh/guides/plugins/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/index.json
+++ b/docs/zh/index.json
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/installation/binaries/index.html
+++ b/docs/zh/installation/binaries/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/installation/chocolatey/index.html
+++ b/docs/zh/installation/chocolatey/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/installation/homebrew/index.html
+++ b/docs/zh/installation/homebrew/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/installation/index.html
+++ b/docs/zh/installation/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/installation/source/index.html
+++ b/docs/zh/installation/source/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/search/index.html
+++ b/docs/zh/search/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.68.3" />
+<meta name="generator" content="Hugo 0.73.0" />
 
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 

--- a/docs/zh/sitemap.xml
+++ b/docs/zh/sitemap.xml
@@ -664,7 +664,7 @@
   
   <url>
     <loc>https://kubernetes-sigs.github.io/kustomize/zh/</loc>
-    <lastmod>2020-06-15T13:39:13+08:00</lastmod>
+    <lastmod>2020-06-15T14:21:15+08:00</lastmod>
     <xhtml:link
                 rel="alternate"
                 hreflang="en"

--- a/site/content/en/api-reference/kustomization/configmapgenerator/_index.md
+++ b/site/content/en/api-reference/kustomization/configmapgenerator/_index.md
@@ -9,9 +9,11 @@ description: >
 Each entry in this list results in the creation of
 one ConfigMap resource (it's a generator of n maps).
 
-The example below creates three ConfigMaps. One with the names and contents of
-the given files, one with key/value as data, and a third which sets an
-annotation and label via `options` for that single ConfigMap.
+The example below creates four ConfigMaps:
+- first, with the names and contents of the given files
+- second, with key/value as data using key/value pairs from files
+- third, also with key/value as data, directly specified using `literals`
+- and a fourth, which sets an annotation and label via `options` for that single ConfigMap
 
 Each configMapGenerator item accepts a parameter of
 `behavior: [create|replace|merge]`.
@@ -46,8 +48,12 @@ configMapGenerator:
   files:
   - application.properties
   - more.properties
+- name: my-java-server-env-file-vars
+  envs:
+  - my-server-env.properties
+  - more-server-props.env
 - name: my-java-server-env-vars
-  literals:	
+  literals:
   - JAVA_HOME=/opt/java/jdk
   - JAVA_TOOL_OPTIONS=-agentlib:hprof
   options:

--- a/site/content/zh/api-reference/kustomization/configmapgenerator/_index.md
+++ b/site/content/zh/api-reference/kustomization/configmapgenerator/_index.md
@@ -8,7 +8,11 @@ description: >
 
 列表中的每个条目都将生成一个 ConfigMap （合计可以生成 n 个 ConfigMap）。
 
-下面的示例会生成 3 个ConfigMap：第一个带有给定文件的名称和内容，第二个将在 data 中添加 key/value，第三个通过 `options` 为单个 ConfigMap 设置注释和标签。
+以下示例创建四个 ConfigMap：
+- 第一个使用给定文件的名称和内容创建数据
+- 第二个使用文件中的键/值对将数据创建为键/值
+- 第三个使用 `literals` 中的键/值对创建数据作为键/值
+- 第四个通过 `options` 设置单个 ConfigMap 的注释和标签
 
 每个 configMapGenerator 项均接受的参数 `behavior: [create|replace|merge]`，这个参数允许修改或替换父级现有的 configMap。
 
@@ -31,8 +35,12 @@ configMapGenerator:
   files:
   - application.properties
   - more.properties
+- name: my-java-server-env-file-vars
+  envs:
+  - my-server-env.properties
+  - more-server-props.env
 - name: my-java-server-env-vars
-  literals:	
+  literals:
   - JAVA_HOME=/opt/java/jdk
   - JAVA_TOOL_OPTIONS=-agentlib:hprof
   options:


### PR DESCRIPTION
Changes include content addition to configMapGenerator docs.

**Previous:** Docs for configMapGenerator did not mention about the use of `envs` for generating key/value data from files.
**Expected:** Docs for configMapGenerator mentioning about the use of `envs` for generating key/value data from files.

Preview of changes available at [forked repo github pages](https://viggys.github.io/kustomize/api-reference/kustomization/configmapgenerator/)