### PR TITLE
Skip multi-mod check if PULL_NUMBER unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,17 @@
 MYGOBIN := $(shell go env GOPATH)/bin
 SHELL := /bin/bash
 export PATH := $(MYGOBIN):$(PATH)
-MODULES := "cmd/config" "api/" "kustomize/" "kyaml/"
+MODULES := '"cmd/config" "api/" "kustomize/" "kyaml/"'
+
+# Provide defaults for REPO_OWNER and REPO_NAME if not present.
+# Typically these values would be provided by Prow.
+ifndef REPO_OWNER
+REPO_OWNER := "kubernetes-sigs"
+endif
+
+ifndef REPO_NAME
+REPO_NAME := "kustomize"
+endif
 
 .PHONY: all
 all: verify-kustomize
@@ -233,11 +243,14 @@ test-go-mod:
 # https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
 .PHONY: test-multi-module
 test-multi-module: $(MYGOBIN)/prchecker
-	$(MYGOBIN)/prchecker \
-	-owner=$(REPO_OWNER) \
-	-repo=$(REPO_NAME) \
-	-pr=$(PULL_NUMBER) \
-	$(MODULES)
+	( \
+		export MYGOBIN=$(MYGOBIN); \
+		export REPO_OWNER=$(REPO_OWNER); \
+		export REPO_NAME=$(REPO_NAME); \
+		export PULL_NUMBER=$(PULL_NUMBER); \
+		export MODULES=$(MODULES); \
+		./scripts/check-multi-module.sh; \
+	)
 
 .PHONY:
 test-examples-e2e-kustomize: $(MYGOBIN)/mdrip $(MYGOBIN)/kind

--- a/scripts/check-multi-module.sh
+++ b/scripts/check-multi-module.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$PULL_NUMBER" -ne "" ]]; then
+    cmd="$MYGOBIN/prchecker
+    -owner=$REPO_OWNER
+    -repo=$REPO_NAME
+    -pr=$PULL_NUMBER
+    $MODULES"
+
+
+    echo $MYGOBIN
+    echo $REPO_OWNER
+    echo $REPO_NAME
+    echo $PULL_NUMBER
+    echo $MODULES
+    eval $cmd
+else
+    echo "Multi-module check skipped. No PULL_NUMBER provided.
+
+To run this check locally set PULL_NUMBER to the PR ID from GitHub."
+fi


### PR DESCRIPTION
Fixes #3191

When `prow-presubmit-check` is run locally this introduces defaults for `REPO_OWNER` and `REPO_NAME` typically provided by prow. The multi-module check is skipped entirely unless a `PULL_NUMBER` is provided. In prow jobs this value is provided by prow. For local execution this will require anyone wanting to run this check to provide a `PULL_NUMBER` variable to make.