### PR TITLE
Updated link to Kustomize plugins documentation

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubernetes-sigs.github.io/kustomize/guides/plugins)
+Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)


### PR DESCRIPTION
The link to documentation of Kustomize plugins from https://github.com/kubernetes-sigs/kustomize/tree/master/docs/plugins ends up in a 404.

This PR updates the link.