### PR TITLE
Fix go.mod file in cmd/config

### DIFF
--- a/cmd/config/go.mod
+++ b/cmd/config/go.mod
@@ -15,22 +15,7 @@ require (
 	k8s.io/client-go v0.17.3
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
 	sigs.k8s.io/cli-utils v0.16.0
-	// TODO: Fix this -- this should depend on v0.0.0 and be replaced (below),
-	// however the cli-runtime dependency causes `go mod` to set this as the
-	// dependency.
-	sigs.k8s.io/kustomize/kyaml v0.4.0 // Don't change this!
+	sigs.k8s.io/kustomize/kyaml v0.4.0
 )
 
-// TODO: Fix this -- we sould only depend on v0.0.0 and replace that one.
-//
-// This line is managed by the release script -- releasing/releasemodule.sh
-// Pinning to a released version of kyaml will invalidate the e2e tests used to
-// test kyaml changes as the e2e tests will run against the pinned version, not
-// the HEAD.
-//
-// releasing/releasemodule.sh will remove this line and set the require version
-// to the kyaml version specified in releasing/VERSIONS
-replace (
-	sigs.k8s.io/kustomize/kyaml v0.0.0 => ../../kyaml
-	sigs.k8s.io/kustomize/kyaml v0.1.13 => ../../kyaml
-)
+replace sigs.k8s.io/kustomize/kyaml => ../../kyaml

--- a/cmd/config/go.sum
+++ b/cmd/config/go.sum
@@ -622,8 +622,6 @@ sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.4.0 h1:jMQrJOJmiUz5Y018ki0mXWpEreEXjvad1NRfXTdi9vU=
-sigs.k8s.io/kustomize/kyaml v0.4.0/go.mod h1:XJL84E6sOFeNrQ7CADiemc1B0EjIxHo3OhW4o1aJYNw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=


### PR DESCRIPTION
This fixes the kyaml imports in cmd/config. These didn't get set correctly after the last cmd/config release.

Prior to the release, we used to have a dependency on version 0.1.13 of kyaml. This now needs to be 0.4.0 as we have updated the kyaml version in cli-utils. And instead of using replace rules for multiple versions of kyaml, we now just use a single rewrite rule that applies to all versions.

Also removed the comments as they are no longer accurate.

@monopole @pwittrock 