### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash` in scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Makefile for kustomize CLI and API.
 
 MYGOBIN := $(shell go env GOPATH)/bin
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 export PATH := $(MYGOBIN):$(PATH)
 MODULES := '"cmd/config" "api/" "kustomize/" "kyaml/"'
 

--- a/scripts/check-go-mod.sh
+++ b/scripts/check-go-mod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/check-multi-module.sh
+++ b/scripts/check-multi-module.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/kyaml-pre-commit.sh
+++ b/scripts/kyaml-pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
I use a Linux distro that does not have `/bin/bash` but does have `/usr/bin/env`. I understand this
is common in BSDs also.

I expect this change will not cause regressions for other users, but will make these scripts work
for a wider range of systems. However, if this seems likely to cause regressions, or represents a
risk the project is unwilling to accept, please close this PR with that justification. This is
certainly not a hill I will die on.