### PR TITLE
modify the byteioreader to handler windows line ending.

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -115,7 +115,9 @@ func (r *ByteReader) Read() ([]*yaml.RNode, error) {
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	values := strings.Split(input.String(), "\n---\n")
+
+	// replace the ending \r\n (line ending used in windows) with \n and then separate by \n---\n
+	values := strings.Split(strings.Replace(input.String(), "\r\n", "\n", -1), "\n---\n")
 
 	index := 0
 	for i := range values {

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -303,6 +303,38 @@ metadata:
 		//
 		//
 		{
+			name: "windows_line_ending",
+			input: "\r\n---\r\na: b # first resource\r\nc: d\r\n---\r\n# second resource\r\ne: f\r\ng:\r\n- h\r\n---\r\n\r\n---\r\n i: j",
+			expectedItems: []string{
+				`a: b # first resource
+c: d
+metadata:
+  annotations:
+    foo: 'bar'
+`,
+				`# second resource
+e: f
+g:
+- h
+metadata:
+  annotations:
+    foo: 'bar'
+`,
+				`i: j
+metadata:
+  annotations:
+    foo: 'bar'
+`,
+			},
+			instance: ByteReader{
+				OmitReaderAnnotations: true,
+				SetAnnotations:        map[string]string{"foo": "bar"}},
+		},
+
+		//
+		//
+		//
+		{
 			name: "json",
 			input: `
 {


### PR DESCRIPTION
This pr modify the byteioreader to handler windows line ending, which is \r\n by default while linux is \n.
This pr solves the issue reported below:
https://github.com/GoogleContainerTools/kpt/issues/533