### PR TITLE
add arm build

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -99,6 +99,8 @@ builds:
 
   goarch:
   - amd64
+  - arm
+  - arm64
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
close #2235 

 - Add `arm` and `arm64` to `goarch` in goreleaser config. 
 - 2 new binary builds will be crated. `kustomize_vX.X.X_linux_arm64.tar.gz` and `kustomize_vX.X.X_linux_arm.tar.gz`
