### PR TITLE
Support exec plugin on Windows

### DIFF
--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -53,6 +53,11 @@ func (p *ExecPlugin) ErrIfNotExecutable() error {
 	}
 	// In Windows, it is not possible to determine whether a
 	// file is executable through file mode.
+	// TODO: provide for setting the executable FileMode bit on Windows
+	// The (fs *fileStat) Mode() (m FileMode) {} function in
+	// https://golang.org/src/os/types_windows.go
+	// lacks the ability to set the FileMode executable bit in response
+	// to file data on Windows.
 	if f.Mode()&0111 == 0000 && runtime.GOOS != "windows" {
 		return fmt.Errorf("unexecutable plugin at: %s", p.path)
 	}

--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/google/shlex"
@@ -50,7 +51,9 @@ func (p *ExecPlugin) ErrIfNotExecutable() error {
 	if err != nil {
 		return err
 	}
-	if f.Mode()&0111 == 0000 {
+	// In Windows, it is not possible to determine whether a
+	// file is executable through file mode.
+	if f.Mode()&0111 == 0000 && runtime.GOOS != "windows" {
 		return fmt.Errorf("unexecutable plugin at: %s", p.path)
 	}
 	return nil


### PR DESCRIPTION
As discussed on #2924, we are now aware that the exec plugin is not available on Windows. This is because we can't check if the plugin is executable via file mode on Windows.

So, I changed the conditions for loading exec plugin so that the plugin can be used in Windows.