### PR TITLE
Secrets and ConfigMaps with string data in kyaml

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/spec v0.19.5
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/go-cmp v0.3.0

--- a/api/internal/wrappy/factory_test.go
+++ b/api/internal/wrappy/factory_test.go
@@ -5,9 +5,394 @@ package wrappy
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/kv"
+	"sigs.k8s.io/kustomize/api/loader"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	"sigs.k8s.io/kustomize/api/types"
 )
+
+func TestMakeConfigMap(t *testing.T) {
+	factory := &WNodeFactory{}
+	type expected struct {
+		out    string
+		errMsg string
+	}
+
+	testCases := map[string]struct {
+		args types.ConfigMapArgs
+		exp  expected
+	}{
+		"construct config map from env": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "envConfigMap",
+					KvPairSources: types.KvPairSources{
+						EnvSources: []string{
+							filepath.Join("configmap", "app.env"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envConfigMap
+data:
+  DB_USERNAME: admin
+  DB_PASSWORD: qwerty
+`,
+			},
+		},
+		"construct config map from text file": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileConfigMap1",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("configmap", "app-init.ini"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fileConfigMap1
+data:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+`,
+			},
+		},
+		"construct config map from text and binary file": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileConfigMap2",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("configmap", "app-init.ini"),
+							filepath.Join("configmap", "app.bin"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "configMap generate error: key 'app.bin' appears " +
+					"to have non-utf8 data; binaryData field not yet supported",
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fileConfigMap2
+data:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+`,
+			},
+		},
+		"construct config map from literal": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "literalConfigMap1",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{"a=x", "b=y", "c=\"Hello World\"", "d='true'"},
+					},
+					Options: &types.GeneratorOptions{
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: literalConfigMap1
+  labels:
+    foo: 'bar'
+data:
+  a: x
+  b: y
+  c: Hello World
+  d: "true"
+`,
+			},
+		},
+		"construct config map from literal with GeneratorOptions in ConfigMapArgs": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "literalConfigMap2",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{"a=x", "b=y", "c=\"Hello World\"", "d='true'"},
+					},
+					Options: &types.GeneratorOptions{
+						Labels: map[string]string{
+							"veggie": "celery",
+							"dog":    "beagle",
+							"cat":    "annoying",
+						},
+						Annotations: map[string]string{
+							"river": "Missouri",
+							"city":  "Iowa City",
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: literalConfigMap2
+  labels:
+    cat: 'annoying'
+    dog: 'beagle'
+    veggie: 'celery'
+  annotations:
+    city: 'Iowa City'
+    river: 'Missouri'
+data:
+  a: x
+  b: y
+  c: Hello World
+  d: "true"
+`,
+			},
+		},
+	}
+	fSys := filesys.MakeFsInMemory()
+	fSys.WriteFile(
+		filesys.RootedPath("configmap", "app.env"),
+		[]byte("DB_USERNAME=admin\nDB_PASSWORD=qwerty\n"))
+	fSys.WriteFile(
+		filesys.RootedPath("configmap", "app-init.ini"),
+		[]byte("FOO=bar\nBAR=baz\n"))
+	fSys.WriteFile(
+		filesys.RootedPath("configmap", "app.bin"),
+		[]byte{0xff, 0xfd})
+	kvLdr := kv.NewLoader(
+		loader.NewFileLoaderAtRoot(fSys),
+		valtest_test.MakeFakeValidator())
+
+	for n := range testCases {
+		tc := testCases[n]
+		t.Run(n, func(t *testing.T) {
+			rn, err := factory.makeConfigMap(kvLdr, &tc.args)
+			if err != nil {
+				if !assert.EqualError(t, err, tc.exp.errMsg) {
+					t.FailNow()
+				}
+				return
+			}
+			if tc.exp.errMsg != "" {
+				t.Fatalf("%s: should return error '%s'", n, tc.exp.errMsg)
+			}
+			output := rn.MustString()
+			if !assert.Equal(t, tc.exp.out, output) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func TestMakeSecret(t *testing.T) {
+	factory := &WNodeFactory{}
+	type expected struct {
+		out    string
+		errMsg string
+	}
+
+	testCases := map[string]struct {
+		args types.SecretArgs
+		exp  expected
+	}{
+		"construct secret from env": {
+			args: types.SecretArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "envSecret",
+					KvPairSources: types.KvPairSources{
+						EnvSources: []string{
+							filepath.Join("secret", "app.env"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "TODO(WNodeFactory): finish implementation of makeSecret",
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: envSecret
+data:
+  DB_USERNAME: admin
+  DB_PASSWORD: qwerty
+`,
+			},
+		},
+		"construct secret from text file": {
+			args: types.SecretArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileSecret1",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("secret", "app-init.ini"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "TODO(WNodeFactory): finish implementation of makeSecret",
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: fileSecret1
+data:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+`,
+			},
+		},
+		"construct secret from text and binary file": {
+			args: types.SecretArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileSecret2",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("secret", "app-init.ini"),
+							filepath.Join("secret", "app.bin"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "TODO(WNodeFactory): finish implementation of makeSecret",
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: fileSecret2
+data:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+`,
+			},
+		},
+		"construct secret from literal": {
+			args: types.SecretArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "literalSecret1",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{"a=x", "b=y", "c=\"Hello World\"", "d='true'"},
+					},
+					Options: &types.GeneratorOptions{
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "TODO(WNodeFactory): finish implementation of makeSecret",
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: literalSecret1
+  labels:
+    foo: 'bar'
+data:
+  a: x
+  b: y
+  c: Hello World
+  d: "true"
+`,
+			},
+		},
+		"construct secret from literal with GeneratorOptions in SecretArgs": {
+			args: types.SecretArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "literalSecret2",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{"a=x", "b=y", "c=\"Hello World\"", "d='true'"},
+					},
+					Options: &types.GeneratorOptions{
+						Labels: map[string]string{
+							"veggie": "celery",
+							"dog":    "beagle",
+							"cat":    "annoying",
+						},
+						Annotations: map[string]string{
+							"river": "Missouri",
+							"city":  "Iowa City",
+						},
+					},
+				},
+			},
+			exp: expected{
+				errMsg: "TODO(WNodeFactory): finish implementation of makeSecret",
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: literalSecret2
+  labels:
+    cat: 'annoying'
+    dog: 'beagle'
+    veggie: 'celery'
+  annotations:
+    city: 'Iowa City'
+    river: 'Missouri'
+data:
+  a: x
+  b: y
+  c: Hello World
+  d: "true"
+`,
+			},
+		},
+	}
+	fSys := filesys.MakeFsInMemory()
+	fSys.WriteFile(
+		filesys.RootedPath("secret", "app.env"),
+		[]byte("DB_USERNAME=admin\nDB_PASSWORD=qwerty\n"))
+	fSys.WriteFile(
+		filesys.RootedPath("secret", "app-init.ini"),
+		[]byte("FOO=bar\nBAR=baz\n"))
+	fSys.WriteFile(
+		filesys.RootedPath("secret", "app.bin"),
+		[]byte{0xff, 0xfd})
+	kvLdr := kv.NewLoader(
+		loader.NewFileLoaderAtRoot(fSys),
+		valtest_test.MakeFakeValidator())
+
+	for n := range testCases {
+		tc := testCases[n]
+		t.Run(n, func(t *testing.T) {
+			rn, err := factory.makeSecret(kvLdr, &tc.args)
+			if err != nil {
+				if !assert.EqualError(t, err, tc.exp.errMsg) {
+					t.FailNow()
+				}
+				return
+			}
+			if tc.exp.errMsg != "" {
+				t.Fatalf("%s: should return error '%s'", n, tc.exp.errMsg)
+			}
+			output := rn.MustString()
+			if !assert.Equal(t, tc.exp.out, output) {
+				t.FailNow()
+			}
+		})
+	}
+}
 
 func TestSliceFromBytes(t *testing.T) {
 	factory := &WNodeFactory{}

--- a/kyaml/yaml/kfns.go
+++ b/kyaml/yaml/kfns.go
@@ -58,7 +58,7 @@ func (s k8sDataSetter) Filter(rn *RNode) (*RNode, error) {
 		// test in a mapping field called "data" as a string. Pairs with a 'v'
 		// failing this test go into a field called binaryData as a []byte.
 		// TODO: support this distinction in kyaml with NodeTagBytes?
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"key '%s' appears to have non-utf8 data; "+
 				"binaryData field not yet supported", s.Key)
 	}
