### PR TITLE
Don't allow creating setter with same name as substitution

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -408,6 +408,39 @@ spec:
 `,
 			err: "cyclic substitution detected with name my-nested-subst",
 		},
+		{
+			name: "substitution with non-existing setter with same name",
+			args: []string{
+				"foo", "--field-value", "prefix-1234", "--pattern", "prefix-${foo}"},
+			input: `
+apiVersion: test/v1
+kind: Foo
+metadata:
+  name: foo
+spec:
+  setterVal: 1234
+  substVal: prefix-1234
+ `,
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+ `,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+ `,
+			expectedResources: `
+apiVersion: test/v1
+kind: Foo
+metadata:
+  name: foo
+spec:
+  setterVal: 1234
+  substVal: prefix-1234
+        	            	
+ `,
+			err: "setters must have different name than the substitution: foo",
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
We don't allow using the same name for a setter and a substitution. But we don't check for this when making a setter as part of making a substitution. This adds a check to make sure the markers in the substitution doesn't have the same name as the substitution itself.

@pwittrock @phanimarupaka 