### PR TITLE
Error on creation if setter/subst exists

### DIFF
--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -134,6 +134,19 @@ func (r *CreateSetterRunner) preRunE(c *cobra.Command, args []string) error {
 				"substitution and setter can't have same name", r.CreateSetter.Name)
 		}
 
+		// check if setter with same name exists and throw error
+		ref, err = spec.NewRef(fieldmeta.DefinitionsPrefix + fieldmeta.SetterDefinitionPrefix + r.CreateSetter.Name)
+		if err != nil {
+			return err
+		}
+
+		setter, _ := openapi.Resolve(&ref)
+		// if setter already exists with the input setter name, throw error
+		if setter != nil {
+			return errors.Errorf("setter with name %s already exists, "+
+				"if you want to modify it, please delete the existing setter and recreate it", r.CreateSetter.Name)
+		}
+
 		r.CreateSetter.Description = r.Set.SetPartialField.Description
 		r.CreateSetter.SetBy = r.Set.SetPartialField.SetBy
 		r.CreateSetter.Type = r.Set.SetPartialField.Type

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -126,6 +126,24 @@ openAPI:
 		},
 
 		{
+			name: "error if setter with same name exists",
+			args: []string{
+				"my-image", "ubuntu"},
+			inputOpenAPI: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.my-image:
+      x-k8s-cli:
+        setter:
+          name: my-image
+          value: "nginx"
+ `,
+			err: "setter with name my-image already exists, if you want to modify it, please delete the existing setter and recreate it",
+		},
+
+		{
 			name:   "add replicas with schema",
 			args:   []string{"replicas", "3", "--description", "hello world", "--set-by", "me"},
 			schema: `{"maximum": 10, "type": "integer"}`,

--- a/cmd/config/internal/commands/cmdcreatesubstitution.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution.go
@@ -68,8 +68,20 @@ func (r *CreateSubstitutionRunner) preRunE(c *cobra.Command, args []string) erro
 		return err
 	}
 
+	// check if substitution with same name exists and throw error
+	ref, err := spec.NewRef(fieldmeta.DefinitionsPrefix + fieldmeta.SubstitutionDefinitionPrefix + r.CreateSubstitution.Name)
+	if err != nil {
+		return err
+	}
+
+	subst, _ := openapi.Resolve(&ref)
+	// if substitution already exists with the input substitution name, throw error
+	if subst != nil {
+		return errors.Errorf("substitution with name %s already exists", r.CreateSubstitution.Name)
+	}
+
 	// check if setter with same name exists and throw error
-	ref, err := spec.NewRef(fieldmeta.DefinitionsPrefix + fieldmeta.SetterDefinitionPrefix + r.CreateSubstitution.Name)
+	ref, err = spec.NewRef(fieldmeta.DefinitionsPrefix + fieldmeta.SetterDefinitionPrefix + r.CreateSubstitution.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@mortent 

This PR is to throw an error if there is a setter/substitution already exists with the input name. This would address issues like

https://github.com/GoogleContainerTools/kpt/issues/868