### PR TITLE
Expand rnode function comments to point to multi-object options.

### DIFF
--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -50,12 +50,14 @@ func GetValue(node *RNode) string {
 	return node.YNode().Value
 }
 
-// Parse parses a yaml string into an *RNode
+// Parse parses a yaml string into an *RNode.
+// To parse multiple resources, consider a kio.ByteReader
 func Parse(value string) (*RNode, error) {
 	return Parser{Value: value}.Filter(nil)
 }
 
-// ReadFile parses a single Resource from a yaml file
+// ReadFile parses a single Resource from a yaml file.
+// To parse multiple resources, consider a kio.ByteReader
 func ReadFile(path string) (*RNode, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
The rnode Parse and ReadFile functions only return a single object;
suggest kio.ByteReader for the case of parsing multiple objects.