### PR TITLE
[kio] Unwrap ResourceList with a functionConfig but no items

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -178,7 +178,7 @@ func (r *ByteReader) Read() ([]*yaml.RNode, error) {
 		if !r.DisableUnwrapping &&
 			len(values) == 1 && // Only unwrap if there is only 1 value
 			(meta.Kind == ResourceListKind || meta.Kind == "List") &&
-			node.Field("items") != nil {
+			(node.Field("items") != nil || node.Field("functionConfig") != nil) {
 			r.WrappingKind = meta.Kind
 			r.WrappingAPIVersion = meta.APIVersion
 

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -98,6 +98,29 @@ elems:
 			wrappingAPIVersion: ResourceListAPIVersion,
 			wrappingAPIKind:    ResourceListKind,
 		},
+		//
+		//
+		//
+		{
+			name: "wrapped_resource_list_function_config_without_items",
+			input: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+functionConfig:
+  foo: bar
+  elems:
+  - a
+  - b
+  - c
+`,
+			expectedItems: []string{},
+			expectedFunctionConfig: `foo: bar
+elems:
+- a
+- b
+- c`,
+			wrappingAPIVersion: ResourceListAPIVersion,
+			wrappingAPIKind:    ResourceListKind,
+		},
 
 		//
 		//


### PR DESCRIPTION
## Problem

Byteio reader handles these two inputs differently today:

```yaml
# this one unwraps to a functionConfig and empty items list
kind: ResourceList
functionConfig:
  foo: bar
items: []
```

```yaml
# this one does not unwrap, and ends up as an item itself
kind: ResourceList
functionConfig:
  foo: bar
```

At a guess, the code checks for the `items` field because it _doesn't_ check `apiVersion`. But `functionConfig` is also a great indication that we're dealing with the wrapper kind, and the behaviour difference above strikes me as undesirable.

## Solution 

Allow the resource to be unwrapped if it contains `items` _or_ `functionConfig`
