### PR TITLE
Print message if subst doesn't match any field value

### DIFF
--- a/kyaml/setters2/settersutil/settercreator.go
+++ b/kyaml/setters2/settersutil/settercreator.go
@@ -78,7 +78,8 @@ func (c SetterCreator) Create(openAPIPath, resourcesPath string) error {
 		Outputs: []kio.Writer{inout},
 	}.Execute()
 	if a.Count == 0 {
-		fmt.Printf("setter %s doesn't match any field in resources, but creating setter definition\n", c.Name)
+		fmt.Printf("setter %s doesn't match any field in resource configs, "+
+			"but creating setter definition\n", c.Name)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
@mortent We currently create a substitution silently even though there are no field values matching the substitution. This PR is to print a message so that users are aware when this happens.