### PR TITLE
Throw insufficient arguments error for create-setter

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -100,12 +100,16 @@ func (r *CreateSetterRunner) preRunE(c *cobra.Command, args []string) error {
 	if setterVersion == "" {
 		if len(args) == 2 && r.Set.SetPartialField.Type == "array" && c.Flag("field").Changed {
 			setterVersion = "v2"
-		} else if len(args) < 2 || !c.Flag("value").Changed && len(args) < 3 {
-			setterVersion = "v1"
 		} else if err := initSetterVersion(c, args); err != nil {
 			return err
 		}
 	}
+
+	if r.Set.SetPartialField.Type != "array" && !c.Flag("value").Changed && len(args) < 3 {
+		return errors.Errorf("setter name and value must be provided, " +
+			"value can either be an argument or can be passed as a flag --value")
+	}
+
 	if setterVersion == "v2" {
 		var err error
 		r.OpenAPIFile, err = ext.GetOpenAPIFile(args)

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -167,6 +167,36 @@ spec:
 		},
 
 		{
+			name: "add replicas not enough arguments",
+			args: []string{"replicas", "--description", "hello world", "--set-by", "me"},
+			err:  `setter name and value must be provided, value can either be an argument or can be passed as a flag --value`,
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+ `,
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+`,
+			expectedOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+ `,
+			expectedResources: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+ `,
+		},
+
+		{
 			name:   "list values with schema",
 			args:   []string{"list", "--description", "hello world", "--set-by", "me", "--type", "array", "--field", "spec.list"},
 			schema: `{"maxItems": 3, "type": "array", "items": {"type": "string"}}`,


### PR DESCRIPTION
@frankfarzan @mortent 

This PR is to address the issue https://github.com/GoogleContainerTools/kpt/issues/900. Addresses it by throwing error if the value for setter is not passed neither as arg nor as --value flag.