### PR TITLE
Short circuit anno/label transformer for performance.

### DIFF
--- a/api/builtins/AnnotationsTransformer.go
+++ b/api/builtins/AnnotationsTransformer.go
@@ -24,6 +24,9 @@ func (p *AnnotationsTransformerPlugin) Config(
 }
 
 func (p *AnnotationsTransformerPlugin) Transform(m resmap.ResMap) error {
+	if len(p.Annotations) == 0 {
+		return nil
+	}
 	for _, r := range m.Resources() {
 		err := r.ApplyFilter(annotations.Filter{
 			Annotations: p.Annotations,

--- a/api/builtins/LabelTransformer.go
+++ b/api/builtins/LabelTransformer.go
@@ -24,6 +24,9 @@ func (p *LabelTransformerPlugin) Config(
 }
 
 func (p *LabelTransformerPlugin) Transform(m resmap.ResMap) error {
+	if len(p.Labels) == 0 {
+		return nil
+	}
 	for _, r := range m.Resources() {
 		err := r.ApplyFilter(labels.Filter{
 			Labels:  p.Labels,

--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -59,6 +59,15 @@ func (ra *ResAccumulator) GetTransformerConfig() *builtinconfig.TransformerConfi
 	return ra.tConfig
 }
 
+// MergeVars accumulates vars into ResAccumulator.
+// A Var is a tuple of name, object reference and field reference.
+// This func takes a list of vars from the current kustomization file and
+// annotates the accumulated resources with the names of the vars that match
+// those resources.  E.g. if there's a var named "sam" that wants to get
+// its data from a ConfigMap named "james", and the resource list contains a
+// ConfigMap named "james", then that ConfigMap will be annotated with the
+// var name "sam".  Later this annotation is used to find the data for "sam"
+// by digging into a particular fieldpath of "james".
 func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {
 	for _, v := range incoming {
 		targetId := resid.NewResIdWithNamespace(v.ObjRef.GVK(), v.ObjRef.Name, v.ObjRef.Namespace)
@@ -104,12 +113,10 @@ func (ra *ResAccumulator) findVarValueFromResources(v types.Var) (interface{}, e
 						"field specified in var '%v' "+
 							"not found in corresponding resource", v)
 				}
-
 				return s, nil
 			}
 		}
 	}
-
 	return "", fmt.Errorf(
 		"var '%v' cannot be mapped to a field "+
 			"in the set of known resources", v)
@@ -125,10 +132,8 @@ func (ra *ResAccumulator) makeVarReplacementMap() (map[string]interface{}, error
 		if err != nil {
 			return nil, err
 		}
-
 		result[v.Name] = s
 	}
-
 	return result, nil
 }
 

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -1976,67 +1976,64 @@ spec:
 
 func TestDeploymentAnnotations(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
+	th.WriteK(".", `
 configMapGenerator:
-  - name: testConfigMap
-    envs:
-      - test.properties
+- name: theConfigMap
+  envs:
+  - test.properties
 
 vars:
-  - name: FOO
-    objref:
-      kind: ConfigMap
-      name: testConfigMap
-      apiVersion: v1
-    fieldref:
-      fieldpath: data.foo
+- name: SOMERIVER
+  objref:
+    kind: ConfigMap
+    name: theConfigMap
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.waterway
 
 commonAnnotations:
-  foo: $(FOO)
+  river: $(SOMERIVER)
 
 resources:
-  - deployment.yaml
+- deployment.yaml
 `)
 
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: test
+  name: theDeployment
 spec:
   template:
     spec:
       containers:
-        - name: test
+      - name: test
 `)
-	th.WriteF("/app/test.properties", `foo=bar`)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	th.WriteF("test.properties", `waterway=mississippi`)
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    foo: bar
-  name: test
+    river: mississippi
+  name: theDeployment
 spec:
   template:
     metadata:
       annotations:
-        foo: bar
+        river: mississippi
     spec:
       containers:
       - name: test
 ---
 apiVersion: v1
 data:
-  foo: bar
+  waterway: mississippi
 kind: ConfigMap
 metadata:
   annotations:
-    foo: bar
-  name: testConfigMap-798k5k7g9f
+    river: mississippi
+  name: theConfigMap-hdd8h8cgdt
 `)
 }

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -648,9 +648,15 @@ func (s FieldSetter) Filter(rn *RNode) (*RNode, error) {
 	}
 
 	// create the field
-	rn.YNode().Content = append(rn.YNode().Content,
-		&yaml.Node{Kind: yaml.ScalarNode, HeadComment: s.Comments.HeadComment,
-			LineComment: s.Comments.LineComment, FootComment: s.Comments.FootComment, Value: s.Name},
+	rn.YNode().Content = append(
+		rn.YNode().Content,
+		&yaml.Node{
+			Kind:        yaml.ScalarNode,
+			Value:       s.Name,
+			HeadComment: s.Comments.HeadComment,
+			LineComment: s.Comments.LineComment,
+			FootComment: s.Comments.FootComment,
+		},
 		s.Value.YNode())
 	return s.Value, nil
 }

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
@@ -28,6 +28,9 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	if len(p.Annotations) == 0 {
+		return nil
+	}
 	for _, r := range m.Resources() {
 		err := r.ApplyFilter(annotations.Filter{
 			Annotations: p.Annotations,

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -28,6 +28,9 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	if len(p.Labels) == 0 {
+		return nil
+	}
 	for _, r := range m.Resources() {
 		err := r.ApplyFilter(labels.Filter{
 			Labels:  p.Labels,


### PR DESCRIPTION
Eliminating these paths also eases debugging complex transformations.

Also, improve a test that involves several open bugs including #3412, add a comment, and 
make it easier to read `kyaml/yaml/fns.go` as it will be changing behavior shortly.

ALLOW_MODULE_SPAN
