### PR TITLE
Small change to live commands retrieval

### DIFF
--- a/cmd/config/configcobra/live.go
+++ b/cmd/config/configcobra/live.go
@@ -54,9 +54,9 @@ func GetLive(name string) *cobra.Command {
 	cmd.AddCommand(
 		applyCmd,
 		initcmd.NewCmdInit(f, ioStreams),
-		preview.GetPreviewRunner(f, ioStreams).Command,
+		preview.PreviewCommand(f, ioStreams),
 		diff.NewCmdDiff(f, ioStreams),
-		destroy.GetDestroyRunner(f, ioStreams).Command)
+		destroy.DestroyCommand(f, ioStreams))
 	return cmd
 }
 


### PR DESCRIPTION
* Small change to command to retrieve `live` cobra commands. Allows changes to `Runner` commands.