### PR TITLE
Refactor resource to use annotations in the yaml instead of fields in resource struct

### DIFF
--- a/api/builtins/HashTransformer.go
+++ b/api/builtins/HashTransformer.go
@@ -28,6 +28,7 @@ func (p *HashTransformerPlugin) Transform(m resmap.ResMap) error {
 			if err != nil {
 				return err
 			}
+			res.SetOriginalName(res.GetName(), false)
 			res.SetName(fmt.Sprintf("%s-%s", res.GetName(), h))
 		}
 	}

--- a/api/builtins/NamespaceTransformer.go
+++ b/api/builtins/NamespaceTransformer.go
@@ -34,6 +34,7 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
+		r.SetOriginalNs(r.GetNamespace(), false)
 		err := r.ApplyFilter(namespace.Filter{
 			Namespace: p.Namespace,
 			FsSlice:   p.FieldSpecs,

--- a/api/builtins/PatchTransformer.go
+++ b/api/builtins/PatchTransformer.go
@@ -104,6 +104,7 @@ func (p *PatchTransformerPlugin) transformJson6902(m resmap.ResMap, patch jsonpa
 		return err
 	}
 	for _, res := range resources {
+		res.SetOriginalName(res.GetName(), false)
 		err = res.ApplyFilter(patchjson6902.Filter{
 			Patch: p.Patch,
 		})

--- a/api/builtins/PrefixSuffixTransformer.go
+++ b/api/builtins/PrefixSuffixTransformer.go
@@ -66,8 +66,12 @@ func (p *PrefixSuffixTransformerPlugin) Transform(m resmap.ResMap) error {
 				// this will add a prefix and a suffix
 				// to the resource even if those are
 				// empty
+
 				r.AddNamePrefix(p.Prefix)
 				r.AddNameSuffix(p.Suffix)
+				if p.Prefix != "" || p.Suffix != "" {
+					r.SetOriginalName(r.GetName(), false)
+				}
 			}
 			err := r.ApplyFilter(prefixsuffix.Filter{
 				Prefix:    p.Prefix,

--- a/api/internal/accumulator/namereferencetransformer_test.go
+++ b/api/internal/accumulator/namereferencetransformer_test.go
@@ -721,6 +721,7 @@ func TestNameReferenceNamespace(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	m.RemoveIdAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -882,6 +883,7 @@ func TestNameReferenceClusterWide(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	m.RemoveIdAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -1008,6 +1010,7 @@ func TestNameReferenceNamespaceTransformation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	m.RemoveIdAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -1044,6 +1047,7 @@ func TestNameReferenceCandidateSelection(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	m.RemoveIdAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}

--- a/api/internal/accumulator/resaccumulator_test.go
+++ b/api/internal/accumulator/resaccumulator_test.go
@@ -355,7 +355,8 @@ func TestResolveVarsWithNoambiguation(t *testing.T) {
 	// went through a prefix transformer.
 	r := m.GetByIndex(1)
 	r.AddNamePrefix("sub-")
-	r.SetName("sub-backendOne") // original name remains "backendOne"
+	r.SetName("sub-backendOne")
+	r.SetOriginalName("backendOne", true)
 
 	err = ra2.AppendAll(m)
 	if err != nil {

--- a/api/internal/plugins/execplugin/execplugin_test.go
+++ b/api/internal/plugins/execplugin/execplugin_test.go
@@ -45,6 +45,7 @@ s/$BAR/bar baz/g
 			"argsFromFile": "sed-input.txt",
 		})
 
+	pluginConfig.RemoveIdAnnotations()
 	p := NewExecPlugin(
 		pLdr.AbsolutePluginPath(
 			konfig.DisabledPluginConfig(),

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -244,6 +244,7 @@ metadata:
 			t.Fatalf("unexpected error %v", err)
 		}
 	}
+	assert.NoError(t, expected.RemoveIdAnnotations())
 	expYaml, err := expected.AsYaml()
 	assert.NoError(t, err)
 
@@ -251,6 +252,7 @@ metadata:
 	assert.NoError(t, kt.Load())
 	actual, err := kt.MakeCustomizedResMap()
 	assert.NoError(t, err)
+	assert.NoError(t, actual.RemoveIdAnnotations())
 	actYaml, err := actual.AsYaml()
 	assert.NoError(t, err)
 	assert.Equal(t, expYaml, actYaml)

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -93,5 +93,9 @@ func (b *Kustomizer) Run(path string) (resmap.ResMap, error) {
 		}
 		t.Transform(m)
 	}
+	err = m.RemoveIdAnnotations()
+	if err != nil {
+		return nil, err
+	}
 	return m, nil
 }

--- a/api/krusty/transformerplugin_test.go
+++ b/api/krusty/transformerplugin_test.go
@@ -80,7 +80,7 @@ data:
 `)
 
 	m := th.Run("/app", th.MakeOptionsPluginsEnabled())
-	th.AssertActualEqualsExpected(m, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(m, `
 apiVersion: v1
 data:
   foo: foo

--- a/api/resmap/factory_test.go
+++ b/api/resmap/factory_test.go
@@ -389,7 +389,6 @@ spec:
 
 	rm, err := rmF.ConflatePatches([]*resource.Resource{r1, r2})
 	assert.NoError(t, err)
-
 	yml, err = rm.AsYaml()
 	assert.NoError(t, err)
 

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -245,4 +245,6 @@ type ResMap interface {
 	// selected set of resources.
 	ApplySmPatch(
 		selectedSet *resource.IdSet, patch *resource.Resource) error
+
+	RemoveIdAnnotations() error
 }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -589,6 +589,7 @@ func (m *resWrangler) ApplySmPatch(
 		patchCopy.SetName(res.GetName())
 		patchCopy.SetNamespace(res.GetNamespace())
 		patchCopy.SetGvk(res.GetGvk())
+		patchCopy.SetOriginalName(res.GetOriginalName(), true)
 		err := res.ApplySmPatch(patchCopy)
 		if err != nil {
 			// Check for an error string from UnmarshalJSON that's indicative
@@ -617,5 +618,15 @@ func (m *resWrangler) ApplySmPatch(
 	}
 	m.Clear()
 	m.AppendAll(newRm)
+	return nil
+}
+
+func (m *resWrangler) RemoveIdAnnotations() error {
+	for _, r := range m.Resources() {
+		err := r.RemoveIdAnnotations()
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -745,7 +745,6 @@ rules:
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	rnodes, err := rm.ToRNodeSlice()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -999,6 +998,7 @@ spec:
 				return
 			}
 			assert.False(t, tc.errorExpected)
+			assert.NoError(t, m.RemoveIdAnnotations())
 			yml, err := m.AsYaml()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Join(tc.expected, "---\n"), string(yml))
@@ -1111,6 +1111,7 @@ $patch: delete
 			assert.NoError(t, err, name)
 			assert.NoError(t, m.ApplySmPatch(idSet, p), name)
 			assert.Equal(t, tc.finalMapSize, m.Size(), name)
+			assert.NoError(t, m.RemoveIdAnnotations())
 			yml, err := m.AsYaml()
 			assert.NoError(t, err, name)
 			assert.Equal(t, tc.expected, string(yml), name)

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -35,17 +35,17 @@ func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
 
 // FromMapWithName returns a new instance with the given "original" name.
 func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).setOriginalName(n)
+	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalName(n, true)
 }
 
 // FromMapWithNamespace returns a new instance with the given "original" namespace.
 func (rf *Factory) FromMapWithNamespace(n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).setOriginalNs(n)
+	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalNs(n, true)
 }
 
 // FromMapWithNamespaceAndName returns a new instance with the given "original" namespace.
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).setOriginalNs(ns).setOriginalName(n)
+	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalNs(ns, true).SetOriginalName(n, true)
 }
 
 // FromMapAndOption returns a new instance of Resource with given options.
@@ -72,7 +72,7 @@ func (rf *Factory) makeOne(
 		kunStr:  u,
 		options: o,
 	}
-	return r.setOriginalName(r.kunStr.GetName()).setOriginalNs(r.GetNamespace())
+	return r
 }
 
 // SliceFromPatches returns a slice of resources given a patch path
