### PR TITLE
Print Krmfile data for cfg tree

### DIFF
--- a/cmd/config/go.sum
+++ b/cmd/config/go.sum
@@ -623,6 +623,7 @@ sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
+sigs.k8s.io/kustomize/cmd/config v0.7.0/go.mod h1:ORl2Fv3uSV4Wr8FKynZUFe8Xb5ct/bVZrzbiz+/GEFs=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=

--- a/cmd/config/internal/commands/grep.go
+++ b/cmd/config/internal/commands/grep.go
@@ -29,8 +29,6 @@ func GetGrepRunner(name string) *GrepRunner {
 		Args:    cobra.MaximumNArgs(2),
 	}
 	fixDocs(name, c)
-	c.Flags().BoolVar(&r.IncludeSubpackages, "include-subpackages", true,
-		"also print resources from subpackages.")
 	c.Flags().BoolVar(&r.KeepAnnotations, "annotate", true,
 		"annotate resources with their file origins.")
 	c.Flags().BoolVarP(&r.InvertMatch, "invert-match", "", false,
@@ -47,9 +45,8 @@ func GrepCommand(name string) *cobra.Command {
 
 // GrepRunner contains the run function
 type GrepRunner struct {
-	IncludeSubpackages bool
-	KeepAnnotations    bool
-	Command            *cobra.Command
+	KeepAnnotations bool
+	Command         *cobra.Command
 	filters.GrepFilter
 	Format             bool
 	RecurseSubPackages bool

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -90,6 +90,109 @@ spec:
 	}
 }
 
+func TestTreeCommand_subpkgs(t *testing.T) {
+	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	defer os.RemoveAll(d)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	err = os.MkdirAll(filepath.Join(d, "subpkg"), 0700)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+apiVersion: v1
+kind: Abstraction
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/example/reconciler:v1
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 1
+---
+kind: Deployment
+metadata:
+  labels:
+    app: nginx2
+  name: foo
+  annotations:
+    app: nginx2
+spec:
+  replicas: 1
+---
+kind: Service
+metadata:
+  name: foo
+  annotations:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = ioutil.WriteFile(filepath.Join(d, "subpkg", "f2.yaml"), []byte(`kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: bar
+  annotations:
+    app: nginx
+spec:
+  replicas: 3
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = ioutil.WriteFile(filepath.Join(d, "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
+kind: Krmfile
+metadata:
+  name: mainpkg
+openAPI:
+  definitions:
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = ioutil.WriteFile(filepath.Join(d, "subpkg", "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
+kind: Krmfile
+metadata:
+  name: subpkg
+openAPI:
+  definitions:
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// fmt the files
+	b := &bytes.Buffer{}
+	r := commands.GetTreeRunner("")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	if !assert.NoError(t, r.Command.Execute()) {
+		return
+	}
+
+	if !assert.Equal(t, fmt.Sprintf(`%s
+├── [Krmfile]  Krmfile mainpkg
+├── [f1.yaml]  Deployment foo
+├── [f1.yaml]  Service foo
+└── Pkg: subpkg
+    ├── [Krmfile]  Krmfile subpkg
+    └── [f2.yaml]  Deployment bar
+`, d), b.String()) {
+		return
+	}
+}
+
 func TestTreeCommand_stdin(t *testing.T) {
 	// fmt the files
 	b := &bytes.Buffer{}

--- a/kyaml/kio/tree_test.go
+++ b/kyaml/kio/tree_test.go
@@ -6,7 +6,6 @@ package kio_test
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,9 +75,9 @@ spec:
 └── foo-package
     ├── [f1.yaml]  Deployment default/foo
     ├── [f1.yaml]  Service default/foo
-    └── foo-package%s3
+    └── 3
         └── [f3.yaml]  Deployment default/foo
-`, string(filepath.Separator)), out.String()) {
+`), out.String()) {
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
@mortent 

Currently `cfg tree` command doesn't include the information regarding the Krmfile which makes it difficult to the users to distinguish between subpackages and subdirectories. This PR is to print the information regarding Krmfile.

Example Output:
```
  hello-composite-pkg
  ├── [Krmfile]  Krmfile hello-composite-pkg
  ├── [deploy.yaml]  Deployment default/hello-composite
  └── Pkg: hello-subpkg
      ├── [Krmfile]  Krmfile hello-subpkg
      ├── [deploy.yaml]  Deployment default/hello-sub
      ├── hello-dir
      │   └── [configmap.yaml]  ConfigMap default/hello-cm
      └── Pkg: hello-nestedpkg
          ├── [Krmfile]  Krmfile hello-nestedpkg
          └── [deploy.yaml]  Deployment default/hello-nested
```