### PR TITLE
Allow setters/substitutions with . in the name

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -374,6 +374,41 @@ spec:
   replicas: 3 # {"$openapi":"replicas"}
  `,
 		},
+		{
+			name: "add setter with . in the name",
+			args: []string{"foo.bar", "3"},
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+ `,
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+`,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.foo.bar:
+      x-k8s-cli:
+        setter:
+          name: foo.bar
+          value: "3"
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$openapi":"foo.bar"}
+ `,
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/kyaml/fieldmeta/fieldmeta.go
+++ b/kyaml/fieldmeta/fieldmeta.go
@@ -155,8 +155,18 @@ func (fm *FieldMeta) Write(n *yaml.RNode) error {
 	if fm.Schema.Ref.String() != "" {
 		// Ex: {"$ref":"#/definitions/io.k8s.cli.setters.replicas"} should be converted to
 		// {"openAPI":"replicas"} and added to the line comment
-		arr := strings.Split(fm.Schema.Ref.String(), ".")
-		n.YNode().LineComment = fmt.Sprintf(`{"%s":"%s"}`, shortHandRef, arr[len(arr)-1])
+		ref := fm.Schema.Ref.String()
+		var shortHandRefValue string
+		switch {
+		case strings.HasPrefix(ref, DefinitionsPrefix+SetterDefinitionPrefix):
+			shortHandRefValue = strings.TrimPrefix(ref, DefinitionsPrefix+SetterDefinitionPrefix)
+		case strings.HasPrefix(ref, DefinitionsPrefix+SubstitutionDefinitionPrefix):
+			shortHandRefValue = strings.TrimPrefix(ref, DefinitionsPrefix+SubstitutionDefinitionPrefix)
+		default:
+			return fmt.Errorf("unexpected ref format: %s", ref)
+		}
+		n.YNode().LineComment = fmt.Sprintf(`{"%s":"%s"}`, shortHandRef,
+			shortHandRefValue)
 	} else {
 		n.YNode().LineComment = ""
 	}

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -303,7 +303,7 @@ metadata:
 		//
 		//
 		{
-			name: "windows_line_ending",
+			name:  "windows_line_ending",
 			input: "\r\n---\r\na: b # first resource\r\nc: d\r\n---\r\n# second resource\r\ne: f\r\ng:\r\n- h\r\n---\r\n\r\n---\r\n i: j",
 			expectedItems: []string{
 				`a: b # first resource

--- a/kyaml/setters2/add_test.go
+++ b/kyaml/setters2/add_test.go
@@ -171,6 +171,29 @@ spec:
   replicas: 3
  `,
 		},
+		{
+			name: "ref has . in name of setter",
+			add: Add{
+				FieldValue: "3",
+				Ref:        "#/definitions/io.k8s.cli.setters.foo.bar",
+			},
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+ `,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3 # {"$openapi":"foo.bar"}
+ `,
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Currently the code that sets the openapi ref on resources assumes that the setter does not have a . in the name. This change updates this code to strip away the known prefix of the openapi definition, rather than split on . and use the last element.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/808

@marklester @pwittrock @phanimarupaka 