### PR TITLE
make file name more readable when no group

### DIFF
--- a/api/resid/gvk.go
+++ b/api/resid/gvk.go
@@ -79,6 +79,22 @@ func (x Gvk) String() string {
 	return strings.Join([]string{g, v, k}, fieldSep)
 }
 
+// StringWoEmptyField returns a string representation of the GVK. Non-exist
+// fields will be omitted.
+func (x Gvk) StringWoEmptyField() string {
+	var s []string
+	if x.Group != "" {
+		s = append(s, x.Group)
+	}
+	if x.Version != "" {
+		s = append(s, x.Version)
+	}
+	if x.Kind != "" {
+		s = append(s, x.Kind)
+	}
+	return strings.Join(s, fieldSep)
+}
+
 // Equals returns true if the Gvk's have equal fields.
 func (x Gvk) Equals(o Gvk) bool {
 	return x.Group == o.Group && x.Version == o.Version && x.Kind == o.Kind

--- a/api/resid/gvk_test.go
+++ b/api/resid/gvk_test.go
@@ -96,21 +96,30 @@ func TestIsLessThan1(t *testing.T) {
 var stringTests = []struct {
 	x Gvk
 	s string
+	r string
 }{
-	{Gvk{}, "~G_~V_~K"},
-	{Gvk{Kind: "k"}, "~G_~V_k"},
-	{Gvk{Version: "v"}, "~G_v_~K"},
-	{Gvk{Version: "v", Kind: "k"}, "~G_v_k"},
-	{Gvk{Group: "g"}, "g_~V_~K"},
-	{Gvk{Group: "g", Kind: "k"}, "g_~V_k"},
-	{Gvk{Group: "g", Version: "v"}, "g_v_~K"},
-	{Gvk{Group: "g", Version: "v", Kind: "k"}, "g_v_k"},
+	{Gvk{}, "~G_~V_~K", ""},
+	{Gvk{Kind: "k"}, "~G_~V_k", "k"},
+	{Gvk{Version: "v"}, "~G_v_~K", "v"},
+	{Gvk{Version: "v", Kind: "k"}, "~G_v_k", "v_k"},
+	{Gvk{Group: "g"}, "g_~V_~K", "g"},
+	{Gvk{Group: "g", Kind: "k"}, "g_~V_k", "g_k"},
+	{Gvk{Group: "g", Version: "v"}, "g_v_~K", "g_v"},
+	{Gvk{Group: "g", Version: "v", Kind: "k"}, "g_v_k", "g_v_k"},
 }
 
 func TestString(t *testing.T) {
 	for _, hey := range stringTests {
 		if hey.x.String() != hey.s {
 			t.Fatalf("bad string for %v '%s'", hey.x, hey.s)
+		}
+	}
+}
+
+func TestStringWoEmptyField(t *testing.T) {
+	for _, hey := range stringTests {
+		if hey.x.StringWoEmptyField() != hey.r {
+			t.Fatalf("bad string %s for %v '%s'", hey.x.StringWoEmptyField(), hey.x, hey.r)
 		}
 	}
 }

--- a/kustomize/internal/commands/build/build.go
+++ b/kustomize/internal/commands/build/build.go
@@ -191,7 +191,7 @@ func writeIndividualFiles(
 }
 
 func fileName(res *resource.Resource) string {
-	return strings.ToLower(res.GetGvk().String()) +
+	return strings.ToLower(res.GetGvk().StringWoEmptyField()) +
 		"_" + strings.ToLower(res.GetName()) + ".yaml"
 }
 


### PR DESCRIPTION
close #2393

If a resource's version group is empty, the filename used by `build -o` will starts with `~g`. This PR will omit the group name if it doesn't exist.