### PR TITLE
Group regex within anchoring

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -514,7 +514,7 @@ func anchorRegex(pattern string) string {
 	if pattern == "" {
 		return pattern
 	}
-	return "^" + pattern + "$"
+	return "^(?:" + pattern + ")$"
 }
 
 // Select returns a list of resources that


### PR DESCRIPTION
This ensures that anchoring will apply to the entire anchored expression, eg. a pattern like `foo|bar` will only match the strings "foo" and "bar" (`^(?:foo|bar)$`), instead of matching any string that begins with "foo" or ends with "bar" (`^foo|bar$`).