### PR TITLE
Add IsSet to SetterDefinition for kyaml release.

### DIFF
--- a/kyaml/setters2/add.go
+++ b/kyaml/setters2/add.go
@@ -172,6 +172,9 @@ type SetterDefinition struct {
 	// live apply/preview. This field is added to the setter definition to record
 	// the package publisher's intent to make the setter required to be set.
 	Required bool `yaml:"required,omitempty"`
+
+	// IsSet indicates the specified field has been explicitly assigned.
+	IsSet bool `yaml:"isSet,omitempty"`
 }
 
 func (sd SetterDefinition) AddToFile(path string) error {


### PR DESCRIPTION
Add `IsSet` as a field in `SetterDefinition` for release to avoid lint errors in https://github.com/kubernetes-sigs/kustomize/pull/3087/files