### PR TITLE
Pin to api/v0.6.8

### DIFF
--- a/cmd/pluginator/go.mod
+++ b/cmd/pluginator/go.mod
@@ -6,9 +6,7 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.4.0
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../api

--- a/cmd/pluginator/go.sum
+++ b/cmd/pluginator/go.sum
@@ -534,6 +534,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/client-go v0.18.10
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/cmd/config v0.8.7
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
@@ -19,5 +19,3 @@ exclude (
 	sigs.k8s.io/kustomize/api v0.2.0
 	sigs.k8s.io/kustomize/cmd/config v0.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../api

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -622,6 +622,8 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/cmd/config v0.8.7 h1:qhwnysAgGbSRD9AyLHmnybq7O8OuQkdDv7ZcEtkRWQQ=
 sigs.k8s.io/kustomize/cmd/config v0.8.7/go.mod h1:TFvRemJUSkvJykqvrEErHd8GvC/TSEOKfPOpx/+f8Lc=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=

--- a/plugin/builtin/annotationstransformer/go.mod
+++ b/plugin/builtin/annotationstransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/annotationstransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/annotationstransformer/go.sum
+++ b/plugin/builtin/annotationstransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/configmapgenerator/go.mod
+++ b/plugin/builtin/configmapgenerator/go.mod
@@ -3,10 +3,8 @@ module sigs.k8s.io/kustomize/plugin/builtin/configmapgenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/configmapgenerator/go.sum
+++ b/plugin/builtin/configmapgenerator/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/hashtransformer/go.mod
+++ b/plugin/builtin/hashtransformer/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kustomize/plugin/builtin/hashtransformer
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
+require sigs.k8s.io/kustomize/api v0.6.8
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/hashtransformer/go.sum
+++ b/plugin/builtin/hashtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/helmchartinflationgenerator/go.mod
+++ b/plugin/builtin/helmchartinflationgenerator/go.mod
@@ -5,8 +5,6 @@ go 1.15
 require (
 	github.com/imdario/mergo v0.3.5
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/helmchartinflationgenerator/go.sum
+++ b/plugin/builtin/helmchartinflationgenerator/go.sum
@@ -529,6 +529,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/imagetagtransformer/go.mod
+++ b/plugin/builtin/imagetagtransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/imagetagtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/imagetagtransformer/go.sum
+++ b/plugin/builtin/imagetagtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/labeltransformer/go.mod
+++ b/plugin/builtin/labeltransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/labeltransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/labeltransformer/go.sum
+++ b/plugin/builtin/labeltransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/legacyordertransformer/go.mod
+++ b/plugin/builtin/legacyordertransformer/go.mod
@@ -4,9 +4,7 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/legacyordertransformer/go.sum
+++ b/plugin/builtin/legacyordertransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/namespacetransformer/go.mod
+++ b/plugin/builtin/namespacetransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/namespacetransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/namespacetransformer/go.sum
+++ b/plugin/builtin/namespacetransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/patchjson6902transformer/go.mod
+++ b/plugin/builtin/patchjson6902transformer/go.mod
@@ -5,9 +5,7 @@ go 1.15
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/patchjson6902transformer/go.sum
+++ b/plugin/builtin/patchjson6902transformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/patchstrategicmergetransformer/go.mod
+++ b/plugin/builtin/patchstrategicmergetransformer/go.mod
@@ -4,10 +4,8 @@ go 1.15
 
 require (
 	github.com/stretchr/testify v1.4.0
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/patchstrategicmergetransformer/go.sum
+++ b/plugin/builtin/patchstrategicmergetransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/patchtransformer/go.mod
+++ b/plugin/builtin/patchtransformer/go.mod
@@ -4,9 +4,7 @@ go 1.15
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/patchtransformer/go.sum
+++ b/plugin/builtin/patchtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/prefixsuffixtransformer/go.mod
+++ b/plugin/builtin/prefixsuffixtransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/prefixsuffixtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/prefixsuffixtransformer/go.sum
+++ b/plugin/builtin/prefixsuffixtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/replicacounttransformer/go.mod
+++ b/plugin/builtin/replicacounttransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/replicacounttransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/replicacounttransformer/go.sum
+++ b/plugin/builtin/replicacounttransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/builtin/secretgenerator/go.mod
+++ b/plugin/builtin/secretgenerator/go.mod
@@ -3,10 +3,8 @@ module sigs.k8s.io/kustomize/plugin/builtin/secretgenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/secretgenerator/go.sum
+++ b/plugin/builtin/secretgenerator/go.sum
@@ -531,6 +531,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/builtin/valueaddtransformer/go.mod
+++ b/plugin/builtin/valueaddtransformer/go.mod
@@ -3,9 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/valueaddtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 	sigs.k8s.io/yaml v1.2.0
 )
-
-replace sigs.k8s.io/kustomize/api => ../../../api

--- a/plugin/builtin/valueaddtransformer/go.sum
+++ b/plugin/builtin/valueaddtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/bashedconfigmap
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
+require sigs.k8s.io/kustomize/api v0.6.8
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/bashedconfigmap/go.sum
+++ b/plugin/someteam.example.com/v1/bashedconfigmap/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/dateprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/dateprefixer/go.mod
@@ -4,10 +4,8 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/dateprefixer/go.sum
+++ b/plugin/someteam.example.com/v1/dateprefixer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/printpluginenv/go.mod
+++ b/plugin/someteam.example.com/v1/printpluginenv/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/printpluginenv
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
+require sigs.k8s.io/kustomize/api v0.6.8
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/printpluginenv/go.sum
+++ b/plugin/someteam.example.com/v1/printpluginenv/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/go.mod
@@ -3,10 +3,8 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/secretsfromdatabase
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/go.sum
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/sedtransformer/go.mod
+++ b/plugin/someteam.example.com/v1/sedtransformer/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/sedtransformer
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
+require sigs.k8s.io/kustomize/api v0.6.8
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/sedtransformer/go.sum
+++ b/plugin/someteam.example.com/v1/sedtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/someservicegenerator/go.mod
+++ b/plugin/someteam.example.com/v1/someservicegenerator/go.mod
@@ -3,10 +3,8 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/someservicegenerator
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/someservicegenerator/go.sum
+++ b/plugin/someteam.example.com/v1/someservicegenerator/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/stringprefixer/go.mod
+++ b/plugin/someteam.example.com/v1/stringprefixer/go.mod
@@ -4,10 +4,8 @@ go 1.15
 
 require (
 	github.com/pkg/errors v0.8.1
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/stringprefixer/go.sum
+++ b/plugin/someteam.example.com/v1/stringprefixer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/someteam.example.com/v1/validator/go.mod
+++ b/plugin/someteam.example.com/v1/validator/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kustomize/plugin/someteam.example.com/v1/validator
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
+require sigs.k8s.io/kustomize/api v0.6.8
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/someteam.example.com/v1/validator/go.sum
+++ b/plugin/someteam.example.com/v1/validator/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/plugin/untested/v1/gogetter/go.mod
+++ b/plugin/untested/v1/gogetter/go.mod
@@ -2,6 +2,4 @@ module sigs.k8s.io/kustomize/plugin/untested/v1/gogetter
 
 go 1.15
 
-require sigs.k8s.io/kustomize/api v0.7.0
-
-replace sigs.k8s.io/kustomize/api => ../../../../api
+require sigs.k8s.io/kustomize/api v0.6.8

--- a/plugin/untested/v1/gogetter/go.sum
+++ b/plugin/untested/v1/gogetter/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
 sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/plugin/untested/v1/replacementtransformer/go.mod
+++ b/plugin/untested/v1/replacementtransformer/go.mod
@@ -3,10 +3,8 @@ module sigs.k8s.io/kustomize/plugin/untested/v1/replacementtransformer
 go 1.15
 
 require (
-	sigs.k8s.io/kustomize/api v0.7.0
+	sigs.k8s.io/kustomize/api v0.6.8
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace sigs.k8s.io/kustomize/kyaml => ../../../../kyaml
-
-replace sigs.k8s.io/kustomize/api => ../../../../api

--- a/plugin/untested/v1/replacementtransformer/go.sum
+++ b/plugin/untested/v1/replacementtransformer/go.sum
@@ -533,6 +533,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
+sigs.k8s.io/kustomize/api v0.6.8 h1:LWdCuSy58Ls2xxyp5BLW655zPcJyT3bOpGcOtuHzt4A=
+sigs.k8s.io/kustomize/api v0.6.8/go.mod h1:XOt24UrCkv0x63eT5JVaph4Kqf5EVU2UBAXo6SPBaAY=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=


### PR DESCRIPTION
Pin kustomize to `api/v0.6.8`, the latest api release using apimachinery instead of kyaml by default.

I.e. in this release of the api,
```
FlagEnableKyamlDefaultValue = false
```
in `api/konfig/general.go`

This will be used in `kustomize/v3.8.9`