### PR TITLE
Fix issue where the schema was not propagated correctly when walking yaml doc

### DIFF
--- a/kyaml/setters2/add.go
+++ b/kyaml/setters2/add.go
@@ -97,7 +97,7 @@ func (a *Add) visitMapping(object *yaml.RNode, p string, _ *openapi.ResourceSche
 
 // visitScalar implements visitor
 // visitScalar will set the field metadata on each scalar field whose name + value match
-func (a *Add) visitScalar(object *yaml.RNode, p string, _ *openapi.ResourceSchema) error {
+func (a *Add) visitScalar(object *yaml.RNode, p string, _, _ *openapi.ResourceSchema) error {
 	// check if the field matches
 	if a.Type == "array" {
 		return nil

--- a/kyaml/setters2/delete.go
+++ b/kyaml/setters2/delete.go
@@ -45,7 +45,7 @@ func (d *Delete) visitMapping(_ *yaml.RNode, _ string, _ *openapi.ResourceSchema
 
 // visitScalar implements visitor
 // visitScalar will remove the reference on each scalar field whose name matches.
-func (d *Delete) visitScalar(object *yaml.RNode, p string, _ *openapi.ResourceSchema) error {
+func (d *Delete) visitScalar(object *yaml.RNode, p string, _, _ *openapi.ResourceSchema) error {
 	// check if the field matches
 	if d.FieldName != "" && !strings.HasSuffix(p, d.FieldName) {
 		return nil

--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -126,7 +126,7 @@ metadata:
 		},
 		{
 			name:        "set-foo-no-type",
-			description: "if a type is not specified for a setter, keep the existing quoting",
+			description: "if a type is not specified for a setter or k8s schema, keep existing quoting",
 			setter:      "foo",
 			openapi: `
 openAPI:
@@ -138,16 +138,16 @@ openAPI:
           value: "4"
  `,
 			input: `
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: custom/v1
+kind: Example
 metadata:
   name: nginx-deployment
   annotations:
     foo: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.foo"}
  `,
 			expected: `
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: custom/v1
+kind: Example
 metadata:
   name: nginx-deployment
   annotations:

--- a/kyaml/setters2/walk.go
+++ b/kyaml/setters2/walk.go
@@ -16,7 +16,7 @@ type visitor interface {
 	// node is the scalar field value
 	// path is the path to the field; path elements are separated by '.'
 	// oa is the OpenAPI schema for the field
-	visitScalar(node *yaml.RNode, path string, oa *openapi.ResourceSchema) error
+	visitScalar(node *yaml.RNode, path string, oa *openapi.ResourceSchema, fieldOA *openapi.ResourceSchema) error
 
 	// visitSequence is called for each sequence field value on a resource
 	// node is the sequence field value
@@ -69,7 +69,7 @@ func acceptImpl(v visitor, object *yaml.RNode, p string, oa *openapi.ResourceSch
 	case yaml.ScalarNode:
 		// Visit the scalar field
 		fieldSchema := getSchema(object, oa, "")
-		return v.visitScalar(object, p, fieldSchema)
+		return v.visitScalar(object, p, oa, fieldSchema)
 	}
 	return nil
 }

--- a/kyaml/setters2/walk.go
+++ b/kyaml/setters2/walk.go
@@ -50,9 +50,9 @@ func acceptImpl(v visitor, object *yaml.RNode, p string, oa *openapi.ResourceSch
 		}
 		return object.VisitFields(func(node *yaml.MapNode) error {
 			// get the schema for the field and propagate it
-			oa = getSchema(node.Key, oa, node.Key.YNode().Value)
+			fieldSchema := getSchema(node.Key, oa, node.Key.YNode().Value)
 			// Traverse each field value
-			return acceptImpl(v, node.Value, p+"."+node.Key.YNode().Value, oa)
+			return acceptImpl(v, node.Value, p+"."+node.Key.YNode().Value, fieldSchema)
 		})
 	case yaml.SequenceNode:
 		// get the schema for the sequence node, use the schema provided if not present
@@ -61,15 +61,15 @@ func acceptImpl(v visitor, object *yaml.RNode, p string, oa *openapi.ResourceSch
 			return err
 		}
 		// get the schema for the elements
-		oa = getSchema(object, oa, "")
+		schema := getSchema(object, oa, "")
 		return object.VisitElements(func(node *yaml.RNode) error {
 			// Traverse each list element
-			return acceptImpl(v, node, p, oa)
+			return acceptImpl(v, node, p, schema)
 		})
 	case yaml.ScalarNode:
 		// Visit the scalar field
-		oa = getSchema(object, oa, "")
-		return v.visitScalar(object, p, oa)
+		fieldSchema := getSchema(object, oa, "")
+		return v.visitScalar(object, p, fieldSchema)
 	}
 	return nil
 }


### PR DESCRIPTION
The passed-in pointer to a `ResourceSchema` was being updated when visiting fields on a mapping node. This caused the incorrect schema to be used when traversing the yaml document.
This also updates the walker so we can also provide the schema for the type (if available) to the setter functionality. We currently only provide the setter schema, so we are not able to take into account the type for the field in the k8s openapi schema. With this change, we will use the resource-type specific schema information to determine the quoting style of fields if we don't find this information in the setter schema.