### PR TITLE
Fixing all source relative links

### DIFF
--- a/site/content/en/api-reference/glossary/_index.md
+++ b/site/content/en/api-reference/glossary/_index.md
@@ -176,7 +176,7 @@ with [kustomize], it could be in the form of
  * a git archive (ditto),
  * a URL to a git repo (ditto), etc.
 
-A kustomization file contains [fields](fields.md)
+A kustomization file contains [fields](./fields/)
 falling into four categories:
 
  * _resources_ - what existing [resources] are to be customized.

--- a/site/content/en/blog/releases/v3.0.0.md
+++ b/site/content/en/blog/releases/v3.0.0.md
@@ -6,7 +6,7 @@ description: >
   Kustomize v3.0.0
 ---
 
-This release is basically [v2.1.0](v2.1.0.md),
+This release is basically [v2.1.0](/kustomize/blog/2019/06/18/v2.1.0/),
 with many post-v2.1.0 bugs fixed (in about 150
 commits) and a `v3` in Go package paths.
 

--- a/site/content/en/faq/versioningPolicy.md
+++ b/site/content/en/faq/versioningPolicy.md
@@ -30,7 +30,7 @@ behave.
 
 ### Installation
 
-See the [installation docs](INSTALL.md).
+See the [installation docs](../../installation/).
 
 ## Go API Versioning
 

--- a/site/content/en/guides/plugins/_index.md
+++ b/site/content/en/guides/plugins/_index.md
@@ -287,7 +287,7 @@ data:
 
 ### Go plugins
 
-Be sure to read [Go plugin caveats](goPluginCaveats.md).
+Be sure to read [Go plugin caveats](./goplugincaveats/).
 
 [Go plugin]: https://golang.org/pkg/plugin/
 

--- a/site/content/en/guides/plugins/goPluginGuidedExample.md
+++ b/site/content/en/guides/plugins/goPluginGuidedExample.md
@@ -15,7 +15,7 @@ description: >
 This is a (no reading allowed!) 60 second copy/paste guided
 example.
 
-Full plugin docs [here](README.md).
+Full plugin docs [here](../).
 Be sure to read the [Go plugin caveats].
 
 This demo uses a Go plugin, `SopsEncodedSecrets`,

--- a/site/content/zh/api-reference/glossary/_index.md
+++ b/site/content/zh/api-reference/glossary/_index.md
@@ -115,7 +115,7 @@ Kustomize 鼓励对声明式应用程序管理（[Declarative Application Manage
 - 一个 Git 压缩包。
 - 一个 Git 仓库的 URL。
 
-一个 Kustomization 文件包含的[字段](fields.md)，分为四个类别：
+一个 Kustomization 文件包含的[字段](./fields/)，分为四个类别：
 
 - `resources`：待定制的现存[资源]，示例字段：`resources`、`crds`。
 - `generator`：将要创建的**新**资源，示例字段：`configMapGenerator`（传统）、`secretGenerator`（传统）、`generators`（v2.1）

--- a/site/content/zh/blog/releases/v3.0.0.md
+++ b/site/content/zh/blog/releases/v3.0.0.md
@@ -6,7 +6,7 @@ description: >
   Kustomize v3.0.0
 ---
 
-This release is basically [v2.1.0](v2.1.0.md),
+This release is basically [v2.1.0](/kustomize/blog/2019/06/18/v2.1.0/),
 with many post-v2.1.0 bugs fixed (in about 150
 commits) and a `v3` in Go package paths.
 

--- a/site/content/zh/faq/versioningPolicy.md
+++ b/site/content/zh/faq/versioningPolicy.md
@@ -30,7 +30,7 @@ behave.
 
 ### Installation
 
-See the [installation docs](INSTALL.md).
+See the [installation docs](../../installation).
 
 ## Go API Versioning
 

--- a/site/content/zh/guides/plugins/_index.md
+++ b/site/content/zh/guides/plugins/_index.md
@@ -202,7 +202,7 @@ data:
 
 ### Go 插件
 
-请务必阅读 [Go 插件注意事项](goPluginCaveats.md)。
+请务必阅读 [Go 插件注意事项](./goplugincaveats/)。
 
 [Go 插件]: https://golang.org/pkg/plugin/
 


### PR DESCRIPTION
This may not be the correct fix, but I've found several places with broken links on the live site. 

It previously looks like hugo supported what it called `sourceRelativeLinks` but has deprecated that feature as of a while ago.
https://github.com/bep/hugo/commit/234273a5b571128ccb866c176c38171ffeb3f561

It looks like the right fix now might be what hugo calls cross-references:
https://gohugo.io/content-management/cross-references/


That said, I didn't see it used elsewhere in the documentation, and I didn't have time to build the project this afternoon, so I thought I'd just create a commit with all of the relevant places called out and then fix it correctly later.

Feel free to change them to cross-references yourself, just thought I'd call out the broken links :smile: 