### PR TITLE
Multiple declarative functions in the same file should execute in order

### DIFF
--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -252,7 +253,10 @@ func (r RunFns) getFunctionsFromInput(nodes []*yaml.RNode) ([]kio.Filter, error)
 	if err != nil {
 		return nil, err
 	}
-	sortFns(buff)
+	err = sortFns(buff)
+	if err != nil {
+		return nil, err
+	}
 	return r.getFunctionFilters(false, buff.Nodes...)
 }
 
@@ -331,12 +335,33 @@ func (r RunFns) getFunctionFilters(global bool, fns ...*yaml.RNode) (
 }
 
 // sortFns sorts functions so that functions with the longest paths come first
-func sortFns(buff *kio.PackageBuffer) {
+func sortFns(buff *kio.PackageBuffer) error {
+	var outerErr error
 	// sort the nodes so that we traverse them depth first
 	// functions deeper in the file system tree should be run first
 	sort.Slice(buff.Nodes, func(i, j int) bool {
 		mi, _ := buff.Nodes[i].GetMeta()
 		pi := filepath.ToSlash(mi.Annotations[kioutil.PathAnnotation])
+
+		mj, _ := buff.Nodes[j].GetMeta()
+		pj := filepath.ToSlash(mj.Annotations[kioutil.PathAnnotation])
+
+		// If the path is the same, we decide the ordering based on the
+		// index annotation.
+		if pi == pj {
+			iIndex, err := strconv.Atoi(mi.Annotations[kioutil.IndexAnnotation])
+			if err != nil {
+				outerErr = err
+				return false
+			}
+			jIndex, err := strconv.Atoi(mj.Annotations[kioutil.IndexAnnotation])
+			if err != nil {
+				outerErr = err
+				return false
+			}
+			return iIndex < jIndex
+		}
+
 		if filepath.Base(path.Dir(pi)) == "functions" {
 			// don't count the functions dir, the functions are scoped 1 level above
 			pi = filepath.Dir(path.Dir(pi))
@@ -344,8 +369,6 @@ func sortFns(buff *kio.PackageBuffer) {
 			pi = filepath.Dir(pi)
 		}
 
-		mj, _ := buff.Nodes[j].GetMeta()
-		pj := filepath.ToSlash(mj.Annotations[kioutil.PathAnnotation])
 		if filepath.Base(path.Dir(pj)) == "functions" {
 			// don't count the functions dir, the functions are scoped 1 level above
 			pj = filepath.Dir(path.Dir(pj))
@@ -374,6 +397,7 @@ func sortFns(buff *kio.PackageBuffer) {
 		// sort by path names if depths are equal
 		return pi < pj
 	})
+	return outerErr
 }
 
 // init initializes the RunFns with a containerFilterProvider.


### PR DESCRIPTION
If multiple functions are defined in the same file, they should execute in the order which they appear in the file. Currently the sort function doesn't specifically handle this situation, but since the resources are read in the correct order, it mostly works. However, the `sort.Slice` function is not a stable sort, so it might lead to incorrect ordering.