### PR TITLE
Always quote non-string values in labels and annotations

### DIFF
--- a/api/filters/annotations/example_test.go
+++ b/api/filters/annotations/example_test.go
@@ -28,7 +28,9 @@ metadata:
 `)}},
 		Filters: []kio.Filter{Filter{
 			Annotations: map[string]string{
-				"foo": "bar",
+				"foo":          "bar",
+				"booleanValue": "true",
+				"numberValue":  "42",
 			},
 			FsSlice: fss,
 		}},
@@ -44,12 +46,16 @@ metadata:
 	// metadata:
 	//   name: instance
 	//   annotations:
+	//     booleanValue: "true"
 	//     foo: bar
+	//     numberValue: "42"
 	// ---
 	// apiVersion: example.com/v1
 	// kind: Bar
 	// metadata:
 	//   name: instance
 	//   annotations:
+	//     booleanValue: "true"
 	//     foo: bar
+	//     numberValue: "42"
 }

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -757,9 +757,9 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/path: _status/vars
-    prometheus.io/port: %s
-    prometheus.io/scrape: %s
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: %s
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
     app: cockroachdb
   name: dev-base-cockroachdb
@@ -929,12 +929,8 @@ metadata:
 `
 	th.AssertActualEqualsExpected(m,
 		opts.IfApiMachineryElseKyaml(
-			fmt.Sprintf(
-				expFmt,
-				`"8080"`, `"true"`, `"true"`, `8080`, `8080`, `8080`, `8080`),
-			fmt.Sprintf(
-				expFmt,
-				`8080`, `true`, `true`, `"8080"`, `"8080"`, `"8080"`, `"8080"`),
+			fmt.Sprintf(expFmt, `8080`, `8080`, `8080`, `8080`),
+			fmt.Sprintf(expFmt, `"8080"`, `"8080"`, `"8080"`, `"8080"`),
 		))
 }
 

--- a/kyaml/yaml/datamap.go
+++ b/kyaml/yaml/datamap.go
@@ -52,11 +52,13 @@ func makeConfigMapValueRNode(s string) (field string, rN *RNode) {
 }
 
 func (rn *RNode) LoadMapIntoSecretData(m map[string]string) error {
+	mapNode, err := rn.Pipe(LookupCreate(MappingNode, DataField))
+	if err != nil {
+		return err
+	}
 	for _, k := range SortedMapKeys(m) {
 		vrN := makeSecretValueRNode(m[k])
-		if _, err := rn.Pipe(
-			LookupCreate(MappingNode, DataField),
-			SetField(k, vrN)); err != nil {
+		if _, err := mapNode.Pipe(SetField(k, vrN)); err != nil {
 			return err
 		}
 	}

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -9,8 +9,12 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-var (
-	config = `
+func TestAnnotationsTransformer(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckResult(`
 apiVersion: builtin
 kind: AnnotationsTransformer
 metadata:
@@ -18,11 +22,14 @@ metadata:
 annotations:
   app: myApp
   greeting/morning: a string with blanks
+  booleanNaked: true
+  booleanQuoted: "true"
+  numberNaked: 42
+  numberQuoted: "42"
 fieldSpecs:
   - path: metadata/annotations
     create: true
-`
-	input = `
+`, `
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,25 +37,20 @@ metadata:
 spec:
   ports:
   - port: 7002
-`
-	expectedOutput = `
+`, `
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
     app: myApp
+    booleanNaked: "true"
+    booleanQuoted: "true"
     greeting/morning: a string with blanks
+    numberNaked: "42"
+    numberQuoted: "42"
   name: myService
 spec:
   ports:
   - port: 7002
-`
-)
-
-func TestAnnotationsTransformer(t *testing.T) {
-	th := kusttest_test.MakeEnhancedHarness(t).
-		PrepBuiltin("AnnotationsTransformer")
-	defer th.Reset()
-
-	th.RunTransformerAndCheckResult(config, input, expectedOutput)
+`)
 }


### PR DESCRIPTION
Fix #3440 and remove another batch of `if` statements in the path to closing #3304

There are still a few if statements involving quotes.
