### PR TITLE
Add Support for Paginated Pull Request Responses to Multi-Module Check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@
 MYGOBIN := $(shell go env GOPATH)/bin
 SHELL := /bin/bash
 export PATH := $(MYGOBIN):$(PATH)
-MODULES := "cmd/config" "api/" "kustomize/" "kyaml/"
 
 .PHONY: all
 all: verify-kustomize
@@ -25,7 +24,6 @@ verify-kustomize: \
 # https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kustomize
 .PHONY: prow-presubmit-check
 prow-presubmit-check: \
-	test-multi-module \
 	lint-kustomize \
 	test-unit-kustomize-all \
 	test-examples-kustomize-against-HEAD \
@@ -221,17 +219,6 @@ test-unit-cmd-all:
 
 test-go-mod:
 	./travis/check-go-mod.sh
-
-# Environment variables are defined at
-# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
-.PHONY: test-multi-module
-test-multi-module:
-	go install github.com/google/go-github/github
-	go run ./travis/module-span/multi-module-span.go \
-	-owner=$(REPO_OWNER) \
-	-repo=$(REPO_NAME) \
-	-pr=$(PR_NUM) \
-	$(MODULES)
 
 .PHONY:
 test-examples-e2e-kustomize: $(MYGOBIN)/mdrip $(MYGOBIN)/kind

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 MYGOBIN := $(shell go env GOPATH)/bin
 SHELL := /bin/bash
 export PATH := $(MYGOBIN):$(PATH)
+MODULES := "cmd/config" "api/" "kustomize/" "kyaml/"
 
 .PHONY: all
 all: verify-kustomize
@@ -24,6 +25,7 @@ verify-kustomize: \
 # https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kustomize
 .PHONY: prow-presubmit-check
 prow-presubmit-check: \
+	test-multi-module \
 	lint-kustomize \
 	test-unit-kustomize-all \
 	test-examples-kustomize-against-HEAD \
@@ -219,6 +221,17 @@ test-unit-cmd-all:
 
 test-go-mod:
 	./travis/check-go-mod.sh
+
+# Environment variables are defined at
+# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
+.PHONY: test-multi-module
+test-multi-module:
+	go install github.com/google/go-github/github
+	go run ./travis/module-span/multi-module-span.go \
+	-owner=$(REPO_OWNER) \
+	-repo=$(REPO_NAME) \
+	-pr=$(PR_NUM) \
+	$(MODULES)
 
 .PHONY:
 test-examples-e2e-kustomize: $(MYGOBIN)/mdrip $(MYGOBIN)/kind


### PR DESCRIPTION
Updates the go script to handle file lists spanning multiple GitHub api pages. This allows the script to support Pull Requests which include more than 100 files.

See issue #2774