### PR TITLE
Refactored resource to store all previous names and namespaces

### DIFF
--- a/api/builtins/HashTransformer.go
+++ b/api/builtins/HashTransformer.go
@@ -28,7 +28,7 @@ func (p *HashTransformerPlugin) Transform(m resmap.ResMap) error {
 			if err != nil {
 				return err
 			}
-			res.SetOriginalName(res.GetName(), false)
+			res.StorePreviousId()
 			res.SetName(fmt.Sprintf("%s-%s", res.GetName(), h))
 		}
 	}

--- a/api/builtins/NamespaceTransformer.go
+++ b/api/builtins/NamespaceTransformer.go
@@ -34,7 +34,7 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
-		r.SetOriginalNs(r.GetNamespace(), false)
+		r.StorePreviousId()
 		err := r.ApplyFilter(namespace.Filter{
 			Namespace: p.Namespace,
 			FsSlice:   p.FieldSpecs,

--- a/api/builtins/PatchTransformer.go
+++ b/api/builtins/PatchTransformer.go
@@ -104,7 +104,7 @@ func (p *PatchTransformerPlugin) transformJson6902(m resmap.ResMap, patch jsonpa
 		return err
 	}
 	for _, res := range resources {
-		res.SetOriginalName(res.GetName(), false)
+		res.StorePreviousId()
 		err = res.ApplyFilter(patchjson6902.Filter{
 			Patch: p.Patch,
 		})

--- a/api/builtins/PrefixSuffixTransformer.go
+++ b/api/builtins/PrefixSuffixTransformer.go
@@ -70,7 +70,7 @@ func (p *PrefixSuffixTransformerPlugin) Transform(m resmap.ResMap) error {
 				r.AddNamePrefix(p.Prefix)
 				r.AddNameSuffix(p.Suffix)
 				if p.Prefix != "" || p.Suffix != "" {
-					r.SetOriginalName(r.GetName(), false)
+					r.StorePreviousId()
 				}
 			}
 			err := r.ApplyFilter(prefixsuffix.Filter{

--- a/api/builtins/ReplicaCountTransformer.go
+++ b/api/builtins/ReplicaCountTransformer.go
@@ -31,9 +31,7 @@ func (p *ReplicaCountTransformerPlugin) Transform(m resmap.ResMap) error {
 	found := false
 	for _, fs := range p.FieldSpecs {
 		matcher := p.createMatcher(fs)
-		matchOriginal := m.GetMatchingResourcesByOriginalId(matcher)
-		resList := append(
-			matchOriginal, m.GetMatchingResourcesByCurrentId(matcher)...)
+		resList := m.GetMatchingResourcesByAnyId(matcher)
 		if len(resList) > 0 {
 			found = true
 			for _, r := range resList {

--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -304,7 +304,7 @@ func (f Filter) sameCurrentNamespaceAsReferrer() sieveFunc {
 
 // selectReferral picks the best referral from a list of candidates.
 func (f Filter) selectReferral(
-// The name referral that may need to be updated.
+	// The name referral that may need to be updated.
 	oldName string,
 	candidates []*resource.Resource) (*resource.Resource, error) {
 	candidates = doSieve(candidates, originalNameMatches(oldName))

--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -241,7 +241,7 @@ func acceptAll(r *resource.Resource) bool {
 
 func originalNameMatches(name string) sieveFunc {
 	return func(r *resource.Resource) bool {
-		return r.GetOriginalName() == name
+		return r.OrgId().Name == name
 	}
 }
 
@@ -304,7 +304,7 @@ func (f Filter) sameCurrentNamespaceAsReferrer() sieveFunc {
 
 // selectReferral picks the best referral from a list of candidates.
 func (f Filter) selectReferral(
-	// The name referral that may need to be updated.
+// The name referral that may need to be updated.
 	oldName string,
 	candidates []*resource.Resource) (*resource.Resource, error) {
 	candidates = doSieve(candidates, originalNameMatches(oldName))

--- a/api/filters/nameref/nameref_test.go
+++ b/api/filters/nameref/nameref_test.go
@@ -40,7 +40,7 @@ kind: NotSecret
 metadata:
   name: newName2
 `,
-			originalNames: []string{"oldName", ""},
+			originalNames: []string{"oldName", "newName2"},
 			referrerFinal: `
 apiVersion: apps/v1
 kind: Deployment
@@ -79,7 +79,7 @@ kind: NotSecret
 metadata:
   name: newName2
 `,
-			originalNames: []string{"oldName1", ""},
+			originalNames: []string{"oldName1", "newName2"},
 			referrerFinal: `
 apiVersion: apps/v1
 kind: Deployment
@@ -118,7 +118,7 @@ kind: NotSecret
 metadata:
   name: newName2
 `,
-			originalNames: []string{"oldName", ""},
+			originalNames: []string{"oldName", "newName2"},
 			referrerFinal: `
 apiVersion: apps/v1
 kind: Deployment
@@ -204,7 +204,7 @@ kind: NotSecret
 metadata:
   name: newName2
 `,
-			originalNames: []string{"oldName", ""},
+			originalNames: []string{"oldName", "newName2"},
 			referrerFinal: `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -77,7 +77,7 @@ func (ra *ResAccumulator) MergeVars(incoming []types.Var) error {
 			// wildcard search on the namespace hence we still use GvknEquals
 			idMatcher = targetId.Equals
 		}
-		matched := ra.resMap.GetMatchingResourcesByOriginalId(idMatcher)
+		matched := ra.resMap.GetMatchingResourcesByAnyId(idMatcher)
 		if len(matched) > 1 {
 			return fmt.Errorf(
 				"found %d resId matches for var %s "+

--- a/api/internal/accumulator/resaccumulator_test.go
+++ b/api/internal/accumulator/resaccumulator_test.go
@@ -344,19 +344,19 @@ func TestResolveVarsWithNoambiguation(t *testing.T) {
 					},
 				},
 			}}).
+		// Make it seem like this resource
+		// went through a prefix transformer.
 		Add(map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Service",
 			"metadata": map[string]interface{}{
-				"name": "backendOne",
+				"name": "sub-backendOne",
+				"annotations": map[string]interface{}{
+					"config.kubernetes.io/originalName": "backendOne",
+					"config.kubernetes.io/originalNs":   "default",
+					"config.kubernetes.io/prefixes":     "sub-",
+				},
 			}}).ResMap()
-
-	// Make it seem like this resource
-	// went through a prefix transformer.
-	r := m.GetByIndex(1)
-	r.AddNamePrefix("sub-")
-	r.SetName("sub-backendOne")
-	r.SetOriginalName("backendOne", true)
 
 	err = ra2.AppendAll(m)
 	if err != nil {

--- a/api/internal/accumulator/resaccumulator_test.go
+++ b/api/internal/accumulator/resaccumulator_test.go
@@ -352,9 +352,9 @@ func TestResolveVarsWithNoambiguation(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "sub-backendOne",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/originalName": "backendOne",
-					"config.kubernetes.io/originalNs":   "default",
-					"config.kubernetes.io/prefixes":     "sub-",
+					"config.kubernetes.io/previousNames":      "backendOne",
+					"config.kubernetes.io/previousNamespaces": "default",
+					"config.kubernetes.io/prefixes":           "sub-",
 				},
 			}}).ResMap()
 

--- a/api/internal/plugins/utils/utils.go
+++ b/api/internal/plugins/utils/utils.go
@@ -135,9 +135,6 @@ func GetResMapWithIDAnnotation(rm resmap.ResMap) (resmap.ResMap, error) {
 			return nil, err
 		}
 		annotations := r.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string)
-		}
 		annotations[idAnnotation] = string(idString)
 		r.SetAnnotations(annotations)
 	}

--- a/api/resmap/merginator.go
+++ b/api/resmap/merginator.go
@@ -47,7 +47,7 @@ func (m *merginator) ConflatePatches(in []*resource.Resource) (ResMap, error) {
 
 func (m *merginator) appendIfNoMatch(index int) (*resource.Resource, error) {
 	candidate := m.incoming[index]
-	matchedResources := m.result.GetMatchingResourcesByOriginalId(
+	matchedResources := m.result.GetMatchingResourcesByAnyId(
 		candidate.OrgId().Equals)
 	if len(matchedResources) == 0 {
 		m.result.Append(candidate)

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -151,7 +151,7 @@ type ResMap interface {
 	// an exact match, returning an error on multiple or no matches.
 	GetByCurrentId(resid.ResId) (*resource.Resource, error)
 
-	// GetByPreviousId is shorthand for calling
+	// GetById is shorthand for calling
 	// GetMatchingResourcesByAnyId with a matcher requiring
 	// an exact match, returning an error on multiple or no matches.
 	GetById(resid.ResId) (*resource.Resource, error)

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -142,24 +142,18 @@ type ResMap interface {
 	// who's CurId is matched by the argument.
 	GetMatchingResourcesByCurrentId(matches IdMatcher) []*resource.Resource
 
-	// GetMatchingResourcesByOriginalId returns the resources
-	// who's OriginalId is matched by the argument.
-	GetMatchingResourcesByOriginalId(matches IdMatcher) []*resource.Resource
+	// GetMatchingResourcesByAnyId returns the resources
+	// who's current or previous IDs is matched by the argument.
+	GetMatchingResourcesByAnyId(matches IdMatcher) []*resource.Resource
 
 	// GetByCurrentId is shorthand for calling
 	// GetMatchingResourcesByCurrentId with a matcher requiring
 	// an exact match, returning an error on multiple or no matches.
 	GetByCurrentId(resid.ResId) (*resource.Resource, error)
 
-	// GetByOriginalId is shorthand for calling
-	// GetMatchingResourcesByOriginalId with a matcher requiring
+	// GetByPreviousId is shorthand for calling
+	// GetMatchingResourcesByAnyId with a matcher requiring
 	// an exact match, returning an error on multiple or no matches.
-	GetByOriginalId(resid.ResId) (*resource.Resource, error)
-
-	// GetById is a helper function which first
-	// attempts GetByOriginalId, then GetByCurrentId,
-	// returning an error if both fail to find a single
-	// match.
 	GetById(resid.ResId) (*resource.Resource, error)
 
 	// GroupedByCurrentNamespace returns a map of namespace

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -168,10 +168,8 @@ func (m *resWrangler) GetMatchingResourcesByAnyId(
 	matches IdMatcher) []*resource.Resource {
 	var result []*resource.Resource
 	for _, r := range m.rList {
-		prevIds := r.PrevIds()
-		prevIds = append(prevIds, r.CurId())
-		for _, prevId := range prevIds {
-			if matches(prevId) {
+		for _, id := range append(r.PrevIds(), r.CurId()) {
+			if matches(id) {
 				result = append(result, r)
 				break
 			}

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -331,6 +331,134 @@ func TestGetMatchingResourcesByCurrentId(t *testing.T) {
 	}
 }
 
+func TestGetMatchingResourcesByPreviousId(t *testing.T) {
+	r1 := rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": "new-alice",
+				"annotations": map[string]interface{}{
+					"config.kubernetes.io/originalName": "alice",
+					"config.kubernetes.io/originalNs":   "default",
+				},
+			},
+		})
+	r2 := rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": "new-bob",
+				"annotations": map[string]interface{}{
+					"config.kubernetes.io/originalName": "bob,bob2",
+					"config.kubernetes.io/originalNs":   "default,default",
+				},
+			},
+		})
+	r3 := rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "new-bob",
+				"namespace": "new-happy",
+				"annotations": map[string]interface{}{
+					"config.kubernetes.io/originalName": "bob",
+					"config.kubernetes.io/originalNs":   "happy",
+				},
+			},
+		})
+	r4 := rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "charlie",
+				"namespace": "happy",
+				"annotations": map[string]interface{}{
+					"config.kubernetes.io/originalName": "charlie",
+					"config.kubernetes.io/originalNs":   "default",
+				},
+			},
+		})
+	r5 := rf.FromMap(
+		map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "charlie",
+				"namespace": "happy",
+			},
+		})
+
+	m := resmaptest_test.NewRmBuilder(t, rf).
+		AddR(r1).AddR(r2).AddR(r3).AddR(r4).AddR(r5).ResMap()
+
+	// nolint:goconst
+	tests := []struct {
+		name    string
+		matcher IdMatcher
+		count   int
+	}{
+		{
+			"match everything",
+			func(resid.ResId) bool { return true },
+			5,
+		},
+		{
+			"match nothing",
+			func(resid.ResId) bool { return false },
+			0,
+		},
+		{
+			"name is alice",
+			func(x resid.ResId) bool { return x.Name == "alice" },
+			1,
+		},
+		{
+			"name is charlie",
+			func(x resid.ResId) bool { return x.Name == "charlie" },
+			2,
+		},
+		{
+			"name is bob",
+			func(x resid.ResId) bool { return x.Name == "bob" },
+			2,
+		},
+		{
+			"happy namespace",
+			func(x resid.ResId) bool {
+				return x.Namespace == "happy"
+			},
+			3,
+		},
+		{
+			"happy deployment",
+			func(x resid.ResId) bool {
+				return x.Namespace == "happy" &&
+					x.Gvk.Kind == "Deployment"
+			},
+			1,
+		},
+		{
+			"happy ConfigMap",
+			func(x resid.ResId) bool {
+				return x.Namespace == "happy" &&
+					x.Gvk.Kind == "ConfigMap"
+			},
+			2,
+		},
+	}
+	for _, tst := range tests {
+		result := m.GetMatchingResourcesByAnyId(tst.matcher)
+		if len(result) != tst.count {
+			t.Fatalf("test '%s';  actual: %d, expected: %d",
+				tst.name, len(result), tst.count)
+		}
+	}
+}
+
 func TestSubsetThatCouldBeReferencedByResource(t *testing.T) {
 	r1 := rf.FromMap(
 		map[string]interface{}{

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -331,7 +331,7 @@ func TestGetMatchingResourcesByCurrentId(t *testing.T) {
 	}
 }
 
-func TestGetMatchingResourcesByPreviousId(t *testing.T) {
+func TestGetMatchingResourcesByAnyId(t *testing.T) {
 	r1 := rf.FromMap(
 		map[string]interface{}{
 			"apiVersion": "v1",
@@ -339,8 +339,8 @@ func TestGetMatchingResourcesByPreviousId(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "new-alice",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/originalName": "alice",
-					"config.kubernetes.io/originalNs":   "default",
+					"config.kubernetes.io/previousNames":      "alice",
+					"config.kubernetes.io/previousNamespaces": "default",
 				},
 			},
 		})
@@ -351,8 +351,8 @@ func TestGetMatchingResourcesByPreviousId(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "new-bob",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/originalName": "bob,bob2",
-					"config.kubernetes.io/originalNs":   "default,default",
+					"config.kubernetes.io/previousNames":      "bob,bob2",
+					"config.kubernetes.io/previousNamespaces": "default,default",
 				},
 			},
 		})
@@ -364,8 +364,8 @@ func TestGetMatchingResourcesByPreviousId(t *testing.T) {
 				"name":      "new-bob",
 				"namespace": "new-happy",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/originalName": "bob",
-					"config.kubernetes.io/originalNs":   "happy",
+					"config.kubernetes.io/previousNames":      "bob",
+					"config.kubernetes.io/previousNamespaces": "happy",
 				},
 			},
 		})
