### PR TITLE
Bug: configMapRefs in patches are not resolved correctly in diamond structure

### DIFF
--- a/api/krusty/diamondpatchref_test.go
+++ b/api/krusty/diamondpatchref_test.go
@@ -9,7 +9,7 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-func TestNamePrefixSuffixPatch(t *testing.T) {
+func TestConfMapNameResolutionInDiamondWithPatches(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteK("bottom", `

--- a/api/krusty/diamondpatchref_test.go
+++ b/api/krusty/diamondpatchref_test.go
@@ -100,7 +100,7 @@ patches:
 	th.WriteK("top/left/bottom", `namePrefix: left-
 
 resources:
-  - ../../../bottom
+- ../../../bottom
 `)
 
 	th.WriteK("top/right", `resources:
@@ -132,11 +132,11 @@ patches:
 	th.WriteK("top/right/bottom", `namePrefix: right-
 
 resources:
-  - ../../../bottom
+- ../../../bottom
 `)
 
 	m := th.Run("top", th.MakeDefaultOptions())
-	// Per #2609, the desired behavior is for configMapRef.name and configMapKeyRef.name to be "mysql-9792mdchtg" not "mysql"
+	// Desired behaviour: configMapKeyRef should reference ConfigMap names.
 	th.AssertActualEqualsExpected(m, `apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/api/krusty/diamondpatchref_test.go
+++ b/api/krusty/diamondpatchref_test.go
@@ -3,6 +3,20 @@
 
 package krusty_test
 
+// In the following structure `top` patches `left-deploy` and `right-deploy` to reference the
+// configMap in `bottom`. This test verifies `configMapRef.name` in `left-deploy` and
+// `right-deploy` is modified correctly.
+//
+//                       top
+//                 /            \
+//           left                   right
+//          /   \                  /    \
+// left-service  bottom        bottom right-service
+//         |          \       /          |
+// left-deploy          bottom        right-deploy
+//                        |
+//                     configMap
+
 import (
 	"testing"
 

--- a/api/krusty/diamondpatchref_test.go
+++ b/api/krusty/diamondpatchref_test.go
@@ -12,17 +12,20 @@ import (
 func TestNamePrefixSuffixPatch(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteK("bottom", `configMapGenerator:
+	th.WriteK("bottom", `
+configMapGenerator:
 - name: bottom
   literals:
   - KEY=value
 `)
 
-	th.WriteK("left-service", `resources:
+	th.WriteK("left-service", `
+resources:
 - deployment.yaml
 `)
 
-	th.WriteF("left-service/deployment.yaml", `apiVersion: apps/v1
+	th.WriteF("left-service/deployment.yaml", `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: left-deploy
@@ -42,11 +45,13 @@ spec:
         name: service
 `)
 
-	th.WriteK("right-service", `resources:
+	th.WriteK("right-service", `
+resources:
 - deployment.yaml
 `)
 
-	th.WriteF("right-service/deployment.yaml", `apiVersion: apps/v1
+	th.WriteF("right-service/deployment.yaml", `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: right-deploy
@@ -66,12 +71,14 @@ spec:
         name: service
 `)
 
-	th.WriteK("top", `resources:
+	th.WriteK("top", `
+resources:
 - ./left
 - ./right
 `)
 
-	th.WriteK("top/left", `resources:
+	th.WriteK("top/left", `
+resources:
 - ../../left-service
 - ./bottom
 
@@ -97,13 +104,15 @@ patches:
                   key: KEY
 `)
 
-	th.WriteK("top/left/bottom", `namePrefix: left-
+	th.WriteK("top/left/bottom", `
+namePrefix: left-
 
 resources:
 - ../../../bottom
 `)
 
-	th.WriteK("top/right", `resources:
+	th.WriteK("top/right", `
+resources:
 - ../../right-service
 - ./bottom
 
@@ -129,7 +138,8 @@ patches:
                   key: KEY
 `)
 
-	th.WriteK("top/right/bottom", `namePrefix: right-
+	th.WriteK("top/right/bottom", `
+namePrefix: right-
 
 resources:
 - ../../../bottom

--- a/api/krusty/diamondpatchref_test.go
+++ b/api/krusty/diamondpatchref_test.go
@@ -1,0 +1,204 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// Coverage for issue #2609
+func TestNamePrefixSuffixPatch(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteK("bottom/kustomization.yaml", `configMapGenerator:
+- name: bottom
+  literals:
+  - KEY=value
+`)
+
+	th.WriteK("left-service/kustomization.yaml", `resources:
+- deployment.yaml
+`)
+
+	th.WriteF("left-service/deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: left-deploy
+  labels:
+    app.kubernetes.io/name: left-deploy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: left-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: left-pod
+    spec:
+      containers:
+      - image: left-image:v1.0
+        name: service
+`)
+
+	th.WriteK("right-service/kustomization.yaml", `resources:
+- deployment.yaml
+`)
+
+	th.WriteF("right-service/deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: right-deploy
+  labels:
+    app.kubernetes.io/name: right-deploy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: right-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: right-pod
+    spec:
+      containers:
+      - image: right-image:v1.0
+        name: service
+`)
+
+	th.WriteK("top/kustomization.yaml", `resources:
+- ./left
+- ./right
+`)
+
+	th.WriteK("top/left/kustomization.yaml", `resources:
+- ../../left-service
+- ./bottom
+
+patches:
+- target:
+    kind: Deployment
+    name: left-deploy
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ignored-by-kustomize
+    spec:
+      template:
+        spec:
+          containers:
+          - name: service
+            env:
+            - name: MAPPED_CONFIG_ITEM
+              valueFrom:
+                configMapKeyRef:
+                  name: left-bottom
+                  key: KEY
+`)
+
+	th.WriteK("top/left/bottom/kustomization.yaml", `namePrefix: left-
+
+resources:
+  - ../../../bottom
+`)
+
+	th.WriteK("top/right/kustomization.yaml", `resources:
+- ../../right-service
+- ./bottom
+
+patches:
+- target:
+    kind: Deployment
+    name: right-deploy
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ignored-by-kustomize
+    spec:
+      template:
+        spec:
+          containers:
+          - name: service
+            env:
+            - name: MAPPED_CONFIG_ITEM
+              valueFrom:
+                configMapKeyRef:
+                  name: right-bottom
+                  key: KEY
+`)
+
+	th.WriteK("top/right/bottom/kustomization.yaml", `namePrefix: right-
+
+resources:
+  - ../../../bottom
+`)
+
+	m := th.Run("top", th.MakeDefaultOptions())
+	// Per #2609, the desired behavior is for configMapRef.name and configMapKeyRef.name to be "mysql-9792mdchtg" not "mysql"
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+data:
+  KEY: value
+kind: ConfigMap
+metadata:
+  name: left-bottom-9f2t6f5h6d
+---
+apiVersion: v1
+data:
+  KEY: value
+kind: ConfigMap
+metadata:
+  name: right-bottom-9f2t6f5h6d
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: left-deploy
+  name: left-deploy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: left-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: left-pod
+    spec:
+      containers:
+      - env:
+        - name: MAPPED_CONFIG_ITEM
+          valueFrom:
+            configMapKeyRef:
+              key: KEY
+              name: left-bottom-9f2t6f5h6d
+        image: left-image:v1.0
+        name: service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: right-deploy
+  name: right-deploy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: right-pod
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: right-pod
+    spec:
+      containers:
+      - env:
+        - name: MAPPED_CONFIG_ITEM
+          valueFrom:
+            configMapKeyRef:
+              key: KEY
+              name: right-bottom-9f2t6f5h6d
+        image: right-image:v1.0
+        name: service`)
+}


### PR DESCRIPTION
Some notes
- Removing `./left` from resources in `top/kustomization.yaml` and referring to `configMapKeyRef.name: bottom` instead of `configMapKeyRef.name: right-bottom` does what's expected
- When referring to `configMapKeyRef.name: bottom` for both `left` and `right` there is an error indicating the referred name (`bottom`) is not unique- I suppose this is correct behaviour

In other words, this works using the `configMapKeyRef.name: bottom` in the patch, when the overlay structure is not a diamond.