### PR TITLE
Made output of `kustomize openapi info` command more readable

### DIFF
--- a/kyaml/openapi/kubernetesapi/openapiinfo.go
+++ b/kyaml/openapi/kubernetesapi/openapiinfo.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/openapi/kubernetesapi/v1191"
 )
 
-const Info = "{title:Kubernetes,version:v1.18.4},{title:Kubernetes,version:v1.18.6},{title:Kubernetes,version:v1.18.8},{title:Kubernetes,version:v1.19.0},{title:Kubernetes,version:v1.19.1}"
+const Info = "{title:Kubernetes,version:v1.18.4}\n{title:Kubernetes,version:v1.18.6}\n{title:Kubernetes,version:v1.18.8}\n{title:Kubernetes,version:v1.19.0}\n{title:Kubernetes,version:v1.19.1}"
 
 var OpenApiMustAsset = map[string]func(string) []byte{
 	"v1184": v1184.MustAsset,

--- a/kyaml/openapi/scripts/makeOpenApiInfoDotGo.sh
+++ b/kyaml/openapi/scripts/makeOpenApiInfoDotGo.sh
@@ -52,7 +52,7 @@ EOF
 done
 
 # add info string for `kustomize openapi info` command
-OPEN_API_INFO=`echo ${info_list[@]} | tr " " ","`
+OPEN_API_INFO=`echo ${info_list[@]} | sed 's/ /\\\n/g'`
 cat <<EOF >>kubernetesapi/openapiinfo.go
 )
 


### PR DESCRIPTION
With multiple versions of k8s schema, the output of the `openapi info` command was hard to read when separated by commas. Changed it to be separated by newlines for cleaner output