### PR TITLE
Uniform unmarshal function

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -4,7 +4,6 @@
 package target
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -60,7 +59,7 @@ func (kt *KustTarget) Load() error {
 		return err
 	}
 	var k types.Kustomization
-	err = unmarshal(content, &k)
+	err = k.Unmarshal(content)
 	if err != nil {
 		return err
 	}
@@ -102,16 +101,6 @@ func loadKustFile(ldr ifc.Loader) ([]byte, error) {
 		return nil, fmt.Errorf(
 			"Found multiple kustomization files under: %s\n", ldr.Root())
 	}
-}
-
-func unmarshal(y []byte, o interface{}) error {
-	j, err := yaml.YAMLToJSON(y)
-	if err != nil {
-		return err
-	}
-	dec := json.NewDecoder(bytes.NewReader(j))
-	dec.DisallowUnknownFields()
-	return dec.Decode(o)
 }
 
 // MakeCustomizedResMap creates a fully customized ResMap

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -3,6 +3,13 @@
 
 package types
 
+import (
+	"bytes"
+	"encoding/json"
+
+	"sigs.k8s.io/yaml"
+)
+
 const (
 	KustomizationVersion  = "kustomize.config.k8s.io/v1beta1"
 	KustomizationKind     = "Kustomization"
@@ -164,4 +171,21 @@ func (k *Kustomization) EnforceFields() []string {
 		errs = append(errs, "apiVersion for "+k.Kind+" should be "+requiredVersion)
 	}
 	return errs
+}
+
+// Unmarshal replace k with the content in YAML input y
+func (k *Kustomization) Unmarshal(y []byte) error {
+	j, err := yaml.YAMLToJSON(y)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.DisallowUnknownFields()
+	var nk Kustomization
+	err = dec.Decode(&nk)
+	if err != nil {
+		return err
+	}
+	*k = nk
+	return nil
 }

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -24,7 +24,7 @@ func TestFixKustomizationPostUnmarshalling(t *testing.T) {
 	}
 
 	if !fixKustomizationPostUnmarshallingCheck(&k, &expected) {
-		t.Fatalf("unexpected ouput: %v", k)
+		t.Fatalf("unexpected output: %v", k)
 	}
 }
 
