### PR TITLE
List and set setters in folders recursively

### DIFF
--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/kustomize/cmd/config/ext"
 	"sigs.k8s.io/kustomize/cmd/config/internal/commands"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 )
@@ -408,27 +408,19 @@ openAPI:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			f, err := ioutil.TempFile("", "k8s-cli-")
+			dir, err := ioutil.TempDir("", "")
 			if !assert.NoError(t, err) {
 				t.FailNow()
-			}
-			defer os.Remove(f.Name())
-			old := ext.GetOpenAPIFile
-			defer func() { ext.GetOpenAPIFile = old }()
-			ext.GetOpenAPIFile = func(args []string) (s string, err error) {
-				err = ioutil.WriteFile(f.Name(), []byte(test.openapi), 0600)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-				return f.Name(), nil
 			}
 
-			r, err := ioutil.TempFile("", "k8s-cli-*.yaml")
+			defer os.RemoveAll(dir)
+
+			err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.openapi), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+
+			err = ioutil.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -436,18 +428,18 @@ openAPI:
 			runner := commands.NewListSettersRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
-			runner.Command.SetArgs(append([]string{r.Name()}, test.args...))
+			runner.Command.SetArgs(append([]string{dir}, test.args...))
 			err = runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			if !assert.Equal(t, test.expected, actual.String()) {
+			if !assert.Contains(t, actual.String(), test.expected) {
 				t.FailNow()
 			}
 
 			// make sure that the resources are not altered
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := ioutil.ReadFile(filepath.Join(dir, "deployment.yaml"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -457,7 +449,7 @@ openAPI:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f.Name())
+			actualOpenAPI, err := ioutil.ReadFile(filepath.Join(dir, "Krmfile"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/kustomize/cmd/config/ext"
 	"sigs.k8s.io/kustomize/cmd/config/internal/commands"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 )
@@ -949,27 +949,19 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			f, err := ioutil.TempFile("", "k8s-cli-")
+			dir, err := ioutil.TempDir("", "")
 			if !assert.NoError(t, err) {
 				t.FailNow()
-			}
-			defer os.Remove(f.Name())
-			err = ioutil.WriteFile(f.Name(), []byte(test.inputOpenAPI), 0600)
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			old := ext.GetOpenAPIFile
-			defer func() { ext.GetOpenAPIFile = old }()
-			ext.GetOpenAPIFile = func(args []string) (s string, err error) {
-				return f.Name(), nil
 			}
 
-			r, err := ioutil.TempFile("", "k8s-cli-*.yaml")
+			defer os.RemoveAll(dir)
+
+			err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+
+			err = ioutil.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -977,7 +969,7 @@ spec:
 			runner := commands.NewSetRunner("")
 			out := &bytes.Buffer{}
 			runner.Command.SetOut(out)
-			runner.Command.SetArgs(append([]string{r.Name()}, test.args...))
+			runner.Command.SetArgs(append([]string{dir}, test.args...))
 			err = runner.Command.Execute()
 			if test.errMsg != "" {
 				if !assert.NotNil(t, err) {
@@ -992,11 +984,11 @@ spec:
 				t.FailNow()
 			}
 
-			if test.errMsg == "" && !assert.Equal(t, test.out, out.String()) {
+			if test.errMsg == "" && !assert.Contains(t, out.String(), strings.Trim(test.out, "\n")) {
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := ioutil.ReadFile(filepath.Join(dir, "deployment.yaml"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -1006,7 +998,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f.Name())
+			actualOpenAPI, err := ioutil.ReadFile(filepath.Join(dir, "Krmfile"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/e2e/list_setters_test.go
+++ b/cmd/config/internal/commands/e2e/list_setters_test.go
@@ -34,7 +34,9 @@ openAPI:
 `,
 			},
 			expectedStdOut: `
-NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
+[1;32m
+setters in package: [./]
+[0m    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
   replicas   3                              1       No
 `,
 		},

--- a/kyaml/pathutil/pathutil.go
+++ b/kyaml/pathutil/pathutil.go
@@ -1,0 +1,35 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/errors"
+)
+
+// SubDirsWithFile takes the root directory path and returns all the paths of
+// sub-directories which contain file with input fileName including itself
+func SubDirsWithFile(root, fileName string) ([]string, error) {
+	var res []string
+	err := filepath.Walk(root,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if strings.HasSuffix(path, fileName) {
+				if root == "." {
+					path = root + "/" + path
+				}
+				res = append(res, path)
+			}
+			return nil
+		})
+	if err != nil {
+		return res, errors.Wrap(err)
+	}
+	return res, nil
+}

--- a/kyaml/printutil/printutil.go
+++ b/kyaml/printutil/printutil.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package printutil
+
+import (
+	"fmt"
+	"io"
+)
+
+// GreenPrintf formats according to a format specifier and prints the resulting string
+// in green color to the writer
+func GreenPrintf(w io.Writer, format string, args ...string) {
+	msg := fmt.Sprintf(format, args)
+	fmt.Fprintf(w, "\033[1;32m%s\033[0m", msg)
+}
+
+// WarnPrintf formats according to a format specifier and prints the resulting string
+// in yellow color to the writer
+func WarnPrintf(w io.Writer, format string, args ...string) {
+	msg := fmt.Sprintf(format, args)
+	fmt.Fprintf(w, "\033[1;33m%s\033[0m", msg)
+}

--- a/kyaml/setters2/set.go
+++ b/kyaml/setters2/set.go
@@ -34,6 +34,8 @@ type Set struct {
 	SetAll bool
 }
 
+const SetterNotFoundWarn = "unable to find setter with name "
+
 // Filter implements Set as a yaml.Filter
 func (s *Set) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 	return object, accept(s, object)
@@ -328,14 +330,14 @@ func (s SetOpenAPI) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 		return nil, err
 	}
 	if oa == nil {
-		return nil, errors.Errorf("no setter %s found", s.Name)
+		return nil, errors.Errorf(SetterNotFoundWarn + s.Name)
 	}
 	def, err := oa.Pipe(yaml.Lookup("x-k8s-cli", "setter"))
 	if err != nil {
 		return nil, err
 	}
 	if def == nil {
-		return nil, errors.Errorf("no setter %s found", s.Name)
+		return nil, errors.Errorf(SetterNotFoundWarn + s.Name)
 	}
 
 	// record the OpenAPI type for the setter

--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -1209,7 +1209,7 @@ openAPI:
 		{
 			name:   "error",
 			setter: "replicas",
-			err:    "no setter replicas found",
+			err:    "unable to find setter with name replicas",
 			input: `
 openAPI:
   definitions:


### PR DESCRIPTION
@mortent 

This PR is to recursively list and set the setters in nested packages. 

For [this](https://github.com/phanimarupaka/wordpress-in-a-box/) example package, the list-setters looks like

![image](https://user-images.githubusercontent.com/58999035/87969466-0dd1e580-ca77-11ea-9c58-cc870f81757a.png)

Setting a setter would look like

![image](https://user-images.githubusercontent.com/58999035/87971831-d49b7480-ca7a-11ea-9404-2395047a5026.png)

