### PR TITLE
Add command to list builtin plugins

### DIFF
--- a/api/konfig/plugins.go
+++ b/api/konfig/plugins.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -156,4 +157,16 @@ func pwdEnv() string {
 		return "CD"
 	}
 	return "PWD"
+}
+
+// GetBuiltinPluginNames returns a list of builtin plugin names
+func GetBuiltinPluginNames() []string {
+	var ret []string
+	for k := range builtinhelpers.GeneratorFactories {
+		ret = append(ret, k.String())
+	}
+	for k := range builtinhelpers.TransformerFactories {
+		ret = append(ret, k.String())
+	}
+	return ret
 }

--- a/kustomize/internal/commands/edit/all.go
+++ b/kustomize/internal/commands/edit/all.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/add"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/fix"
+	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/listbuiltin"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/remove"
 	"sigs.k8s.io/kustomize/kustomize/v3/internal/commands/edit/set"
 )
@@ -46,6 +47,7 @@ func NewCmdEdit(
 			v),
 		fix.NewCmdFix(fSys),
 		remove.NewCmdRemove(fSys, v),
+		listbuiltin.NewCmdListBuiltinPlugin(),
 	)
 	return c
 }

--- a/kustomize/internal/commands/edit/listbuiltin/listbuiltin.go
+++ b/kustomize/internal/commands/edit/listbuiltin/listbuiltin.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package listbuiltin
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/api/konfig"
+)
+
+// NewCmdListBuiltinPlugin return an instance of list-builtin-plugin
+// subcommand
+func NewCmdListBuiltinPlugin() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-builtin-plugin",
+		Short: "List the builtin plugins",
+		Long:  "",
+		Run: func(cmd *cobra.Command, args []string) {
+			plugins := konfig.GetBuiltinPluginNames()
+			fmt.Print("Builtin plugins:\n\n")
+			for _, p := range plugins {
+				fmt.Printf(" * %s\n", p)
+			}
+		},
+	}
+	return cmd
+}

--- a/kustomize/internal/commands/edit/listbuiltin/listbuiltin.go
+++ b/kustomize/internal/commands/edit/listbuiltin/listbuiltin.go
@@ -14,8 +14,8 @@ import (
 // subcommand
 func NewCmdListBuiltinPlugin() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-builtin-plugin",
-		Short: "List the builtin plugins",
+		Use:   "alpha-list-builtin-plugin",
+		Short: "[Alpha] List the builtin plugins",
 		Long:  "",
 		Run: func(cmd *cobra.Command, args []string) {
 			plugins := konfig.GetBuiltinPluginNames()


### PR DESCRIPTION
close #3193 

Output:
```
$ kustomize edit list-builtin-plugin
Builtin plugins:

 * ConfigMapGenerator
 * SecretGenerator
 * HelmChartInflationGenerator
 * AnnotationsTransformer
 * ImageTagTransformer
 * NamespaceTransformer
 * PatchStrategicMergeTransformer
 * PrefixSuffixTransformer
 * ValueAddTransformer
 * HashTransformer
 * LabelTransformer
 * LegacyOrderTransformer
 * PatchJson6902Transformer
 * PatchTransformer
 * ReplicaCountTransformer
```