### PR TITLE
fix version in releasing/cloudbuild_kustomize_image.yaml 

### DIFF
--- a/releasing/cloudbuild_kustomize_image.yaml
+++ b/releasing/cloudbuild_kustomize_image.yaml
@@ -9,8 +9,7 @@ steps:
       - "PROJECT_ID=$PROJECT_ID"
       - "_GIT_TAG=$_GIT_TAG"
       - "_PULL_BASE_REF=$_PULL_BASE_REF"
-      - "_VERSION=$_VERSION"
-# We need to use bash to configure the build date properly.
+# We need to use bash to configure the build date and version properly.
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: /bin/bash
     args:
@@ -23,15 +22,15 @@ steps:
         -t
         gcr.io/$PROJECT_ID/kustomize:latest
         -t
-        gcr.io/$PROJECT_ID/kustomize:${_PULL_BASE_REF#*/}
+        gcr.io/$PROJECT_ID/kustomize:${_PULL_BASE_REF}
         -f
         kustomize.Dockerfile
         --build-arg
-        VERSION=${_PULL_BASE_REF#*/}
+        VERSION=${_PULL_BASE_REF}
         --build-arg
         COMMIT=$(git rev-parse HEAD)
         --build-arg
-        DATE=`date -u +%FT%TZ`
+        DATE=$(date -u +%FT%TZ)
         .
 
 images:


### PR DESCRIPTION
Looks like the [Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) doesn't work in cloud build. I suspect the cloud build will do the replacement for substitutions before running bash scripts and won't export substitutions to the scripts. So I will use `${_PULL_BASE_REF}` directly as version. The value of it will be `master` for master branch pushes and `kustomize/vX.X.X` for kustomize releases.

The issue like this is hard to debug since it's triggered by k8s test-infra build bot and different from the manual cloud build trigger.