### PR TITLE
Isolate scalar int and bool quoting oddities to one test set.

### DIFF
--- a/api/krusty/component_test.go
+++ b/api/krusty/component_test.go
@@ -39,8 +39,8 @@ resources:
 configMapGenerator:
 - name: my-configmap
   literals:	
-  - testValue=1
-  - otherValue=10
+  - testValue=purple
+  - otherValue=green
 `)
 	th.WriteF("/app/base/deploy.yaml", `
 apiVersion: v1
@@ -64,8 +64,8 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
-  - testValue=2
-  - compValue=5
+  - testValue=blue
+  - compValue=red
 `)
 	th.WriteF("/app/comp/stub.yaml", `
 apiVersion: v1
@@ -125,12 +125,12 @@ spec:
 ---
 apiVersion: v1
 data:
-  compValue: "5"
-  otherValue: "10"
-  testValue: "2"
+  compValue: red
+  otherValue: green
+  testValue: blue
 kind: ConfigMap
 metadata:
-  name: comp-my-configmap-kc6k2kmkh9
+  name: comp-my-configmap-97647ckcmg
 ---
 apiVersion: v1
 kind: Deployment
@@ -154,7 +154,7 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
-  - otherValue=9
+  - otherValue=orange
 `),
 				writeK("/app/prod", `
 resources:
@@ -177,12 +177,12 @@ spec:
 ---
 apiVersion: v1
 data:
-  compValue: "5"
-  otherValue: "9"
-  testValue: "2"
+  compValue: red
+  otherValue: orange
+  testValue: blue
 kind: ConfigMap
 metadata:
-  name: comp-my-configmap-55249mf5kb
+  name: comp-my-configmap-g486mb229k
 ---
 apiVersion: v1
 kind: Deployment
@@ -208,7 +208,7 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:
-  - otherValue=9
+  - otherValue=orange
 `),
 				writeK("/app/prod", `
 resources:
@@ -230,12 +230,12 @@ spec:
 ---
 apiVersion: v1
 data:
-  compValue: "5"
-  otherValue: "9"
-  testValue: "2"
+  compValue: red
+  otherValue: orange
+  testValue: blue
 kind: ConfigMap
 metadata:
-  name: comp-my-configmap-55249mf5kb
+  name: comp-my-configmap-g486mb229k
 ---
 apiVersion: v1
 kind: Deployment
@@ -273,11 +273,11 @@ spec:
 ---
 apiVersion: v1
 data:
-  otherValue: "10"
-  testValue: "1"
+  otherValue: green
+  testValue: purple
 kind: ConfigMap
 metadata:
-  name: my-configmap-2g9c94mhb8
+  name: my-configmap-9cd648hm8f
 ---
 apiVersion: v1
 kind: Deployment
@@ -288,12 +288,12 @@ spec:
 ---
 apiVersion: v1
 data:
-  compValue: "5"
-  otherValue: "10"
-  testValue: "2"
+  compValue: red
+  otherValue: green
+  testValue: blue
 kind: ConfigMap
 metadata:
-  name: comp-my-configmap-kc6k2kmkh9
+  name: comp-my-configmap-97647ckcmg
 ---
 apiVersion: v1
 kind: Deployment
@@ -319,8 +319,8 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
-  - compValue=5
-  - testValue=2
+  - compValue=red
+  - testValue=blue
 `),
 			},
 			runPath: "/app/direct-component",
@@ -334,12 +334,12 @@ spec:
 ---
 apiVersion: v1
 data:
-  compValue: "5"
-  otherValue: "10"
-  testValue: "2"
+  compValue: red
+  otherValue: green
+  testValue: blue
 kind: ConfigMap
 metadata:
-  name: my-configmap-kc6k2kmkh9
+  name: my-configmap-97647ckcmg
 `,
 		},
 		"missing-optional-component-api-version": {
@@ -350,7 +350,7 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
-  - otherValue=9
+  - otherValue=orange
 `),
 			},
 			runPath: "/app/prod",
@@ -364,11 +364,11 @@ spec:
 ---
 apiVersion: v1
 data:
-  otherValue: "9"
-  testValue: "1"
+  otherValue: orange
+  testValue: purple
 kind: ConfigMap
 metadata:
-  name: my-configmap-5g7gh5mgt5
+  name: my-configmap-6hhdg8gkdg
 ---
 apiVersion: v1
 kind: Deployment
@@ -411,11 +411,11 @@ spec:
 ---
 apiVersion: v1
 data:
-  otherValue: "10"
-  testValue: "1"
+  otherValue: green
+  testValue: purple
 kind: ConfigMap
 metadata:
-  name: my-configmap-a-b-2g9c94mhb8
+  name: my-configmap-a-b-9cd648hm8f
 ---
 apiVersion: v1
 kind: Deployment
@@ -426,11 +426,11 @@ spec:
 ---
 apiVersion: v1
 data:
-  otherValue: "10"
-  testValue: "1"
+  otherValue: green
+  testValue: purple
 kind: ConfigMap
 metadata:
-  name: my-configmap-b-2g9c94mhb8
+  name: my-configmap-b-9cd648hm8f
 `,
 		},
 
@@ -562,7 +562,7 @@ configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
-  - otherValue=9
+  - otherValue=orange
 `),
 			},
 			runPath:       "/app/prod",

--- a/api/krusty/fnplugin_test.go
+++ b/api/krusty/fnplugin_test.go
@@ -1,6 +1,7 @@
 package krusty_test
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -128,8 +129,9 @@ stringData:
     bootcmd:
     - mkdir /mnt/vda
 `)
