### PR TITLE
Sync openAPI setter values with schema

### DIFF
--- a/kyaml/setters2/settersutil/fieldsetter_test.go
+++ b/kyaml/setters2/settersutil/fieldsetter_test.go
@@ -6,14 +6,26 @@ package settersutil
 import (
 	"io/ioutil"
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetAllSetterDefinitions(t *testing.T) {
-	srcOpenAPIFile := `openAPI:
+	var tests = []struct {
+		name                    string
+		srcOpenAPIFile          string
+		destFile                string
+		destOpenAPI             string
+		expectedDestFile        string
+		expectedDestOpenAPIFile string
+		syncSchema              bool
+	}{
+		{
+			name:       "set definitions with syncSchema",
+			syncSchema: true,
+			srcOpenAPIFile: `openAPI:
   definitions:
     io.k8s.cli.setters.namespace:
       x-k8s-cli:
@@ -24,83 +36,163 @@ func TestSetAllSetterDefinitions(t *testing.T) {
       x-k8s-cli:
         setter:
           name: replicas
-          value: "4"`
+          value: "4"`,
 
-	destFile1 := `apiVersion: apps/v1
+			destFile: `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
   namespace: some-other-namespace # {"$ref": "#/definitions/io.k8s.cli.setters.namespace"}
 spec:
-  replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}`
+  replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas-new"}`,
 
-	destFile2 := `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  namespace: some-other-namespace2 # {"$ref": "#/definitions/io.k8s.cli.setters.namespace"}
-spec:
-  replicas: 2 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}`
+			destOpenAPI: `openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: "some-other-namespace"
+    io.k8s.cli.setters.replicas-new:
+      x-k8s-cli:
+        setter:
+          name: replicas-new
+          value: "3"`,
 
-	expectedDestFile := `apiVersion: apps/v1
+			expectedDestFile: `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
   namespace: project-namespace # {"$ref": "#/definitions/io.k8s.cli.setters.namespace"}
 spec:
-  replicas: 4 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}`
+  replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas-new"}
+`,
 
-	srcDir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+			expectedDestOpenAPIFile: `openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: "project-namespace"
+          isSet: true
+    io.k8s.cli.setters.replicas-new:
+      x-k8s-cli:
+        setter:
+          name: replicas-new
+          value: "3"
+`,
+		},
+		{
+			name:       "set values only to resources and not the openAPI",
+			syncSchema: false,
+			srcOpenAPIFile: `openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: "project-namespace"
+    io.k8s.cli.setters.replicas:
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "4"`,
 
-	destDir1, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+			destFile: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: some-other-namespace # {"$ref": "#/definitions/io.k8s.cli.setters.namespace"}
+spec:
+  replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas-new"}`,
 
-	destDir2, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+			destOpenAPI: `openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: "some-other-namespace"
+    io.k8s.cli.setters.replicas-new:
+      x-k8s-cli:
+        setter:
+          name: replicas-new
+          value: "3"`,
 
-	defer os.RemoveAll(srcDir)
-	defer os.RemoveAll(destDir1)
-	defer os.RemoveAll(destDir2)
+			expectedDestFile: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: project-namespace # {"$ref": "#/definitions/io.k8s.cli.setters.namespace"}
+spec:
+  replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas-new"}
+`,
 
-	err = ioutil.WriteFile(srcDir+"/OpenAPIFile", []byte(srcOpenAPIFile), 0600)
-	if !assert.NoError(t, err) {
-		t.FailNow()
+			expectedDestOpenAPIFile: `openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: "some-other-namespace"
+    io.k8s.cli.setters.replicas-new:
+      x-k8s-cli:
+        setter:
+          name: replicas-new
+          value: "3"`,
+		},
 	}
-	err = ioutil.WriteFile(destDir1+"/destFile.yaml", []byte(destFile1), 0600)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			srcDir, err := ioutil.TempDir("", "")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
 
-	err = ioutil.WriteFile(destDir2+"/destFile.yaml", []byte(destFile2), 0600)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+			destDir, err := ioutil.TempDir("", "")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
 
-	err = SetAllSetterDefinitions(srcDir+"/OpenAPIFile", destDir1, destDir2)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+			defer os.RemoveAll(srcDir)
+			defer os.RemoveAll(destDir)
 
-	actualdestFile1, err := ioutil.ReadFile(destDir1 + "/destFile.yaml")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, strings.Trim(string(actualdestFile1), "\n"), expectedDestFile) {
-		t.FailNow()
-	}
+			err = ioutil.WriteFile(filepath.Join(srcDir, "Krmfile"), []byte(test.srcOpenAPIFile), 0600)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			err = ioutil.WriteFile(filepath.Join(destDir, "destFile.yaml"), []byte(test.destFile), 0600)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			err = ioutil.WriteFile(filepath.Join(destDir, "Krmfile"), []byte(test.destOpenAPI), 0600)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
 
-	actualdestFile2, err := ioutil.ReadFile(destDir2 + "/destFile.yaml")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, strings.Trim(string(actualdestFile2), "\n"), expectedDestFile) {
-		t.FailNow()
+			err = SetAllSetterDefinitions(test.syncSchema, filepath.Join(srcDir, "Krmfile"), destDir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			actualDestFile1, err := ioutil.ReadFile(filepath.Join(destDir, "destFile.yaml"))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if !assert.Equal(t, test.expectedDestFile, string(actualDestFile1)) {
+				t.FailNow()
+			}
+
+			actualDestOpenAPIFile1, err := ioutil.ReadFile(filepath.Join(destDir, "Krmfile"))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			if !assert.Equal(t, test.expectedDestOpenAPIFile, string(actualDestOpenAPIFile1)) {
+				t.FailNow()
+			}
+		})
 	}
 }


### PR DESCRIPTION
@mortent 

This PR is to add a new method which syncs the setter values in global openAPI schema with the ones in input openAPIPath and writes them back. This is optionally used by SetAllSetterDefinitions method which is in turn used by Auto setters logic.