### PR TITLE
Add isSet to ListSetters cmd.

### DIFF
--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -108,7 +109,7 @@ func (r *ListSettersRunner) ListSetters(w io.Writer, openAPIPath, resourcePath s
 		return err
 	}
 	table := newTable(w, r.Markdown)
-	table.SetHeader([]string{"NAME", "VALUE", "SET BY", "DESCRIPTION", "COUNT", "REQUIRED"})
+	table.SetHeader([]string{"NAME", "VALUE", "IS SET", "SET BY", "DESCRIPTION", "COUNT", "REQUIRED"})
 	for i := range r.List.Setters {
 		s := r.List.Setters[i]
 		v := s.Value
@@ -124,8 +125,17 @@ func (r *ListSettersRunner) ListSetters(w io.Writer, openAPIPath, resourcePath s
 		} else {
 			required = "No"
 		}
+
+		var isSet = "No"
+		if s.IsSet != "" {
+			var b, _ = strconv.ParseBool(s.IsSet)
+			if b {
+				isSet = "Yes"
+			}
+		}
+
 		table.Append([]string{
-			s.Name, v, s.SetBy, s.Description, fmt.Sprintf("%d", s.Count), required})
+			s.Name, v, isSet, s.SetBy, s.Description, fmt.Sprintf("%d", s.Count), required})
 	}
 	table.Render()
 

--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -109,7 +108,7 @@ func (r *ListSettersRunner) ListSetters(w io.Writer, openAPIPath, resourcePath s
 		return err
 	}
 	table := newTable(w, r.Markdown)
-	table.SetHeader([]string{"NAME", "VALUE", "IS SET", "SET BY", "DESCRIPTION", "COUNT", "REQUIRED"})
+	table.SetHeader([]string{"NAME", "VALUE", "SET BY", "DESCRIPTION", "COUNT", "REQUIRED", "IS SET"})
 	for i := range r.List.Setters {
 		s := r.List.Setters[i]
 		v := s.Value
@@ -119,23 +118,17 @@ func (r *ListSettersRunner) ListSetters(w io.Writer, openAPIPath, resourcePath s
 			v = strings.Join(s.ListValues, ",")
 			v = fmt.Sprintf("[%s]", v)
 		}
-		var required string
+		required := "No"
 		if s.Required {
 			required = "Yes"
-		} else {
-			required = "No"
 		}
-
-		var isSet = "No"
-		if s.IsSet != "" {
-			var b, _ = strconv.ParseBool(s.IsSet)
-			if b {
-				isSet = "Yes"
-			}
+		isSet := "No"
+		if s.IsSet {
+			isSet = "Yes"
 		}
 
 		table.Append([]string{
-			s.Name, v, isSet, s.SetBy, s.Description, fmt.Sprintf("%d", s.Count), required})
+			s.Name, v, s.SetBy, s.Description, fmt.Sprintf("%d", s.Count), required, isSet})
 	}
 	table.Render()
 

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -46,8 +46,8 @@ metadata:
 spec:
   replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}
  `,
-			expected: `    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   3       No       me       hello world   1       Yes       
+			expected: `    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  replicas   3       me       hello world   1       Yes        No      
 `,
 		},
 
@@ -72,8 +72,8 @@ metadata:
 spec:
   replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}
  `,
-			expected: `    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   4       No       me       hello world   1       No        
+			expected: `    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  replicas   4       me       hello world   1       No         No      
 `,
 		},
 		{
@@ -131,10 +131,10 @@ spec:
       - name: nginx2
         image: nginx # {"$ref": "#/definitions/io.k8s.cli.setters.image"}
  `,
-			expected: `    NAME     VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image      nginx   No       me2      hello world 2   2       No        
-  replicas   3       No       me1      hello world 1   1       No        
-  tag        1.7.9   No       me3      hello world 3   1       Yes       
+			expected: `    NAME     VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED   IS SET  
+  image      nginx   me2      hello world 2   2       No         No      
+  replicas   3       me1      hello world 1   1       No         No      
+  tag        1.7.9   me3      hello world 3   1       Yes        No      
 --------------- ----------- --------------
   SUBSTITUTION    PATTERN    REFERENCES   
   image          IMAGE:TAG   [image,tag]  
@@ -207,10 +207,10 @@ spec:
       - name: nginx2
         image: nginx
 `,
-			expected: `    NAME     VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image      nginx   No       me2      hello world 2   3       No        
-  replicas   3       No       me1      hello world 1   2       No        
-  tag        1.7.9   No       me3      hello world 3   2       No        
+			expected: `    NAME     VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED   IS SET  
+  image      nginx   me2      hello world 2   3       No         No      
+  replicas   3       me1      hello world 1   2       No         No      
+  tag        1.7.9   me3      hello world 3   2       No         No      
 --------------- ----------- --------------
   SUBSTITUTION    PATTERN    REFERENCES   
   image          IMAGE:TAG   [image,tag]  
@@ -284,8 +284,8 @@ spec:
       - name: nginx2
         image: nginx
 `,
-			expected: `  NAME    VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image   nginx   No       me2      hello world 2   3       Yes       
+			expected: `  NAME    VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED   IS SET  
+  image   nginx   me2      hello world 2   3       Yes        No      
 `,
 		},
 
