### PR TITLE
Fix comment on SplitIndexNameValue

### DIFF
--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -605,7 +605,7 @@ func IsListIndex(p string) bool {
 // SplitIndexNameValue splits a lookup part Val index into the field name
 // and field value to match.
 // e.g. splits [name=nginx] into (name, nginx)
-// e.g. splits [=-jar] into ("", jar)
+// e.g. splits [=-jar] into ("", -jar)
 func SplitIndexNameValue(p string) (string, string, error) {
 	elem := strings.TrimSuffix(p, "]")
 	elem = strings.TrimPrefix(elem, "[")

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -518,6 +518,11 @@ func TestSplitIndexNameValue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "a", k)
 	assert.Equal(t, "b=c", v)
+
+	k, v, err = SplitIndexNameValue("=-jar")
+	assert.NoError(t, err)
+	assert.Equal(t, "", k)
+	assert.Equal(t, "-jar", v)
 }
 
 type filter struct {


### PR DESCRIPTION
It was incorrect and suggested some behaviour which isn't present.
Added test to verify the documented behaviour.