### PR TITLE
[kyaml] Option to continue pipeline processing when filter returns empty result

### DIFF
--- a/kyaml/kio/kio.go
+++ b/kyaml/kio/kio.go
@@ -75,6 +75,16 @@ type Pipeline struct {
 
 	// Outputs are where the transformed Resource Configuration is written.
 	Outputs []Writer `yaml:"outputs,omitempty"`
+
+	// ContinueOnEmptyResult configures what happens when a filter in the pipeline
+	// returns an empty result.
+	// If it is false (default), subsequent filters will be skipped and the result
+	// will be returned immediately. This is useful as an optimization when you
+	// know that subsequent filters will not alter the empty result.
+	// If it is true, the empty result will be provided as input to the next
+	// filter in the list. This is useful when subsequent functions in the
+	// pipeline may generate new resources.
+	ContinueOnEmptyResult bool `yaml:"continueOnEmptyResult,omitempty"`
 }
 
 // Execute executes each step in the sequence, returning immediately after encountering
@@ -111,7 +121,7 @@ func (p Pipeline) ExecuteWithCallback(callback PipelineExecuteCallbackFunc) erro
 		// TODO (issue 2872): This len(result) == 0 should be removed and empty result list should be
 		// handled by outputs. However currently some writer like LocalPackageReadWriter
 		// will clear the output directory and which will cause unpredictable results
-		if len(result) == 0 || err != nil {
+		if len(result) == 0 && !p.ContinueOnEmptyResult || err != nil {
 			return errors.Wrap(err)
 		}
 	}


### PR DESCRIPTION
**Problem**: Currently, `Pipeline` execution silently halts and returns successfully (no error) if one of the filters in the chain returns an empty result. That makes sense as an optimization in a context where filters are expected to be transforming the initial input. However, if you are using `Pipeline` in a context where subsequent filters may _add_ to the resource set, this optimization leads to incorrect results. 

**Proposed solution**: Give `Pipeline` a configuration option that, when true, allows the pipeline to continue when a filter returns empty results. This option is `false` by default to preserve backwards compatibility.

@pwittrock 