@@ -377,8 +377,8 @@ func TestGetMatchingResourcesByPreviousId(t *testing.T) {
 				"name":      "charlie",
 				"namespace": "happy",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/originalName": "charlie",
-					"config.kubernetes.io/originalNs":   "default",
+					"config.kubernetes.io/previousNames":      "charlie",
+					"config.kubernetes.io/previousNamespaces": "default",
 				},
 			},
 		})

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -153,7 +153,7 @@ func (rf *Factory) SliceFromBytesWithNames(names []string, in []byte) ([]*Resour
 		return nil, fmt.Errorf("number of names doesn't match number of resources")
 	}
 	for i, res := range result {
-		res.setPreviousNamespaceAndName("", names[i])
+		res.setPreviousNamespaceAndName(resid.DefaultNamespace, names[i])
 	}
 	return result, nil
 }

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -11,6 +11,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/kusterr"
+	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -35,17 +36,12 @@ func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
 
 // FromMapWithName returns a new instance with the given "original" name.
 func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalName(n, true)
-}
-
-// FromMapWithNamespace returns a new instance with the given "original" namespace.
-func (rf *Factory) FromMapWithNamespace(n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalNs(n, true)
+	return rf.FromMapWithNamespaceAndName(resid.DefaultNamespace, n, m)
 }
 
 // FromMapWithNamespaceAndName returns a new instance with the given "original" namespace.
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
-	return rf.makeOne(rf.kf.FromMap(m), nil).SetOriginalNs(ns, true).SetOriginalName(n, true)
+	return rf.makeOne(rf.kf.FromMap(m), nil).setPreviousNamespaceAndName(ns, n)
 }
 
 // FromMapAndOption returns a new instance of Resource with given options.
