### PR TITLE
helm values on inflator config - types

### DIFF
--- a/api/builtins/HelmChartInflationGenerator.go
+++ b/api/builtins/HelmChartInflationGenerator.go
@@ -6,12 +6,15 @@ package builtins
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"regexp"
 	"strings"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -62,6 +65,9 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	if p.Values == "" {
 		p.Values = path.Join(p.ChartHome, p.ChartName, "values.yaml")
 	}
+	if p.ValuesMerge == "" {
+		p.ValuesMerge = "override"
+	}
 	// runHelmCommand will run `helm` command with args provided. Return stdout
 	// and error if there is any.
 	p.runHelmCommand = func(args []string) ([]byte, error) {
@@ -88,6 +94,21 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	return nil
 }
 
+// EncodeValues for writing
+func (p *HelmChartInflationGeneratorPlugin) EncodeValues(w io.Writer) error {
+	d, err := yaml.Marshal(p.ValuesLocal)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//
+
 // Generate implements generator
 func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 	// cleanup
@@ -104,6 +125,50 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 			return nil, err
 		}
 	}
+
+	// values
+	if len(p.ValuesLocal) > 0 {
+		fn := path.Join(p.ChartHome, p.ChartName, "kustomize-values.yaml")
+		vf, err := os.Create(fn)
+		defer vf.Close()
+		if err != nil {
+			return nil, err
+		}
+		// override, merge, none
+		if p.ValuesMerge == "none" || p.ValuesMerge == "no" || p.ValuesMerge == "false" {
+			p.Values = fn
+		} else {
+			pValues, err := ioutil.ReadFile(p.Values)
+			if err != nil {
+				return nil, err
+			}
+			chValues := make(map[string]interface{})
+			err = yaml.Unmarshal(pValues, &chValues)
+			if err != nil {
+				return nil, err
+			}
+			if p.ValuesMerge == "override" {
+				err = mergo.Merge(&chValues, p.ValuesLocal, mergo.WithOverride)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if p.ValuesMerge == "merge" {
+				err = mergo.Merge(&chValues, p.ValuesLocal)
+				if err != nil {
+					return nil, err
+				}
+			}
+			p.ValuesLocal = chValues
+			p.Values = fn
+		}
+		err = p.EncodeValues(vf)
+		if err != nil {
+			return nil, err
+		}
+		vf.Sync()
+	}
+
 	// render the charts
 	stdout, err := p.runHelmCommand(p.getTemplateCommandArgs())
 	if err != nil {

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -10,11 +10,13 @@ type HelmChartArgs struct {
 	ChartRepoURL string `json:"chartRepoUrl,omitempty" yaml:"chartRepoUrl,omitempty"`
 	ChartHome    string `json:"chartHome,omitempty" yaml:"chartHome,omitempty"`
 	// Use chartRelease to keep compatible with old exec plugin
-	ChartRepoName    string   `json:"chartRelease,omitempty" yaml:"chartRelease,omitempty"`
-	HelmBin          string   `json:"helmBin,omitempty" yaml:"helmBin,omitempty"`
-	HelmHome         string   `json:"helmHome,omitempty" yaml:"helmHome,omitempty"`
-	Values           string   `json:"values,omitempty" yaml:"values,omitempty"`
-	ReleaseName      string   `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
-	ReleaseNamespace string   `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
-	ExtraArgs        []string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	ChartRepoName    string                 `json:"chartRelease,omitempty" yaml:"chartRelease,omitempty"`
+	HelmBin          string                 `json:"helmBin,omitempty" yaml:"helmBin,omitempty"`
+	HelmHome         string                 `json:"helmHome,omitempty" yaml:"helmHome,omitempty"`
+	Values           string                 `json:"values,omitempty" yaml:"values,omitempty"`
+	ValuesLocal      map[string]interface{} `json:"valuesLocal,omitempty" yaml:"valuesLocal,omitempty"`
+	ValuesMerge      string                 `json:"valuesMerge,omitempty" yaml:"valuesMerge,omitempty"`
+	ReleaseName      string                 `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
+	ReleaseNamespace string                 `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
+	ExtraArgs        []string               `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
 }


### PR DESCRIPTION
Proper PR for accidentally merged https://github.com/kubernetes-sigs/kustomize/pull/3316

Sbd. asked to split into packages

Let me know whether welcome and suggest updates.

* It solve issue with relative path to values + allows some merge capabilities for values.yaml
* Would be nice to rename to: Values (map[string]interface{} and today Values -> ValuesFile string as a path, but such change now would not be backward compatible.


Please discuss whether 
* ValuesLocal, ValuesMerge are good "stable" labels for what they do and we want to use them

Dependency for PR
* https://github.com/kubernetes-sigs/kustomize/pull/3353
