### PR TITLE
Pin kustomize to api/v0.7.0, enabling kyaml by default

### DIFF
--- a/cmd/pluginator/go.mod
+++ b/cmd/pluginator/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/cmd/pluginator/go.sum
+++ b/cmd/pluginator/go.sum
@@ -533,8 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/client-go v0.18.10
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/cmd/config v0.8.6
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
@@ -19,5 +19,3 @@ exclude (
 	sigs.k8s.io/kustomize/api v0.2.0
 	sigs.k8s.io/kustomize/cmd/config v0.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../api

--- a/plugin/builtin/annotationstransformer/go.mod
+++ b/plugin/builtin/annotationstransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/annotationstransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/annotationstransformer/go.sum
+++ b/plugin/builtin/annotationstransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/configmapgenerator/go.mod
+++ b/plugin/builtin/configmapgenerator/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/configmapgenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/builtin/configmapgenerator/go.sum
+++ b/plugin/builtin/configmapgenerator/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/hashtransformer/go.mod
+++ b/plugin/builtin/hashtransformer/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/builtin/hashtransformer
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml

--- a/plugin/builtin/hashtransformer/go.sum
+++ b/plugin/builtin/hashtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/helmchartinflationgenerator/go.mod
+++ b/plugin/builtin/helmchartinflationgenerator/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/helmchartinflationgenerator/go.sum
+++ b/plugin/builtin/helmchartinflationgenerator/go.sum
@@ -528,8 +528,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/imagetagtransformer/go.mod
+++ b/plugin/builtin/imagetagtransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/imagetagtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/imagetagtransformer/go.sum
+++ b/plugin/builtin/imagetagtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/labeltransformer/go.mod
+++ b/plugin/builtin/labeltransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/labeltransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/labeltransformer/go.sum
+++ b/plugin/builtin/labeltransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/legacyordertransformer/go.mod
+++ b/plugin/builtin/legacyordertransformer/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml

--- a/plugin/builtin/legacyordertransformer/go.sum
+++ b/plugin/builtin/legacyordertransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/namespacetransformer/go.mod
+++ b/plugin/builtin/namespacetransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/namespacetransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/namespacetransformer/go.sum
+++ b/plugin/builtin/namespacetransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/patchjson6902transformer/go.mod
+++ b/plugin/builtin/patchjson6902transformer/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/patchjson6902transformer/go.sum
+++ b/plugin/builtin/patchjson6902transformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/patchstrategicmergetransformer/go.mod
+++ b/plugin/builtin/patchstrategicmergetransformer/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/stretchr/testify v1.4.0
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/builtin/patchstrategicmergetransformer/go.sum
+++ b/plugin/builtin/patchstrategicmergetransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/patchtransformer/go.mod
+++ b/plugin/builtin/patchtransformer/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/patchtransformer/go.sum
+++ b/plugin/builtin/patchtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/prefixsuffixtransformer/go.mod
+++ b/plugin/builtin/prefixsuffixtransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/prefixsuffixtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/prefixsuffixtransformer/go.sum
+++ b/plugin/builtin/prefixsuffixtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/replicacounttransformer/go.mod
+++ b/plugin/builtin/replicacounttransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/replicacounttransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/replicacounttransformer/go.sum
+++ b/plugin/builtin/replicacounttransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/secretgenerator/go.mod
+++ b/plugin/builtin/secretgenerator/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/secretgenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/builtin/secretgenerator/go.sum
+++ b/plugin/builtin/secretgenerator/go.sum
@@ -530,8 +530,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/valueaddtransformer/go.mod
+++ b/plugin/builtin/valueaddtransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/valueaddtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/kustomize/kyaml v0.10.3
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/plugin/builtin/valueaddtransformer/go.sum
+++ b/plugin/builtin/valueaddtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/bashedconfigmap
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/bashedconfigmap/go.sum
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/chartinflator/go.mod
+++ b/plugin/someteam.example.com/v1/chartinflator/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/chartinflator
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/chartinflator/go.sum
+++ b/plugin/someteam.example.com/v1/chartinflator/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/dateprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/dateprefixer/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/someteam.example.com/v1/dateprefixer/go.sum
+++ b/plugin/someteam.example.com/v1/dateprefixer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/printpluginenv/go.mod
+++ b/plugin/someteam.example.com/v1/printpluginenv/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/printpluginenv
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/printpluginenv/go.sum
+++ b/plugin/someteam.example.com/v1/printpluginenv/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/secretsfromdatabase
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/go.sum
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/sedtransformer/go.mod
+++ b/plugin/someteam.example.com/v1/sedtransformer/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/sedtransformer
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/sedtransformer/go.sum
+++ b/plugin/someteam.example.com/v1/sedtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/someservicegenerator/go.mod
+++ b/plugin/someteam.example.com/v1/someservicegenerator/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/someservicegenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/someteam.example.com/v1/someservicegenerator/go.sum
+++ b/plugin/someteam.example.com/v1/someservicegenerator/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/stringprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/stringprefixer/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/someteam.example.com/v1/stringprefixer/go.sum
+++ b/plugin/someteam.example.com/v1/stringprefixer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/validator/go.mod
+++ b/plugin/someteam.example.com/v1/validator/go.mod
@@ -2,6 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/validator
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml

--- a/plugin/someteam.example.com/v1/validator/go.sum
+++ b/plugin/someteam.example.com/v1/validator/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/untested/v1/gogetter/go.mod
+++ b/plugin/untested/v1/gogetter/go.mod
@@ -2,4 +2,4 @@ module sigs.k8s.io/kustomize/plugin/untested/v1/gogetter
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.6.7
+require sigs.k8s.io/kustomize/api v0.7.0

--- a/plugin/untested/v1/gogetter/go.sum
+++ b/plugin/untested/v1/gogetter/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/untested/v1/replacementtransformer/go.mod
+++ b/plugin/untested/v1/replacementtransformer/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kustomize/plugin/untested/v1/replacementtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.6.7
+	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/plugin/untested/v1/replacementtransformer/go.sum
+++ b/plugin/untested/v1/replacementtransformer/go.sum
@@ -532,8 +532,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
-sigs.k8s.io/kustomize/api v0.6.7 h1:12tbj8x8S3hqus6obQrMWTqpcibf3v4iFo+hX/jIQ8g=
-sigs.k8s.io/kustomize/api v0.6.7/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
+sigs.k8s.io/kustomize/api v0.7.0 h1:djxH9k1izeU1BvdP1i23qqKwhmWu2BuKNEKr/Da7Dpw=
+sigs.k8s.io/kustomize/api v0.7.0/go.mod h1:3TxKEyaxwOIfHmRbQF14hDUSRmVQI0iSn8qDA5zaO/0=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=


### PR DESCRIPTION
In service of #2506 

This PR changes the default value of the `kustomize build` flag `--enable_kyaml` from false to true.

[release-api-v0.6]: https://github.com/kubernetes-sigs/kustomize/tree/release-api-v0.6
[release-api-v0.7]: https://github.com/kubernetes-sigs/kustomize/tree/release-api-v0.7

Going forward from here, the following api branches (if used for new releases) should
only differ in the value of `FlagEnableKyamlDefaultValue`

 - [release-api-v0.6] `FlagEnableKyamlDefaultValue == false`
 - [release-api-v0.7] `FlagEnableKyamlDefaultValue == true`

Hopefully we won't have to do more releases in the v0.6 series, but if we do it's a matter
of merging everything in from the main branch but keeping `FlagEnableKyamlDefaultValue` false

ALLOW_MODULE_SPAN
