### PR TITLE
Add namespace name to namespace transformer defaults

### DIFF
--- a/api/konfig/builtinpluginconsts/namespace.go
+++ b/api/konfig/builtinpluginconsts/namespace.go
@@ -8,6 +8,9 @@ const (
 namespace:
 - path: metadata/namespace
   create: true
+- path: metadata/name
+  kind: Namespace
+  create: true
 - path: subjects
   kind: RoleBinding
 - path: subjects


### PR DESCRIPTION
This MR enables to override the Namespace name Namespace objects, i.e.

```yaml
apiVersion: v1
kind: Namespace
metadata:
  # this one
  name: foo 
```