### PR TITLE
Added list of env variables for fn-plugins

### DIFF
--- a/api/internal/plugins/fnplugin/fnplugin.go
+++ b/api/internal/plugins/fnplugin/fnplugin.go
@@ -78,6 +78,7 @@ func NewFnPlugin(o *types.FnPluginLoadingOptions) *FnPlugin {
 			EnableStarlark: o.EnableStar,
 			EnableExec:     o.EnableExec,
 			StorageMounts:  toStorageMounts(o.Mounts),
+			Env:            o.Env,
 		},
 	}
 }

--- a/api/types/pluginrestrictions.go
+++ b/api/types/pluginrestrictions.go
@@ -53,4 +53,6 @@ type FnPluginLoadingOptions struct {
 	NetworkName string
 	// list of mounts
 	Mounts []string
+	// list of env variables to pass to fn
+	Env []string
 }

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -90,6 +90,9 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 	cmd.Flags().StringArrayVar(
 		&o.fnOptions.Mounts, "mount", []string{},
 		"a list of storage options read from the filesystem")
+	cmd.Flags().StringArrayVarP(
+		&o.fnOptions.Env, "env", "e", []string{},
+		"a list of environment variables to be used by functions")
 
 	addFlagLoadRestrictor(cmd.Flags())
 	addFlagEnablePlugins(cmd.Flags())


### PR DESCRIPTION
KRM-functions should be able to get env variables.
After changes of runfn object fn based plugins don't
get them anymore.
Reflecting in `build` cmd args added in [1]
for `fn run` cmd.

[1]
https://github.com/kubernetes-sigs/kustomize/pull/2988/