### PR TITLE
Implement WNode methods

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-openapi/spec v0.19.5
 	github.com/golangci/golangci-lint v1.21.0
+	github.com/google/go-cmp v0.3.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0

--- a/api/internal/wrappy/factory_test.go
+++ b/api/internal/wrappy/factory_test.go
@@ -1,4 +1,4 @@
 // Copyright 2020 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package wrappy_test
+package wrappy


### PR DESCRIPTION
I had some time today and made an attempt at implementing some of the methods in WNode for issue https://github.com/kubernetes-sigs/kustomize/issues/2893. Let me know what you think, and if this is what you had in mind.

A question that came to mind while I was working on this... should this logic be in RNode (`GetFieldValue()` for example)?  And should WNode just be a thin wrapper over RNode?  Let me know if I've put too much in WNode.

---

Implemented the following WNode methods:
* GetFieldValue
* GetSlice
* GetString
* Map
* SetAnnotations
* SetGvk
* SetLabels
* SetName
* SetNamespace

The following methods still *have not* been implemented yet:
* MatchesAnnotationSelector
* MatchesLabelSelector

I didn't look too much into the two selector methods, but it seems like this might be a little more work and can be a separate PR.  I didn't want to go too much further without getting some feedback.