@@ -157,7 +157,7 @@ func (rf *Factory) SliceFromBytesWithNames(names []string, in []byte) ([]*Resour
 		return nil, fmt.Errorf("number of names doesn't match number of resources")
 	}
 	for i, res := range result {
-		res.originalName = names[i]
+		res.SetOriginalName(names[i], true)
 	}
 	return result, nil
 }

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -695,6 +695,325 @@ spec:
 	}
 }
 
+func TestSetOriginalNameAndNs(t *testing.T) {
+	input := `apiVersion: apps/v1
+kind: Secret
+metadata:
+ name: newName`
+
+	factory := provider.NewDefaultDepProvider().GetResourceFactory()
+	resources, err := factory.SliceFromBytes([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := resources[0]
+	res.SetOriginalName("oldName", false)
+	res.SetOriginalNs("default", false)
+
+	expected := `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+    config.kubernetes.io/originalNs: default
+  name: newName
+`
+	bytes, err := res.AsYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, expected, string(bytes))
+}
+
+func TestGetOriginalName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			// no name annotation, return the name
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: mySecret`,
+			expected: "mySecret",
+		},
+
+		{
+			// return name from name annotation
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName`,
+			expected: "oldName",
+		},
+	}
+
+	for _, test := range tests {
+		factory := provider.NewDefaultDepProvider().GetResourceFactory()
+		resources, err := factory.SliceFromBytes([]byte(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, test.expected, resources[0].GetOriginalName())
+	}
+}
+
+func TestSetOriginalName(t *testing.T) {
+	tests := []struct {
+		input        string
+		originalName string
+		overwrite    bool
+		expected     string
+	}{
+		{
+			// no original name set, overwrite is false
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName`,
+			originalName: "oldName",
+			overwrite:    false,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName
+`,
+		},
+
+		{
+			// no original name set, overwrite is true
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName`,
+			originalName: "oldName",
+			overwrite:    true,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName
+`,
+		},
+
+		{
+			// original name is set, overwrite is false, resource shouldn't change
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName`,
+			originalName: "newOriginalName",
+			overwrite:    false,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName
+`,
+		},
+
+		{
+			// original name is set, overwrite is true, resource should change
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+  name: newName`,
+			originalName: "newOriginalName",
+			overwrite:    true,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: newOriginalName
+  name: newName
+`,
+		},
+	}
+
+	for _, test := range tests {
+		factory := provider.NewDefaultDepProvider().GetResourceFactory()
+		resources, err := factory.SliceFromBytes([]byte(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res := resources[0]
+		res.SetOriginalName(test.originalName, test.overwrite)
+
+		bytes, err := res.AsYAML()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, test.expected, string(bytes))
+	}
+}
+
+func TestGetOriginalNs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			// no namespace, return default
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: mySecret`,
+			expected: "",
+		},
+
+		{
+			// return old namespace
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: mySecret
+  namespace: myNamespace`,
+			expected: "oldNamespace",
+		},
+
+		{
+			// return namespace
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: mySecret
+  namespace: myNamespace`,
+			expected: "myNamespace",
+		},
+	}
+
+	for _, test := range tests {
+		factory := provider.NewDefaultDepProvider().GetResourceFactory()
+		resources, err := factory.SliceFromBytes([]byte(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, test.expected, resources[0].GetOriginalNs())
+	}
+}
+
+func TestSetOriginalNs(t *testing.T) {
+	tests := []struct {
+		input      string
+		originalNs string
+		overwrite  bool
+		expected   string
+	}{
+		{
+			// no original namespace set, overwrite is false
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+  namespace: newNamespace`,
+			originalNs: "oldNamespace",
+			overwrite:  false,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: newName
+  namespace: newNamespace
+`,
+		},
+
+		{
+			// no original name set, overwrite is true
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+  namespace: newNamespace`,
+
+			originalNs: "oldNamespace",
+			overwrite:  true,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: newName
+  namespace: newNamespace
+`,
+		},
+
+		{
+			// original name is set, overwrite is false, resource shouldn't change
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: newName
+  namespace: newNamespace`,
+			originalNs: "newOriginalNamespace",
+			overwrite:  false,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: newName
+  namespace: newNamespace
+`,
+		},
+
+		{
+			// original name is set, overwrite is true, resource should change
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: oldNamespace
+  name: newName
+  namespace: newNamespace`,
+			originalNs: "newOriginalNamespace",
+			overwrite:  true,
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalNs: newOriginalNamespace
+  name: newName
+  namespace: newNamespace
+`,
+		},
+	}
+
+	for _, test := range tests {
+		factory := provider.NewDefaultDepProvider().GetResourceFactory()
+		resources, err := factory.SliceFromBytes([]byte(test.input))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res := resources[0]
+		res.SetOriginalNs(test.originalNs, test.overwrite)
+
+		bytes, err := res.AsYAML()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, test.expected, string(bytes))
+	}
+}
+
 // baseResource produces a base object which used to test
 // patch transformation
 // Also the structure is matching the Deployment syntax

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -126,6 +126,14 @@ func (th Harness) AssertActualEqualsExpected(
 	th.AssertActualEqualsExpectedWithTweak(m, nil, expected)
 }
 
+func (th Harness) AssertActualEqualsExpectedNoIdAnnotations(m resmap.ResMap, expected string) {
+	err := m.RemoveIdAnnotations()
+	if err != nil {
+		th.t.Fatalf("Err: %v", err)
+	}
+	th.AssertActualEqualsExpectedWithTweak(m, nil, expected)
+}
+
 func (th Harness) AssertActualEqualsExpectedWithTweak(
 	m resmap.ResMap, tweaker func([]byte) []byte, expected string) {
 	assertActualEqualsExpectedWithTweak(th, m, tweaker, expected)

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -109,6 +109,7 @@ func (th *HarnessEnhanced) LoadAndRunGenerator(
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
+	rm.RemoveIdAnnotations()
 	return rm
 }
 
@@ -124,7 +125,7 @@ func (th *HarnessEnhanced) LoadAndRunTransformer(
 func (th *HarnessEnhanced) RunTransformerAndCheckResult(
 	config, input, expected string) {
 	resMap := th.LoadAndRunTransformer(config, input)
-	th.AssertActualEqualsExpected(resMap, expected)
+	th.AssertActualEqualsExpectedNoIdAnnotations(resMap, expected)
 }
 
 func (th *HarnessEnhanced) ErrorFromLoadAndRunTransformer(

--- a/plugin/builtin/hashtransformer/HashTransformer.go
+++ b/plugin/builtin/hashtransformer/HashTransformer.go
@@ -32,6 +32,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			if err != nil {
 				return err
 			}
+			res.SetOriginalName(res.GetName(), false)
 			res.SetName(fmt.Sprintf("%s-%s", res.GetName(), h))
 		}
 	}

--- a/plugin/builtin/hashtransformer/HashTransformer_test.go
+++ b/plugin/builtin/hashtransformer/HashTransformer_test.go
@@ -53,7 +53,7 @@ spec:
         image: nginx:1.7.9
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -52,7 +52,7 @@ spec:
         name: init-alpine
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -122,7 +122,7 @@ spec:
         name: init-alpine
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -194,7 +194,7 @@ spec:
         name: init-alpine
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -265,7 +265,7 @@ spec:
         name: init-alpine
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -337,7 +337,7 @@ spec:
         name: init-alpine
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -395,7 +395,7 @@ spec:
       containers:
       initContainers:
 `)
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -438,7 +438,7 @@ spec:
         name: my-image
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment
@@ -480,7 +480,7 @@ spec:
         name: my-image
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 group: apps
 kind: Deployment

