### PR TITLE
Eliminate extraneous label and anno maps.

### DIFF
--- a/api/krusty/component_test.go
+++ b/api/krusty/component_test.go
@@ -130,8 +130,6 @@ data:
   testValue: "2"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: comp-my-configmap-kc6k2kmkh9
 ---
 apiVersion: v1
@@ -184,8 +182,6 @@ data:
   testValue: "2"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: comp-my-configmap-55249mf5kb
 ---
 apiVersion: v1
@@ -239,8 +235,6 @@ data:
   testValue: "2"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: comp-my-configmap-55249mf5kb
 ---
 apiVersion: v1
@@ -299,8 +293,6 @@ data:
   testValue: "2"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: comp-my-configmap-kc6k2kmkh9
 ---
 apiVersion: v1
@@ -347,8 +339,6 @@ data:
   testValue: "2"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: my-configmap-kc6k2kmkh9
 `,
 		},
@@ -378,8 +368,6 @@ data:
   testValue: "1"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: my-configmap-5g7gh5mgt5
 ---
 apiVersion: v1

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -197,8 +197,6 @@ data:
   veggie: broccoli
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: p-cm-877mt5hc89
 `)
 }
@@ -259,8 +257,6 @@ data:
   from: overlay
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: p1-com1-8tc62428t2
 ---
 apiVersion: v1
@@ -268,8 +264,6 @@ data:
   from: overlay
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: p2-com2-87mcggf7d7
 `)
 }
@@ -316,8 +310,6 @@ data:
   foo: bar
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: o1-cm-ft9mmdc8c6
 ---
 apiVersion: v1
@@ -326,8 +318,6 @@ data:
   foo: bar
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: cm-o2-5k95kd76ft
 `)
 }

--- a/api/krusty/nameprefixsuffixpatch_test.go
+++ b/api/krusty/nameprefixsuffixpatch_test.go
@@ -88,8 +88,6 @@ data:
   PORT: "3306"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: mysql-9792mdchtg
 ---
 apiVersion: apps/v1

--- a/api/krusty/namespacedgenerators_test.go
+++ b/api/krusty/namespacedgenerators_test.go
@@ -102,8 +102,6 @@ data:
   overlay: "true"
 kind: ConfigMap
 metadata:
-  annotations: {}
-  labels: {}
   name: testCase-bcbmmg48hd
   namespace: overlay
 `)

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -95,6 +95,11 @@ func (r *Resource) MatchesAnnotationSelector(selector string) (bool, error) {
 }
 
 func (r *Resource) SetAnnotations(m map[string]string) {
+	if len(m) == 0 {
+		// Force field erasure.
+		r.kunStr.SetAnnotations(nil)
+		return
+	}
 	r.kunStr.SetAnnotations(m)
 }
 
@@ -107,6 +112,11 @@ func (r *Resource) SetGvk(gvk resid.Gvk) {
 }
 
 func (r *Resource) SetLabels(m map[string]string) {
+	if len(m) == 0 {
+		// Force field erasure.
+		r.kunStr.SetLabels(nil)
+		return
+	}
 	r.kunStr.SetLabels(m)
 }
 


### PR DESCRIPTION
In service of #3343 

Under kyaml, these aren't created, so don't create them on the k8sdeps path