### PR TITLE
In kyaml, loosen interpretation of string node and add tests.

### DIFF
--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -723,7 +723,7 @@ j: k
 	assert.Nil(t, rn)
 }
 
-func TestSetField_Fn(t *testing.T) {
+func TestFieldSetter(t *testing.T) {
 	// Change field
 	node, err := Parse(`
 foo: baz
@@ -801,6 +801,40 @@ foo
 		assert.Contains(t, err.Error(), "wrong Node Kind")
 	}
 	assert.Nil(t, k)
+}
+
+func TestFieldSetterNumberInKeyRegression(t *testing.T) {
+	node := NewMapRNode(&map[string]string{"river": "mississippi"})
+
+	k, err := FieldSetter{
+		Name:  "forty 2",
+		Value: NewScalarRNode("number key one"),
+	}.Filter(node)
+	assert.NoError(t, err)
+	assert.Equal(t, `number key one
+`, assertNoErrorString(t)(k.String()))
+
+	k, err = FieldSetter{
+		Name:  "fortytwo",
+		Value: NewScalarRNode("number key two"),
+	}.Filter(node)
+	assert.NoError(t, err)
+	assert.Equal(t, `number key two
+`, assertNoErrorString(t)(k.String()))
+
+	k, err = FieldSetter{
+		Name:  "42",
+		Value: NewScalarRNode("number key three"),
+	}.Filter(node)
+	assert.NoError(t, err)
+	assert.Equal(t, `number key three
+`, assertNoErrorString(t)(k.String()))
+
+	assert.Equal(t, `river: mississippi
+forty 2: number key one
+fortytwo: number key two
+42: number key three
+`, assertNoErrorString(t)(node.String()))
 }
 
 func TestSet_Fn(t *testing.T) {

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -51,7 +51,8 @@ func IsYNodeEmptyDoc(n *yaml.Node) bool {
 }
 
 func IsYNodeString(n *yaml.Node) bool {
-	return n.Kind == yaml.ScalarNode && n.Tag == NodeTagString
+	return n.Kind == yaml.ScalarNode &&
+		(n.Tag == NodeTagString || n.Tag == NodeTagEmpty)
 }
 
 // IsYNodeZero is true if all the public fields in the Node are empty.

--- a/kyaml/yaml/types_test.go
+++ b/kyaml/yaml/types_test.go
@@ -58,6 +58,27 @@ func TestCopyYNode(t *testing.T) {
 	}
 }
 
+func TestIsYNodeString(t *testing.T) {
+	if IsYNodeTaggedNull(nil) {
+		t.Fatalf("nil cannot be tagged null")
+	}
+	if IsYNodeTaggedNull(&Node{}) {
+		t.Fatalf("untagged node is not tagged")
+	}
+	if IsYNodeString(&Node{Tag: NodeTagString}) {
+		t.Fatalf("non-scalar node is not a string")
+	}
+	if IsYNodeString(&Node{Kind: ScalarNode, Tag: NodeTagFloat}) {
+		t.Fatalf("float tagged node is not tagged")
+	}
+	if !IsYNodeString(&Node{Kind: ScalarNode}) {
+		t.Fatalf("this looks like a string - no tag implies string")
+	}
+	if !IsYNodeString(&Node{Kind: ScalarNode, Tag: NodeTagString}) {
+		t.Fatalf("this looks like a string")
+	}
+}
+
 func TestIsYNodeTaggedNull(t *testing.T) {
 	if IsYNodeTaggedNull(nil) {
 		t.Fatalf("nil cannot be tagged null")


### PR DESCRIPTION
A scalar yaml node that isn't explicitly tagged should be treated as if it holds a string.

Towards #3412 and #3424