@@ -46,7 +46,7 @@ func TestFixKustomizationPostUnmarshalling_2(t *testing.T) {
 	}
 
 	if !fixKustomizationPostUnmarshallingCheck(&k, &expected) {
-		t.Fatalf("unexpected ouput: %v", k)
+		t.Fatalf("unexpected output: %v", k)
 	}
 }
 

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -1,0 +1,184 @@
+package types
+
+import (
+	"testing"
+)
+
+func fixKustomizationPostUnmarshallingCheck(k, e *Kustomization) bool {
+	return (k.Kind == e.Kind && k.APIVersion == e.APIVersion &&
+		len(k.Resources) == len(e.Resources) && k.Resources[0] == e.Resources[0] &&
+		k.Bases == nil)
+}
+
+func TestFixKustomizationPostUnmarshalling(t *testing.T) {
+	var k Kustomization
+	k.Bases = append(k.Bases, "foo")
+	k.FixKustomizationPostUnmarshalling()
+
+	expected := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       KustomizationKind,
+			APIVersion: KustomizationVersion,
+		},
+		Resources: []string{"foo"},
+	}
+
+	if !fixKustomizationPostUnmarshallingCheck(&k, &expected) {
+		t.Fatalf("unexpected ouput: %v", k)
+	}
+}
+
+func TestFixKustomizationPostUnmarshalling_2(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind: ComponentKind,
+		},
+	}
+	k.Bases = append(k.Bases, "foo")
+	k.FixKustomizationPostUnmarshalling()
+
+	expected := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       ComponentKind,
+			APIVersion: ComponentVersion,
+		},
+		Resources: []string{"foo"},
+	}
+
+	if !fixKustomizationPostUnmarshallingCheck(&k, &expected) {
+		t.Fatalf("unexpected ouput: %v", k)
+	}
+}
+
+func TestEnforceFields_InvalidKindAndVersion(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       "foo",
+			APIVersion: "bar",
+		},
+	}
+
+	errs := k.EnforceFields()
+	if len(errs) != 2 {
+		t.Fatalf("number of errors should be 2 but got: %v", errs)
+	}
+}
+
+func TestEnforceFields_InvalidKind(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       "foo",
+			APIVersion: KustomizationVersion,
+		},
+	}
+
+	errs := k.EnforceFields()
+	if len(errs) != 1 {
+		t.Fatalf("number of errors should be 1 but got: %v", errs)
+	}
+
+	expected := "kind should be " + KustomizationKind + " or " + ComponentKind
+	if errs[0] != expected {
+		t.Fatalf("error should be %v but got: %v", expected, errs[0])
+	}
+}
+
+func TestEnforceFields_InvalidVersion(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       KustomizationKind,
+			APIVersion: "bar",
+		},
+	}
+
+	errs := k.EnforceFields()
+	if len(errs) != 1 {
+		t.Fatalf("number of errors should be 1 but got: %v", errs)
+	}
+
+	expected := "apiVersion for " + k.Kind + " should be " + KustomizationVersion
+	if errs[0] != expected {
+		t.Fatalf("error should be %v but got: %v", expected, errs[0])
+	}
+}
+
+func TestEnforceFields_ComponentKind(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       ComponentKind,
+			APIVersion: "bar",
+		},
+	}
+
+	errs := k.EnforceFields()
+	if len(errs) != 1 {
+		t.Fatalf("number of errors should be 1 but got: %v", errs)
+	}
+
+	expected := "apiVersion for " + k.Kind + " should be " + ComponentVersion
+	if errs[0] != expected {
+		t.Fatalf("error should be %v but got: %v", expected, errs[0])
+	}
+}
+
+func TestEnforceFields(t *testing.T) {
+	k := Kustomization{
+		TypeMeta: TypeMeta{
+			Kind:       KustomizationKind,
+			APIVersion: KustomizationVersion,
+		},
+	}
+
+	errs := k.EnforceFields()
+	if len(errs) != 0 {
+		t.Fatalf("number of errors should be 0 but got: %v", errs)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	y := []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- foo
+- bar
+nameSuffix: dog
+namePrefix: cat`)
+	var k Kustomization
+	err := k.Unmarshal(y)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Kind != KustomizationKind || k.APIVersion != KustomizationVersion ||
+		len(k.Resources) != 2 || k.NamePrefix != "cat" || k.NameSuffix != "dog" {
+		t.Fatalf("wrong unmarshal result: %v", k)
+	}
+}
+
+func TestUnmarshal_UnkownField(t *testing.T) {
+	y := []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+unknown: foo`)
+	var k Kustomization
+	err := k.Unmarshal(y)
+	if err == nil {
+		t.Fatalf("expect an error")
+	}
+	expect := "json: unknown field \"unknown\""
+	if err.Error() != expect {
+		t.Fatalf("expect %v but got: %v", expect, err.Error())
+	}
+}
+
+func TestUnmarshal_InvalidYaml(t *testing.T) {
+	y := []byte(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+unknown`)
+	var k Kustomization
+	err := k.Unmarshal(y)
+	if err == nil {
+		t.Fatalf("expect an error")
+	}
+}

--- a/kustomize/internal/commands/kustfile/kustomizationfile.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile.go
@@ -153,7 +153,7 @@ func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
 		return nil, err
 	}
 	var k types.Kustomization
-	err = yaml.Unmarshal(data, &k)
+	err = k.Unmarshal(data)
 	if err != nil {
 		return nil, err
 	}

--- a/kustomize/internal/commands/kustfile/kustomizationfile_test.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile_test.go
@@ -340,3 +340,21 @@ kind: Kustomization
 			string(expected), string(bytes))
 	}
 }
+
+func TestUnknownFieldInKustomization(t *testing.T) {
+	kContent := []byte(`
+foo:
+  bar
+`)
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(fSys, kContent)
+	mf, err := NewKustomizationFile(fSys)
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+
+	_, err = mf.Read()
+	if err == nil || err.Error() != "json: unknown field \"foo\"" {
+		t.Fatalf("Expect an unknown field error but got: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #2681

Use a simpler methods and won't complain about unknown fields in `kustomization.yaml`