### PR TITLE
add option to choose prepend/append patch items to list in merge

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge.go
@@ -18,7 +18,12 @@ var _ kio.Filter = Filter{}
 func (pf Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	var result []*yaml.RNode
 	for i := range nodes {
-		r, err := merge2.Merge(pf.Patch, nodes[i])
+		r, err := merge2.Merge(
+			pf.Patch, nodes[i],
+			yaml.MergeOptions{
+				ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+			},
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -366,10 +366,10 @@ spec:
   template:
     spec:
       containers:
-      - name: test
-        image: test
       - name: test2
         image: test2
+      - name: test
+        image: test
 `,
 		},
 	}

--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -67,10 +67,10 @@ spec:
   template:
     spec:
       containers:
+      - name: foo0
       - name: foo1
       - name: foo2
       - name: foo3
-      - name: foo0
 `,
 		},
 		"volumes patch": {
@@ -107,10 +107,10 @@ spec:
   template:
     spec:
       volumes:
+      - name: foo0
       - name: foo1
       - name: foo2
       - name: foo3
-      - name: foo0
 `,
 		},
 		"nested patch": {

--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -225,13 +225,13 @@ spec:
     spec:
       containers:
       - env:
-        - name: foo
-          value: bar
         - name: FOO
           valueFrom:
             configMapKeyRef:
               key: somekey
               name: test-infra-app-env-8h5mh7f7ch
+        - name: foo
+          value: bar
         image: nginx:1.8.0
         name: nginx
         ports:

--- a/api/krusty/generatormergeandreplace_test.go
+++ b/api/krusty/generatormergeandreplace_test.go
@@ -386,11 +386,11 @@ spec:
           pdName: nginx-persistent-storage
         name: nginx-persistent-storage
       - configMap:
-          name: staging-team-foo-configmap-in-base-hc6g9dk6g9
-        name: configmap-in-base
-      - configMap:
           name: staging-configmap-in-overlay-dc6fm46dhm
         name: configmap-in-overlay
+      - configMap:
+          name: staging-team-foo-configmap-in-base-hc6g9dk6g9
+        name: configmap-in-base
 ---
 apiVersion: v1
 kind: Service

--- a/api/krusty/multiplepatch_test.go
+++ b/api/krusty/multiplepatch_test.go
@@ -147,11 +147,11 @@ spec:
           pdName: nginx-persistent-storage
         name: nginx-persistent-storage
       - configMap:
-          name: a-b-configmap-in-base-798k5k7g9f
-        name: configmap-in-base
-      - configMap:
           name: a-configmap-in-overlay-dc6fm46dhm
         name: configmap-in-overlay
+      - configMap:
+          name: a-b-configmap-in-base-798k5k7g9f
+        name: configmap-in-base
 ---
 apiVersion: v1
 kind: Service
@@ -352,11 +352,11 @@ spec:
           pdName: nginx-persistent-storage
         name: nginx-persistent-storage
       - configMap:
-          name: staging-team-foo-configmap-in-base-798k5k7g9f
-        name: configmap-in-base
-      - configMap:
           name: staging-configmap-in-overlay-dc6fm46dhm
         name: configmap-in-overlay
+      - configMap:
+          name: staging-team-foo-configmap-in-base-798k5k7g9f
+        name: configmap-in-base
 ---
 apiVersion: v1
 kind: Service

--- a/examples/patchMultipleObjects.md
+++ b/examples/patchMultipleObjects.md
@@ -9,23 +9,23 @@ operation/target/value tuples in a particular
 syntax).
 
 A kustomize file lets one specify many
-patches.  Each patch must be associated with
+patches. Each patch must be associated with
 a _target selector_:
 
 [strategic merge patch]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
-[JSON patch]: jsonpatch.md
+[json patch]: jsonpatch.md
 
 > ```yaml
 > patches:
-> - path: <relative path to file containing patch>
->   target:
->     group: <optional group>
->     version: <optional version>
->     kind: <optional kind>
->     name: <optional name>
->     namespace: <optional namespace>
->     labelSelector: <optional label selector>
->     annotationSelector: <optional annotation selector>
+>   - path: <relative path to file containing patch>
+>     target:
+>       group: <optional group>
+>       version: <optional version>
+>       kind: <optional kind>
+>       name: <optional name>
+>       namespace: <optional namespace>
+>       labelSelector: <optional label selector>
+>       annotationSelector: <optional annotation selector>
 > ```
 
 E.g. select resources with _name_ matching `foo*`:
@@ -61,10 +61,10 @@ The example below shows how to inject a
 sidecar container for multiple Deployment
 resources.
 
-
 Make a place to work:
 
 <!-- @demoHome @testAgainstLatestRelease -->
+
 ```
 DEMO_HOME=$(mktemp -d)
 ```
@@ -72,6 +72,7 @@ DEMO_HOME=$(mktemp -d)
 Make a file describing two Deployments:
 
 <!-- @createDeployments @testAgainstLatestRelease -->
+
 ```
 cat <<EOF >$DEMO_HOME/deployments.yaml
 apiVersion: apps/v1
@@ -111,6 +112,7 @@ Declare a [strategic merge patch] file
 to inject a sidecar container:
 
 <!-- @definePatch @testAgainstLatestRelease -->
+
 ```
 cat <<EOF >$DEMO_HOME/patch.yaml
 apiVersion: apps/v1
@@ -134,6 +136,7 @@ that specifies both a `patches` and `resources`
 entry:
 
 <!-- @createKustomization @testAgainstLatestRelease -->
+
 ```
 cat <<EOF >$DEMO_HOME/kustomization.yaml
 resources:
@@ -149,6 +152,7 @@ EOF
 The expected result is:
 
 <!-- @definedExpectedOutput @testAgainstLatestRelease -->
+
 ```
 cat <<EOF >$DEMO_HOME/out_expected.yaml
 apiVersion: apps/v1
@@ -163,15 +167,15 @@ spec:
     spec:
       containers:
       - args:
-        - one
-        - two
-        image: nginx
-        name: nginx
-      - args:
         - proxy
         - sidecar
         image: docker.io/istio/proxyv2
         name: istio-proxy
+      - args:
+        - one
+        - two
+        image: nginx
+        name: nginx
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -184,18 +188,20 @@ spec:
         key: value
     spec:
       containers:
-      - image: busybox
-        name: busybox
       - args:
         - proxy
         - sidecar
         image: docker.io/istio/proxyv2
         name: istio-proxy
+      - image: busybox
+        name: busybox
 EOF
 ```
 
 Run the build:
+
 <!-- @runIt @testAgainstLatestRelease -->
+
 ```
 kustomize build $DEMO_HOME >$DEMO_HOME/out_actual.yaml
 ```
@@ -203,6 +209,7 @@ kustomize build $DEMO_HOME >$DEMO_HOME/out_actual.yaml
 Confirm expectations:
 
 <!-- @diffShouldExitZero @testAgainstLatestRelease -->
+
 ```
 diff $DEMO_HOME/out_actual.yaml $DEMO_HOME/out_expected.yaml
 ```

--- a/kyaml/kio/filters/merge.go
+++ b/kyaml/kio/filters/merge.go
@@ -67,7 +67,9 @@ func (c MergeFilter) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
 				// first resources, don't merge it
 				merged = resources[i]
 			} else {
-				merged, err = merge2.Merge(patch, merged)
+				merged, err = merge2.Merge(patch, merged, yaml.MergeOptions{
+					ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+				})
 				if err != nil {
 					return nil, err
 				}

--- a/kyaml/yaml/merge2/element_test.go
+++ b/kyaml/yaml/merge2/element_test.go
@@ -3,6 +3,10 @@
 
 package merge2_test
 
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
 var elementTestCases = []testCase{
 	{description: `merge Element -- keep field in dest`,
 		source: `
@@ -37,6 +41,9 @@ spec:
         image: foo:v1
         command: ['run.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Element -- add field to dest`,
@@ -72,6 +79,9 @@ spec:
         image: foo:v1
         command: ['run.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Element -- add list, empty in dest`,
@@ -105,6 +115,9 @@ spec:
         image: foo:v1
         command: ['run.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Element -- add list, missing from dest`,
@@ -134,6 +147,9 @@ spec:
         image: foo:v1
         command: ['run.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Element -- add Element first`,
@@ -173,6 +189,9 @@ spec:
         image: bar:v1
         command: ['run2.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Element -- add Element second`,
@@ -212,7 +231,94 @@ spec:
         image: bar:v1
         command: ['run2.sh']
 `,
-	},
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+  },
+  
+  {description: `merge Element -- add Element third`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']
+      - name: foo
+        image: foo:v1
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']
+      - name: foo
+        image: foo:v1
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+  },
+  
+  {description: `merge Element -- add Element fourth`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v1
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v0
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: foo:v1
+      - name: bar
+        image: bar:v1
+        command: ['run2.sh']
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+  },
 
 	//
 	// Test Case
@@ -248,6 +354,9 @@ spec:
         image: bar:v1
         command: ['run2.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -290,6 +399,9 @@ spec:
         image: bar:v1
         command: ['run2.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -330,6 +442,9 @@ spec:
         image: bar:v1
         command: ['run2.sh']
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -364,6 +479,9 @@ spec:
   template:
     spec: {}
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -393,6 +511,9 @@ containers:
   command: ['run2.sh']
 `,
 		infer: true,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -431,6 +552,9 @@ spec:
         command: ['run2.sh']
 `,
 		infer: false,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -460,6 +584,9 @@ containers: # {"items":{"$ref": "#/definitions/io.k8s.api.core.v1.Container"},"t
   command: ['run2.sh']
 `,
 		infer: false,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge_primitive_finalizers`,
@@ -488,6 +615,9 @@ metadata:
   - c
   - a
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge_primitive_items`,
@@ -513,5 +643,8 @@ items:
 - c
 - a
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 }

--- a/kyaml/yaml/merge2/list_test.go
+++ b/kyaml/yaml/merge2/list_test.go
@@ -3,6 +3,10 @@
 
 package merge2_test
 
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
 var listTestCases = []testCase{
 	{description: `strategic merge patch delete 1`,
 		source: `
@@ -38,6 +42,9 @@ spec:
       - name: foo2
       - name: foo3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 	{description: `strategic merge patch delete 2`,
 		source: `
@@ -73,8 +80,48 @@ spec:
       - name: foo1
       - name: foo2
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
-	{description: `merge k8s deployment containers`,
+	{description: `merge k8s deployment containers - prepend`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo1
+      - name: foo2
+      - name: foo3
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo0
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo1
+      - name: foo2
+      - name: foo3
+      - name: foo0
+      `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+	},
+	{description: `merge k8s deployment containers - append`,
 		source: `
 apiVersion: apps/v1
 kind: Deployment
@@ -107,8 +154,11 @@ spec:
       - name: foo2
       - name: foo3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
-	{description: `merge k8s deployment volumes`,
+	{description: `merge k8s deployment volumes - append`,
 		source: `
 apiVersion: apps/v1
 kind: Deployment
@@ -141,6 +191,46 @@ spec:
       - name: foo2
       - name: foo3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
+	{description: `merge k8s deployment volumes - prepend`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+      - name: foo1
+      - name: foo2
+      - name: foo3
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+      - name: foo0
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+      - name: foo1
+      - name: foo2
+      - name: foo3
+      - name: foo0
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
 	},
 	{description: `merge k8s deployment containers -- $patch directive`,
 		source: `
@@ -267,6 +357,9 @@ items:
 - 2
 - 3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `replace List -- missing from dest`,
@@ -287,6 +380,9 @@ items:
 - 2
 - 3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -314,6 +410,9 @@ items:
 - 2
 - 3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -337,6 +436,9 @@ items:
 - 2
 - 3
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -357,6 +459,9 @@ items:
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -378,5 +483,8 @@ items:
 kind: Deployment
 items: []
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 }

--- a/kyaml/yaml/merge2/map_test.go
+++ b/kyaml/yaml/merge2/map_test.go
@@ -3,6 +3,10 @@
 
 package merge2_test
 
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
 var mapTestCases = []testCase{
 
 	{description: `strategic merge patch delete 1`,
@@ -16,6 +20,9 @@ spec:
   foo: bar1
 `,
 		expected: ``,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `strategic merge patch delete 2`,
@@ -33,6 +40,9 @@ spec:
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `strategic merge patch delete 3`,
@@ -61,6 +71,9 @@ spec:
   metadata:
     name: wut
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `strategic merge patch delete 4`,
@@ -89,6 +102,9 @@ spec:
 `,
 		expected: `
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `strategic merge patch replace 1`,
@@ -111,6 +127,9 @@ spec:
   metal: heavy
   veggie: carrot
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- update field in dest`,
@@ -131,6 +150,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- add field to dest`,
@@ -151,6 +173,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- add list, empty in dest`,
@@ -170,6 +195,9 @@ spec:
   baz: buz
   foo: bar1
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- add list, missing from dest`,
@@ -188,6 +216,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- add Map first`,
@@ -208,6 +239,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `merge Map -- add Map second`,
@@ -228,6 +262,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -249,6 +286,9 @@ spec:
   foo: bar1
   baz: buz
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -272,6 +312,9 @@ spec:
   baz: buz
 items: {}
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -291,5 +334,8 @@ spec:
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 }

--- a/kyaml/yaml/merge2/merge2.go
+++ b/kyaml/yaml/merge2/merge2.go
@@ -12,12 +12,16 @@ import (
 )
 
 // Merge merges fields from src into dest.
-func Merge(src, dest *yaml.RNode) (*yaml.RNode, error) {
-	return walk.Walker{Sources: []*yaml.RNode{dest, src}, Visitor: Merger{}}.Walk()
+func Merge(src, dest *yaml.RNode, mergeOptions yaml.MergeOptions) (*yaml.RNode, error) {
+	return walk.Walker{
+		Sources:      []*yaml.RNode{dest, src},
+		Visitor:      Merger{},
+		MergeOptions: mergeOptions,
+	}.Walk()
 }
 
 // Merge parses the arguments, and merges fields from srcStr into destStr.
-func MergeStrings(srcStr, destStr string, infer bool) (string, error) {
+func MergeStrings(srcStr, destStr string, infer bool, mergeOptions yaml.MergeOptions) (string, error) {
 	src, err := yaml.Parse(srcStr)
 	if err != nil {
 		return "", err
@@ -31,6 +35,7 @@ func MergeStrings(srcStr, destStr string, infer bool) (string, error) {
 		Sources:               []*yaml.RNode{dest, src},
 		Visitor:               Merger{},
 		InferAssociativeLists: infer,
+		MergeOptions:          mergeOptions,
 	}.Walk()
 	if err != nil {
 		return "", err

--- a/kyaml/yaml/merge2/merge2_old_test.go
+++ b/kyaml/yaml/merge2/merge2_old_test.go
@@ -55,7 +55,9 @@ metadata:
     m: n1
 `)
 
-	result, err := Merge(src, dest)
+	result, err := Merge(src, dest, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListAppend,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -114,7 +116,9 @@ metadata:
   annotations: null
 `)
 
-	result, err := Merge(src, dest)
+	result, err := Merge(src, dest, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListAppend,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -174,7 +178,9 @@ metadata:
     m: n1
 `)
 
-	result, err := Merge(dest, src)
+	result, err := Merge(dest, src, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListAppend,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -241,7 +247,9 @@ spec:
           value: "Another Env Not In The Dest"
 `)
 
-	result, err := Merge(src, dest)
+	result, err := Merge(src, dest, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListAppend,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -305,7 +313,9 @@ spec:
         args: ['e', 'd', 'f']
 `)
 
-	result, err := Merge(src, dest)
+	result, err := Merge(src, dest, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListAppend,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -365,7 +375,9 @@ a:
   b:
     # header comment
     c: d
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -385,7 +397,9 @@ a:
   b:
     c: d
     # footer comment
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -404,7 +418,9 @@ a:
 a:
   b:
     c: d # line comment
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -426,7 +442,9 @@ a:
   b:
     # replace comment
     c: d
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -447,7 +465,9 @@ a:
   b:
     c: d
     # replace comment
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -466,7 +486,9 @@ a:
 a:
   b:
     c: d # replace comment
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -484,7 +506,9 @@ a:
 a:
   b:
     c: d # replace comment
-`, true)
+`, true, yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/kyaml/yaml/merge2/merge2_test.go
+++ b/kyaml/yaml/merge2/merge2_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 	. "sigs.k8s.io/kustomize/kyaml/yaml/merge2"
 )
 
@@ -20,7 +21,7 @@ func TestMerge(t *testing.T) {
 		for j := range testCases[i] {
 			tc := testCases[i][j]
 			t.Run(tc.description, func(t *testing.T) {
-				actual, err := MergeStrings(tc.source, tc.dest, tc.infer)
+				actual, err := MergeStrings(tc.source, tc.dest, tc.infer, tc.mergeOptions)
 				if !assert.NoError(t, err, tc.description) {
 					t.FailNow()
 				}
@@ -43,9 +44,10 @@ func TestMerge(t *testing.T) {
 }
 
 type testCase struct {
-	description string
-	source      string
-	dest        string
-	expected    string
-	infer       bool
+	description  string
+	source       string
+	dest         string
+	expected     string
+	infer        bool
+	mergeOptions yaml.MergeOptions
 }

--- a/kyaml/yaml/merge2/scalar_test.go
+++ b/kyaml/yaml/merge2/scalar_test.go
@@ -3,6 +3,10 @@
 
 package merge2_test
 
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
 var scalarTestCases = []testCase{
 	{description: `replace scalar -- different value in dest`,
 		source: `
@@ -17,6 +21,9 @@ field: value0
 kind: Deployment
 field: value1
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	{description: `replace scalar -- missing from dest`,
@@ -31,6 +38,9 @@ kind: Deployment
 kind: Deployment
 field: value1
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -49,6 +59,9 @@ field: value1
 kind: Deployment
 field: value1
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -66,6 +79,9 @@ field: value1
 kind: Deployment
 field: value1
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -83,6 +99,9 @@ field: value1
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -100,6 +119,9 @@ field: value1
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -116,6 +138,9 @@ kind: Deployment
 		expected: `
 kind: Deployment
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 
 	//
@@ -133,5 +158,8 @@ kind: Deployment
 kind: Deployment
 field: {}
 `,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
 	},
 }

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -247,3 +247,18 @@ func String(node *yaml.Node, opts ...string) (string, error) {
 	}
 	return val, errors.Wrap(err)
 }
+
+// MergeOptionsListIncreaseDirection is the type of list growth in merge
+type MergeOptionsListIncreaseDirection int
+
+const (
+	MergeOptionsListAppend MergeOptionsListIncreaseDirection = iota
+	MergeOptionsListPrepend
+)
+
+// MergeOptions is a struct which contains the options for merge
+type MergeOptions struct {
+	// ListIncreaseDirection indicates should merge function prepend the items from
+	// source list to destination or append.
+	ListIncreaseDirection MergeOptionsListIncreaseDirection
+}

--- a/kyaml/yaml/walk/map.go
+++ b/kyaml/yaml/walk/map.go
@@ -68,6 +68,7 @@ func (l Walker) walkMap() (*yaml.RNode, error) {
 			Visitor:               l,
 			Schema:                s,
 			Sources:               fv,
+			MergeOptions:          l.MergeOptions,
 			Path:                  append(l.Path, key)}.Walk()
 		if err != nil {
 			return nil, err

--- a/plugin/builtin/configmapgenerator/go.mod
+++ b/plugin/builtin/configmapgenerator/go.mod
@@ -7,4 +7,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../kyaml
+
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../api

--- a/plugin/builtin/hashtransformer/go.mod
+++ b/plugin/builtin/hashtransformer/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../kyaml

--- a/plugin/builtin/legacyordertransformer/go.mod
+++ b/plugin/builtin/legacyordertransformer/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../kyaml

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -321,13 +321,13 @@ spec:
         old-label: old-value
     spec:
       containers:
-      - image: nginx
-        name: nginx
       - args:
         - proxy
         - sidecar
         image: docker.io/istio/proxyv2
         name: istio-proxy
+      - image: nginx
+        name: nginx
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -747,10 +747,7 @@ spec:
         name: test-deployment
         ports:
         - containerPort: 8080
-          name: take-over-the-world
-          protocol: TCP
-        - containerPort: 8080
-          name: take-over-the-world
+          name: disappearing-act
           protocol: TCP
 `)
 }

--- a/plugin/builtin/patchtransformer/go.mod
+++ b/plugin/builtin/patchtransformer/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/pkg/errors v0.8.1
 	sigs.k8s.io/kustomize/api v0.6.2
 	sigs.k8s.io/kustomize/kyaml v0.8.1
-	github.com/pkg/errors v0.8.1
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/builtin/secretgenerator/go.mod
+++ b/plugin/builtin/secretgenerator/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../kyaml

--- a/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/chartinflator/go.mod
+++ b/plugin/someteam.example.com/v1/chartinflator/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/dateprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/dateprefixer/go.mod
@@ -9,3 +9,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/gogetter/go.mod
+++ b/plugin/someteam.example.com/v1/gogetter/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/printpluginenv/go.mod
+++ b/plugin/someteam.example.com/v1/printpluginenv/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/replacementtransformer/go.mod
+++ b/plugin/someteam.example.com/v1/replacementtransformer/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/sedtransformer/go.mod
+++ b/plugin/someteam.example.com/v1/sedtransformer/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/someservicegenerator/go.mod
+++ b/plugin/someteam.example.com/v1/someservicegenerator/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/stringprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/stringprefixer/go.mod
@@ -9,3 +9,5 @@ require (
 )
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/validator/go.mod
+++ b/plugin/someteam.example.com/v1/validator/go.mod
@@ -5,3 +5,5 @@ go 1.14
 require sigs.k8s.io/kustomize/api v0.6.2
 
 replace sigs.k8s.io/kustomize/api v0.6.2 => ../../../../api
+
+replace sigs.k8s.io/kustomize/kyaml v0.8.1 => ../../../../kyaml


### PR DESCRIPTION
fix #2907 

 - From v3.8.0, strategic merge patches are changed from prepending items to appending(#2907). This PR is changing **back to the original behavior** for **strategic merge patches**. Other places that use `kyaml.merge2.Merge` are still keeping appending.
 - The API `merge2.Merge` and `merge2.MergeStrings` have a new parameter `mergeOptions yaml.MergeOptions`
   - `yaml.MergeOptions` has a member `ListIncreaseDirection` which can be `MergeOptionsListAppend` and `MergeOptionsListPrepend`.
   - If the `ListIncreaseDirection` is not set when create `yaml.MergeOptions` struct, it will be `MergeOptionsListAppend` by default.