### PR TITLE
Remove count field, convert error to warning

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -55,7 +55,6 @@ openAPI:
           name: replicas
           value: "3"
           setBy: me
-          count: 1
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -64,6 +63,44 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 3 # {"$openapi":"replicas"}
+ `,
+		},
+
+		{
+			name: "add replicas no match",
+			args: []string{"replicas", "3", "--description", "hello world", "--set-by", "me"},
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  foo: 2
+ `,
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+`,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  foo: 2
  `,
 		},
 		{
@@ -118,7 +155,6 @@ openAPI:
           name: replicas
           value: "3"
           setBy: me
-          count: 1
  `,
 			expectedResources: `
 apiVersion: apps/v1
@@ -190,7 +226,6 @@ openAPI:
           - b
           - c
           setBy: me
-          count: 2
  `,
 			expectedResources: `
 apiVersion: example.com/v1beta1
@@ -290,7 +325,6 @@ openAPI:
           - b
           - c
           setBy: me
-          count: 1
  `,
 			expectedResources: `
 apiVersion: example.com/v1beta1
@@ -330,7 +364,6 @@ openAPI:
           name: replicas
           value: "3"
           setBy: me
-          count: 1
  `,
 			expectedResources: `
 apiVersion: apps/v1

--- a/cmd/config/internal/commands/e2e/create_setter_test.go
+++ b/cmd/config/internal/commands/e2e/create_setter_test.go
@@ -49,7 +49,6 @@ openAPI:
         setter:
           name: replicas
           value: "3"
-          count: 1
 `,
 			},
 		},

--- a/kyaml/setters2/settersutil/settercreator.go
+++ b/kyaml/setters2/settersutil/settercreator.go
@@ -4,9 +4,9 @@
 package settersutil
 
 import (
+	"fmt"
 	"io/ioutil"
 
-	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/fieldmeta"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
@@ -65,7 +65,7 @@ func (c SetterCreator) Create(openAPIPath, resourcesPath string) error {
 		Outputs: []kio.Writer{inout},
 	}.Execute()
 	if a.Count == 0 {
-		return errors.Errorf("created setter doesn't match any fields")
+		fmt.Printf("setter %s doesn't match any field in resources, but creating setter definition\n", c.Name)
 	}
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (c SetterCreator) Create(openAPIPath, resourcesPath string) error {
 	// Update the OpenAPI definitions to hace the setter
 	sd := setters2.SetterDefinition{
 		Name: c.Name, Value: c.FieldValue, SetBy: c.SetBy, Description: c.Description,
-		Count: a.Count, Type: c.Type, Schema: schema, Required: c.Required,
+		Type: c.Type, Schema: schema, Required: c.Required,
 	}
 	if err := sd.AddToFile(openAPIPath); err != nil {
 		return err


### PR DESCRIPTION
@trodge @mortent @monopole 

This PR is to remove the count field in openAPI file and convert the error to warning when no fields match with setter. We should not throw error in such cases because user might want to create a setter to be used by a substitution. Count field should not be added to setter definition as it should be calculated runtime which listing setters as storing it as static value will not take into considerations of substitutions which are using it.

This is follow-up to https://github.com/kubernetes-sigs/kustomize/pull/2661