### PR TITLE
Transform namespace inside of APIService

### DIFF
--- a/api/konfig/builtinpluginconsts/namespace.go
+++ b/api/konfig/builtinpluginconsts/namespace.go
@@ -12,5 +12,9 @@ namespace:
   kind: RoleBinding
 - path: subjects
   kind: ClusterRoleBinding
+- path: spec/service/namespace
+  group: apiregistration.k8s.io
+  kind: APIService
+  create: true
 `
 )


### PR DESCRIPTION
As outlined in https://kubernetes-sigs.github.io/kustomize/faq/#some-field-is-not-transformed-by-kustomize