### PR TITLE
Format the output of cfg commands

### DIFF
--- a/cmd/config/internal/commands/annotate.go
+++ b/cmd/config/internal/commands/annotate.go
@@ -103,10 +103,10 @@ func (r *AnnotateRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if there are multiple packages to annotate
-			fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "added annotations in package %q\n", pkgPath)
+		fmt.Fprint(w, "added annotations in the package\n")
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/annotate_test.go
+++ b/cmd/config/internal/commands/annotate_test.go
@@ -501,9 +501,11 @@ func TestAnnotateSubPackages(t *testing.T) {
 			name:    "annotate-recurse-subpackages",
 			dataset: "dataset-without-setters",
 			args:    []string{"--kv", "foo=bar", "-R"},
-			expected: `
-added annotations in package "${baseDir}/mysql"
-added annotations in package "${baseDir}/mysql/storage"
+			expected: `${baseDir}/mysql/
+added annotations in the package
+
+${baseDir}/mysql/storage/
+added annotations in the package
 `,
 		},
 		{
@@ -511,14 +513,18 @@ added annotations in package "${baseDir}/mysql/storage"
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql",
 			args:        []string{"--kv", "foo=bar"},
-			expected:    `added annotations in package "${baseDir}/mysql"`,
+			expected: `${baseDir}/mysql/
+added annotations in the package
+`,
 		},
 		{
 			name:        "annotate-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"--kv", "foo=bar"},
-			expected:    `added annotations in package "${baseDir}/mysql/storage"`,
+			expected: `${baseDir}/mysql/storage/
+added annotations in the package
+`,
 		},
 	}
 	for i := range tests {
@@ -550,7 +556,7 @@ added annotations in package "${baseDir}/mysql/storage"
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cat.go
+++ b/cmd/config/internal/commands/cat.go
@@ -102,6 +102,7 @@ func (r *CatRunner) runE(c *cobra.Command, args []string) error {
 		recurseSubPackages: r.RecurseSubPackages,
 		cmdRunner:          r,
 		rootPkgPath:        args[0],
+		skipPkgPathPrint:   true,
 	}
 
 	return e.execute()
@@ -133,7 +134,7 @@ func (r *CatRunner) executeCmd(w io.Writer, pkgPath string) error {
 			fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
 		}
 	}
-	fmt.Fprintf(w, "---\n")
+	fmt.Fprintf(w, "---")
 	return nil
 }
 

--- a/cmd/config/internal/commands/cat_test.go
+++ b/cmd/config/internal/commands/cat_test.go
@@ -115,8 +115,7 @@ metadata:
     app: nginx
 spec:
   replicas: 3
----
-`, b.String()) {
+---`, b.String()) {
 		return
 	}
 }
@@ -172,8 +171,7 @@ metadata:
   annotations:
     app: nginx
 spec:
-  replicas: 3
-`), 0600)
+  replicas: 3`), 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -227,8 +225,7 @@ metadata:
     app: nginx
 spec:
   replicas: 3
----
-`, b.String()) {
+---`, b.String()) {
 		return
 	}
 }
@@ -310,8 +307,7 @@ metadata:
       image: gcr.io/example/reconciler:v1
 spec:
   replicas: 3
----
-`, b.String()) {
+---`, b.String()) {
 		return
 	}
 }
@@ -368,8 +364,7 @@ metadata:
   annotations:
     app: nginx
 spec:
-  replicas: 3
-`), 0600)
+  replicas: 3`), 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -426,8 +421,7 @@ metadata:
     app: nginx
 spec:
   replicas: 3
----
-`, string(actual)) {
+---`, string(actual)) {
 		return
 	}
 }
@@ -484,8 +478,7 @@ metadata:
   annotations:
     app: nginx
 spec:
-  replicas: 3
-`), 0600)
+  replicas: 3`), 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -543,8 +536,7 @@ metadata:
     app: nginx
 spec:
   replicas: 3
----
-`, string(actual)) {
+---`, string(actual)) {
 		return
 	}
 }
@@ -560,8 +552,7 @@ func TestCatSubPackages(t *testing.T) {
 		{
 			name:    "cat-recurse-subpackages",
 			dataset: "dataset-without-setters",
-			expected: `
-# Copyright 2019 The Kubernetes Authors.
+			expected: `# Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apps/v1
@@ -592,16 +583,14 @@ spec:
       containers:
       - name: storage
         image: storage:1.7.7
----
-`,
+---`,
 		},
 		{
 			name:        "cat-top-level-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			args:        []string{"-R=false"},
 			packagePath: "mysql",
-			expected: `
-# Copyright 2019 The Kubernetes Authors.
+			expected: `# Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apps/v1
@@ -616,16 +605,14 @@ spec:
       containers:
       - name: mysql
         image: mysql:1.7.9
----
-`,
+---`,
 		},
 		{
 			name:        "cat-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"-R=false"},
-			expected: `
-# Copyright 2019 The Kubernetes Authors.
+			expected: `# Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apps/v1
@@ -672,7 +659,7 @@ spec:
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -231,10 +231,10 @@ func (r *CreateSetterRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "created setter %q in package %q\n\n", r.CreateSetter.Name, pkgPath)
+		fmt.Fprintf(w, "created setter %q\n", r.CreateSetter.Name)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -44,7 +44,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -83,7 +83,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -162,7 +162,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -204,7 +204,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter replicas in package ${baseDir}`,
+			out: `created setter replicas`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -259,7 +259,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "list" in package "${baseDir}"`,
+			out: `created setter "list"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -360,7 +360,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter replicas in package ${baseDir}`,
+			out: `created setter replicas`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -407,7 +407,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -445,7 +445,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "foo.bar" in package "${baseDir}"`,
+			out: `created setter "foo.bar"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -596,7 +596,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -722,7 +722,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
 `,
-			out: `created setter "replicas" in package "${baseDir}"`,
+			out: `created setter "replicas"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -814,7 +814,7 @@ spec:
 				strings.Replace(out.String(), "\\", "/", -1),
 				"//", "/", -1)
 
-			if !assert.Equal(t, expectedNormalized, strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, actualNormalized, expectedNormalized) {
 				t.FailNow()
 			}
 
@@ -853,10 +853,11 @@ func TestCreateSetterSubPackages(t *testing.T) {
 			name:    "create-setter-recurse-subpackages",
 			dataset: "dataset-without-setters",
 			args:    []string{"namespace", "myspace", "-R"},
-			expected: `
-created setter "namespace" in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+created setter "namespace"
 
-created setter "namespace" in package "${baseDir}/mysql/storage"
+${baseDir}/mysql/storage/
+created setter "namespace"
 `,
 		},
 		{
@@ -864,25 +865,33 @@ created setter "namespace" in package "${baseDir}/mysql/storage"
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql",
 			args:        []string{"namespace", "myspace"},
-			expected:    `created setter "namespace" in package "${baseDir}/mysql"`,
+			expected: `${baseDir}/mysql/
+created setter "namespace"
+`,
 		},
 		{
 			name:        "create-setter-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"namespace", "myspace"},
-			expected:    `created setter "namespace" in package "${baseDir}/mysql/storage"`,
+			expected: `${baseDir}/mysql/storage/
+created setter "namespace"
+`,
 		},
 		{
 			name:        "create-setter-already-exists",
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql",
 			args:        []string{"namespace", "myspace", "-R"},
-			expected: `setter with name "namespace" already exists, if you want to modify it, please delete the existing setter and recreate it in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+setter with name "namespace" already exists, if you want to modify it, please delete the existing setter and recreate it
 
-created setter "namespace" in package "${baseDir}/mysql/nosetters"
+${baseDir}/mysql/nosetters/
+created setter "namespace"
 
-setter with name "namespace" already exists, if you want to modify it, please delete the existing setter and recreate it in package "${baseDir}/mysql/storage"`,
+${baseDir}/mysql/storage/
+setter with name "namespace" already exists, if you want to modify it, please delete the existing setter and recreate it
+`,
 		},
 	}
 	for i := range tests {
@@ -914,7 +923,7 @@ setter with name "namespace" already exists, if you want to modify it, please de
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdcreatesubstitution.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution.go
@@ -87,10 +87,10 @@ func (r *CreateSubstitutionRunner) executeCmd(w io.Writer, pkgPath string) error
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "created substitution %q in package %q\n\n", r.CreateSubstitution.Name, pkgPath)
+		fmt.Fprintf(w, "created substitution %q\n", r.CreateSubstitution.Name)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -63,7 +63,7 @@ openAPI:
           name: my-tag-setter
           value: "1.7.9"
  `,
-			out: `created substitution "my-image-subst" in package "${baseDir}"`,
+			out: `created substitution "my-image-subst"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -167,7 +167,7 @@ spec:
 apiVersion: v1alpha1
 kind: Example
  `,
-			out: `created substitution "my-image-subst" in package "${baseDir}"`,
+			out: `created substitution "my-image-subst"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -256,7 +256,7 @@ openAPI:
           - marker: ${my-tag-setter}
             ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
  `,
-			out: `created substitution "my-nested-subst" in package "${baseDir}"`,
+			out: `created substitution "my-nested-subst"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -400,7 +400,7 @@ spec:
 				strings.Replace(out.String(), "\\", "/", -1),
 				"//", "/", -1)
 
