### PR TITLE
Avoid error when the node has local-config

### DIFF
--- a/api/internal/crawl/go.sum
+++ b/api/internal/crawl/go.sum
@@ -220,6 +220,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=

--- a/api/resmap/factory.go
+++ b/api/resmap/factory.go
@@ -152,11 +152,11 @@ func (rmF *Factory) NewResMapFromRNodeSlice(rnodes []*yaml.RNode) (ResMap, error
 		if err != nil {
 			return nil, err
 		}
-		r, err := rmF.resF.FromBytes([]byte(s))
+		r, err := rmF.resF.SliceFromBytes([]byte(s))
 		if err != nil {
 			return nil, err
 		}
-		resources = append(resources, r)
+		resources = append(resources, r...)
 	}
 	return newResMapFromResourceSlice(resources)
 }


### PR DESCRIPTION
`FromBytes` will throw an error when the input resource has annotation `config.kubernetes.io/local-config` because the resource with this annotation will be ignored. Use `SliceFromBytes` to avoid this error. https://github.com/GoogleContainerTools/kpt/issues/1305

`api/builtins/HelmChartInflationGenerator.go` is not updated in previous PR. Update it here.