@@ -73,8 +73,8 @@ func (s k8sDataSetter) Filter(rn *RNode) (*RNode, error) {
 	}
 	v := NewScalarRNode(s.Value)
 	v.YNode().Tag = NodeTagString
-	// Add quotes?
-	// v.YNode().Style = yaml.SingleQuotedStyle
+	// TODO: use schema to determine node style and tag.
+	// FormatNonStringStyle(v.YNode(), *k8sSch)
 	_, err = rn.Pipe(
 		LookupCreate(yaml.MappingNode, DataField), SetField(s.Key, v))
 	return rn, err

--- a/kyaml/yaml/kfns_test.go
+++ b/kyaml/yaml/kfns_test.go
@@ -39,8 +39,8 @@ data:
   fruit: apple
   veggie: celery
 `
-	if output != expected {
-		t.Fatalf("expected \n%s\nbut got \n%s\n", expected, output)
+	if !assert.Equal(t, expected, output) {
+		t.FailNow()
 	}
 }
 
@@ -79,8 +79,8 @@ metadata:
   name: foo
   namespace: bar
 `
-	if output != expected {
-		t.Fatalf("expected \n%s\nbut got \n%s\n", expected, output)
+	if !assert.Equal(t, expected, output) {
+		t.FailNow()
 	}
 }
 

