### PR TITLE
Add metadata field to kustomization file

### DIFF
--- a/api/krusty/kustomizationmetadata_test.go
+++ b/api/krusty/kustomizationmetadata_test.go
@@ -1,0 +1,57 @@
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestKustomizationMetadata(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("/app/resources.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testing123
+spec:
+  replicas: 1
+  selector: null
+  template:
+    spec:
+      containers:
+      - name: event
+        image: testing123
+        imagePullPolicy: IfNotPresent
+      imagePullSecrets: []`)
+
+	th.WriteK("/app", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  annotations:
+    config.kubernetes.io/local-config: "true"
+  labels:
+    foo: bar
+  name: test_kustomization
+resources:
+- resources.yaml  
+`)
+
+	m := th.Run("/app", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testing123
+spec:
+  replicas: 1
+  selector: null
+  template:
+    spec:
+      containers:
+      - image: testing123
+        imagePullPolicy: IfNotPresent
+        name: event
+      imagePullSecrets: []
+`)
+}

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -22,6 +22,9 @@ const (
 type Kustomization struct {
 	TypeMeta `json:",inline" yaml:",inline"`
 
+	// MetaData is a pointer to avoid marshalling empty struct
+	MetaData *ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
 	//
 	// Operators - what kustomize can do.
 	//

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -141,6 +141,13 @@ func TestUnmarshal(t *testing.T) {
 	y := []byte(`
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  name: kust
+  namespace: default
+  labels:
+    foo: bar
+  annotations:
+    foo: bar
 resources:
 - foo
 - bar
@@ -151,8 +158,20 @@ namePrefix: cat`)
 	if err != nil {
 		t.Fatal(err)
 	}
+	meta := ObjectMeta{
+		Name:      "kust",
+		Namespace: "default",
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		Annotations: map[string]string{
+			"foo": "bar",
+		},
+	}
 	if k.Kind != KustomizationKind || k.APIVersion != KustomizationVersion ||
-		len(k.Resources) != 2 || k.NamePrefix != "cat" || k.NameSuffix != "dog" {
+		len(k.Resources) != 2 || k.NamePrefix != "cat" || k.NameSuffix != "dog" ||
+		k.MetaData.Name != meta.Name || k.MetaData.Namespace != meta.Namespace ||
+		k.MetaData.Labels["foo"] != meta.Labels["foo"] || k.MetaData.Annotations["foo"] != meta.Annotations["foo"] {
 		t.Fatalf("wrong unmarshal result: %v", k)
 	}
 }

--- a/api/types/objectmeta.go
+++ b/api/types/objectmeta.go
@@ -6,6 +6,8 @@ package types
 // ObjectMeta partially copies apimachinery/pkg/apis/meta/v1.ObjectMeta
 // No need for a direct dependence; the fields are stable.
 type ObjectMeta struct {
-	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Name        string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }


### PR DESCRIPTION
fix #3043 

 - Add a `MetaData` field to `Kustomization` struct.
 - The type is a pointer to `types.ObjectMeta`
 - String maps `Labels` and `Annotations` are added to the `types.ObjectMeta`.