### PR TITLE
Handle some incorrect type values like 'int' and 'bool' in setters

### DIFF
--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -668,6 +668,68 @@ spec:
   - "3"
  `,
 		},
+		{
+			name:        "set-with-invalid-type-int",
+			description: "if a type is set to int instead of integer, we accept it",
+			setter:      "foo",
+			openapi: `
+openAPI:
+  definitions:
+    io.k8s.cli.setters.foo:
+      x-k8s-cli:
+        setter:
+          name: foo
+          value: "4"
+      type: int
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.foo"}
+ `,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: 4 # {"$ref": "#/definitions/io.k8s.cli.setters.foo"}
+ `,
+		},
+		{
+			name:        "set-with-invalid-type-bool",
+			description: "if a type is set to bool instead of boolean, we accept it",
+			setter:      "foo",
+			openapi: `
+openAPI:
+  definitions:
+    io.k8s.cli.setters.foo:
+      x-k8s-cli:
+        setter:
+          name: foo
+          value: "true"
+      type: bool
+ `,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: false # {"$ref": "#/definitions/io.k8s.cli.setters.foo"}
+ `,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: true # {"$ref": "#/definitions/io.k8s.cli.setters.foo"}
+ `,
+		},
 	}
 	for i := range tests {
 		test := tests[i]


### PR DESCRIPTION
Since we don't have any validation that the type of a setter is actually a valid type, we have reports that users with invalid types have experienced problems after we added type validation. This addresses some known issues where users have a type set to 'int' instead of 'integer'.

Fixes: #871