@@ -324,8 +324,8 @@ spec:
   - "b"
   - "c"
 `,
-			expected: `  NAME    VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  list   [a,b,c]   No       me       hello world   1       Yes       
+			expected: `  NAME    VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  list   [a,b,c]   me       hello world   1       Yes        No      
 `,
 		},
 
@@ -390,10 +390,10 @@ openAPI:
           name: my-other-setter
           value: nginxotherthing
  `,
-			expected: `       NAME              VALUE        IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  my-image-setter   nginx             No                              2       No        
-  my-other-setter   nginxotherthing   No                              1       No        
-  my-tag-setter     1.7.9             Yes                             2       Yes       
+			expected: `       NAME              VALUE        SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  my-image-setter   nginx                                    2       No         No      
+  my-other-setter   nginxotherthing                          1       No         No      
+  my-tag-setter     1.7.9                                    2       Yes        Yes     
 ------------------ ------------------------------------------------ -----------------------------------
    SUBSTITUTION                        PATTERN                                  REFERENCES             
   my-image-subst    ${my-image-setter}::${my-tag-setter}             [my-image-setter,my-tag-setter]   
@@ -476,20 +476,20 @@ func TestListSettersSubPackages(t *testing.T) {
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/
-    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  image       mysql     No                              1       No        
-  namespace   myspace   No                              1       No        
-  tag         1.7.9     No                              1       No        
+    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  image       mysql                            1       No         No      
+  namespace   myspace                          1       No         No      
+  tag         1.7.9                            1       No         No      
 --------------- ----------------- --------------
   SUBSTITUTION       PATTERN       REFERENCES   
   image-tag      ${image}:${tag}   [image,tag]  
 
 test/testdata/dataset-with-setters/mysql/nosetters/
-  NAME   VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  NAME   VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
 
 test/testdata/dataset-with-setters/mysql/storage/
-    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  namespace   myspace   No                              1       No
+    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  namespace   myspace                          1       No         No
 `,
 		},
 		{
@@ -499,10 +499,10 @@ test/testdata/dataset-with-setters/mysql/storage/
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/
-    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  image       mysql     No                              1       No        
-  namespace   myspace   No                              1       No        
-  tag         1.7.9     No                              1       No        
+    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  image       mysql                            1       No         No      
+  namespace   myspace                          1       No         No      
+  tag         1.7.9                            1       No         No
 `,
 		},
 	}

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -46,8 +46,8 @@ metadata:
 spec:
   replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}
  `,
-			expected: `    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   3       me       hello world   1       Yes       
+			expected: `    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  replicas   3       No       me       hello world   1       Yes       
 `,
 		},
 
@@ -72,8 +72,8 @@ metadata:
 spec:
   replicas: 3 # {"$ref": "#/definitions/io.k8s.cli.setters.replicas"}
  `,
-			expected: `    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   4       me       hello world   1       No        
+			expected: `    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  replicas   4       No       me       hello world   1       No        
 `,
 		},
 		{
@@ -131,10 +131,10 @@ spec:
       - name: nginx2
         image: nginx # {"$ref": "#/definitions/io.k8s.cli.setters.image"}
  `,
-			expected: `    NAME     VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image      nginx   me2      hello world 2   2       No        
-  replicas   3       me1      hello world 1   1       No        
-  tag        1.7.9   me3      hello world 3   1       Yes       
+			expected: `    NAME     VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
+  image      nginx   No       me2      hello world 2   2       No        
+  replicas   3       No       me1      hello world 1   1       No        
+  tag        1.7.9   No       me3      hello world 3   1       Yes       
 --------------- ----------- --------------
   SUBSTITUTION    PATTERN    REFERENCES   
   image          IMAGE:TAG   [image,tag]  
@@ -207,10 +207,10 @@ spec:
       - name: nginx2
         image: nginx
 `,
-			expected: `    NAME     VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image      nginx   me2      hello world 2   3       No        
-  replicas   3       me1      hello world 1   2       No        
-  tag        1.7.9   me3      hello world 3   2       No        
+			expected: `    NAME     VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
+  image      nginx   No       me2      hello world 2   3       No        
+  replicas   3       No       me1      hello world 1   2       No        
+  tag        1.7.9   No       me3      hello world 3   2       No        
 --------------- ----------- --------------
   SUBSTITUTION    PATTERN    REFERENCES   
   image          IMAGE:TAG   [image,tag]  
@@ -284,8 +284,8 @@ spec:
       - name: nginx2
         image: nginx
 `,
-			expected: `  NAME    VALUE   SET BY    DESCRIPTION    COUNT   REQUIRED  
-  image   nginx   me2      hello world 2   3       Yes       
+			expected: `  NAME    VALUE   IS SET   SET BY    DESCRIPTION    COUNT   REQUIRED  
+  image   nginx   No       me2      hello world 2   3       Yes       
 `,
 		},
 
@@ -324,8 +324,8 @@ spec:
   - "b"
   - "c"
 `,
-			expected: `  NAME    VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED  
-  list   [a,b,c]   me       hello world   1       Yes       
+			expected: `  NAME    VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  list   [a,b,c]   No       me       hello world   1       Yes       
 `,
 		},
 
@@ -390,10 +390,10 @@ openAPI:
           name: my-other-setter
           value: nginxotherthing
  `,
-			expected: `       NAME              VALUE        SET BY   DESCRIPTION   COUNT   REQUIRED  
-  my-image-setter   nginx                                    2       No        
-  my-other-setter   nginxotherthing                          1       No        
-  my-tag-setter     1.7.9                                    2       Yes       
+			expected: `       NAME              VALUE        IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  my-image-setter   nginx             No                              2       No        
+  my-other-setter   nginxotherthing   No                              1       No        
+  my-tag-setter     1.7.9             Yes                             2       Yes       
 ------------------ ------------------------------------------------ -----------------------------------
    SUBSTITUTION                        PATTERN                                  REFERENCES             
   my-image-subst    ${my-image-setter}::${my-tag-setter}             [my-image-setter,my-tag-setter]   
@@ -476,20 +476,20 @@ func TestListSettersSubPackages(t *testing.T) {
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/
-    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED  
-  image       mysql                            1       No        
-  namespace   myspace                          1       No        
-  tag         1.7.9                            1       No        
+    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  image       mysql     No                              1       No        
+  namespace   myspace   No                              1       No        
+  tag         1.7.9     No                              1       No        
 --------------- ----------------- --------------
   SUBSTITUTION       PATTERN       REFERENCES   
   image-tag      ${image}:${tag}   [image,tag]  
 
 test/testdata/dataset-with-setters/mysql/nosetters/
-  NAME   VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  NAME   VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
 
 test/testdata/dataset-with-setters/mysql/storage/
-    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED  
-  namespace   myspace                          1       No        
+    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  namespace   myspace   No                              1       No
 `,
 		},
 		{
@@ -499,10 +499,10 @@ test/testdata/dataset-with-setters/mysql/storage/
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/
-    NAME       VALUE    SET BY   DESCRIPTION   COUNT   REQUIRED  
-  image       mysql                            1       No        
-  namespace   myspace                          1       No        
-  tag         1.7.9                            1       No         
+    NAME       VALUE    IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  image       mysql     No                              1       No        
+  namespace   myspace   No                              1       No        
+  tag         1.7.9     No                              1       No        
 `,
 		},
 	}

