### PR TITLE
files for building image when release kustomize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github
+docs
+examples
+functions
+hack
+site
+travis
+*.md

--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -1,0 +1,18 @@
+# build
+FROM golang:alpine as builder
+ARG VERSION
+ARG COMMIT
+ARG DATE
+RUN mkdir /build 
+ADD . /build/
+WORKDIR /build/kustomize
+RUN CGO_ENABLED=0 GO111MODULE=on go build \
+    -ldflags="-s -X sigs.k8s.io/kustomize/api/provenance.version=${VERSION} \
+    -X sigs.k8s.io/kustomize/api/provenance.gitCommit=${COMMIT} \
+    -X sigs.k8s.io/kustomize/api/provenance.buildDate=${DATE}"
+
+# only copy binary
+FROM alpine
+COPY --from=builder /build/kustomize /app/
+WORKDIR /app
+ENTRYPOINT ["./kustomize"]

--- a/releasing/cloudbuild_kustomize_image.yaml
+++ b/releasing/cloudbuild_kustomize_image.yaml
@@ -1,0 +1,44 @@
+# This cloud build job is only used to build kustomize docker image and push
+# it to gcr.io repo.
+steps:
+  - name: "bash"
+    args:
+      - "echo"
+      - "Cloud build substitution check: "
+      - "BUILD_ID=$BUILD_ID"
+      - "PROJECT_ID=$PROJECT_ID"
+      - "REVISION_ID=$REVISION_ID"
+      - "REPO_NAME=$REPO_NAME"
+      - "COMMIT_SHA=$COMMIT_SHA"
+      - "BRANCH_NAME=$BRANCH_NAME"
+      - "TAG_NAME=$TAG_NAME"
+
+# We need to use bash to configure the build date properly.
+  - name: "gcr.io/cloud-builders/docker"
+    entrypoint: /bin/bash
+    args:
+      - -c
+      - >
+        docker
+        build
+        -t
+        gcr.io/$PROJECT_ID/$_MODULE_NAME:$_MODULE_VERSION
+        -t
+        gcr.io/$PROJECT_ID/$_MODULE_NAME:latest
+        -f
+        kustomize.Dockerfile
+        --build-arg
+        VERSION=$TAG_NAME
+        --build-arg
+        COMMIT=$COMMIT_SHA
+        --build-arg
+        DATE=`date -u +%FT%TZ`
+        .
+
+images:
+  - "gcr.io/$PROJECT_ID/$_MODULE_NAME:$_MODULE_VERSION"
+  - "gcr.io/$PROJECT_ID/$_MODULE_NAME:latest"
+
+substitutions:
+  _MODULE_NAME: ${TAG_NAME%/*}
+  _MODULE_VERSION: ${TAG_NAME#*/}


### PR DESCRIPTION
These files are used to build a docker image when a new kustomize version is released. Only releasing kustomize should trigger docker build.

#2374 