### PR TITLE
Drop dependence on k8s.io/kube-openapi

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -20,7 +20,6 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
-	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	sigs.k8s.io/kustomize/kyaml v0.10.8
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/api/internal/accumulator/loadconfigfromcrds.go
+++ b/api/internal/accumulator/loadconfigfromcrds.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/pkg/errors"
-	"k8s.io/kube-openapi/pkg/common"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"
@@ -18,8 +17,16 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// OpenAPIDefinition describes single type.
+// Normally these definitions are auto-generated using gen-openapi.
+// Same as in k8s.io / kube-openapi / pkg / common.
+type OpenAPIDefinition struct {
+	Schema       spec.Schema
+	Dependencies []string
+}
+
 type myProperties map[string]spec.Schema
-type nameToApiMap map[string]common.OpenAPIDefinition
+type nameToApiMap map[string]OpenAPIDefinition
 
 // LoadConfigFromCRDs parse CRD schemas from paths into a TransformerConfig
 func LoadConfigFromCRDs(


### PR DESCRIPTION
In service of #2506