### PR TITLE
doc: add varReference example

### DIFF
--- a/site/content/en/api-reference/kustomization/vars/_index.md
+++ b/site/content/en/api-reference/kustomization/vars/_index.md
@@ -72,15 +72,15 @@ vars:
     fieldpath: data.MY_PORT
     
 configurations:
-  - linkage.yaml
+  - lookup.yaml
 ```
 
-Define the linkage of the consuming resource(s) and the field(s) inside.
+Define the consuming resource(s) and the field(s) inside need to lookup.
 
 ```yaml
-# linkage.yaml
+# lookup.yaml
 varReference:
-  # the path of resource(s) that you want the parser to lookup
+  # the path of field that you want the parser to lookups and replace.
   - path: spec/template/spec/containers/livenessProbe/httpGet/port
     kind: Deployment
 ```

--- a/site/content/en/api-reference/kustomization/vars/_index.md
+++ b/site/content/en/api-reference/kustomization/vars/_index.md
@@ -25,6 +25,7 @@ containers:
     livenessProbe:
        httpGet:
          path: /healthz
+         # it enables the parser to lookup this field
          port: $(APP_PORT)
 ```
 
@@ -59,6 +60,9 @@ vars:
     apiVersion: apps/v1
   fieldref:
     fieldpath: spec.template.spec.restartPolicy
+# it exports a value as `APP_PORT` 
+# from `ConfigMap` named `my-config`
+# in `data.MY_PORT`
 - name: APP_PORT
   objref:
     kind: ConfigMap
@@ -76,6 +80,7 @@ Define the linkage of the consuming resource(s) and the field(s) inside.
 ```yaml
 # linkage.yaml
 varReference:
+  # the path of resource(s) that you want the parser to lookup
   - path: spec/template/spec/containers/livenessProbe/httpGet/port
     kind: Deployment
 ```


### PR DESCRIPTION
Missing example.

I think it is better to have an example of `varReference` in `var` section. As I cannot find any resource from official doc and people are keep asking it in issue and it is a good feature of Kustomize.

# related
1. https://github.com/kubernetes-sigs/kustomize/issues/2704
1. https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/crd/README.md
1. https://github.com/kubernetes-sigs/kustomize/issues/1250#issuecomment-505455209