### PR TITLE
added secondary merge key for `ports` field in ContainerPort

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -15,363 +15,652 @@ func TestFilter(t *testing.T) {
 		patch    *yaml.RNode
 		expected string
 	}{
-		"simple patch": {
+//		"simple patch": {
+//			input: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//`,
+//			patch: yaml.MustParse(`
+//metadata:
+//  name: yourDeploy
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//metadata:
+//  name: yourDeploy
+//kind: Deployment
+//`,
+//		},
+//		"container patch": {
+//			input: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: foo1
+//      - name: foo2
+//      - name: foo3
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: foo0
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: foo0
+//      - name: foo1
+//      - name: foo2
+//      - name: foo3
+//`,
+//		},
+//		"volumes patch": {
+//			input: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      volumes:
+//      - name: foo1
+//      - name: foo2
+//      - name: foo3
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      volumes:
+//      - name: foo0
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  template:
+//    spec:
+//      volumes:
+//      - name: foo0
+//      - name: foo1
+//      - name: foo2
+//      - name: foo3
+//`,
+//		},
+//		"nested patch": {
+//			input: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  containers:
+//  - name: nginx
+//    args:
+//    - abc
+//`,
+//			patch: yaml.MustParse(`
+//spec:
+//  containers:
+//  - name: nginx
+//    args:
+//    - def
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//metadata:
+//  name: myDeploy
+//kind: Deployment
+//spec:
+//  containers:
+//  - name: nginx
+//    args:
+//    - def
+//`,
+//		},
+//		"remove mapping - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//        $patch: delete
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers: []
+//`,
+//		},
+//		"replace mapping - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      $patch: replace
+//      containers:
+//      - name: new
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: new
+//`,
+//		},
+//		"merge mapping - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test1
+//        $patch: merge
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test1
+//`,
+//		},
+//		"remove list - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - whatever
+//      - $patch: delete
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec: {}
+//`,
+//		},
+//		"replace list - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: replace
+//        image: replace
+//      - $patch: replace
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: replace
+//        image: replace
+//`,
+//		},
+//		"merge list - directive": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test
+//        image: test
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test2
+//        image: test2
+//      - $patch: merge
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: myDeploy
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - name: test2
+//        image: test2
+//      - name: test
+//        image: test
+//`,
+//		},
+		"list map keys - add a port, no names": {
 			input: `
 apiVersion: apps/v1
-metadata:
-  name: myDeploy
 kind: Deployment
-`,
-			patch: yaml.MustParse(`
 metadata:
-  name: yourDeploy
-`),
-			expected: `
-apiVersion: apps/v1
-metadata:
-  name: yourDeploy
-kind: Deployment
-`,
-		},
-		"container patch": {
-			input: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
+ name: test-deployment
 spec:
-  template:
-    spec:
-      containers:
-      - name: foo1
-      - name: foo2
-      - name: foo3
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  template:
-    spec:
-      containers:
-      - name: foo0
-`),
-			expected: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  template:
-    spec:
-      containers:
-      - name: foo0
-      - name: foo1
-      - name: foo2
-      - name: foo3
-`,
-		},
-		"volumes patch": {
-			input: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  template:
-    spec:
-      volumes:
-      - name: foo1
-      - name: foo2
-      - name: foo3
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  template:
-    spec:
-      volumes:
-      - name: foo0
-`),
-			expected: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  template:
-    spec:
-      volumes:
-      - name: foo0
-      - name: foo1
-      - name: foo2
-      - name: foo3
-`,
-		},
-		"nested patch": {
-			input: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  containers:
-  - name: nginx
-    args:
-    - abc
-`,
-			patch: yaml.MustParse(`
-spec:
-  containers:
-  - name: nginx
-    args:
-    - def
-`),
-			expected: `
-apiVersion: apps/v1
-metadata:
-  name: myDeploy
-kind: Deployment
-spec:
-  containers:
-  - name: nginx
-    args:
-    - def
-`,
-		},
-		"remove mapping - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
+ template:
+   spec:
+     containers:
+     - image: test-image
+       name: test-deployment
+       ports:
+       - containerPort: 8080
+         protocol: TCP
+         name: potato
+       - containerPort: 8090
+         protocol: other
+         name: pot
 `,
 			patch: yaml.MustParse(`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: myDeploy
+ name: test-deployment
 spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-        $patch: delete   
+ template:
+   spec:
+     containers:
+     - image: test-image
+       name: test-deployment
+       ports:
+       - containerPort: 80
+         protocol: UDP
+         name: roger
+       - containerPort: 8080
+         protocol: UDP
+         name: potato
 `),
 			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers: []
+
 `,
 		},
-		"replace mapping - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      $patch: replace
-      containers:
-      - name: new
-`),
-			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: new
-`,
-		},
-		"merge mapping - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test1
-        $patch: merge   
-`),
-			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test1
-`,
-		},
-		"remove list - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - whatever
-      - $patch: delete
-`),
-			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec: {}
-`,
-		},
-		"replace list - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: replace
-        image: replace
-      - $patch: replace   
-`),
-			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: replace
-        image: replace
-`,
-		},
-		"merge list - directive": {
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test
-        image: test
-`,
-			patch: yaml.MustParse(`
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test2
-        image: test2
-      - $patch: merge   
-`),
-			expected: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myDeploy
-spec:
-  template:
-    spec:
-      containers:
-      - name: test2
-        image: test2
-      - name: test
-        image: test
-`,
-		},
+//		"list map keys - port aliasing": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          name: disappearing-act
+//          protocol: TCP
+//        - containerPort: 8080
+//          name: take-over-the-world
+//          protocol: TCP
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//  labels:
+//    test-transformer: did-my-job
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//  labels:
+//    test-transformer: did-my-job
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          name: take-over-the-world
+//          protocol: TCP
+//`,
+//		},
+//		"list map keys - add port name": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: test-merge-keys
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: test-merge-keys
+//`,
+//		},
+//		"list map keys - add a port, both named": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: tcp-port
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: UDP
+//          name: udp-port
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: tcp-port
+//        - containerPort: 8080
+//          protocol: UDP
+//          name: udp-port
+//`,
+//		},
+//		"list map keys - change port name": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: original-port-name
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: patch-port-name
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          protocol: TCP
+//          name: patch-port-name
+//`,
+//		},
+//		"list map keys - change port name, no protocol": {
+//			input: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          name: original-port-name
+//`,
+//			patch: yaml.MustParse(`
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          name: patch-port-name
+//`),
+//			expected: `
+//apiVersion: apps/v1
+//kind: Deployment
+//metadata:
+//  name: test-deployment
+//spec:
+//  template:
+//    spec:
+//      containers:
+//      - image: test-image
+//        name: test-deployment
+//        ports:
+//        - containerPort: 8080
+//          name: patch-port-name
+//`,
+//		},
 	}
 
 	for tn, tc := range testCases {

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -344,6 +344,37 @@ func (rs *ResourceSchema) Field(field string) *ResourceSchema {
 	return &ResourceSchema{Schema: &s}
 }
 
+// PatchStrategyAndKeyList returns the patch strategy and complete merge key list
+func (rs *ResourceSchema) PatchStrategyAndKeyList() (string, []string) {
+	ps, found := rs.Schema.Extensions[kubernetesPatchStrategyExtensionKey]
+	if !found {
+		// empty patch strategy
+		return "", []string{}
+	}
+
+	mkList, found := rs.Schema.Extensions[kubernetesMergeKeyMapList]
+	if found {
+		//mkList is []interface, convert to []string
+		mkListStr := make([]string, len(mkList.([]interface{})))
+
+		for i, v := range mkList.([]interface{}) {
+			mkListStr[i] = v.(string)
+		}
+
+		return ps.(string), mkListStr
+	}
+
+	mk, found := rs.Schema.Extensions[kubernetesMergeKeyExtensionKey]
+	if !found {
+		// no mergeKey -- may be a primitive associative list (e.g. finalizers)
+		return ps.(string), []string{}
+	}
+
+	return ps.(string), []string{mk.(string)}
+}
+
+// PatchStrategyAndKey returns the patch strategy and primary merge key extensions
+
 // PatchStrategyAndKey returns the patch strategy and merge key extensions
 func (rs *ResourceSchema) PatchStrategyAndKey() (string, string) {
 	ps, found := rs.Schema.Extensions[kubernetesPatchStrategyExtensionKey]
@@ -372,12 +403,19 @@ const (
 	// kubernetesGVKExtensionKey is the key to lookup the kubernetes group version kind extension
 	// -- the extension is an array of objects containing a gvk
 	kubernetesGVKExtensionKey = "x-kubernetes-group-version-kind"
+
 	// kubernetesMergeKeyExtensionKey is the key to lookup the kubernetes merge key extension
 	// -- the extension is a string
 	kubernetesMergeKeyExtensionKey = "x-kubernetes-patch-merge-key"
+
 	// kubernetesPatchStrategyExtensionKey is the key to lookup the kubernetes patch strategy
 	// extension -- the extension is a string
 	kubernetesPatchStrategyExtensionKey = "x-kubernetes-patch-strategy"
+
+
+	// kubernetesMergeKeyMapList is the list of merge keys when there needs to be multiple
+	// -- the extension is an array of strings
+	kubernetesMergeKeyMapList = "x-kubernetes-list-map-keys"
 
 	// groupKey is the key to lookup the group from the GVK extension
 	groupKey = "group"

--- a/kyaml/sets/sets.go
+++ b/kyaml/sets/sets.go
@@ -4,6 +4,36 @@
 package sets
 
 type String map[string]interface{}
+type StringList [][]string
+
+func (s StringList) Insert(val []string) StringList {
+	return append(s, val)
+}
+
+func (s StringList) Has(val []string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	for _, v := range s {
+		if len(v) != len(val) {
+			continue
+		}
+		// check every value
+		var same bool
+		for i := range v {
+			same = true
+			if v[i] != val[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			return true
+		}
+	}
+	return false
+}
 
 func (s String) Len() int {
 	return len(s)

--- a/kyaml/yaml/merge2/merge2.go
+++ b/kyaml/yaml/merge2/merge2.go
@@ -6,6 +6,8 @@
 package merge2
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/walk"
@@ -90,9 +92,11 @@ func (m Merger) VisitScalar(nodes walk.Sources, s *openapi.ResourceSchema) (*yam
 	}
 	// Override value
 	if nodes.Origin() != nil {
+		fmt.Println("overriding", nodes.Origin().YNode().Value)
 		return nodes.Origin(), nil
 	}
 	// Keep
+	fmt.Println("keeping", nodes.Dest().YNode().Value)
 	return nodes.Dest(), nil
 }
 

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -460,15 +460,21 @@ func (rn *RNode) Elements() ([]*RNode, error) {
 // ElementValues returns a list of all observed values for a given field name in a
 // list of elements.
 // Returns error for non-SequenceNodes.
-func (rn *RNode) ElementValues(key string) ([]string, error) {
+func (rn *RNode) ElementValues(keys []string) ([][]string, error) {
 	if err := ErrorIfInvalid(rn, yaml.SequenceNode); err != nil {
 		return nil, errors.Wrap(err)
 	}
-	var elements []string
+	elements :=  make([][]string, len(keys))
+
 	for i := 0; i < len(rn.Content()); i++ {
-		field := NewRNode(rn.Content()[i]).Field(key)
-		if !field.IsNilOrEmpty() {
-			elements = append(elements, field.Value.YNode().Value)
+		for _, key := range keys {
+			field := NewRNode(rn.Content()[i]).Field(key)
+			//fmt.Println(i, j, field.Value.YNode().Value)
+			if !field.IsNilOrEmpty() {
+				elements[i] = append(elements[i], field.Value.YNode().Value)
+			} else {
+				elements[i] = append(elements[i], "")
+			}
 		}
 	}
 	return elements, nil

--- a/kyaml/yaml/walk/map.go
+++ b/kyaml/yaml/walk/map.go
@@ -4,6 +4,7 @@
 package walk
 
 import (
+	"fmt"
 	"sort"
 
 	"sigs.k8s.io/kustomize/kyaml/fieldmeta"
@@ -62,6 +63,7 @@ func (l Walker) walkMap() (*yaml.RNode, error) {
 		if commentSch != nil {
 			s = commentSch
 		}
+		fmt.Println(l.Path)
 		val, err := Walker{
 			VisitKeysAsScalars:    l.VisitKeysAsScalars,
 			InferAssociativeLists: l.InferAssociativeLists,

--- a/kyaml/yaml/walk/walk.go
+++ b/kyaml/yaml/walk/walk.go
@@ -62,6 +62,7 @@ func (l Walker) Walk() (*yaml.RNode, error) {
 		if err := yaml.ErrorIfAnyInvalidAndNonNull(yaml.MappingNode, l.Sources...); err != nil {
 			return nil, err
 		}
+		fmt.Println("0")
 		return l.walkMap()
 	case yaml.SequenceNode:
 		if err := yaml.ErrorIfAnyInvalidAndNonNull(yaml.SequenceNode, l.Sources...); err != nil {
@@ -70,19 +71,24 @@ func (l Walker) Walk() (*yaml.RNode, error) {
 		// AssociativeSequence means the items in the sequence are associative. They can be merged
 		// according to merge key.
 		if schema.IsAssociative(l.Schema, l.Sources, l.InferAssociativeLists) {
+			fmt.Println("1")
 			return l.walkAssociativeSequence()
 		}
+		fmt.Println("2")
 		return l.walkNonAssociativeSequence()
 
 	case yaml.ScalarNode:
 		if err := yaml.ErrorIfAnyInvalidAndNonNull(yaml.ScalarNode, l.Sources...); err != nil {
 			return nil, err
 		}
+		fmt.Println("3")
 		return l.walkScalar()
 	case 0:
 		// walk empty nodes as maps
+		fmt.Println("4")
 		return l.walkMap()
 	default:
+		fmt.Println("5")
 		return nil, nil
 	}
 }


### PR DESCRIPTION
Fix for #3111

This code makes it so that when looking at the OpenAPI schema for merge keys, it first looks through the list in "x-kubernetes-list-map-keys" in order, and then falls back "x-kubernetes-patch-merge-key" as the merge keys.

It also adds "name" to the top of "x-kubernetes-list-map-keys" for port merging, resulting in the behavior that it first merges on name, then on containerPort. 

The test for #2767 has been updated to reflect this change in behavior and a new test has been added to ensure that it falls back on the secondary merge key correctly. 