@@ -157,7 +153,7 @@ func (rf *Factory) SliceFromBytesWithNames(names []string, in []byte) ([]*Resour
 		return nil, fmt.Errorf("number of names doesn't match number of resources")
 	}
 	for i, res := range result {
-		res.SetOriginalName(names[i], true)
+		res.setPreviousNamespaceAndName("", names[i])
 	}
 	return result, nil
 }

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -282,24 +282,6 @@ func (r *Resource) appendCsvAnnotation(name, value string) {
 	r.SetAnnotations(annotations)
 }
 
-// Implements ResCtx GetOutermostNamePrefix
-func (r *Resource) GetOutermostNamePrefix() string {
-	namePrefixes := r.GetNamePrefixes()
-	if len(namePrefixes) == 0 {
-		return ""
-	}
-	return namePrefixes[len(namePrefixes)-1]
-}
-
-// Implements ResCtx GetOutermostNameSuffix
-func (r *Resource) GetOutermostNameSuffix() string {
-	nameSuffixes := r.GetNameSuffixes()
-	if len(nameSuffixes) == 0 {
-		return ""
-	}
-	return nameSuffixes[len(nameSuffixes)-1]
-}
-
 func SameEndingSubarray(shortest, longest []string) bool {
 	if len(shortest) > len(longest) {
 		longest, shortest = shortest, longest

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -714,8 +714,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName
-    config.kubernetes.io/originalNs: default
+    config.kubernetes.io/previousNames: oldName
+    config.kubernetes.io/previousNamespaces: default
   name: newName
 `,
 		},
@@ -725,8 +725,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName
-    config.kubernetes.io/originalNs: default
+    config.kubernetes.io/previousNames: oldName
+    config.kubernetes.io/previousNamespaces: default
   name: oldName2
 `,
 			newName: "newName",
@@ -735,8 +735,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName,oldName2
-    config.kubernetes.io/originalNs: default,default
+    config.kubernetes.io/previousNames: oldName,oldName2
+    config.kubernetes.io/previousNamespaces: default,default
   name: newName
 `,
 		},
@@ -746,8 +746,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName
-    config.kubernetes.io/originalNs: default
+    config.kubernetes.io/previousNames: oldName
+    config.kubernetes.io/previousNamespaces: default
   name: oldName2
   namespace: oldNamespace
 `,
@@ -757,8 +757,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName,oldName2
-    config.kubernetes.io/originalNs: default,oldNamespace
+    config.kubernetes.io/previousNames: oldName,oldName2
+    config.kubernetes.io/previousNamespaces: default,oldNamespace
   name: newName
   namespace: newNamespace
 `,
@@ -806,8 +806,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName
-    config.kubernetes.io/originalNs: default
+    config.kubernetes.io/previousNames: oldName
+    config.kubernetes.io/previousNamespaces: default
   name: newName
 `,
 			expected: []resid.ResId{
@@ -824,8 +824,8 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName,oldName2
-    config.kubernetes.io/originalNs: default,oldNamespace
+    config.kubernetes.io/previousNames: oldName,oldName2
+    config.kubernetes.io/previousNamespaces: default,oldNamespace
   name: newName
   namespace: newNamespace
 `,

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -695,322 +695,165 @@ spec:
 	}
 }
 
-func TestSetOriginalNameAndNs(t *testing.T) {
-	input := `apiVersion: apps/v1
+func TestResource_StorePreviousId(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		newName  string
+		newNs    string
+		expected string
+	}{
+		"default namespace, first previous name": {
+			input: `apiVersion: apps/v1
 kind: Secret
 metadata:
- name: newName`
-
-	factory := provider.NewDefaultDepProvider().GetResourceFactory()
-	resources, err := factory.SliceFromBytes([]byte(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	res := resources[0]
-	res.SetOriginalName("oldName", false)
-	res.SetOriginalNs("default", false)
-
-	expected := `apiVersion: apps/v1
+  name: oldName
+`,
+			newName: "newName",
+			newNs:   "",
+			expected: `apiVersion: apps/v1
 kind: Secret
 metadata:
   annotations:
     config.kubernetes.io/originalName: oldName
     config.kubernetes.io/originalNs: default
   name: newName
-`
-	bytes, err := res.AsYAML()
-	if err != nil {
-		t.Fatal(err)
+`,
+		},
+
+		"default namespace, second previous name": {
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+    config.kubernetes.io/originalNs: default
+  name: oldName2
+`,
+			newName: "newName",
+			newNs:   "",
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName,oldName2
+    config.kubernetes.io/originalNs: default,default
+  name: newName
+`,
+		},
+
+		"non-default namespace": {
+			input: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName
+    config.kubernetes.io/originalNs: default
+  name: oldName2
+  namespace: oldNamespace
+`,
+			newName: "newName",
+			newNs:   "newNamespace",
+			expected: `apiVersion: apps/v1
+kind: Secret
+metadata:
+  annotations:
+    config.kubernetes.io/originalName: oldName,oldName2
+    config.kubernetes.io/originalNs: default,oldNamespace
+  name: newName
+  namespace: newNamespace
+`,
+		},
 	}
-	assert.Equal(t, expected, string(bytes))
+	factory := provider.NewDefaultDepProvider().GetResourceFactory()
+	for i := range tests {
+		test := tests[i]
+		t.Run(i, func(t *testing.T) {
+			resources, err := factory.SliceFromBytes([]byte(test.input))
+			if !assert.NoError(t, err) || len(resources) == 0 {
+				t.FailNow()
+			}
+			r := resources[0]
+			r.StorePreviousId()
+			r.SetName(test.newName)
+			if test.newNs != "" {
+				r.SetNamespace(test.newNs)
+			}
+			bytes, err := r.AsYAML()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			assert.Equal(t, test.expected, string(bytes))
+		})
+	}
 }
 
-func TestGetOriginalName(t *testing.T) {
-	tests := []struct {
+func TestResource_PrevIds(t *testing.T) {
+	tests := map[string]struct {
 		input    string
-		expected string
+		expected []resid.ResId
 	}{
-		{
-			// no name annotation, return the name
+		"no previous IDs": {
 			input: `apiVersion: apps/v1
 kind: Secret
 metadata:
-  name: mySecret`,
-			expected: "mySecret",
+  name: name
+`,
+			expected: nil,
 		},
 
-		{
-			// return name from name annotation
+		"one previous ID": {
 			input: `apiVersion: apps/v1
 kind: Secret
 metadata:
   annotations:
     config.kubernetes.io/originalName: oldName
-  name: newName`,
-			expected: "oldName",
-		},
-	}
-
-	for _, test := range tests {
-		factory := provider.NewDefaultDepProvider().GetResourceFactory()
-		resources, err := factory.SliceFromBytes([]byte(test.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, test.expected, resources[0].GetOriginalName())
-	}
-}
-
-func TestSetOriginalName(t *testing.T) {
-	tests := []struct {
-		input        string
-		originalName string
-		overwrite    bool
-		expected     string
-	}{
-		{
-			// no original name set, overwrite is false
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName`,
-			originalName: "oldName",
-			overwrite:    false,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalName: oldName
+    config.kubernetes.io/originalNs: default
   name: newName
 `,
+			expected: []resid.ResId{
+				{
+					Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Secret"},
+					Name:      "oldName",
+					Namespace: resid.DefaultNamespace,
+				},
+			},
 		},
 
-		{
-			// no original name set, overwrite is true
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName`,
-			originalName: "oldName",
-			overwrite:    true,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalName: oldName
-  name: newName
-`,
-		},
-
-		{
-			// original name is set, overwrite is false, resource shouldn't change
+		"two ids": {
 			input: `apiVersion: apps/v1
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/originalName: oldName
-  name: newName`,
-			originalName: "newOriginalName",
-			overwrite:    false,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalName: oldName
-  name: newName
-`,
-		},
-
-		{
-			// original name is set, overwrite is true, resource should change
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalName: oldName
-  name: newName`,
-			originalName: "newOriginalName",
-			overwrite:    true,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalName: newOriginalName
-  name: newName
-`,
-		},
-	}
-
-	for _, test := range tests {
-		factory := provider.NewDefaultDepProvider().GetResourceFactory()
-		resources, err := factory.SliceFromBytes([]byte(test.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		res := resources[0]
-		res.SetOriginalName(test.originalName, test.overwrite)
-
-		bytes, err := res.AsYAML()
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, test.expected, string(bytes))
-	}
-}
-
-func TestGetOriginalNs(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{
-			// no namespace, return default
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: mySecret`,
-			expected: "",
-		},
-
-		{
-			// return old namespace
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
-  name: mySecret
-  namespace: myNamespace`,
-			expected: "oldNamespace",
-		},
-
-		{
-			// return namespace
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: mySecret
-  namespace: myNamespace`,
-			expected: "myNamespace",
-		},
-	}
-
-	for _, test := range tests {
-		factory := provider.NewDefaultDepProvider().GetResourceFactory()
-		resources, err := factory.SliceFromBytes([]byte(test.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, test.expected, resources[0].GetOriginalNs())
-	}
-}
-
-func TestSetOriginalNs(t *testing.T) {
-	tests := []struct {
-		input      string
-		originalNs string
-		overwrite  bool
-		expected   string
-	}{
-		{
-			// no original namespace set, overwrite is false
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName
-  namespace: newNamespace`,
-			originalNs: "oldNamespace",
-			overwrite:  false,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
+    config.kubernetes.io/originalName: oldName,oldName2
+    config.kubernetes.io/originalNs: default,oldNamespace
   name: newName
   namespace: newNamespace
 `,
-		},
-
-		{
-			// no original name set, overwrite is true
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName
-  namespace: newNamespace`,
-
-			originalNs: "oldNamespace",
-			overwrite:  true,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
-  name: newName
-  namespace: newNamespace
-`,
-		},
-
-		{
-			// original name is set, overwrite is false, resource shouldn't change
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
-  name: newName
-  namespace: newNamespace`,
-			originalNs: "newOriginalNamespace",
-			overwrite:  false,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
-  name: newName
-  namespace: newNamespace
-`,
-		},
-
-		{
-			// original name is set, overwrite is true, resource should change
-			input: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: oldNamespace
-  name: newName
-  namespace: newNamespace`,
-			originalNs: "newOriginalNamespace",
-			overwrite:  true,
-			expected: `apiVersion: apps/v1
-kind: Secret
-metadata:
-  annotations:
-    config.kubernetes.io/originalNs: newOriginalNamespace
-  name: newName
-  namespace: newNamespace
-`,
+			expected: []resid.ResId{
+				{
+					Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Secret"},
+					Name:      "oldName",
+					Namespace: resid.DefaultNamespace,
+				},
+				{
+					Gvk:       resid.Gvk{Group: "apps", Version: "v1", Kind: "Secret"},
+					Name:      "oldName2",
+					Namespace: "oldNamespace",
+				},
+			},
 		},
 	}
-
-	for _, test := range tests {
-		factory := provider.NewDefaultDepProvider().GetResourceFactory()
-		resources, err := factory.SliceFromBytes([]byte(test.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		res := resources[0]
-		res.SetOriginalNs(test.originalNs, test.overwrite)
-
-		bytes, err := res.AsYAML()
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, test.expected, string(bytes))
+	factory := provider.NewDefaultDepProvider().GetResourceFactory()
+	for i := range tests {
+		test := tests[i]
+		t.Run(i, func(t *testing.T) {
+			resources, err := factory.SliceFromBytes([]byte(test.input))
+			if !assert.NoError(t, err) || len(resources) == 0 {
+				t.FailNow()
+			}
+			r := resources[0]
+			assert.Equal(t, test.expected, r.PrevIds())
+		})
 	}
 }
 

--- a/api/testutils/resmaptest/rmbuilder.go
+++ b/api/testutils/resmaptest/rmbuilder.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resid"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 )
@@ -48,15 +49,7 @@ func (rm *rmBuilder) AddR(r *resource.Resource) *rmBuilder {
 }
 
 func (rm *rmBuilder) AddWithName(n string, m map[string]interface{}) *rmBuilder {
-	err := rm.m.Append(rm.rf.FromMapWithName(n, m))
-	if err != nil {
-		rm.t.Fatalf("test setup failure: %v", err)
-	}
-	return rm
-}
-
-func (rm *rmBuilder) AddWithNs(ns string, m map[string]interface{}) *rmBuilder {
-	err := rm.m.Append(rm.rf.FromMapWithNamespace(ns, m))
+	err := rm.m.Append(rm.rf.FromMapWithNamespaceAndName(resid.DefaultNamespace, n, m))
 	if err != nil {
 		rm.t.Fatalf("test setup failure: %v", err)
 	}

--- a/plugin/builtin/hashtransformer/HashTransformer.go
+++ b/plugin/builtin/hashtransformer/HashTransformer.go
@@ -32,7 +32,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			if err != nil {
 				return err
 			}
-			res.SetOriginalName(res.GetName(), false)
+			res.StorePreviousId()
 			res.SetName(fmt.Sprintf("%s-%s", res.GetName(), h))
 		}
 	}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -38,7 +38,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
-		r.SetOriginalNs(r.GetNamespace(), false)
+		r.StorePreviousId()
 		err := r.ApplyFilter(namespace.Filter{
 			Namespace: p.Namespace,
 			FsSlice:   p.FieldSpecs,

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -108,7 +108,7 @@ func (p *plugin) transformJson6902(m resmap.ResMap, patch jsonpatch.Patch) error
 		return err
 	}
 	for _, res := range resources {
-		res.SetOriginalName(res.GetName(), false)
+		res.StorePreviousId()
 		err = res.ApplyFilter(patchjson6902.Filter{
 			Patch: p.Patch,
 		})

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer.go
@@ -73,7 +73,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 				r.AddNamePrefix(p.Prefix)
 				r.AddNameSuffix(p.Suffix)
 				if p.Prefix != "" || p.Suffix != "" {
-					r.SetOriginalName(r.GetName(), false)
+					r.StorePreviousId()
 				}
 			}
 			err := r.ApplyFilter(prefixsuffix.Filter{

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -63,9 +63,9 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    config.kubernetes.io/originalName: apple
-    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: baked-
+    config.kubernetes.io/previousNames: apple
+    config.kubernetes.io/previousNamespaces: default
     config.kubernetes.io/suffixes: -pie
   name: baked-apple-pie
 spec:
@@ -86,9 +86,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    config.kubernetes.io/originalName: cm
-    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: baked-
+    config.kubernetes.io/previousNames: cm
+    config.kubernetes.io/previousNamespaces: default
     config.kubernetes.io/suffixes: -pie
   name: baked-cm-pie
 `)
@@ -137,9 +137,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    config.kubernetes.io/originalName: deployment
-    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: test-
+    config.kubernetes.io/previousNames: deployment
+    config.kubernetes.io/previousNamespaces: default
   name: test-deployment
 spec:
   template:

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -64,6 +64,7 @@ kind: Service
 metadata:
   annotations:
     config.kubernetes.io/originalName: apple
+    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: baked-
     config.kubernetes.io/suffixes: -pie
   name: baked-apple-pie
@@ -86,6 +87,7 @@ kind: ConfigMap
 metadata:
   annotations:
     config.kubernetes.io/originalName: cm
+    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: baked-
     config.kubernetes.io/suffixes: -pie
   name: baked-cm-pie
@@ -136,6 +138,7 @@ kind: Deployment
 metadata:
   annotations:
     config.kubernetes.io/originalName: deployment
+    config.kubernetes.io/originalNs: default
     config.kubernetes.io/prefixes: test-
   name: test-deployment
 spec:

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
@@ -35,9 +35,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	found := false
 	for _, fs := range p.FieldSpecs {
 		matcher := p.createMatcher(fs)
-		matchOriginal := m.GetMatchingResourcesByOriginalId(matcher)
-		resList := append(
-			matchOriginal, m.GetMatchingResourcesByCurrentId(matcher)...)
+		resList := m.GetMatchingResourcesByAnyId(matcher)
 		if len(resList) > 0 {
 			found = true
 			for _, r := range resList {


### PR DESCRIPTION
Some resource refactoring to store intermediate names. Reference to #3493 and #3455. A future PR will refactor name reference transformer to remove more of the prefix/suffix logic from the resource code.

Removed:

Resource
- getOriginalName/Ns
- setOriginalName/Ns
- GetOutermostNamePrefix
- GetOutermostNameSuffix
- OutermostPrefixSuffixEquals

Resmap
- GetMatchingResourcesByOriginalId
- GetByOriginalId

Added:
Resource
- StorePreviousId
- PrevIds
- setOriginalNamespaceAndName

Resmap
- GetMatchingResourceByAnyId
