### PR TITLE
compilation type error

### DIFF
--- a/api/internal/accumulator/loadconfigfromcrds.go
+++ b/api/internal/accumulator/loadconfigfromcrds.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type myProperties map[string]spec.Schema
+type myProperties = map[string]spec.Schema
 type nameToApiMap map[string]common.OpenAPIDefinition
 
 // LoadConfigFromCRDs parse CRD schemas from paths into a TransformerConfig


### PR DESCRIPTION
Type definition is creating a new distinct type, which causes Type errors, changed to Alias

When using Type definition which is a new distinct type, it´s not handled as proper type.