### PR TITLE
Rename id annotations to build annotations.

### DIFF
--- a/api/internal/accumulator/namereferencetransformer_test.go
+++ b/api/internal/accumulator/namereferencetransformer_test.go
@@ -721,7 +721,7 @@ func TestNameReferenceNamespace(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -883,7 +883,7 @@ func TestNameReferenceClusterWide(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -1010,7 +1010,7 @@ func TestNameReferenceNamespaceTransformation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestNameReferenceCandidateSelection(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	if err = expected.ErrorIfNotEqualLists(m); err != nil {
 		t.Fatalf("actual doesn't match expected: %v", err)
 	}

--- a/api/internal/plugins/execplugin/execplugin_test.go
+++ b/api/internal/plugins/execplugin/execplugin_test.go
@@ -45,7 +45,7 @@ s/$BAR/bar baz/g
 			"argsFromFile": "sed-input.txt",
 		})
 
-	pluginConfig.RemoveIdAnnotations()
+	pluginConfig.RemoveBuildAnnotations()
 	p := NewExecPlugin(
 		pLdr.AbsolutePluginPath(
 			konfig.DisabledPluginConfig(),

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -244,7 +244,7 @@ metadata:
 			t.Fatalf("unexpected error %v", err)
 		}
 	}
-	expected.RemoveIdAnnotations()
+	expected.RemoveBuildAnnotations()
 	expYaml, err := expected.AsYaml()
 	assert.NoError(t, err)
 
@@ -252,7 +252,7 @@ metadata:
 	assert.NoError(t, kt.Load())
 	actual, err := kt.MakeCustomizedResMap()
 	assert.NoError(t, err)
-	actual.RemoveIdAnnotations()
+	actual.RemoveBuildAnnotations()
 	actYaml, err := actual.AsYaml()
 	assert.NoError(t, err)
 	assert.Equal(t, expYaml, actYaml)

--- a/api/internal/wrappy/factory.go
+++ b/api/internal/wrappy/factory.go
@@ -58,7 +58,7 @@ func (k *WNodeFactory) SliceFromBytes(bs []byte) ([]ifc.Kunstructured, error) {
 
 // shouldDropObject returns true if the resource should not be accumulated.
 func shouldDropObject(m yaml.ResourceMeta) bool {
-	_, y := m.ObjectMeta.Annotations[konfig.IgnoredByKustomizeResourceAnnotation]
+	_, y := m.ObjectMeta.Annotations[konfig.IgnoredByKustomizeAnnotation]
 	return y
 }
 

--- a/api/k8sdeps/kunstruct/factory.go
+++ b/api/k8sdeps/kunstruct/factory.go
@@ -125,7 +125,7 @@ func (kf *KunstructuredFactoryImpl) skipResource(u unstructured.Unstructured) bo
 		return false
 	}
 	// check if the Resource has opt-ed out of kustomize
-	_, found := an[konfig.IgnoredByKustomizeResourceAnnotation]
+	_, found := an[konfig.IgnoredByKustomizeAnnotation]
 	return found
 }
 

--- a/api/konfig/general.go
+++ b/api/konfig/general.go
@@ -56,8 +56,11 @@ const (
 	// A program name, for use in help, finding the XDG_CONFIG_DIR, etc.
 	ProgramName = "kustomize"
 
+	// ConfigAnnoDomain is configuration-related annotation namespace.
+	ConfigAnnoDomain = "config.kubernetes.io"
+
 	// If a resource has this annotation, kustomize will drop it.
-	IgnoredByKustomizeResourceAnnotation = "config.kubernetes.io/local-config"
+	IgnoredByKustomizeAnnotation = ConfigAnnoDomain + "/local-config"
 
 	// Label key that indicates the resources are built from Kustomize
 	ManagedbyLabelKey = "app.kubernetes.io/managed-by"

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -93,6 +93,6 @@ func (b *Kustomizer) Run(path string) (resmap.ResMap, error) {
 		}
 		t.Transform(m)
 	}
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	return m, nil
 }

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -246,6 +246,6 @@ type ResMap interface {
 	ApplySmPatch(
 		selectedSet *resource.IdSet, patch *resource.Resource) error
 
-	// Remove annotations used exclusively by the kustomize build process.
-	RemoveIdAnnotations()
+	// RemoveBuildAnnotations removes annotations created by the build process.
+	RemoveBuildAnnotations()
 }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -621,8 +621,8 @@ func (m *resWrangler) ApplySmPatch(
 	return nil
 }
 
-func (m *resWrangler) RemoveIdAnnotations() {
+func (m *resWrangler) RemoveBuildAnnotations() {
 	for _, r := range m.Resources() {
-		r.RemoveIdAnnotations()
+		r.RemoveBuildAnnotations()
 	}
 }

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -998,7 +998,7 @@ spec:
 				return
 			}
 			assert.False(t, tc.errorExpected)
-			m.RemoveIdAnnotations()
+			m.RemoveBuildAnnotations()
 			yml, err := m.AsYaml()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.Join(tc.expected, "---\n"), string(yml))
@@ -1111,7 +1111,7 @@ $patch: delete
 			assert.NoError(t, err, name)
 			assert.NoError(t, m.ApplySmPatch(idSet, p), name)
 			assert.Equal(t, tc.finalMapSize, m.Size(), name)
-			m.RemoveIdAnnotations()
+			m.RemoveBuildAnnotations()
 			yml, err := m.AsYaml()
 			assert.NoError(t, err, name)
 			assert.Equal(t, tc.expected, string(yml), name)

--- a/api/testutils/kusttest/harness.go
+++ b/api/testutils/kusttest/harness.go
@@ -127,7 +127,7 @@ func (th Harness) AssertActualEqualsExpected(
 }
 
 func (th Harness) AssertActualEqualsExpectedNoIdAnnotations(m resmap.ResMap, expected string) {
-	m.RemoveIdAnnotations()
+	m.RemoveBuildAnnotations()
 	th.AssertActualEqualsExpectedWithTweak(m, nil, expected)
 }
 

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -109,7 +109,7 @@ func (th *HarnessEnhanced) LoadAndRunGenerator(
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
-	rm.RemoveIdAnnotations()
+	rm.RemoveBuildAnnotations()
 	return rm
 }
 


### PR DESCRIPTION
just trying to document more clearly that this things are used in the build process.
I think more are coming, and we should name them similarly.
@natasha41575 