### PR TITLE
Update release notes generation

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -35,7 +35,7 @@ module=${fullTag%/*}
 echo "module=$module"
 
 # Find previous tag that matches the tags module
-prevTag=$(git tag -l "$module*" --sort=-version:refname --no-contains=$currentTag | head -n 1)
+prevTag=$(git tag -l "$module*" --sort=-version:refname --no-contains=$fullTag | head -n 1)
 
 # Generate the changelog for this release
 # using the last two tags for the module

--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -34,15 +34,13 @@ echo "Remaining args:  $remainingArgs"
 module=${fullTag%/*}
 echo "module=$module"
 
-# Obtain most recent commit hash associated with the module.
-lastCommitHash=$(
-  git log --tags=$module -1 \
-  --oneline --no-walk --pretty=format:%h)
+# Find previous tag that matches the tags module
+prevTag=$(git tag -l "$module*" --sort=-version:refname --no-contains=$currentTag | head -n 1)
 
 # Generate the changelog for this release
-# using commit hashes and commit messages.
+# using the last two tags for the module
 changeLogFile=$(mktemp)
-git log $lastCommitHash.. \
+git log $prevTag..$fullTag \
   --pretty=oneline \
   --abbrev-commit --no-decorate --no-color --no-merges \
   -- $module > $changeLogFile


### PR DESCRIPTION
Fixes #2773

Update to release notes generation to use the current tag and the tag prior to it instead of using a commitSha.

The previous tag version is detected using tag version numbers.