### PR TITLE
fix rnode string format converted from resmap

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -568,7 +568,7 @@ func (m *resWrangler) Select(s types.Selector) ([]*resource.Resource, error) {
 func (m *resWrangler) ToRNodeSlice() ([]*kyaml_yaml.RNode, error) {
 	var rnodes []*kyaml_yaml.RNode
 	for _, r := range m.Resources() {
-		s, err := r.MarshalJSON()
+		s, err := r.AsYAML()
 		if err != nil {
 			return nil, err
 		}

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/kustomize/api/resource"
 	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/yaml"
 )
 
 var rf = resource.NewFactory(
@@ -769,11 +768,7 @@ rules:
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		y, err := yaml.JSONToYAML([]byte(s))
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		b.WriteString(string(y))
+		b.WriteString(s)
 	}
 
 	if !reflect.DeepEqual(input, b.String()) {


### PR DESCRIPTION
Looks like the RNode string style is affected by the format in source string.