### PR TITLE
Inline repeated types.

### DIFF
--- a/kyaml/kio/kioutil/kioutil_test.go
+++ b/kyaml/kio/kioutil/kioutil_test.go
@@ -275,40 +275,67 @@ func TestCreatePathAnnotationValue(t *testing.T) {
 	}{
 		{
 			`dir`,
-			yaml.ResourceMeta{Kind: "foo",
-				APIVersion: "apps/v1",
-				ObjectMeta: yaml.ObjectMeta{Name: "bar", Namespace: "baz"},
+			yaml.ResourceMeta{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "foo",
+				},
+				ObjectMeta: yaml.ObjectMeta{
+					NameMeta: yaml.NameMeta{
+						Name: "bar", Namespace: "baz",
+					},
+				},
 			},
 			`dir/baz/foo_bar.yaml`, `with namespace`,
 		},
 		{
 			``,
-			yaml.ResourceMeta{Kind: "foo",
-				APIVersion: "apps/v1",
-				ObjectMeta: yaml.ObjectMeta{Name: "bar", Namespace: "baz"},
+			yaml.ResourceMeta{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "foo",
+				},
+				ObjectMeta: yaml.ObjectMeta{
+					NameMeta: yaml.NameMeta{
+						Name: "bar", Namespace: "baz",
+					},
+				},
 			},
 			`baz/foo_bar.yaml`, `without dir`,
 		},
 		{
 			`dir`,
-			yaml.ResourceMeta{Kind: "foo",
-				APIVersion: "apps/v1",
-				ObjectMeta: yaml.ObjectMeta{Name: "bar"},
+			yaml.ResourceMeta{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "foo",
+				},
+				ObjectMeta: yaml.ObjectMeta{
+					NameMeta: yaml.NameMeta{Name: "bar"},
+				},
 			},
 			`dir/foo_bar.yaml`, `without namespace`,
 		},
 		{
 			``,
-			yaml.ResourceMeta{Kind: "foo",
-				APIVersion: "apps/v1",
-				ObjectMeta: yaml.ObjectMeta{Name: "bar"},
+			yaml.ResourceMeta{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "foo",
+				},
+				ObjectMeta: yaml.ObjectMeta{
+					NameMeta: yaml.NameMeta{Name: "bar"},
+				},
 			},
 			`foo_bar.yaml`, `without namespace or dir`,
 		},
 		{
 			``,
-			yaml.ResourceMeta{Kind: "foo",
-				APIVersion: "apps/v1",
+			yaml.ResourceMeta{
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "foo",
+				},
 				ObjectMeta: yaml.ObjectMeta{},
 			},
 			`foo_.yaml`, `without namespace, dir or name`,
@@ -316,7 +343,9 @@ func TestCreatePathAnnotationValue(t *testing.T) {
 		{
 			``,
 			yaml.ResourceMeta{
-				APIVersion: "apps/v1",
+				TypeMeta: yaml.TypeMeta{
+					APIVersion: "apps/v1",
+				},
 				ObjectMeta: yaml.ObjectMeta{},
 			},
 			`_.yaml`, `without any`,

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -698,11 +698,15 @@ metadata:
 		return
 	}
 	assert.Equal(t, ResourceMeta{
-		Kind:       "Deployment",
-		APIVersion: "v1/apps",
+		TypeMeta: TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "v1/apps",
+		},
 		ObjectMeta: ObjectMeta{
-			Name:      "foo",
-			Namespace: "bar",
+			NameMeta: NameMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
 			Annotations: map[string]string{
 				"ka": "va",
 			},

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -36,11 +36,15 @@ spec:
 	}
 
 	expected := ResourceMeta{
-		APIVersion: "rbac.istio.io/v1alpha1",
-		Kind:       "ServiceRole",
+		TypeMeta: TypeMeta{
+			APIVersion: "rbac.istio.io/v1alpha1",
+			Kind:       "ServiceRole",
+		},
 		ObjectMeta: ObjectMeta{
-			Name:        "wildcard",
-			Namespace:   "default",
+			NameMeta: NameMeta{
+				Name:      "wildcard",
+				Namespace: "default",
+			},
 			Annotations: map[string]string{"foo": "bar"},
 		},
 	}

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -88,27 +88,33 @@ func (f FilterFunc) Filter(object *RNode) (*RNode, error) {
 	return f(object)
 }
 
+// TypeMeta partially copies apimachinery/pkg/apis/meta/v1.TypeMeta
+// No need for a direct dependence; the fields are stable.
 type TypeMeta struct {
-	Kind       string
-	APIVersion string
+	// APIVersion is the apiVersion field of a Resource
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	// Kind is the kind field of a Resource
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+}
+
+// NameMeta contains name information.
+type NameMeta struct {
+	// Name is the metadata.name field of a Resource
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Namespace is the metadata.namespace field of a Resource
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
 // ResourceMeta contains the metadata for a both Resource Type and Resource.
 type ResourceMeta struct {
-	// APIVersion is the apiVersion field of a Resource
-	APIVersion string `yaml:"apiVersion,omitempty"`
-	// Kind is the kind field of a Resource
-	Kind string `yaml:"kind,omitempty"`
+	TypeMeta `json:",inline" yaml:",inline"`
 	// ObjectMeta is the metadata field of a Resource
 	ObjectMeta `yaml:"metadata,omitempty"`
 }
 
 // ObjectMeta contains metadata about a Resource
 type ObjectMeta struct {
-	// Name is the metadata.name field of a Resource
-	Name string `yaml:"name,omitempty"`
-	// Namespace is the metadata.namespace field of a Resource
-	Namespace string `yaml:"namespace,omitempty"`
+	NameMeta `json:",inline" yaml:",inline"`
 	// Labels is the metadata.labels field of a Resource
 	Labels map[string]string `yaml:"labels,omitempty"`
 	// Annotations is the metadata.annotations field of a Resource.
@@ -119,24 +125,16 @@ type ObjectMeta struct {
 // the information needed to uniquely identify a resource in a cluster.
 func (m *ResourceMeta) GetIdentifier() ResourceIdentifier {
 	return ResourceIdentifier{
-		Name:       m.Name,
-		Namespace:  m.Namespace,
-		APIVersion: m.APIVersion,
-		Kind:       m.Kind,
+		TypeMeta: m.TypeMeta,
+		NameMeta: m.NameMeta,
 	}
 }
 
 // ResourceIdentifier contains the information needed to uniquely
 // identify a resource in a cluster.
 type ResourceIdentifier struct {
-	// Name is the name of the resource as set in metadata.name
-	Name string `yaml:"name,omitempty"`
-	// Namespace is the namespace of the resource as set in metadata.namespace
-	Namespace string `yaml:"namespace,omitempty"`
-	// ApiVersion is the apiVersion of the resource
-	APIVersion string `yaml:"apiVersion,omitempty"`
-	// Kind is the kind of the resource
-	Kind string `yaml:"kind,omitempty"`
+	TypeMeta `json:",inline" yaml:",inline"`
+	NameMeta `json:",inline" yaml:",inline"`
 }
 
 func (r *ResourceIdentifier) GetName() string {


### PR DESCRIPTION
Moving to consolidate use of these definitions instead of those in kustomize/api/types
(e.g. https://github.com/kubernetes-sigs/kustomize/blob/master/api/types/typemeta.go)

Goal is to have just one set of these definitions, in kyaml, used by everyone (kpt, kustomize, function authors etc)