### PR TITLE
Add three dashes (---) at the very beginning of the output

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -110,13 +110,8 @@ func (m *resWrangler) AllIds() (ids []resid.ResId) {
 // Debug implements ResMap.
 func (m *resWrangler) Debug(title string) {
 	fmt.Println("--------------------------- " + title)
-	firstObj := true
 	for i, r := range m.rList {
-		if firstObj {
-			firstObj = false
-		} else {
-			fmt.Println("---")
-		}
+		fmt.Println("---")
 		fmt.Printf("# %d  %s\n", i, r.OrgId())
 		blob, err := yaml.Marshal(r.Map())
 		if err != nil {
@@ -267,7 +262,6 @@ func (m *resWrangler) groupedByOriginalNamespace() map[string][]*resource.Resour
 
 // AsYaml implements ResMap.
 func (m *resWrangler) AsYaml() ([]byte, error) {
-	firstObj := true
 	var b []byte
 	buf := bytes.NewBuffer(b)
 	for _, res := range m.Resources() {
@@ -275,12 +269,8 @@ func (m *resWrangler) AsYaml() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if firstObj {
-			firstObj = false
-		} else {
-			if _, err = buf.WriteString("---\n"); err != nil {
-				return nil, err
-			}
+		if _, err = buf.WriteString("---\n"); err != nil {
+			return nil, err
 		}
 		if _, err = buf.Write(out); err != nil {
 			return nil, err


### PR DESCRIPTION
Three dashes (---) can be also used to start the first document
as seen in the examples of Section 2.2 in the Yaml specifications
(1.1, 1.2). Adding this will be helpful when we need to concatenate
multiple kustomize outputs:

  (kustomize build foo; kustomize build bar;) | kubectl apply -f-

I have not seen the need of dropping (---) from the first doc.
I suspect the tests would be updated, howerver for the first commit
I will keep it simple.