### PR TITLE
Fix apiversion slash

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -15,6 +15,29 @@ func TestFilter(t *testing.T) {
 		patch    *yaml.RNode
 		expected string
 	}{
+		"simple": {
+			input: `apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 1
+`,
+			patch: yaml.MustParse(`apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`),
+			expected: `apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`,
+		},
 		"nullMapEntry1": {
 			input: `
 apiVersion: example.com/v1

--- a/api/internal/wrappy/wnode.go
+++ b/api/internal/wrappy/wnode.go
@@ -182,9 +182,7 @@ func (wn *WNode) SetAnnotations(annotations map[string]string) {
 // SetGvk implements ifc.Kunstructured.
 func (wn *WNode) SetGvk(gvk resid.Gvk) {
 	wn.setMapField(yaml.NewScalarRNode(gvk.Kind), yaml.KindField)
-	wn.setMapField(
-		yaml.NewScalarRNode(
-			fmt.Sprintf("%s/%s", gvk.Group, gvk.Version)), yaml.APIVersionField)
+	wn.setMapField(yaml.NewScalarRNode(gvk.ApiVersion()), yaml.APIVersionField)
 }
 
 // SetLabels implements ifc.Kunstructured.

--- a/api/krusty/simple_test.go
+++ b/api/krusty/simple_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestSimple1(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("/dep.yaml", `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 1
+`)
+	th.WriteF("/patch.yaml", `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`)
+
+	th.WriteK("/", `
+resources:
+- dep.yaml
+patchesStrategicMerge:
+- patch.yaml
+`)
+	m := th.Run("/", th.MakeDefaultOptions())
+
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`)
+}

--- a/api/resid/gvk.go
+++ b/api/resid/gvk.go
@@ -80,6 +80,14 @@ func (x Gvk) String() string {
 	return strings.Join([]string{g, v, k}, fieldSep)
 }
 
+// ApiVersion returns the combination of Group and Version
+func (x Gvk) ApiVersion() string {
+	if x.Group == "" {
+		return x.Version
+	}
+	return x.Group + "/" + x.Version
+}
+
 // StringWoEmptyField returns a string representation of the GVK. Non-exist
 // fields will be omitted.
 func (x Gvk) StringWoEmptyField() string {

--- a/api/resid/gvk_test.go
+++ b/api/resid/gvk_test.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2018 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
 
 package resid
 
@@ -112,17 +99,31 @@ var stringTests = []struct {
 
 func TestString(t *testing.T) {
 	for _, hey := range stringTests {
-		if hey.x.String() != hey.s {
-			t.Fatalf("bad string for %v '%s'", hey.x, hey.s)
-		}
+		assert.Equal(t, hey.s, hey.x.String())
+	}
+}
+
+func TestApiVersion(t *testing.T) {
+	for _, hey := range []struct {
+		x   Gvk
+		exp string
+	}{
+		{Gvk{}, ""},
+		{Gvk{Kind: "k"}, ""},
+		{Gvk{Version: "v"}, "v"},
+		{Gvk{Version: "v", Kind: "k"}, "v"},
+		{Gvk{Group: "g"}, "g/"},
+		{Gvk{Group: "g", Kind: "k"}, "g/"},
+		{Gvk{Group: "g", Version: "v"}, "g/v"},
+		{Gvk{Group: "g", Version: "v", Kind: "k"}, "g/v"},
+	} {
+		assert.Equal(t, hey.exp, hey.x.ApiVersion())
 	}
 }
 
 func TestStringWoEmptyField(t *testing.T) {
 	for _, hey := range stringTests {
-		if hey.x.StringWoEmptyField() != hey.r {
-			t.Fatalf("bad string %s for %v '%s'", hey.x.StringWoEmptyField(), hey.x, hey.r)
-		}
+		assert.Equal(t, hey.r, hey.x.StringWoEmptyField())
 	}
 }
 
@@ -141,12 +142,8 @@ func TestParseGroupVersion(t *testing.T) {
 	}
 	for _, tc := range tests {
 		g, v := ParseGroupVersion(tc.input)
-		if g != tc.g {
-			t.Errorf("%s: expected group '%s', got '%s'", tc.input, tc.g, g)
-		}
-		if v != tc.v {
-			t.Errorf("%s: expected version '%s', got '%s'", tc.input, tc.v, v)
-		}
+		assert.Equal(t, tc.g, g, tc.input)
+		assert.Equal(t, tc.v, v, tc.input)
 	}
 }
 
@@ -252,9 +249,7 @@ func TestSelectByGVK(t *testing.T) {
 
 	for _, tc := range testCases {
 		filtered := tc.in.IsSelected(tc.filter)
-		if filtered != tc.expected {
-			t.Fatalf("unexpected filter result for test case: %v", tc.description)
-		}
+		assert.Equal(t, tc.expected, filtered, tc.description)
 	}
 }
 

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -804,6 +804,34 @@ spec:
 		errorExpected bool
 		errorMsg      string
 	}{
+		"clown": {
+			base: []string{`apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 1
+`,
+			},
+			patches: []string{`apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`,
+			},
+			errorExpected: false,
+			expected: []string{
+				`apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`,
+			},
+		},
 		"confusion": {
 			base: []string{`apiVersion: example.com/v1
 kind: Foo

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -250,6 +250,37 @@ spec:
 `, string(bytes))
 }
 
+func TestApplySmPatch_3(t *testing.T) {
+	resource, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 1
+`))
+	assert.NoError(t, err)
+	patch, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`))
+	assert.NoError(t, err)
+	assert.NoError(t, resource.ApplySmPatch(patch))
+	bytes, err := resource.AsYAML()
+	assert.NoError(t, err)
+	assert.Equal(t, `apiVersion: v1
+kind: Deployment
+metadata:
+  name: clown
+spec:
+  numReplicas: 999
+`, string(bytes))
+}
+
 func TestApplySmPatch_SwapOrder(t *testing.T) {
 	s1 := `
 apiVersion: example.com/v1


### PR DESCRIPTION
Partially address #3343

This PR eliminates an extra slash appearing the the apiVersion fields post strategic merge when the apiGroup is unspecified.
Allows more krusty tests to pass when kyaml enabled.