--- a/cmd/config/internal/commands/e2e/list_setters_test.go
+++ b/cmd/config/internal/commands/e2e/list_setters_test.go
@@ -35,8 +35,8 @@ openAPI:
 			},
 			expectedStdOut: `
 ./
-    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   3                              1       No
+    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
+  replicas   3       No                              1       No
 `,
 		},
 	}

--- a/cmd/config/internal/commands/e2e/list_setters_test.go
+++ b/cmd/config/internal/commands/e2e/list_setters_test.go
@@ -35,8 +35,8 @@ openAPI:
 			},
 			expectedStdOut: `
 ./
-    NAME     VALUE   IS SET   SET BY   DESCRIPTION   COUNT   REQUIRED  
-  replicas   3       No                              1       No
+    NAME     VALUE   SET BY   DESCRIPTION   COUNT   REQUIRED   IS SET  
+  replicas   3                              1       No         No      
 `,
 		},
 	}

--- a/kyaml/setters2/add.go
+++ b/kyaml/setters2/add.go
@@ -145,6 +145,9 @@ type SetterDefinition struct {
 	// ListValues are the value of a list setter.
 	ListValues []string `yaml:"listValues,omitempty"`
 
+	// IsSet indicates the specified field has been explicitly assigned.
+	IsSet string `yaml:"isSet,omitempty"`
+
 	// SetBy is the person or role that last set the value.
 	SetBy string `yaml:"setBy,omitempty"`
 

--- a/kyaml/setters2/add.go
+++ b/kyaml/setters2/add.go
@@ -145,9 +145,6 @@ type SetterDefinition struct {
 	// ListValues are the value of a list setter.
 	ListValues []string `yaml:"listValues,omitempty"`
 
-	// IsSet indicates the specified field has been explicitly assigned.
-	IsSet string `yaml:"isSet,omitempty"`
-
 	// SetBy is the person or role that last set the value.
 	SetBy string `yaml:"setBy,omitempty"`
 


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/989 in that the ListSetters command will no longer be misleading as to whether or not a required field has in fact been set explicitly, as opposed to having an inferred placeholder value.