--- a/plugin/builtin/labeltransformer/LabelTransformer_test.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer_test.go
@@ -65,7 +65,7 @@ spec:
         image: nginx
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 kind: Service
 metadata:

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer_test.go
@@ -65,7 +65,7 @@ metadata:
   name: apricot
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -38,6 +38,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
+		r.SetOriginalNs(r.GetNamespace(), false)
 		err := r.ApplyFilter(namespace.Filter{
 			Namespace: p.Namespace,
 			FsSlice:   p.FieldSpecs,

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
@@ -603,7 +603,7 @@ spec:
     B: Y
 `)
 	assert.NoError(t, err)
-	th.AssertActualEqualsExpected(
+	th.AssertActualEqualsExpectedNoIdAnnotations(
 		resMap,
 		// In kyaml/yaml.merge2, the empty "B: " is dropped
 		// when patch1 and patch2 are merged, so the patch
@@ -652,7 +652,7 @@ spec:
     B: Y
 `)
 	assert.NoError(t, err)
-	th.AssertActualEqualsExpected(
+	th.AssertActualEqualsExpectedNoIdAnnotations(
 		resMap,
 		// This time only patch2 was applied.  Same answer on the kyaml
 		// path, but different answer on apimachinery path (B becomes "true"?)
@@ -1388,7 +1388,7 @@ paths:
 - patch.yaml
 `, target)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1430,7 +1430,7 @@ paths:
 - patch.yaml
 `, target)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -108,6 +108,7 @@ func (p *plugin) transformJson6902(m resmap.ResMap, patch jsonpatch.Patch) error
 		return err
 	}
 	for _, res := range resources {
+		res.SetOriginalName(res.GetName(), false)
 		err = res.ApplyFilter(patchjson6902.Filter{
 			Patch: p.Patch,
 		})

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -306,7 +306,7 @@ path: patch.yaml
 target:
   name: myDeploy
 `, someDeploymentResources)
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"errors"
-
 	"sigs.k8s.io/kustomize/api/filters/prefixsuffix"
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -70,8 +69,12 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 				// this will add a prefix and a suffix
 				// to the resource even if those are
 				// empty
+
 				r.AddNamePrefix(p.Prefix)
 				r.AddNameSuffix(p.Suffix)
+				if p.Prefix != "" || p.Suffix != "" {
+					r.SetOriginalName(r.GetName(), false)
+				}
 			}
 			err := r.ApplyFilter(prefixsuffix.Filter{
 				Prefix:    p.Prefix,

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -62,6 +62,10 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    config.kubernetes.io/originalName: apple
+    config.kubernetes.io/prefixes: baked-
+    config.kubernetes.io/suffixes: -pie
   name: baked-apple-pie
 spec:
   ports:
@@ -80,6 +84,10 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    config.kubernetes.io/originalName: cm
+    config.kubernetes.io/prefixes: baked-
+    config.kubernetes.io/suffixes: -pie
   name: baked-cm-pie
 `)
 
@@ -126,6 +134,10 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    config.kubernetes.io/originalName: deployment
+    config.kubernetes.io/prefixes: test-
+    config.kubernetes.io/suffixes: null
   name: test-deployment
 spec:
   template:

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -91,7 +91,7 @@ spec:
       app: app
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 kind: Service
 metadata:
@@ -180,7 +180,7 @@ fieldSpecs:
 - path: spec/replicas
   create: true
   kind: Deployment`, rm)
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer_test.go
@@ -26,7 +26,7 @@ metadata:
   name: meatball
 `)
 
-	th.AssertActualEqualsExpected(m, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(m, `
 apiVersion: apps/v1
 kind: MeatBall
 metadata:

--- a/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
+++ b/plugin/someteam.example.com/v1/sedtransformer/SedTransformer_test.go
@@ -36,7 +36,7 @@ fruit: $FRUIT
 vegetable: $VEGGIE
 `)
 
-	th.AssertActualEqualsExpected(rm, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
 apiVersion: apps/v1
 beans: two two two two
 fruit: orange

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer_test.go
@@ -27,7 +27,7 @@ metadata:
   name: meatball
 `)
 
-	th.AssertActualEqualsExpected(m, `
+	th.AssertActualEqualsExpectedNoIdAnnotations(m, `
 apiVersion: apps/v1
 kind: MeatBall
 metadata:


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/kustomize/issues/3280

This doesn't add any name or kind changing functionality; it just refactors existing code to use annotations in the yaml.

ALLOW_MODULE_SPAN