### PR TITLE
Fix prefix bug in copier.

### DIFF
--- a/cmd/k8scopy/internal/copier.go
+++ b/cmd/k8scopy/internal/copier.go
@@ -32,7 +32,7 @@ func (c Copier) subPath() string {
 	return filepath.Join("internal", c.pgmName)
 }
 
-func (c Copier) print() {
+func (c Copier) Print() {
 	fmt.Printf("   apiMachineryModule: %s\n", c.spec.Module)
 	fmt.Printf("      replacementPath: %s\n", c.replacementPath())
 	fmt.Printf("           goModCache: %s\n", c.goModCache)
@@ -44,14 +44,14 @@ func (c Copier) print() {
 	fmt.Printf("                  pwd: %s\n", os.Getenv("PWD"))
 }
 
-func NewCopier(s *ModuleSpec) Copier {
+func NewCopier(s *ModuleSpec, prefix string) Copier {
 	tmp := Copier{
 		spec:       s,
 		pgmName:    os.Getenv("GOPACKAGE"),
 		goModCache: RunGetOutputCommand("go", "env", "GOMODCACHE"),
 	}
 	goMod := RunGetOutputCommand("go", "env", "GOMOD")
-	topPackage := filepath.Join(goMod[:len(goMod)-len("go.mod")-1], "yaml")
+	topPackage := filepath.Join(goMod[:len(goMod)-len("go.mod")-1], prefix)
 	k := strings.Index(topPackage, sigsK8sIo)
 	if k < 1 {
 		log.Fatalf("cannot find %s in %s", sigsK8sIo, topPackage)

--- a/cmd/k8scopy/main.go
+++ b/cmd/k8scopy/main.go
@@ -34,11 +34,11 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("Need name of yaml file containing module specs.")
+	if len(os.Args) < 3 {
+		log.Fatal("Need name of yaml file containing module specs and prefix.")
 	}
 	spec := internal.ReadSpec(os.Args[1])
-	c := internal.NewCopier(spec)
+	c := internal.NewCopier(spec, os.Args[2])
 	internal.RunNoOutputCommand("go", "get", spec.Name())
 	for _, p := range spec.Packages {
 		for _, n := range p.Files {

--- a/kyaml/Makefile
+++ b/kyaml/Makefile
@@ -5,13 +5,6 @@ MYGOBIN := $(shell go env GOPATH)/bin
 export PATH := $(MYGOBIN):$(PATH)
 
 .PHONY: generate license fix vet fmt test lint tidy clean
-all: license fix vet fmt test lint tidy
-
-fix:
-	go fix ./...
-
-fmt:
-	go fmt ./...
 
 $(MYGOBIN)/addlicense:
 	go get github.com/google/addlicense
@@ -25,25 +18,38 @@ $(MYGOBIN)/k8scopy:
 $(MYGOBIN)/stringer:
 	go get golang.org/x/tools/cmd/stringer
 
+all: license fix vet fmt test lint tidy
+
+k8sGenDir := yaml/internal/k8sgen/pkg
+
 generate: $(MYGOBIN)/stringer $(MYGOBIN)/k8scopy
 	go generate ./...
 
 clean:
-	rm -rf yaml/internal/k8sgen/pkg
-
-license: $(MYGOBIN)/addlicense
-	$(MYGOBIN)/addlicense -c "The Kubernetes Authors." -f LICENSE_TEMPLATE .
-
-tidy:
-	go mod tidy
+	rm -rf $(k8sGenDir)
 
 lint: $(MYGOBIN)/golangci-lint
 	$(MYGOBIN)/golangci-lint \
-	  --skip-dirs yaml/internal/k8sgen/pkg \
+	  --skip-dirs $(k8sGenDir) \
 	  run ./...
 
-test:
+license: $(MYGOBIN)/addlicense
+	$(MYGOBIN)/addlicense \
+	  -y 2021 \
+	  -c "The Kubernetes Authors." \
+	  -f LICENSE_TEMPLATE .
+
+test: generate
 	go test -cover ./...
+
+fix:
+	go fix ./...
+
+fmt:
+	go fmt ./...
+
+tidy:
+	go mod tidy
 
 vet:
 	go vet ./...

--- a/kyaml/yaml/internal/k8sgen/doc.go
+++ b/kyaml/yaml/internal/k8sgen/doc.go
@@ -3,5 +3,5 @@
 
 // All code below this directory is generated.
 // See {repo}/cmd/k8scopy/main.go for more info.
-//go:generate k8scopy k8scopy.yaml
+//go:generate k8scopy k8scopy.yaml yaml
 package k8sgen

--- a/scripts/kyaml-pre-commit.sh
+++ b/scripts/kyaml-pre-commit.sh
@@ -21,6 +21,8 @@ functions/examples/application-cr
 export KUSTOMIZE_DOCKER_E2E=${KUSTOMIZE_DOCKER_E2E:-"false"}
 
 for target in $targets; do
+  echo " "
+  echo " "
   echo "----- Making $target -----"
   pushd .
   cd $target


### PR DESCRIPTION
ALLOW_MODULE_SPAN

Must add a path prefix argument to the k8s copier.
Also clean up make file deps and add some LFs to kyaml-pre-commit.sh

