### PR TITLE
absolute path to entrypoint

### DIFF
--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -17,4 +17,4 @@ FROM alpine
 RUN apk add git openssh
 COPY --from=builder /build/kustomize /app/
 WORKDIR /app
-ENTRYPOINT ["./kustomize"]
+ENTRYPOINT ["/app/kustomize"]


### PR DESCRIPTION
Make the kustomize container tolerant of alternative working directory. 
Mounting my project and making it the working directory will now work.

ie. docker run -w /pkg -v $(shell pwd):/pkg kustomize version