### PR TITLE
Order PersistentVolume before Deployment

### DIFF
--- a/api/resid/gvk.go
+++ b/api/resid/gvk.go
@@ -95,6 +95,8 @@ var orderFirst = []string{
 	"Service",
 	"LimitRange",
 	"PriorityClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
 	"Deployment",
 	"StatefulSet",
 	"CronJob",


### PR DESCRIPTION
Solves issue https://github.com/kubernetes-sigs/kustomize/issues/202

Ordering is not being maintained for "PersistentVolume" and "PersistentVolumeClaim" which leads to the creation of "Deployment" before persistent volume leading to container crashes.