### PR TITLE
Add Ingress v1 support to builtin name references

### DIFF
--- a/api/konfig/builtinpluginconsts/namereference.go
+++ b/api/konfig/builtinpluginconsts/namereference.go
@@ -377,5 +377,12 @@ nameReference:
     kind: Job
   - path: spec/template/spec/priorityClassName
     kind: DaemonSet
+
+- kind: IngressClass
+  version: v1
+  group: networking.k8s.io/v1
+  fieldSpecs:
+  - path: spec/ingressClassName
+    kind: Ingress
 `
 )

--- a/api/konfig/builtinpluginconsts/namereference.go
+++ b/api/konfig/builtinpluginconsts/namereference.go
@@ -267,6 +267,10 @@ nameReference:
     kind: Ingress
   - path: spec/backend/serviceName
     kind: Ingress
+  - path: spec/rules/http/paths/backend/service/name
+    kind: Ingress
+  - path: spec/defaultBackend/service/name
+    kind: Ingress
   - path: spec/service/name
     kind: APIService
     group: apiregistration.k8s.io


### PR DESCRIPTION
Since Kubernetes v1.19 networking.k8s.io/v1 adds...
- IngressClass
- Ingress v1 with...
  - two fields referencing Service name
  - one field reference to an IngressClass name

See:
- https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource
- https://kubernetes.io/docs/setup/release/notes/