### PR TITLE
Helm values on inflator config plugin

### DIFF
--- a/api/builtins/HelmChartInflationGenerator.go
+++ b/api/builtins/HelmChartInflationGenerator.go
@@ -6,12 +6,15 @@ package builtins
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"regexp"
 	"strings"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -62,6 +65,9 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	if p.Values == "" {
 		p.Values = path.Join(p.ChartHome, p.ChartName, "values.yaml")
 	}
+	if p.ValuesMerge == "" {
+		p.ValuesMerge = "override"
+	}
 	// runHelmCommand will run `helm` command with args provided. Return stdout
 	// and error if there is any.
 	p.runHelmCommand = func(args []string) ([]byte, error) {
@@ -88,6 +94,21 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	return nil
 }
 
+// EncodeValues for writing
+func (p *HelmChartInflationGeneratorPlugin) EncodeValues(w io.Writer) error {
+	d, err := yaml.Marshal(p.ValuesLocal)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//
+
 // Generate implements generator
 func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 	// cleanup
@@ -104,6 +125,50 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 			return nil, err
 		}
 	}
+
+	// values
+	if len(p.ValuesLocal) > 0 {
+		fn := path.Join(p.ChartHome, p.ChartName, "kustomize-values.yaml")
+		vf, err := os.Create(fn)
+		defer vf.Close()
+		if err != nil {
+			return nil, err
+		}
+		// override, merge, none
+		if p.ValuesMerge == "none" || p.ValuesMerge == "no" || p.ValuesMerge == "false" {
+			p.Values = fn
+		} else {
+			pValues, err := ioutil.ReadFile(p.Values)
+			if err != nil {
+				return nil, err
+			}
+			chValues := make(map[string]interface{})
+			err = yaml.Unmarshal(pValues, &chValues)
+			if err != nil {
+				return nil, err
+			}
+			if p.ValuesMerge == "override" {
+				err = mergo.Merge(&chValues, p.ValuesLocal, mergo.WithOverride)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if p.ValuesMerge == "merge" {
+				err = mergo.Merge(&chValues, p.ValuesLocal)
+				if err != nil {
+					return nil, err
+				}
+			}
+			p.ValuesLocal = chValues
+			p.Values = fn
+		}
+		err = p.EncodeValues(vf)
+		if err != nil {
+			return nil, err
+		}
+		vf.Sync()
+	}
+
 	// render the charts
 	stdout, err := p.runHelmCommand(p.getTemplateCommandArgs())
 	if err != nil {

--- a/api/go.mod
+++ b/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/imdario/mergo v0.3.5
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf

--- a/api/go.sum
+++ b/api/go.sum
@@ -252,6 +252,7 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -10,11 +10,13 @@ type HelmChartArgs struct {
 	ChartRepoURL string `json:"chartRepoUrl,omitempty" yaml:"chartRepoUrl,omitempty"`
 	ChartHome    string `json:"chartHome,omitempty" yaml:"chartHome,omitempty"`
 	// Use chartRelease to keep compatible with old exec plugin
-	ChartRepoName    string   `json:"chartRelease,omitempty" yaml:"chartRelease,omitempty"`
-	HelmBin          string   `json:"helmBin,omitempty" yaml:"helmBin,omitempty"`
-	HelmHome         string   `json:"helmHome,omitempty" yaml:"helmHome,omitempty"`
-	Values           string   `json:"values,omitempty" yaml:"values,omitempty"`
-	ReleaseName      string   `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
-	ReleaseNamespace string   `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
-	ExtraArgs        []string `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
+	ChartRepoName    string                 `json:"chartRelease,omitempty" yaml:"chartRelease,omitempty"`
+	HelmBin          string                 `json:"helmBin,omitempty" yaml:"helmBin,omitempty"`
+	HelmHome         string                 `json:"helmHome,omitempty" yaml:"helmHome,omitempty"`
+	Values           string                 `json:"values,omitempty" yaml:"values,omitempty"`
+	ValuesLocal      map[string]interface{} `json:"valuesLocal,omitempty" yaml:"valuesLocal,omitempty"`
+	ValuesMerge      string                 `json:"valuesMerge,omitempty" yaml:"valuesMerge,omitempty"`
+	ReleaseName      string                 `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
+	ReleaseNamespace string                 `json:"releaseNamespace,omitempty" yaml:"releaseNamespace,omitempty"`
+	ExtraArgs        []string               `json:"extraArgs,omitempty" yaml:"extraArgs,omitempty"`
 }

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -13,12 +13,15 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"regexp"
 	"strings"
 
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -70,6 +73,9 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	if p.Values == "" {
 		p.Values = path.Join(p.ChartHome, p.ChartName, "values.yaml")
 	}
+	if p.ValuesMerge == "" {
+		p.ValuesMerge = "override"
+	}
 	// runHelmCommand will run `helm` command with args provided. Return stdout
 	// and error if there is any.
 	p.runHelmCommand = func(args []string) ([]byte, error) {
@@ -96,6 +102,63 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 	return nil
 }
 
+// EncodeValues for writing
+func (p *HelmChartInflationGeneratorPlugin) EncodeValues(w io.Writer) error {
+	d, err := yaml.Marshal(p.ValuesLocal)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// useValuesLocal process (merge) inflator config provided values with chart default values.yaml
+func (p *HelmChartInflationGeneratorPlugin) useValuesLocal() error {
+	fn := path.Join(p.ChartHome, p.ChartName, "kustomize-values.yaml")
+	vf, err := os.Create(fn)
+	defer vf.Close()
+	if err != nil {
+		return err
+	}
+	// override, merge, none
+	if p.ValuesMerge == "none" || p.ValuesMerge == "no" || p.ValuesMerge == "false" {
+		p.Values = fn
+	} else {
+		pValues, err := ioutil.ReadFile(p.Values)
+		if err != nil {
+			return err
+		}
+		chValues := make(map[string]interface{})
+		err = yaml.Unmarshal(pValues, &chValues)
+		if err != nil {
+			return err
+		}
+		if p.ValuesMerge == "override" {
+			err = mergo.Merge(&chValues, p.ValuesLocal, mergo.WithOverride)
+			if err != nil {
+				return err
+			}
+		}
+		if p.ValuesMerge == "merge" {
+			err = mergo.Merge(&chValues, p.ValuesLocal)
+			if err != nil {
+				return err
+			}
+		}
+		p.ValuesLocal = chValues
+		p.Values = fn
+	}
+	err = p.EncodeValues(vf)
+	if err != nil {
+		return err
+	}
+	vf.Sync()
+	return nil
+}
+
 // Generate implements generator
 func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 	// cleanup
@@ -112,6 +175,15 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (resmap.ResMap, error) {
 			return nil, err
 		}
 	}
+
+	// inflator config valuesLocal
+	if len(p.ValuesLocal) > 0 {
+		err := p.useValuesLocal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// render the charts
 	stdout, err := p.runHelmCommand(p.getTemplateCommandArgs())
 	if err != nil {

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -114,6 +114,14 @@ releaseName: test
 releaseNamespace: testNamespace
 values: %s
 `, tempDir, tempDir, valuesPath))
+valuesLocal:
+  resources:
+    limits:
+      memory: 512Mi
+      cpu: 1000m
+    requests:
+      memory: 512Mi
+      cpu: 200m
 
 	th.AssertActualEqualsExpected(rm, `
 apiVersion: v1

--- a/plugin/builtin/helmchartinflationgenerator/go.mod
+++ b/plugin/builtin/helmchartinflationgenerator/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/helmchartinflationgenerator
 go 1.15
 
 require (
+	github.com/imdario/mergo v0.3.5
 	github.com/pkg/errors v0.8.1
 	sigs.k8s.io/kustomize/api v0.7.0
 	sigs.k8s.io/yaml v1.2.0

--- a/plugin/builtin/helmchartinflationgenerator/go.sum
+++ b/plugin/builtin/helmchartinflationgenerator/go.sum
@@ -216,6 +216,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=


### PR DESCRIPTION
Proper PR for accidentally merged https://github.com/kubernetes-sigs/kustomize/pull/3316

Sbd. asked to split into packages

Let me know whether welcome and suggest updates.

* It solve issue with relative path to values + allows some merge capabilities for values.yaml
* Would be nice to rename to: Values (map[string]interface{} and today Values -> ValuesFile string as a path, but such change now would not be backward compatible.

Please discuss whether 
* ValuesLocal, ValuesMerge are good "stable" labels for what they do and we want to use them

Tests
* currently disabled, see: https://github.com/kubernetes-sigs/kustomize/pull/3206
* i am open to add some + doc once functional
* works in my use-case, but wider audience testing it, merge function, other features etc.. before it will get into an release is welcome

Depends on PR
* https://github.com/kubernetes-sigs/kustomize/pull/3352 (reason for two commits in PR)

Related:
* https://github.com/kubernetes-sigs/cli-experimental/pull/65