### PR TITLE
Simplify the cmd/config ext package

### DIFF
--- a/cmd/config/ext/ext.go
+++ b/cmd/config/ext/ext.go
@@ -3,22 +3,8 @@
 
 package ext
 
-import (
-	"path/filepath"
-)
-
-// GetOpenAPIFile returns the path to the file containing supplementary OpenAPI definitions.
-// Maybe be overridden to configure which file to read OpenAPI definitions from.
-var GetOpenAPIFile = func(args []string) (string, error) {
-	return filepath.Join(args[0], "Krmfile"), nil
-}
-
-// OpenAPIFileName returns the name of the file with openAPI definitions
-// uses OpenAPIFile function to derive it
-func OpenAPIFileName() (string, error) {
-	openAPIFileName, err := GetOpenAPIFile([]string{"."})
-	if err != nil {
-		return "", err
-	}
-	return openAPIFileName, nil
+// KRMFileName returns the name of the KRM file. KRM file determines package
+// boundaries and contains the openapi information for a package.
+var KRMFileName = func() string {
+	return "Krmfile"
 }

--- a/cmd/config/internal/commands/annotate.go
+++ b/cmd/config/internal/commands/annotate.go
@@ -85,14 +85,14 @@ func (r *AnnotateRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *AnnotateRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
+	rw := &kio.LocalPackageReadWriter{
+		PackagePath:     pkgPath,
+		NoDeleteFiles:   true,
+		PackageFileName: ext.KRMFileName(),
 	}
-	rw := &kio.LocalPackageReadWriter{PackagePath: pkgPath, NoDeleteFiles: true, PackageFileName: openAPIFileName}
 	input := []kio.Reader{rw}
 	output := []kio.Writer{rw}
-	err = kio.Pipeline{
+	err := kio.Pipeline{
 		Inputs:  input,
 		Filters: []kio.Filter{r},
 		Outputs: output,

--- a/cmd/config/internal/commands/cat.go
+++ b/cmd/config/internal/commands/cat.go
@@ -109,12 +109,7 @@ func (r *CatRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *CatRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
-
-	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: openAPIFileName}
+	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: ext.KRMFileName()}
 	outputs, err := r.out(w)
 	if err != nil {
 		return err

--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -205,10 +205,6 @@ func (r *CreateSetterRunner) createSetter(c *cobra.Command, args []string) error
 }
 
 func (r *CreateSetterRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
 	r.CreateSetter = settersutil.SetterCreator{
 		Name:               r.CreateSetter.Name,
 		SetBy:              r.CreateSetter.SetBy,
@@ -219,12 +215,12 @@ func (r *CreateSetterRunner) executeCmd(w io.Writer, pkgPath string) error {
 		FieldValue:         r.CreateSetter.FieldValue,
 		Required:           r.CreateSetter.Required,
 		RecurseSubPackages: r.CreateSetter.RecurseSubPackages,
-		OpenAPIFileName:    openAPIFileName,
-		OpenAPIPath:        filepath.Join(pkgPath, openAPIFileName),
+		OpenAPIFileName:    ext.KRMFileName(),
+		OpenAPIPath:        filepath.Join(pkgPath, ext.KRMFileName()),
 		ResourcesPath:      pkgPath,
 	}
 
-	err = r.CreateSetter.Create()
+	err := r.CreateSetter.Create()
 	if err != nil {
 		// return err if RecurseSubPackages is false
 		if !r.CreateSetter.RecurseSubPackages {

--- a/cmd/config/internal/commands/cmdcreatesubstitution.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution.go
@@ -65,22 +65,18 @@ func (r *CreateSubstitutionRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *CreateSubstitutionRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
 	r.CreateSubstitution = settersutil.SubstitutionCreator{
 		Name:               r.CreateSubstitution.Name,
 		FieldName:          r.CreateSubstitution.FieldName,
 		FieldValue:         r.CreateSubstitution.FieldValue,
 		RecurseSubPackages: r.CreateSubstitution.RecurseSubPackages,
 		Pattern:            r.CreateSubstitution.Pattern,
-		OpenAPIFileName:    openAPIFileName,
-		OpenAPIPath:        filepath.Join(pkgPath, openAPIFileName),
+		OpenAPIFileName:    ext.KRMFileName(),
+		OpenAPIPath:        filepath.Join(pkgPath, ext.KRMFileName()),
 		ResourcesPath:      pkgPath,
 	}
 
-	err = r.CreateSubstitution.Create()
+	err := r.CreateSubstitution.Create()
 	if err != nil {
 		// return err if RecurseSubPackages is false
 		if !r.CreateSubstitution.RecurseSubPackages {

--- a/cmd/config/internal/commands/cmddeletesetter.go
+++ b/cmd/config/internal/commands/cmddeletesetter.go
@@ -47,14 +47,10 @@ type DeleteSetterRunner struct {
 }
 
 func (r *DeleteSetterRunner) preRunE(c *cobra.Command, args []string) error {
-	var err error
 	r.DeleteSetter.Name = args[1]
 	r.DeleteSetter.DefinitionPrefix = fieldmeta.SetterDefinitionPrefix
 
-	r.OpenAPIFile, err = ext.GetOpenAPIFile(args)
-	if err != nil {
-		return err
-	}
+	r.OpenAPIFile = filepath.Join(args[0], ext.KRMFileName())
 
 	return nil
 }
@@ -75,20 +71,17 @@ func (r *DeleteSetterRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *DeleteSetterRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
+
 	r.DeleteSetter = settersutil.DeleterCreator{
 		Name:               r.DeleteSetter.Name,
 		DefinitionPrefix:   fieldmeta.SetterDefinitionPrefix,
 		RecurseSubPackages: r.RecurseSubPackages,
-		OpenAPIFileName:    openAPIFileName,
-		OpenAPIPath:        filepath.Join(pkgPath, openAPIFileName),
+		OpenAPIFileName:    ext.KRMFileName(),
+		OpenAPIPath:        filepath.Join(pkgPath, ext.KRMFileName()),
 		ResourcesPath:      pkgPath,
 	}
 
-	err = r.DeleteSetter.Delete()
+	err := r.DeleteSetter.Delete()
 	if err != nil {
 		// return err if RecurseSubPackages is false
 		if !r.DeleteSetter.RecurseSubPackages {

--- a/cmd/config/internal/commands/cmddeletesubstitution.go
+++ b/cmd/config/internal/commands/cmddeletesubstitution.go
@@ -43,14 +43,10 @@ type DeleteSubstitutionRunner struct {
 }
 
 func (r *DeleteSubstitutionRunner) preRunE(c *cobra.Command, args []string) error {
-	var err error
 	r.DeleteSubstitution.Name = args[1]
 	r.DeleteSubstitution.DefinitionPrefix = fieldmeta.SubstitutionDefinitionPrefix
 
-	r.OpenAPIFile, err = ext.GetOpenAPIFile(args)
-	if err != nil {
-		return err
-	}
+	r.OpenAPIFile = filepath.Join(args[0], ext.KRMFileName())
 
 	return nil
 }
@@ -71,20 +67,16 @@ func (r *DeleteSubstitutionRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *DeleteSubstitutionRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
 	r.DeleteSubstitution = settersutil.DeleterCreator{
 		Name:               r.DeleteSubstitution.Name,
 		DefinitionPrefix:   fieldmeta.SubstitutionDefinitionPrefix,
 		RecurseSubPackages: r.RecurseSubPackages,
-		OpenAPIFileName:    openAPIFileName,
-		OpenAPIPath:        filepath.Join(pkgPath, openAPIFileName),
+		OpenAPIFileName:    ext.KRMFileName(),
+		OpenAPIPath:        filepath.Join(pkgPath, ext.KRMFileName()),
 		ResourcesPath:      pkgPath,
 	}
 
-	err = r.DeleteSubstitution.Delete()
+	err := r.DeleteSubstitution.Delete()
 	if err != nil {
 		// return err if RecurseSubPackages is false
 		if !r.DeleteSubstitution.RecurseSubPackages {

--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -85,15 +85,11 @@ func (r *ListSettersRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *ListSettersRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
 	r.List = setters2.List{
 		Name:            r.List.Name,
-		OpenAPIFileName: openAPIFileName,
+		OpenAPIFileName: ext.KRMFileName(),
 	}
-	openAPIPath := filepath.Join(pkgPath, openAPIFileName)
+	openAPIPath := filepath.Join(pkgPath, ext.KRMFileName())
 	if err := r.ListSetters(w, openAPIPath, pkgPath); err != nil {
 		return err
 	}

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -108,7 +108,6 @@ func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
 		}
 	}
 	if setterVersion == "v2" {
-		var err error
 		r.Set.Name = args[1]
 		if valueFlagSet {
 			r.Set.Value = r.Values[0]
@@ -125,10 +124,7 @@ func (r *SetRunner) preRunE(c *cobra.Command, args []string) error {
 
 		r.Set.Description = r.Perform.Description
 		r.Set.SetBy = r.Perform.SetBy
-		r.OpenAPIFile, err = ext.GetOpenAPIFile(args)
-		if err != nil {
-			return err
-		}
+		r.OpenAPIFile = filepath.Join(args[0], ext.KRMFileName())
 	}
 	return nil
 }
@@ -155,10 +151,6 @@ func (r *SetRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *SetRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
 	r.Set = settersutil.FieldSetter{
 		Name:               r.Set.Name,
 		Value:              r.Set.Value,
@@ -166,8 +158,8 @@ func (r *SetRunner) executeCmd(w io.Writer, pkgPath string) error {
 		Description:        r.Set.Description,
 		SetBy:              r.Set.SetBy,
 		Count:              0,
-		OpenAPIPath:        filepath.Join(pkgPath, openAPIFileName),
-		OpenAPIFileName:    openAPIFileName,
+		OpenAPIPath:        filepath.Join(pkgPath, ext.KRMFileName()),
+		OpenAPIFileName:    ext.KRMFileName(),
 		ResourcesPath:      pkgPath,
 		RecurseSubPackages: r.Set.RecurseSubPackages,
 	}

--- a/cmd/config/internal/commands/count.go
+++ b/cmd/config/internal/commands/count.go
@@ -69,14 +69,9 @@ func (r *CountRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *CountRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
+	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: ext.KRMFileName()}
 
-	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: openAPIFileName}
-
-	err = kio.Pipeline{
+	err := kio.Pipeline{
 		Inputs:  []kio.Reader{input},
 		Outputs: r.out(w),
 	}.Execute()

--- a/cmd/config/internal/commands/fmt.go
+++ b/cmd/config/internal/commands/fmt.go
@@ -96,16 +96,11 @@ func (r *FmtRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *FmtRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
-
 	rw := &kio.LocalPackageReadWriter{
 		NoDeleteFiles:         true,
 		PackagePath:           pkgPath,
-		KeepReaderAnnotations: r.KeepAnnotations, PackageFileName: openAPIFileName}
-	err = kio.Pipeline{
+		KeepReaderAnnotations: r.KeepAnnotations, PackageFileName: ext.KRMFileName()}
+	err := kio.Pipeline{
 		Inputs: []kio.Reader{rw}, Filters: r.fmtFilters(), Outputs: []kio.Writer{rw}}.Execute()
 
 	if err != nil {

--- a/cmd/config/internal/commands/grep.go
+++ b/cmd/config/internal/commands/grep.go
@@ -128,14 +128,9 @@ func (r *GrepRunner) runE(c *cobra.Command, args []string) error {
 }
 
 func (r *GrepRunner) executeCmd(w io.Writer, pkgPath string) error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
+	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: ext.KRMFileName()}
 
-	input := kio.LocalPackageReader{PackagePath: pkgPath, PackageFileName: openAPIFileName}
-
-	err = kio.Pipeline{
+	err := kio.Pipeline{
 		Inputs:  []kio.Reader{input},
 		Filters: []kio.Filter{r.GrepFilter},
 		Outputs: []kio.Writer{kio.ByteWriter{

--- a/cmd/config/internal/commands/tree.go
+++ b/cmd/config/internal/commands/tree.go
@@ -77,11 +77,7 @@ type TreeRunner struct {
 func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 	var input kio.Reader
 	var root = "."
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
-	matchFilesGlob := append([]string{openAPIFileName}, kio.DefaultMatch...)
+	matchFilesGlob := append([]string{ext.KRMFileName()}, kio.DefaultMatch...)
 	if len(args) == 1 {
 		root = filepath.Clean(args[0])
 		input = kio.LocalPackageReader{PackagePath: args[0], MatchFilesGlob: matchFilesGlob}
@@ -163,7 +159,7 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 			Writer:          c.OutOrStdout(),
 			Fields:          fields,
 			Structure:       kio.TreeStructure(r.structure),
-			OpenAPIFileName: openAPIFileName,
+			OpenAPIFileName: ext.KRMFileName(),
 		}},
 	}.Execute())
 }

--- a/cmd/config/internal/commands/util.go
+++ b/cmd/config/internal/commands/util.go
@@ -37,12 +37,7 @@ type executeCmdOnPkgs struct {
 // executeCmdOnPkgs takes the function definition for a command to be executed on single package, applies that definition
 // recursively on all the subpackages present in rootPkgPath if recurseSubPackages is true, else applies the command on rootPkgPath only
 func (e executeCmdOnPkgs) execute() error {
-	openAPIFileName, err := ext.OpenAPIFileName()
-	if err != nil {
-		return err
-	}
-
-	pkgsPaths, err := pathutil.DirsWithFile(e.rootPkgPath, openAPIFileName, e.recurseSubPackages)
+	pkgsPaths, err := pathutil.DirsWithFile(e.rootPkgPath, ext.KRMFileName(), e.recurseSubPackages)
 	if err != nil {
 		return err
 	}
@@ -51,7 +46,7 @@ func (e executeCmdOnPkgs) execute() error {
 		// at this point, there are no openAPI files in the rootPkgPath
 		if e.needOpenAPI {
 			// few executions need openAPI file to be present(ex: setters commands), if true throw an error
-			return errors.Errorf("unable to find %q in package %q", openAPIFileName, e.rootPkgPath)
+			return errors.Errorf("unable to find %q in package %q", ext.KRMFileName(), e.rootPkgPath)
 		}
 
 		// add root path for commands which doesn't need openAPI(ex: annotate, fmt)
@@ -62,7 +57,7 @@ func (e executeCmdOnPkgs) execute() error {
 		pkgPath := pkgsPaths[i]
 		// Add schema present in openAPI file for current package
 		if e.needOpenAPI {
-			if err := openapi.AddSchemaFromFile(filepath.Join(pkgPath, openAPIFileName)); err != nil {
+			if err := openapi.AddSchemaFromFile(filepath.Join(pkgPath, ext.KRMFileName())); err != nil {
 				return err
 			}
 		}
@@ -82,7 +77,7 @@ func (e executeCmdOnPkgs) execute() error {
 
 		// Delete schema present in openAPI file for current package
 		if e.needOpenAPI {
-			if err := openapi.DeleteSchemaInFile(filepath.Join(pkgPath, openAPIFileName)); err != nil {
+			if err := openapi.DeleteSchemaInFile(filepath.Join(pkgPath, ext.KRMFileName())); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Instead of having the `GetOpenAPIFile` function that returns the full path to the Krmfile, it should just return the name of the Krmfile and it is up to the caller to create the path.