### PR TITLE
Chore: docs : Add basic structure for command line options

### DIFF
--- a/site/content/en/guides/cmd/_index.md
+++ b/site/content/en/guides/cmd/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Command Line Options"
+linkTitle: "Command Line Options"
+type: docs
+description: >
+    Usage of command line options
+---

--- a/site/content/en/guides/cmd/build/_index.md
+++ b/site/content/en/guides/cmd/build/_index.md
@@ -1,0 +1,7 @@
+---
+title: "build"
+linkTitle: "build"
+type: docs
+description: >
+    Print configuration per contents of kustomization.yaml
+---

--- a/site/content/en/guides/cmd/cfg/_index.md
+++ b/site/content/en/guides/cmd/cfg/_index.md
@@ -1,0 +1,7 @@
+---
+title: "cfg"
+linkTitle: "cfg"
+type: docs
+description: >
+    Commands for reading and writing configuration.
+---

--- a/site/content/en/guides/cmd/create/_index.md
+++ b/site/content/en/guides/cmd/create/_index.md
@@ -1,0 +1,7 @@
+---
+title: "create"
+linkTitle: "create"
+type: docs
+description: >
+    Create a new kustomization in the current directory
+---

--- a/site/content/en/guides/cmd/edit/_index.md
+++ b/site/content/en/guides/cmd/edit/_index.md
@@ -1,0 +1,7 @@
+---
+title: "edit"
+linkTitle: "edit"
+type: docs
+description: >
+    Edits a kustomization file
+---

--- a/site/content/en/guides/cmd/fn/_index.md
+++ b/site/content/en/guides/cmd/fn/_index.md
@@ -1,0 +1,7 @@
+---
+title: "fn"
+linkTitle: "fn"
+type: docs
+description: >
+    Commands for running functions against configuration
+---

--- a/site/content/en/guides/cmd/help/_index.md
+++ b/site/content/en/guides/cmd/help/_index.md
@@ -1,0 +1,42 @@
+---
+title: "help"
+linkTitle: "help"
+type: docs
+description: >
+    Help about any command
+---
+
+> ```
+> kustomize help
+> 
+> Manages declarative configuration of Kubernetes.
+> See https://sigs.k8s.io/kustomize
+>
+> Usage:
+>   kustomize [command]
+>
+> Available Commands:
+>   build                     Print configuration per contents of kustomization.yaml
+>   cfg                       Commands for reading and writing configuration.
+>   create                    Create a new kustomization in the current directory
+>   edit                      Edits a kustomization file
+>   fn                        Commands for running functions against configuration.
+>   help                      Help about any command
+>   install-completion        Install shell completion.
+>   live                      Commands for reading and writing resources to a cluster.
+>   version                   Prints the kustomize version
+>
+> Flags:
+>   -h, --help          help for kustomize
+>       --stack-trace   print a stack-trace on error
+> 
+> Additional help topics:
+>   kustomize docs-fn                   [Alpha] Documentation for developing and invoking Configuration Functions.
+>   kustomize docs-fn-spec              [Alpha] Documentation for Configuration Functions Specification.
+>   kustomize docs-io-annotations       [Alpha] Documentation for annotations used by io.
+>   kustomize docs-merge                [Alpha] Documentation for merging Resources (2-way merge).
+>   kustomize docs-merge3               [Alpha] Documentation for merging Resources (3-way merge).
+>   kustomize tutorials-command-basics  [Alpha] Tutorials for using basic config commands.
+>   kustomize tutorials-function-basics [Alpha] Tutorials for using functions.
+> 
+> Use "kustomize [command] --help" for more information about a command.

--- a/site/content/en/guides/cmd/install-completion/_index.md
+++ b/site/content/en/guides/cmd/install-completion/_index.md
@@ -1,0 +1,7 @@
+---
+title: "install-completion"
+linkTitle: "install-completion"
+type: docs
+description: >
+    Installs shell completion
+---

--- a/site/content/en/guides/cmd/live/_index.md
+++ b/site/content/en/guides/cmd/live/_index.md
@@ -1,0 +1,7 @@
+---
+title: "live"
+linkTitle: "live"
+type: docs
+description: >
+    Commands for reading and writing resources to a cluster.
+---

--- a/site/content/en/guides/cmd/version/_index.md
+++ b/site/content/en/guides/cmd/version/_index.md
@@ -1,0 +1,14 @@
+---
+title: "version"
+linkTitle: "version"
+type: docs
+description: >
+    Prints the kustomize version
+---
+
+Prints the current kustomize version
+
+> ```
+> kustomize version
+> {Version:kustomize/v3.8.1 GitCommit:0b359d0ef0272e6545eda0e99aacd63aef99c4d0 BuildDate:2020-07-16T00:58:46Z GoOs:linux GoArch:amd64}
+> ```


### PR DESCRIPTION
So users may be able to expand them further. 