-	m := th.Run("/app", th.MakeOptionsPluginsEnabled())
-	th.AssertActualEqualsExpected(m, `
+	opts := th.MakeOptionsPluginsEnabled()
+	m := th.Run("/app", opts)
+	expFmt := `
 apiVersion: v1
 kind: Secret
 metadata:
@@ -152,7 +154,7 @@ metadata:
     name: demo
   name: demo-budget
 spec:
-  minAvailable: 67%
+  minAvailable: 67%%
   selector:
     matchLabels:
       app: cockroachdb
@@ -185,9 +187,7 @@ metadata:
   annotations:
     config.kubernetes.io/path: config/demo_service.yaml
     prometheus.io/path: _status/vars
-    prometheus.io/port: "8080"
-    prometheus.io/scrape: "true"
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+%s
   labels:
     app: cockroachdb
     name: demo
@@ -244,7 +244,7 @@ spec:
         - /bin/bash
         - -ecx
         - |
-          # The use of qualified `+"`hostname -f`"+` is crucial:
+          # The use of qualified ` + "`hostname -f`" + ` is crucial:
           # Other nodes aren't able to look up the unqualified hostname.
           CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0")
           # We only want to initialize a new cluster (by omitting the join flag)
@@ -302,7 +302,14 @@ spec:
       resources:
         requests:
           storage: 1Gi
-`)
+`
+	th.AssertActualEqualsExpected(m, opts.IfApiMachineryElseKyaml(
+		fmt.Sprintf(expFmt, `    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"`),
+		fmt.Sprintf(expFmt, `    prometheus.io/port: 8080
+    prometheus.io/scrape: true
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: true`)))
 }
 
 func TestFnContainerTransformer(t *testing.T) {

--- a/api/krusty/nameprefixsuffixpatch_test.go
+++ b/api/krusty/nameprefixsuffixpatch_test.go
@@ -38,7 +38,7 @@ configMapGenerator:
   literals:
   - MYSQL_USER=default
   - MYSQL_DATABASE=default
-  - PORT=3306
+  - HOST=everest
 `)
 
 	th.WriteK(".", `
@@ -82,13 +82,13 @@ patches:
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
+  HOST: everest
   MYSQL_DATABASE: db
   MYSQL_PASSWORD: correct horse battery staple
   MYSQL_USER: my-user
-  PORT: "3306"
 kind: ConfigMap
 metadata:
-  name: mysql-9792mdchtg
+  name: mysql-t7tt4cdbmf
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -102,10 +102,10 @@ spec:
         - valueFrom:
             configMapKeyRef:
               key: MYSQL_DATABASE
-              name: mysql-9792mdchtg
+              name: mysql-t7tt4cdbmf
         envFrom:
         - configMapRef:
-            name: mysql-9792mdchtg
+            name: mysql-t7tt4cdbmf
         name: handler
 `)
 }

--- a/api/krusty/namespacedgenerators_test.go
+++ b/api/krusty/namespacedgenerators_test.go
@@ -80,7 +80,7 @@ namespace: base
 configMapGenerator:
 - name: testCase
   literals:
-    - base=true
+    - base=apple
 `)
 	th.WriteK("/app/overlay", `
 resources:
@@ -92,17 +92,17 @@ configMapGenerator:
   - name: testCase
     behavior: merge
     literals:
-      - overlay=true
+      - overlay=peach
 `)
 	m := th.Run("/app/overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
-  base: "true"
-  overlay: "true"
+  base: apple
+  overlay: peach
 kind: ConfigMap
 metadata:
-  name: testCase-bcbmmg48hd
+  name: testCase-gmfch8gkbt
   namespace: overlay
 `)
 }

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -55,3 +55,10 @@ func MakeDefaultOptions() *Options {
 		AllowResourceIdChanges: false,
 	}
 }
+
+func (o Options) IfApiMachineryElseKyaml(s1, s2 string) string {
+	if !o.UseKyaml {
+		return s1
+	}
+	return s2
+}

--- a/api/krusty/transformerplugin_test.go
+++ b/api/krusty/transformerplugin_test.go
@@ -74,7 +74,7 @@ kind: ConfigMap
 metadata:
   name: configmap-a
   annotations:
-    kustomize.k8s.io/Generated: "false"
+    fruit: peach
 data:
   foo: $FOO
 `)
@@ -87,7 +87,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    kustomize.k8s.io/Generated: "false"
+    fruit: peach
   name: configmap-a
 ---
 apiVersion: v1

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -70,12 +70,6 @@ func (th Harness) MakeDefaultOptions() krusty.Options {
 	return th.MakeOptionsPluginsDisabled()
 }
 
-func (th Harness) MakeDefaultOptionsWithProperEnableKyaml() krusty.Options {
-	o := th.MakeOptionsPluginsDisabled()
-	o.UseKyaml = konfig.FlagEnableKyamlDefaultValue
-	return o
-}
-
 // This has no impact on Builtin plugins, as they are always enabled.
 func (th Harness) MakeOptionsPluginsDisabled() krusty.Options {
 	return *krusty.MakeDefaultOptions()


### PR DESCRIPTION
The apimachinery code path, in its final marshalling
for output, calls Marshall

  https://github.com/go-yaml/yaml/blob/v2/yaml.go#L199

This code path (via apimachinery Unstructured types)
has no JSON schema tags

  https://yaml.org/spec/1.2/spec.html#id2803311

and always quotes configmap data values that smell like
booleans and ints (e.g. `false` becomes `"false"`, `62` becomes `"62"`).

The kyaml code path, OTOH, uses such tags,
so generally does not quote ints and booleans - but
at the moment if a configmap merge is performed, they
do get quoted.

This PR isolates this difference in behavior to
one set of tests (using data fields in configmaps
in api/krusty/configmaps_test.go) so that
they don't confuse other tests that cover
completely different behaviors.

In service of #3343 