-			if !assert.Equal(t, expectedNormalized, strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, actualNormalized, expectedNormalized) {
 				t.FailNow()
 			}
 
@@ -439,10 +439,11 @@ func TestCreateSubstSubPackages(t *testing.T) {
 			name:    "create-subst-recurse-subpackages",
 			dataset: "dataset-without-setters",
 			args:    []string{"image-tag", "--field-value", "mysql:1.7.9", "--pattern", "${image}:${tag}", "-R"},
-			expected: `
-created substitution "image-tag" in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+created substitution "image-tag"
 
-created substitution "image-tag" in package "${baseDir}/mysql/storage"
+${baseDir}/mysql/storage/
+created substitution "image-tag"
 `,
 		},
 		{
@@ -450,25 +451,30 @@ created substitution "image-tag" in package "${baseDir}/mysql/storage"
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql",
 			args:        []string{"image-tag", "--field-value", "mysql:1.7.9", "--pattern", "${image}:${tag}"},
-			expected:    `created substitution "image-tag" in package "${baseDir}/mysql"`,
+			expected: `${baseDir}/mysql/
+created substitution "image-tag"`,
 		},
 		{
 			name:        "create-subst-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"image-tag", "--field-value", "storage:1.7.9", "--pattern", "${image}:${tag}"},
-			expected:    `created substitution "image-tag" in package "${baseDir}/mysql/storage"`,
+			expected: `${baseDir}/mysql/storage/
+created substitution "image-tag"`,
 		},
 		{
 			name:        "create-subst-already-exists",
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql",
 			args:        []string{"image-tag", "--field-value", "mysql:1.7.9", "--pattern", "${image}:${tag}", "-R"},
-			expected: `substitution with name "image-tag" already exists in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+substitution with name "image-tag" already exists
 
-created substitution "image-tag" in package "${baseDir}/mysql/nosetters"
+${baseDir}/mysql/nosetters/
+created substitution "image-tag"
 
-created substitution "image-tag" in package "${baseDir}/mysql/storage"`,
+${baseDir}/mysql/storage/
+created substitution "image-tag"`,
 		},
 	}
 	for i := range tests {

--- a/cmd/config/internal/commands/cmddeletesetter.go
+++ b/cmd/config/internal/commands/cmddeletesetter.go
@@ -95,10 +95,10 @@ func (r *DeleteSetterRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "deleted setter %q in package %q\n\n", r.DeleteSetter.Name, pkgPath)
+		fmt.Fprintf(w, "deleted setter %q\n", r.DeleteSetter.Name)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/cmddeletesetter_test.go
+++ b/cmd/config/internal/commands/cmddeletesetter_test.go
@@ -53,7 +53,7 @@ openAPI:
           value: "3"
           setBy: me
 `,
-			out: `deleted setter "replicas-setter" in package "${baseDir}"`,
+			out: `deleted setter "replicas-setter"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -97,7 +97,7 @@ openAPI:
           name: image
           value: nginx
 `,
-			out: `deleted setter "replicas-setter" in package "${baseDir}"`,
+			out: `deleted setter "replicas-setter"`,
 			expectedOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -161,7 +161,7 @@ spec:
   - "b"
   - "c"
  `,
-			out: `deleted setter "list" in package "${baseDir}"`,
+			out: `deleted setter "list"`,
 			expectedResources: `
 apiVersion: example.com/v1beta1
 kind: Example1
@@ -347,7 +347,7 @@ kind: Deployment
 			expectedOut := strings.Replace(test.out, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expectedOut, "\\", "/", -1)
 
-			if !assert.Equal(t, expectedNormalized, strings.TrimSpace(actualNorm)) {
+			if !assert.Contains(t, strings.TrimSpace(actualNorm), expectedNormalized) {
 				t.FailNow()
 			}
 
@@ -386,12 +386,14 @@ func TestDeleteSetterSubPackages(t *testing.T) {
 			name:    "delete-setter-recurse-subpackages",
 			dataset: "dataset-with-setters",
 			args:    []string{"namespace", "-R"},
-			expected: `
-deleted setter "namespace" in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+deleted setter "namespace"
 
-setter "namespace" does not exist in package "${baseDir}/mysql/nosetters"
+${baseDir}/mysql/nosetters/
+setter "namespace" does not exist
 
-deleted setter "namespace" in package "${baseDir}/mysql/storage"
+${baseDir}/mysql/storage/
+deleted setter "namespace"
 `,
 		},
 		{
@@ -399,14 +401,18 @@ deleted setter "namespace" in package "${baseDir}/mysql/storage"
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql",
 			args:        []string{"namespace"},
-			expected:    `deleted setter "namespace" in package "${baseDir}/mysql"`,
+			expected: `${baseDir}/mysql/
+deleted setter "namespace"
+`,
 		},
 		{
 			name:        "delete-setter-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"namespace"},
-			expected:    `deleted setter "namespace" in package "${baseDir}/mysql/storage"`,
+			expected: `${baseDir}/mysql/storage/
+deleted setter "namespace"
+`,
 		},
 	}
 	for i := range tests {
@@ -438,7 +444,7 @@ deleted setter "namespace" in package "${baseDir}/mysql/storage"
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmddeletesubstitution.go
+++ b/cmd/config/internal/commands/cmddeletesubstitution.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/ext"
 	"sigs.k8s.io/kustomize/kyaml/fieldmeta"
-	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/setters2/settersutil"
 )
 
@@ -50,10 +49,6 @@ func (r *DeleteSubstitutionRunner) preRunE(c *cobra.Command, args []string) erro
 
 	r.OpenAPIFile, err = ext.GetOpenAPIFile(args)
 	if err != nil {
-		return err
-	}
-
-	if err := openapi.AddSchemaFromFile(r.OpenAPIFile); err != nil {
 		return err
 	}
 
@@ -96,10 +91,10 @@ func (r *DeleteSubstitutionRunner) executeCmd(w io.Writer, pkgPath string) error
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "deleted substitution %q in package %q\n\n", r.DeleteSubstitution.Name, pkgPath)
+		fmt.Fprintf(w, "deleted substitution %q\n", r.DeleteSubstitution.Name)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -94,7 +94,6 @@ func (r *ListSettersRunner) executeCmd(w io.Writer, pkgPath string) error {
 		OpenAPIFileName: openAPIFileName,
 	}
 	openAPIPath := filepath.Join(pkgPath, openAPIFileName)
