### PR TITLE
Fix exec plugins on windows

### DIFF
--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"plugin"
 	"reflect"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -177,7 +178,11 @@ func (l *Loader) loadPlugin(res *resource.Resource) (resmap.Configurable, error)
 
 func (l *Loader) loadExecOrGoPlugin(resId resid.ResId) (resmap.Configurable, error) {
 	// First try to load the plugin as an executable.
-	p := execplugin.NewExecPlugin(l.absolutePluginPath(resId))
+	pluginPath := l.absolutePluginPath(resId)
+	if runtime.GOOS == "windows" {
+		pluginPath = fmt.Sprintf("%s.exe", pluginPath)
+	}
+	p := execplugin.NewExecPlugin(pluginPath)
 	err := p.ErrIfNotExecutable()
 	if err == nil {
 		return p, nil


### PR DESCRIPTION
The exec plugin implementation checks if an executable file exists but
on windows it won't check for files with .exe suffix thus falling back
to go plugin implementation