### PR TITLE
Retain components field in edit

### DIFF
--- a/kustomize/internal/commands/kustfile/kustomizationfile.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile.go
@@ -59,6 +59,7 @@ func determineFieldOrder() []string {
 		"Generators",
 		"Transformers",
 		"Inventory",
+		"Components",
 	}
 
 	// Add deprecated fields here.

--- a/kustomize/internal/commands/kustfile/kustomizationfile_test.go
+++ b/kustomize/internal/commands/kustfile/kustomizationfile_test.go
@@ -39,6 +39,7 @@ func TestFieldOrder(t *testing.T) {
 		"Generators",
 		"Transformers",
 		"Inventory",
+		"Components",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {


### PR DESCRIPTION
Partially fixes #2761, retain components field in `kustomize edit` 