### PR TITLE
Allow reading resources from stdin

### DIFF
--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -334,6 +335,12 @@ func (fl *fileLoader) Load(path string) ([]byte, error) {
 			return nil, err
 		}
 		return body, nil
+	}
+
+	// Skip verifications done on normal files and directories to allow
+	// reading resources directly from stdin
+	if path == "{stdin}" {
+		return ioutil.ReadAll(os.Stdin)
 	}
 
 	if !filepath.IsAbs(path) {


### PR DESCRIPTION
Allow reading resources from stdin, using os.Stdin
and ioutil.ReadAll to stay platform agnostic.

This change allows specifying {stdin} in the "resources: {}" block to
read resources from stdin, while still processing all other resources as
normal.

This is useful for helms post render hooks

Adding test for this with my knowledge would get quite a bit more 
complicated than the change so I let that be for now.

closes: #2985