### PR TITLE
Add additional namespace ocurrances to transformer specs

### DIFF
--- a/api/konfig/builtinpluginconsts/namespace.go
+++ b/api/konfig/builtinpluginconsts/namespace.go
@@ -8,6 +8,12 @@ const (
 namespace:
 - path: metadata/namespace
   create: true
+- path: spec/template/metadata/namespace
+  kind: Deployment
+- path: spec/template/metadata/namespace
+  kind: StatefulSet
+- path: spec/template/metadata/namespace
+  kind: DaemonSet
 - path: metadata/name
   kind: Namespace
   create: true

--- a/api/krusty/namespaces_test.go
+++ b/api/krusty/namespaces_test.go
@@ -197,6 +197,29 @@ subjects:
   name: default
   namespace: irrelevant
 ---
+kind: Deployment
+metadata:
+  name: example
+spec:
+  template:
+    metadata:
+      namespace: foo
+---
+kind: StatefulSet
+metadata:
+  name: example
+spec:
+  template:
+    metadata:
+      namespace: foo
+kind: DaemonSet
+metadata:
+  name: example
+spec:
+  template:
+    metadata:
+      namespace: foo
+---
 kind: PersistentVolume
 metadata:
   name: pv1
@@ -294,6 +317,29 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: newnamespace
+---
+kind: Deployment
+metadata:
+  name: p1-example-s1
+spec:
+  template:
+    metadata:
+      namespace: newnamespace
+---
+kind: StatefulSet
+metadata:
+  name: p1-example-s1
+spec:
+  template:
+    metadata:
+      namespace: newnamespace
+kind: DaemonSet
+metadata:
+  name: p1-example-s1
+spec:
+  template:
+    metadata:
+      namespace: newnamespace
 ---
 kind: PersistentVolume
 metadata:


### PR DESCRIPTION
Please review if this is the _correct_ fix as opposed to _quick fix_. See: https://github.com/kubernetes-sigs/kustomize/issues/3035#issuecomment-698020445

closes #3035 

EDIT: I'd think a recursing implementation around

 https://github.com/kubernetes-sigs/kustomize/blob/master/api/filters/namespace/namespace.go#L77

 would be a betted approach. Please reject this PR, if reviewer agrees. Test casss should be reusable 