### PR TITLE
Use go-getter only for archive fetches

### DIFF
--- a/api/loader/getter.go
+++ b/api/loader/getter.go
@@ -78,18 +78,21 @@ func getRemoteTarget(rs *remoteTargetSpec) error {
 		log.Fatalf("Error getting wd: %s", err)
 	}
 
+	httpGetter := &getter.HttpGetter{
+		Netrc: true,
+	}
+
 	opts := []getter.ClientOption{}
 	client := &getter.Client{
-		Ctx:  context.TODO(),
-		Src:  rs.Raw,
-		Dst:  rs.Dir.String(),
-		Pwd:  pwd,
-		Mode: getter.ClientModeAny,
-		Detectors: []getter.Detector{
-			new(getter.GitHubDetector),
-			new(getter.GitLabDetector),
-			new(getter.GitDetector),
-			new(getter.BitBucketDetector),
+		Ctx:       context.TODO(),
+		Src:       rs.Raw,
+		Dst:       rs.Dir.String(),
+		Pwd:       pwd,
+		Mode:      getter.ClientModeDir,
+		Detectors: []getter.Detector{},
+		Getters: map[string]getter.Getter{
+			"http":  httpGetter,
+			"https": httpGetter,
 		},
 		Options: opts,
 	}


### PR DESCRIPTION
This is another attempt to address #2538. This uses go-getter only to fetch archives via http. Otherwise, it uses the git cloner to clone repositories. Having 2 different ways of cloning git repositories was a big cause of confusion with url formats and we address this by just removing go-getter as an option entirely.