### PR TITLE
Fix an index.

### DIFF
--- a/kyaml/filtersutil/filtersutil.go
+++ b/kyaml/filtersutil/filtersutil.go
@@ -41,7 +41,7 @@ func ApplyToJSON(filter kio.Filter, objs ...marshalerUnmarshaler) error {
 
 	// convert the rnodes to json objects
 	for i := range nodes {
-		err = setRNode(objs[i], nodes[0])
+		err = setRNode(objs[i], nodes[i])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This seems to have been this way since submission.
Missed till i was working on the apimachinery deletion in the patch code.

After this goes in, we'll push kyaml v0.3.3, and then switch everything to it, then merge #2668 
Once we delete apimachinery and ResMap, this adapter function will no longer be needed.
