### PR TITLE
Fix 3424 by avoiding a JSON round trip

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge.go
@@ -4,6 +4,7 @@
 package patchstrategicmerge
 
 import (
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
@@ -28,7 +29,9 @@ func (pf Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, r)
+		if !konfig.FlagEnableKyamlDefaultValue || r != nil {
+			result = append(result, r)
+		}
 	}
 	return result, nil
 }

--- a/api/internal/accumulator/refvartransformer_test.go
+++ b/api/internal/accumulator/refvartransformer_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
@@ -123,8 +124,18 @@ func TestRefVarTransformer(t *testing.T) {
 							"slice": []interface{}{5}, // noticeably *not* a []string
 						}}).ResMap(),
 			},
-			errMessage: `obj '{"apiVersion": "v1", "data": {"slice": [5]}, "kind": "ConfigMap", "metadata": {"name": "cm1"}}
+			errMessage: konfig.IfApiMachineryElseKyaml(
+				`obj '{"apiVersion": "v1", "data": {"slice": [5]}, "kind": "ConfigMap", "metadata": {"name": "cm1"}}
 ' at path 'data/slice': invalid value type expect a string`,
+				`obj 'apiVersion: v1
+data:
+  slice:
+  - 5
+kind: ConfigMap
+metadata:
+  name: cm1
+' at path 'data/slice': invalid value type expect a string`,
+			),
 		},
 		{
 			description: "var replacement in nil",

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -10,10 +10,12 @@ import (
 
 	"sigs.k8s.io/kustomize/api/filters/patchstrategicmerge"
 	"sigs.k8s.io/kustomize/api/ifc"
+	"sigs.k8s.io/kustomize/api/internal/wrappy"
 	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filtersutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -437,6 +439,14 @@ func (r *Resource) ApplySmPatch(patch *Resource) error {
 }
 
 func (r *Resource) ApplyFilter(f kio.Filter) error {
+	if wn, ok := r.kunStr.(*wrappy.WNode); ok {
+		l, err := f.Filter([]*kyaml.RNode{wn.AsRNode()})
+		if len(l) == 0 {
+			// Hack to deal with deletion.
+			r.kunStr = wrappy.NewWNode()
+		}
+		return err
+	}
 	return filtersutil.ApplyToJSON(f, r)
 }
 


### PR DESCRIPTION
Fermez #3424 

When `--enable_kyaml` is true, `Resource` objects are backed by `WNodes`, and thus don't need to be marshaled to JSON for manipulation.  This change should also improve performance of the 3.9 branch.

