### PR TITLE
Allow hash suffixing of arbitrary types

### DIFF
--- a/site/content/en/guides/plugins/_index.md
+++ b/site/content/en/guides/plugins/_index.md
@@ -255,7 +255,11 @@ A generator exec plugin can adjust the generator options for the resources it em
 
 Resources can be marked as needing to be processed by the internal hash transformer by including the `needs-hash` annotation. When set valid values for the annotation are `"true"` and `"false"` which respectively enable or disable hash suffixing for the resource. Omitting the annotation is equivalent to setting the value `"false"`.
 
-If this annotation is set on a resource not supported by the hash transformer the build will fail.
+Hashes are determined as follows:
+
+* For `ConfigMap` resources, hashes are based on the values of the `name`, `data`, and `binaryData` fields.
+* For `Secret` resources, hashes are based on the values of the `name`, `type`, `data`, and `stringData` fields.
+* For any other object type, hashes are based on the entire object content (i.e. all fields).
 
 Example:
 ```yaml


### PR DESCRIPTION
When using a custom generator plugin, the `kustomize.config.k8s.io/needs-hash` hash suffix generator only works for `ConfigMap` and `Secret` resources, and fails the build process if used on a different type of resource. I had hit the exact same issue as described in #1167, where I wanted to use a generator plugin to create a custom `SealedSecret` resource with a hash suffix, as it should behave the same as a built-in `Secret`.

This change applies the suggested approach commented in #1167 (before it was auto-closed for inactivity) which is to hash the entire object for unknown types.

I appreciate the original issue is a little old and this approach may no longer be wanted, but I wanted to put this for your consideration just in case.