### PR TITLE
Generate release notes per module.

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -35,10 +35,14 @@ module=${fullTag%/*}
 echo "module=$module"
 
 # Obtain most recent commit hash associated with the module.
-lastCommitHash=$(git log --tags=$module -1 --oneline --no-walk --pretty=format:%h)
+lastCommitHash=$(
+    git log --tags=$module -1 --oneline --no-walk --pretty=format:%h)
 
-# Generate the changelog for this release using commit hashes and commit messages.
-cl=$(git log $lastCommitHash.. --pretty=oneline --abbrev-commit --no-decorate --no-color -- $module)
+# Generate the changelog for this release
+# using commit hashes and commit messages.
+cl=$(
+    git log $lastCommitHash.. --pretty=oneline \
+    --abbrev-commit --no-decorate --no-color -- $module)
 
 # Take everything after the last slash.
 # This should be something like "v1.2.3".


### PR DESCRIPTION
Generated changelog is fed as input to goreleaser. Addresses https://github.com/kubernetes-sigs/kustomize/issues/2773