### PR TITLE
Add more tests and explain some quoting behavior.

### DIFF
--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -244,7 +244,7 @@ metadata:
 			t.Fatalf("unexpected error %v", err)
 		}
 	}
-	assert.NoError(t, expected.RemoveIdAnnotations())
+	expected.RemoveIdAnnotations()
 	expYaml, err := expected.AsYaml()
 	assert.NoError(t, err)
 
@@ -252,7 +252,7 @@ metadata:
 	assert.NoError(t, kt.Load())
 	actual, err := kt.MakeCustomizedResMap()
 	assert.NoError(t, err)
-	assert.NoError(t, actual.RemoveIdAnnotations())
+	actual.RemoveIdAnnotations()
 	actYaml, err := actual.AsYaml()
 	assert.NoError(t, err)
 	assert.Equal(t, expYaml, actYaml)

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -27,10 +27,6 @@ configMapGenerator:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    port: 8080
-    happy: true
-    color: green
   name: demo
 spec:
   clusterIP: None
@@ -41,10 +37,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    color: green
-    happy: true
-    port: 8080
   name: demo
 spec:
   clusterIP: None

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -93,9 +93,6 @@ func (b *Kustomizer) Run(path string) (resmap.ResMap, error) {
 		}
 		t.Transform(m)
 	}
-	err = m.RemoveIdAnnotations()
-	if err != nil {
-		return nil, err
-	}
+	m.RemoveIdAnnotations()
 	return m, nil
 }

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -246,5 +246,6 @@ type ResMap interface {
 	ApplySmPatch(
 		selectedSet *resource.IdSet, patch *resource.Resource) error
 
-	RemoveIdAnnotations() error
+	// Remove annotations used exclusively by the kustomize build process.
+	RemoveIdAnnotations()
 }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -621,12 +621,8 @@ func (m *resWrangler) ApplySmPatch(
 	return nil
 }
 
-func (m *resWrangler) RemoveIdAnnotations() error {
+func (m *resWrangler) RemoveIdAnnotations() {
 	for _, r := range m.Resources() {
-		err := r.RemoveIdAnnotations()
-		if err != nil {
-			return err
-		}
+		r.RemoveIdAnnotations()
 	}
-	return nil
 }

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -998,7 +998,7 @@ spec:
 				return
 			}
 			assert.False(t, tc.errorExpected)
-			assert.NoError(t, m.RemoveIdAnnotations())
+			m.RemoveIdAnnotations()
 			yml, err := m.AsYaml()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Join(tc.expected, "---\n"), string(yml))
@@ -1111,7 +1111,7 @@ $patch: delete
 			assert.NoError(t, err, name)
 			assert.NoError(t, m.ApplySmPatch(idSet, p), name)
 			assert.Equal(t, tc.finalMapSize, m.Size(), name)
-			assert.NoError(t, m.RemoveIdAnnotations())
+			m.RemoveIdAnnotations()
 			yml, err := m.AsYaml()
 			assert.NoError(t, err, name)
 			assert.Equal(t, tc.expected, string(yml), name)

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -127,10 +127,7 @@ func (th Harness) AssertActualEqualsExpected(
 }
 
 func (th Harness) AssertActualEqualsExpectedNoIdAnnotations(m resmap.ResMap, expected string) {
-	err := m.RemoveIdAnnotations()
-	if err != nil {
-		th.t.Fatalf("Err: %v", err)
-	}
+	m.RemoveIdAnnotations()
 	th.AssertActualEqualsExpectedWithTweak(m, nil, expected)
 }
 

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -137,7 +137,6 @@ metadata:
   annotations:
     config.kubernetes.io/originalName: deployment
     config.kubernetes.io/prefixes: test-
-    config.kubernetes.io/suffixes: null
   name: test-deployment
 spec:
   template:


### PR DESCRIPTION
This PR adds tests around annotation processing, and drops the error returned from
```
resource.RemoveIdAnnotations 
```
since the error behavior of methods backing this method (GetAnnotations, SetAnnotations) isn't currently useful.

In general, adding errors to annotation setters and getters isn't productive, as the only error that should happen here is an unrecoverable programmer error (these should panic).

Also, this makes all the tests pass if
```
FlagEnableKyamlDefaultValue = false
```
which is unfortunately not tested by CI/CD