-	fmt.Fprintf(w, "\n%s/\n", pkgPath)
 	if err := r.ListSetters(w, openAPIPath, pkgPath); err != nil {
 		return err
 	}

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -178,10 +178,10 @@ func (r *SetRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n", err.Error(), r.Set.ResourcesPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "set %d fields in package %q\n", count, r.Set.ResourcesPath)
+		fmt.Fprintf(w, "set %d field(s)\n", count)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -31,7 +31,7 @@ func TestSetCommand(t *testing.T) {
 		{
 			name: "set replicas",
 			args: []string{"replicas", "4", "--description", "hi there", "--set-by", "pw"},
-			out:  "set 1 fields\n",
+			out:  "set 1 field(s)\n",
 			inputOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -127,7 +127,7 @@ spec:
 		{
 			name: "set replicas no description",
 			args: []string{"replicas", "4"},
-			out:  "set 1 fields\n",
+			out:  "set 1 field(s)\n",
 			inputOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -175,7 +175,7 @@ spec:
 		{
 			name: "set image with value",
 			args: []string{"tag", "1.8.1"},
-			out:  "set 1 fields\n",
+			out:  "set 1 field(s)\n",
 			inputOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -510,7 +510,7 @@ list in body should have at most 2 items`,
 		{
 			name: "set replicas with value set by flag",
 			args: []string{"replicas", "--values", "4", "--description", "hi there"},
-			out:  "set 1 fields\n",
+			out:  "set 1 field(s)\n",
 			inputOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -606,7 +606,7 @@ spec:
 		{
 			name: "openAPI list values set by flag success",
 			args: []string{"list", "--values", "10", "--values", "11"},
-			out:  "set 1 fields\n",
+			out:  "set 1 field(s)\n",
 			inputOpenAPI: `
 kind: Kptfile
 openAPI:
@@ -710,7 +710,7 @@ list in body should have at most 2 items`,
 		{
 			name: "nested substitution",
 			args: []string{"my-image-setter", "ubuntu"},
-			out:  "set 2 fields\n",
+			out:  "set 2 field(s)\n",
 			inputOpenAPI: `
 apiVersion: v1alpha1
 kind: Example
@@ -1093,10 +1093,14 @@ func TestSetSubPackages(t *testing.T) {
 			name:    "set-recurse-subpackages",
 			dataset: "dataset-with-setters",
 			args:    []string{"namespace", "otherspace", "-R"},
-			expected: `
-set 1 fields in package "${baseDir}/mysql"
-setter "namespace" is not found in package "${baseDir}/mysql/nosetters"
-set 1 fields in package "${baseDir}/mysql/storage"
+			expected: `${baseDir}/mysql/
+set 1 field(s)
+
+${baseDir}/mysql/nosetters/
+setter "namespace" is not found
+
+${baseDir}/mysql/storage/
+set 1 field(s)
 `,
 		},
 		{
@@ -1104,8 +1108,8 @@ set 1 fields in package "${baseDir}/mysql/storage"
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql",
 			args:        []string{"namespace", "otherspace"},
-			expected: `
-set 1 fields in package "${baseDir}/mysql"
+			expected: `${baseDir}/mysql/
+set 1 field(s)
 `,
 		},
 		{
@@ -1113,8 +1117,8 @@ set 1 fields in package "${baseDir}/mysql"
 			dataset:     "dataset-with-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"namespace", "otherspace"},
-			expected: `
-set 1 fields in package "${baseDir}/mysql/storage"
+			expected: `${baseDir}/mysql/storage/
+set 1 field(s)
 `,
 		},
 	}

--- a/cmd/config/internal/commands/count.go
+++ b/cmd/config/internal/commands/count.go
@@ -76,7 +76,6 @@ func (r *CountRunner) executeCmd(w io.Writer, pkgPath string) error {
 
 	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: openAPIFileName}
 
-	fmt.Fprintf(w, "%q:\n", pkgPath)
 	err = kio.Pipeline{
 		Inputs:  []kio.Reader{input},
 		Outputs: r.out(w),
@@ -88,7 +87,7 @@ func (r *CountRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if there are multiple packages to annotate
-			fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	}
 	return nil

--- a/cmd/config/internal/commands/count_test.go
+++ b/cmd/config/internal/commands/count_test.go
@@ -86,10 +86,10 @@ func TestCountSubPackages(t *testing.T) {
 		{
 			name:    "count-recurse-subpackages",
 			dataset: "dataset-without-setters",
-			expected: `
-"${baseDir}/mysql":
+			expected: `${baseDir}/mysql/
 Deployment: 1
-"${baseDir}/mysql/storage":
+
+${baseDir}/mysql/storage/
 Deployment: 1
 `,
 		},
@@ -98,16 +98,18 @@ Deployment: 1
 			dataset:     "dataset-without-setters",
 			args:        []string{"-R=false"},
 			packagePath: "mysql",
-			expected: `"${baseDir}/mysql":
-Deployment: 1`,
+			expected: `${baseDir}/mysql/
+Deployment: 1
+`,
 		},
 		{
 			name:        "count-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"-R=false"},
-			expected: `"${baseDir}/mysql/storage":
-Deployment: 1`,
+			expected: `${baseDir}/mysql/storage/
+Deployment: 1
+`,
 		},
 	}
 	for i := range tests {
@@ -139,7 +141,7 @@ Deployment: 1`,
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/fmt.go
+++ b/cmd/config/internal/commands/fmt.go
@@ -114,10 +114,10 @@ func (r *FmtRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if RecurseSubPackages is true
-			fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	} else {
-		fmt.Fprintf(w, "formatted resource files in package %q\n", pkgPath)
+		fmt.Fprint(w, "formatted resource files in the package\n")
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/fmt_test.go
+++ b/cmd/config/internal/commands/fmt_test.go
@@ -179,23 +179,31 @@ func TestFmtSubPackages(t *testing.T) {
 			name:    "fmt-recurse-subpackages",
 			dataset: "dataset-with-setters",
 			args:    []string{"-R"},
-			expected: `
-formatted resource files in package "${baseDir}/mysql"
-formatted resource files in package "${baseDir}/mysql/nosetters"
-formatted resource files in package "${baseDir}/mysql/storage"
+			expected: `${baseDir}/mysql/
+formatted resource files in the package
+
+${baseDir}/mysql/nosetters/
+formatted resource files in the package
+
+${baseDir}/mysql/storage/
+formatted resource files in the package
 `,
 		},
 		{
 			name:        "fmt-top-level-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql",
-			expected:    `formatted resource files in package "${baseDir}/mysql"`,
+			expected: `${baseDir}/mysql/
+formatted resource files in the package
+`,
 		},
 		{
 			name:        "fmt-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
-			expected:    `formatted resource files in package "${baseDir}/mysql/storage"`,
+			expected: `${baseDir}/mysql/storage/
+formatted resource files in the package
+`,
 		},
 	}
 	for i := range tests {

--- a/cmd/config/internal/commands/grep.go
+++ b/cmd/config/internal/commands/grep.go
@@ -137,7 +137,6 @@ func (r *GrepRunner) executeCmd(w io.Writer, pkgPath string) error {
 
 	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: openAPIFileName}
 
-	fmt.Fprintf(w, "%q:\n", pkgPath)
 	err = kio.Pipeline{
 		Inputs:  []kio.Reader{input},
 		Filters: []kio.Filter{r.GrepFilter},
@@ -153,7 +152,7 @@ func (r *GrepRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return err
 		} else {
 			// print error message and continue if there are multiple packages to annotate
-			fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
+			fmt.Fprintf(w, "%s\n", err.Error())
 		}
 	}
 	return nil

--- a/cmd/config/internal/commands/grep_test.go
+++ b/cmd/config/internal/commands/grep_test.go
@@ -283,8 +283,7 @@ func TestGrepSubPackages(t *testing.T) {
 			name:    "grep-recurse-subpackages",
 			dataset: "dataset-without-setters",
 			args:    []string{"kind=Deployment"},
-			expected: `
-"${baseDir}/mysql":
+			expected: `${baseDir}/mysql/
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -303,7 +302,8 @@ spec:
       containers:
       - name: mysql
         image: mysql:1.7.9
-"${baseDir}/mysql/storage":
+
+${baseDir}/mysql/storage/
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -329,8 +329,7 @@ spec:
 			dataset:     "dataset-without-setters",
 			args:        []string{"kind=Deployment", "-R=false"},
 			packagePath: "mysql",
-			expected: `
-"${baseDir}/mysql":
+			expected: `${baseDir}/mysql/
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -348,15 +347,15 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: mysql:1.7.9`,
+        image: mysql:1.7.9
+`,
 		},
 		{
 			name:        "grep-nested-pkg-no-recurse-subpackages",
 			dataset:     "dataset-without-setters",
 			packagePath: "mysql/storage",
 			args:        []string{"kind=Deployment", "-R=false"},
-			expected: `
-"${baseDir}/mysql/storage":
+			expected: `${baseDir}/mysql/storage/
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -374,7 +373,8 @@ spec:
     spec:
       containers:
       - name: storage
-        image: storage:1.7.7`,
+        image: storage:1.7.7
+`,
 		},
 	}
 	for i := range tests {
@@ -403,7 +403,7 @@ spec:
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/util_test.go
+++ b/cmd/config/internal/commands/util_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -35,23 +34,27 @@ func TestExecuteCmdOnPkgs(t *testing.T) {
 			recurse:     true,
 			needOpenAPI: false,
 			pkgPath:     "subpkg1/subdir1",
-			expectedOut: `${baseDir}/subpkg1/subdir1`,
+			expectedOut: `${baseDir}/subpkg1/subdir1/
+`,
 		},
 		{
 			name:        "executeCmd_returns_error",
 			recurse:     true,
 			needOpenAPI: false,
 			pkgPath:     "subpkg4",
-			errMsg:      `this command returns an error if package has error.txt file`,
+			expectedOut: `${baseDir}/subpkg4/
+`,
+			errMsg: `this command returns an error if package has error.txt file`,
 		},
 		{
 			name:        "executeCmd_prints_pkgpaths",
 			recurse:     true,
 			needOpenAPI: false,
 			pkgPath:     "subpkg2",
-			expectedOut: `
-${baseDir}/subpkg2
-${baseDir}/subpkg2/subpkg3`,
+			expectedOut: `${baseDir}/subpkg2/
+
+${baseDir}/subpkg2/subpkg3/
+`,
 		},
 	}
 
@@ -96,11 +99,11 @@ ${baseDir}/subpkg2/subpkg3`,
 				strings.Replace(actual.String(), "\\", "/", -1),
 				"//", "/", -1)
 
-			expected := strings.Replace(test.expectedOut, "${baseDir}", dir, -1)
+			expected := strings.Replace(test.expectedOut, "${baseDir}", dir+"/", -1)
 			expectedNormalized := strings.Replace(
 				strings.Replace(expected, "\\", "/", -1),
 				"//", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Equal(t, expectedNormalized, actualNormalized) {
 				t.FailNow()
 			}
 		})
@@ -174,6 +177,5 @@ func (r *TestRunner) executeCmd(w io.Writer, pkgPath string) error {
 			return errors.Errorf("this command returns an error if package has error.txt file")
 		}
 	}
-	fmt.Fprintf(w, "%s\n", pkgPath)
 	return nil
 }

--- a/kyaml/setters2/settersutil/settercreator.go
+++ b/kyaml/setters2/settersutil/settercreator.go
@@ -87,7 +87,7 @@ func (c SetterCreator) Create() error {
 	}.Execute()
 	if a.Count == 0 {
 		fmt.Printf("setter %q doesn't match any field in resource configs, "+
-			"but creating setter definition in package %q\n", c.Name, c.ResourcesPath)
+			"but creating setter definition\n", c.Name)
 	}
 	if err != nil {
 		return err

--- a/kyaml/setters2/settersutil/substitutioncreator.go
+++ b/kyaml/setters2/settersutil/substitutioncreator.go
@@ -147,7 +147,7 @@ func (c SubstitutionCreator) Create() error {
 
 	if a.Count == 0 {
 		fmt.Printf("substitution %s doesn't match any field value in resource configs, "+
-			"but creating substitution definition in package %q\n", c.Name, c.ResourcesPath)
+			"but creating substitution definition\n", c.Name)
 	}
 	return err
 }


### PR DESCRIPTION
@mortent 

This PR is to make the output of all the commands consistent. Examples of commands output

```
$ kpt cfg set hello-composite-pkg namespace myspace -R
hello-composite-pkg/
set 1 field(s)

hello-composite-pkg/hello-subpkg/
set 2 field(s)

hello-composite-pkg/hello-subpkg/hello-nestedpkg/
set 1 field(s)
```

```
$ kpt cfg create-setter hello-composite-pkg foo bar -R
hello-composite-pkg/
created setter "foo"

hello-composite-pkg/hello-subpkg/
created setter "foo"

hello-composite-pkg/hello-subpkg/hello-nestedpkg/
setter "foo" doesn't match any field in resource configs, but creating setter definition
created setter "foo"
```

All the rest of the commands follow the same format. Refer to the tests for more info.

Exception: Cat command doesn't output the package name as the output might be piped to a file.
