### PR TITLE
IsFieldEmpty renamed to MapNode.IsNilOrEmpty

### DIFF
--- a/kyaml/kio/tree.go
+++ b/kyaml/kio/tree.go
@@ -238,10 +238,10 @@ func ownerToString(node *yaml.RNode) (string, error) {
 	owner := elements[0]
 	var kind, name string
 
-	if value := owner.Field("kind"); !yaml.IsFieldEmpty(value) {
+	if value := owner.Field("kind"); !value.IsNilOrEmpty() {
 		kind = value.Value.YNode().Value
 	}
-	if value := owner.Field("name"); !yaml.IsFieldEmpty(value) {
+	if value := owner.Field("name"); !value.IsNilOrEmpty() {
 		name = value.Value.YNode().Value
 	}
 

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -84,7 +84,7 @@ func AddSchemaFromFileUsingField(path, field string) error {
 	if field != "" {
 		// get the field containing the openAPI
 		m := y.Field(field)
-		if yaml.IsFieldEmpty(m) {
+		if m.IsNilOrEmpty() {
 			// doesn't contain openAPI definitions
 			return nil
 		}

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -568,7 +568,7 @@ var nodeTypeIndex = map[yaml.Kind]string{
 }
 
 func ErrorIfInvalid(rn *RNode, kind yaml.Kind) error {
-	if rn == nil || rn.YNode() == nil || rn.IsTaggedNull() {
+	if IsMissingOrNull(rn) {
 		// node has no type, pass validation
 		return nil
 	}

--- a/kyaml/yaml/types_test.go
+++ b/kyaml/yaml/types_test.go
@@ -239,16 +239,17 @@ func TestIsMissingOrNull(t *testing.T) {
 		t.Fatalf("input: with NullNodeTag")
 	}
 
-	node := NewListRNode()
 	// empty array. empty array is not expected as empty
-	if IsMissingOrNull(node) {
+	if IsMissingOrNull(NewListRNode()) {
 		t.Fatalf("input: empty array")
 	}
+
 	// array with 1 item
-	node = NewListRNode("foo")
+	node := NewListRNode("foo")
 	if IsMissingOrNull(node) {
 		t.Fatalf("input: array with 1 item")
 	}
+
 	// delete the item in array
 	node.value.Content = nil
 	if IsMissingOrNull(node) {
@@ -352,6 +353,49 @@ func TestRNodeIsNilOrEmpty(t *testing.T) {
 	}
 
 	if NewListRNode("foo").IsNilOrEmpty() {
+		t.Fatalf("non-empty list should not be empty")
+	}
+}
+
+func TestMapNodeIsNilOrEmpty(t *testing.T) {
+	var mn *MapNode
+
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("nil should be empty")
+	}
+
+	mn = &MapNode{Key: MakeNullNode()}
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("missing value should be empty")
+	}
+
+	mn.Value = NewRNode(nil)
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("missing value YNode should be empty")
+	}
+
+	mn.Value = MakeNullNode()
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("value tagged null should be empty")
+	}
+
+	mn.Value = NewMapRNode(nil)
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("empty map should be empty")
+	}
+
+	mn.Value = NewMapRNode(&map[string]string{"foo": "bar"})
+	if mn.IsNilOrEmpty() {
+		t.Fatalf("non-empty map should not be empty")
+	}
+
+	mn.Value = NewListRNode()
+	if !mn.IsNilOrEmpty() {
+		t.Fatalf("empty list should be empty")
+	}
+
+	mn.Value = NewListRNode("foo")
+	if mn.IsNilOrEmpty() {
 		t.Fatalf("non-empty list should not be empty")
 	}
 }


### PR DESCRIPTION
In service of #2809

### `IsFieldEmpty` renamed to `MapNode.IsNilOrEmpty`
 - Neither kpt or kustomize use this directly.
 - This method is actually a test on a map, not a field, so the
   old name was misleading.
 - Added test.

### `IsEmpty`
 - Neither kpt or kustomize uses IsNil.
 - Dropping it.  IsMissingOrNull does the same thing.

### IsFieldNull
 - Neither kpt or kustomize uses IsNil.
 - IsNull renamed to RNode.IsTaggedNull.

@Shell32-Natsu 