### PR TITLE
Remove merge commits from release notes

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -44,7 +44,7 @@ lastCommitHash=$(
 changeLogFile=$(mktemp)
 git log $lastCommitHash.. \
   --pretty=oneline \
-  --abbrev-commit --no-decorate --no-color \
+  --abbrev-commit --no-decorate --no-color --no-merges \
   -- $module > $changeLogFile
 echo "Release notes:"
 cat $changeLogFile


### PR DESCRIPTION
Introduces `--no-merges` flag to generated release notes which should prevent "Merged pull request..." from being included in release notes in future releases.