### PR TITLE
Make isSet a parameter

### DIFF
--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -163,6 +163,7 @@ func (r *SetRunner) ExecuteCmd(w io.Writer, pkgPath string) error {
 		OpenAPIFileName:    ext.KRMFileName(),
 		ResourcesPath:      pkgPath,
 		RecurseSubPackages: r.Set.RecurseSubPackages,
+		IsSet:              true,
 	}
 	count, err := r.Set.Set()
 	if err != nil {

--- a/kyaml/setters2/set.go
+++ b/kyaml/setters2/set.go
@@ -353,6 +353,8 @@ type SetOpenAPI struct {
 	Description string `yaml:"description"`
 
 	SetBy string `yaml:"setBy"`
+
+	IsSet bool `yaml:"isSet"`
 }
 
 // UpdateFile updates the OpenAPI definitions in a file with the given setter value.
@@ -458,8 +460,10 @@ func (s SetOpenAPI) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 		return nil, err
 	}
 
-	if err := def.PipeE(&yaml.FieldSetter{Name: "isSet", StringValue: "true"}); err != nil {
-		return nil, err
+	if s.IsSet {
+		if err := def.PipeE(&yaml.FieldSetter{Name: "isSet", StringValue: "true"}); err != nil {
+			return nil, err
+		}
 	}
 
 	if s.Description != "" {

--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -971,11 +971,13 @@ func TestSetOpenAPI_Filter(t *testing.T) {
 		description string
 		setBy       string
 		err         string
+		isSet       bool
 	}{
 		{
 			name:   "set-replicas",
 			setter: "replicas",
 			value:  "3",
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1023,6 +1025,7 @@ openAPI:
 			name:   "set-annotation-quoted",
 			setter: "replicas",
 			value:  "3",
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1048,6 +1051,7 @@ openAPI:
 			setter:      "replicas",
 			value:       "3",
 			description: "hello world",
+			isSet:       true,
 			input: `
 openAPI:
   definitions:
@@ -1094,6 +1098,7 @@ openAPI:
 			setter: "replicas",
 			value:  "3",
 			setBy:  "carl",
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1139,6 +1144,7 @@ openAPI:
 			name:   "set-replicas-set-by-empty",
 			setter: "replicas",
 			value:  "3",
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1229,7 +1235,6 @@ openAPI:
           enumValues:
             foo: bar
             baz: biz
-          isSet: true
     io.k8s.cli.setters.no-match-2':
       x-k8s-cli:
         setter:
@@ -1242,6 +1247,7 @@ openAPI:
 			name:   "set-replicas-fail",
 			setter: "replicas",
 			value:  "hello",
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1272,6 +1278,7 @@ openAPI:
 			name:   "error",
 			setter: "replicas",
 			err:    `setter "replicas" is not found`,
+			isSet:  true,
 			input: `
 openAPI:
   definitions:
@@ -1328,7 +1335,6 @@ openAPI:
           name: args
           listValues: ["2", "3", "4"]
           required: true
-          isSet: true
 `,
 		},
 	}
@@ -1343,7 +1349,7 @@ openAPI:
 			// invoke the setter
 			instance := &SetOpenAPI{
 				Name: test.setter, Value: test.value, ListValues: test.values,
-				SetBy: test.setBy, Description: test.description}
+				SetBy: test.setBy, Description: test.description, IsSet: test.isSet}
 			result, err := instance.Filter(in)
 			if test.err != "" {
 				if !assert.EqualError(t, err, test.err) {

--- a/kyaml/setters2/settersutil/fieldsetter.go
+++ b/kyaml/setters2/settersutil/fieldsetter.go
@@ -38,6 +38,8 @@ type FieldSetter struct {
 	ResourcesPath string
 
 	RecurseSubPackages bool
+
+	IsSet bool
 }
 
 func (fs *FieldSetter) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
@@ -54,6 +56,7 @@ func (fs FieldSetter) Set() (int, error) {
 		ListValues:  fs.ListValues,
 		Description: fs.Description,
 		SetBy:       fs.SetBy,
+		IsSet:       fs.IsSet,
 	}
 
 	// the input field value is updated in the openAPI file and then parsed
@@ -156,6 +159,7 @@ func syncOpenAPIValuesWithSchema(openAPIPath string) error {
 			Name:       cliExt.Setter.Name,
 			Value:      cliExt.Setter.Value,
 			ListValues: cliExt.Setter.ListValues,
+			IsSet:      true,
 		}
 		if err := soa.UpdateFile(openAPIPath); err != nil {
 			return err


### PR DESCRIPTION
@mortent 

Currently, isSet is always set to true when set api operation is invoked. This PR is to make it a parameter so that the callers to the api can decide whether to set isSet to true or not. This is because the upstream callers might not want to turn isSet to true when the set api is called to set the fields which are not provided by users. In general, isSet should only be set to true if the value is provided by user. The case of inheriting default values from parent should not turn isSet to true as those values are not provided by user.