### PR TITLE
Add test for adding setter with path inside a sequence

### DIFF
--- a/kyaml/setters2/add_test.go
+++ b/kyaml/setters2/add_test.go
@@ -157,6 +157,40 @@ spec:
  `,
 		},
 		{
+			name: "add-field-inside-sequence",
+			add: Add{
+				FieldValue: "/usr/share/nginx",
+				FieldName:  "spec.containers.volumeMounts.mountPath",
+				Ref:        "#/definitions/io.k8s.cli.setters.mountPath",
+			},
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - name: nginx
+      mountPath: /usr/share/nginx
+ `,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+    - name: nginx
+      mountPath: /usr/share/nginx # {"$openapi":"mountPath"}
+ `,
+		},
+		{
 			name: "add-replicas-error",
 			add: Add{
 				Ref: "#/definitions/io.k8s.cli.setters.replicas",


### PR DESCRIPTION
Adding a test that documents the behavior of creating a setter targeting a field inside a sequence using the `--field` flag.