### PR TITLE
Add full github link to varreference.go

### DIFF
--- a/site/content/en/api-reference/kustomization/vars/_index.md
+++ b/site/content/en/api-reference/kustomization/vars/_index.md
@@ -71,7 +71,7 @@ can only be placed in particular fields of
 particular objects as specified by kustomize's
 configuration data.
 
-The default config data for vars is at [/api/konfig/builtinpluginconsts/varreference.go](/konfig/builtinpluginconsts/varreference.go)
+The default config data for vars is at [/api/konfig/builtinpluginconsts/varreference.go](https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/varreference.go)
 Long story short, the default targets are all
 container command args and env value fields.
 


### PR DESCRIPTION
Otherwise, the link is broken on github.io: https://kubernetes-sigs.github.io/kustomize/api-reference/kustomization/vars/