--- a/kyaml/yaml/kfns_test.go
+++ b/kyaml/yaml/kfns_test.go
@@ -5,6 +5,8 @@ package yaml
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var input = `apiVersion: v1
@@ -15,6 +17,72 @@ data:
   altGreeting: "Good Morning!"
   enableRisky: "false"
 `
+
+func TestSetK8sData(t *testing.T) {
+	rn := MustParse(`apiVersion: v1
+kind: ConfigMap
+data:
+  altGreeting: "Good Morning!"
+`)
+	_, err := rn.Pipe(
+		SetK8sData("foo", "bar"),
+		SetK8sData("fruit", "apple"),
+		SetK8sData("veggie", "celery"))
+	assert.NoError(t, err)
+	output := rn.MustString()
+
+	expected := `apiVersion: v1
+kind: ConfigMap
+data:
+  altGreeting: "Good Morning!"
+  foo: bar
+  fruit: apple
+  veggie: celery
+`
+	if output != expected {
+		t.Fatalf("expected \n%s\nbut got \n%s\n", expected, output)
+	}
+}
+
+func TestSetK8sDataForbidOverwrite(t *testing.T) {
+	rn := MustParse(`apiVersion: v1
+kind: ConfigMap
+data:
+  altGreeting: "Good Morning!"
+`)
+	_, err := rn.Pipe(
+		SetK8sData("foo", "bar"),
+		SetK8sData("altGreeting", "hey"),
+		SetK8sData("veggie", "celery"))
+	assert.EqualError(
+		t, err, "protecting existing altGreeting='\"Good Morning!\"' "+
+			"against attempt to add new value 'hey'")
+}
+
+func TestSetMeta(t *testing.T) {
+	rn := MustParse(`apiVersion: v1
+kind: ConfigMap
+data:
+  altGreeting: "Good Morning!"
+`)
+	_, err := rn.Pipe(SetK8sName("foo"), SetK8sNamespace("bar"))
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	output := rn.MustString()
+
+	expected := `apiVersion: v1
+kind: ConfigMap
+data:
+  altGreeting: "Good Morning!"
+metadata:
+  name: foo
+  namespace: bar
+`
+	if output != expected {
+		t.Fatalf("expected \n%s\nbut got \n%s\n", expected, output)
+	}
+}
 
 func TestSetLabel1(t *testing.T) {
 	rn := MustParse(input)


### PR DESCRIPTION
In service of #2894

This is part of the biggest chunk of work needed to close 2894, allowing generation
of configmaps and secrets using the existing code flow but without using apimachinery.

The basic string stuff seems complete.  Still to be completed is the treatment of binary
`[]byte` data that would go into the `binaryData` fields (as opposed to the `data`) field
of a ConfigMap.   The test structure is in place for that, but it's not yet complete.
Likewise, treatment if hexified binary data in a Secret isn't complete, but the test structure
is in place.  We may need a new `NodeTagBytes` to help flag strings that aren't utf8 valid.
ptal.

background:

The code is structured to allow use of the `--enable_kyaml  ` flag, e.g.
```
kustomize build --enable_kyaml
```
to switch away from apimachinery based code and use only kyaml.
Using this flag allows an easy switch back and forth in the existing code structure.

Right now we cannot flip it yet and pass all tests but this gets us much closer.

Once we flip that flag hard over, this code can move out of the wrappy package and
into a KRM function or whatever is trending at that point.


