### PR TITLE
Fix 3489

### DIFF
--- a/api/krusty/namespaces_test.go
+++ b/api/krusty/namespaces_test.go
@@ -143,10 +143,73 @@ resources:
 - ../ov2
 - ../ov3
 `)
-	err := th.RunWithErr(".", th.MakeDefaultOptions())
-	if err == nil {
-		t.Fatal("TODO(3489): this should work")
-	}
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pp-myMap
+---
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: pp-myDep
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: CM_FOO
+          valueFrom:
+            configMapKeyRef:
+              key: foo
+              name: pp-myMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myMap-ss
+---
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: myDep-ss
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: CM_FOO
+          valueFrom:
+            configMapKeyRef:
+              key: foo
+              name: myMap-ss
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myMap-xx
+  namespace: fred
+---
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: myDep-xx
+  namespace: fred
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: CM_FOO
+          valueFrom:
+            configMapKeyRef:
+              key: foo
+              name: myMap-xx
+`)
 }
 
 // TestNameAndNsTransformation validates that NamespaceTransformer,

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -294,20 +294,16 @@ func (r *Resource) GetOutermostNameSuffix() string {
 	return nameSuffixes[len(nameSuffixes)-1]
 }
 
-func SameEndingSubarray(a, b []string) bool {
-	compareLen := len(b)
-	if len(a) < len(b) {
-		compareLen = len(a)
+func SameEndingSubarray(shortest, longest []string) bool {
+	if len(shortest) > len(longest) {
+		longest, shortest = shortest, longest
 	}
-
-	if compareLen == 0 {
-		return true
+	diff := len(longest) - len(shortest)
+	if len(shortest) == 0 {
+		return diff == 0
 	}
-
-	alen := len(a) - 1
-	blen := len(b) - 1
-	for i := 0; i <= compareLen-1; i++ {
-		if a[alen-i] != b[blen-i] {
+	for i := len(shortest) - 1; i >= 0; i-- {
+		if longest[i+diff] != shortest[i] {
 			return false
 		}
 	}

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -1196,10 +1196,10 @@ func TestSameEndingSubarray(t *testing.T) {
 			b:        []string{},
 			expected: true,
 		},
-		"no1 - TODO(3489) this should be false": {
+		"no1": {
 			a:        []string{"a"},
 			b:        []string{},
-			expected: true,
+			expected: false,
 		},
 		"no2": {
 			a:        []string{"b", "a"},


### PR DESCRIPTION
Fixes #3489

For some time,  SameEndingSubarray (formerly private, with no unit test) was treating an empty array and a one entry array as having the same "ending subarray" which was failing to eliminate referral targets that differed by one prefix or suffix in one referral target.  This change fixes that, improving referral target filtering.  This comes up in diamond patterns, where one branch adds a prefix or suffix, and the other branch doesn't.
