### PR TITLE
Makefile: check and use GOBIN environment variable first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@
 #
 # Makefile for kustomize CLI and API.
 
-MYGOBIN := $(shell go env GOPATH)/bin
 SHELL := /usr/bin/env bash
+MYGOBIN = $(shell go env GOBIN)
+ifeq ($(MYGOBIN),)
+MYGOBIN = $(shell go env GOPATH)/bin
+endif
 export PATH := $(MYGOBIN):$(PATH)
 MODULES := '"cmd/config" "api/" "kustomize/" "kyaml/"'
 

--- a/cmd/config/Makefile
+++ b/cmd/config/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy clean
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 $(GOBIN)/addlicense:
 	go get github.com/google/addlicense

--- a/cmd/gorepomod/Makefile
+++ b/cmd/gorepomod/Makefile
@@ -1,4 +1,7 @@
-MYGOBIN := $(shell go env GOPATH)/bin
+MYGOBIN = $(shell go env GOBIN)
+ifeq ($(MYGOBIN),)
+MYGOBIN = $(shell go env GOPATH)/bin
+endif
 
 $(MYGOBIN)/gorepomod: usage.go
 	go install .

--- a/functions/examples/application-cr/Makefile
+++ b/functions/examples/application-cr/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 build:
 	(cd image && go build -v -o $(GOBIN)/config-function .)

--- a/functions/examples/injection-tshirt-sizes/Makefile
+++ b/functions/examples/injection-tshirt-sizes/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 build:
 	(cd image && go build -v -o $(GOBIN)/config-function .)

--- a/functions/examples/template-go-nginx/Makefile
+++ b/functions/examples/template-go-nginx/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 build:
 	(cd image && go build -v -o $(GOBIN)/config-function .)

--- a/functions/examples/template-heredoc-cockroachdb/Makefile
+++ b/functions/examples/template-heredoc-cockroachdb/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: license image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 license:
 	(which $(GOBIN)/addlicense || go get github.com/google/addlicense)

--- a/functions/examples/validator-kubeval/Makefile
+++ b/functions/examples/validator-kubeval/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 build:
 	(cd image && go build -v -o $(GOBIN)/config-function .)

--- a/functions/examples/validator-resource-requests/Makefile
+++ b/functions/examples/validator-resource-requests/Makefile
@@ -3,7 +3,10 @@
 
 .PHONY: generate license fix vet fmt test build tidy image
 
-GOBIN := $(shell go env GOPATH)/bin
+GOBIN = $(shell go env GOBIN)
+ifeq ($(GOBIN),)
+GOBIN = $(shell go env GOPATH)/bin
+endif
 
 build:
 	(cd image && go build -v -o $(GOBIN)/config-function .)

--- a/hack/testExamplesAgainstKustomize.sh
+++ b/hack/testExamplesAgainstKustomize.sh
@@ -14,9 +14,11 @@ version=$1
 
 echo "Installing kustomize ${version}"
 
+MYGOBIN=$(go env GOBIN)
+MYGOBIN="${MYGOBIN:-$(go env GOPATH)/bin}"
 # Always rebuild, never assume the installed verion is
 # the right one to test.
-rm -f $(go env GOPATH)/bin/kustomize
+rm -f $MYGOBIN/kustomize
 if [ "$version" == "HEAD" ]; then
   (cd kustomize; go install .)
 else
@@ -35,7 +37,7 @@ if onLinuxAndNotOnRemoteCI; then
   echo "On linux, and not on remote CI.  Running expensive tests."
 
   # Requires helm.
-  make $(go env GOPATH)/bin/helm
+  make $MYGOBIN/helm
   mdrip --mode test --label helmtest examples/chart.md
 fi
 
@@ -43,6 +45,6 @@ fi
 # rely on whatever this script just did.  Tests should
 # be order independent.
 echo "Removing kustomize ${version}"
-rm $(go env GOPATH)/bin/kustomize
+rm $MYGOBIN/kustomize
 
 echo "Example tests passed against ${version}."

--- a/hack/testUnitKustomizePlugins.sh
+++ b/hack/testUnitKustomizePlugins.sh
@@ -14,6 +14,9 @@ set -o pipefail
 
 rcAccumulator=0
 
+MYGOBIN=$(go env GOBIN)
+MYGOBIN="${MYGOBIN:-$(go env GOPATH)/bin}"
+
 # All hack scripts should run from top level.
 . hack/shellHelpers.sh
 
@@ -49,10 +52,10 @@ function scanDir {
 
 if onLinuxAndNotOnRemoteCI; then
   # Some of these tests have special deps.
-  make $(go env GOPATH)/bin/helmV2
-  make $(go env GOPATH)/bin/helmV3
-  make $(go env GOPATH)/bin/helm
-  make $(go env GOPATH)/bin/kubeval
+  make $MYGOBIN/helmV2
+  make $MYGOBIN/helmV3
+  make $MYGOBIN/helm
+  make $MYGOBIN/kubeval
 fi
 
 for goMod in $(find ./plugin -name 'go.mod' -not -path "./plugin/untested/*"); do

--- a/kyaml/Makefile
+++ b/kyaml/Makefile
@@ -1,7 +1,10 @@
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-MYGOBIN := $(shell go env GOPATH)/bin
+MYGOBIN = $(shell go env GOBIN)
+ifeq ($(MYGOBIN),)
+MYGOBIN = $(shell go env GOPATH)/bin
+endif
 export PATH := $(MYGOBIN):$(PATH)
 
 .PHONY: generate license fix vet fmt test lint tidy clean

--- a/kyaml/openapi/Makefile
+++ b/kyaml/openapi/Makefile
@@ -1,7 +1,10 @@
 # Copyright 2020 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-MYGOBIN := $(shell go env GOPATH)/bin
+MYGOBIN = $(shell go env GOBIN)
+ifeq ($(MYGOBIN),)
+MYGOBIN = $(shell go env GOPATH)/bin
+endif
 API_VERSION := "v1.19.1"
 
 .PHONY: all

--- a/kyaml/openapi/scripts/fetchSchemaFromCluster.sh
+++ b/kyaml/openapi/scripts/fetchSchemaFromCluster.sh
@@ -2,7 +2,8 @@
 # Copyright 2020 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-MYGOBIN=$(go env GOPATH)/bin
+MYGOBIN=$(go env GOBIN)
+MYGOBIN="${MYGOBIN:-$(go env GOPATH)/bin}"
 VERSION=$1
 
 cp $HOME/.kube/config /tmp/kubeconfig.txt | true

--- a/kyaml/openapi/scripts/generateSwaggerDotGo.sh
+++ b/kyaml/openapi/scripts/generateSwaggerDotGo.sh
@@ -2,7 +2,8 @@
 # Copyright 2020 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-MYGOBIN=$(go env GOPATH)/bin
+MYGOBIN=$(go env GOBIN)
+MYGOBIN="${MYGOBIN:-$(go env GOPATH)/bin}"
 VERSION=$1
 
 $MYGOBIN/go-bindata \


### PR DESCRIPTION
'go get/install' will install binaries into GOBIN when it's set which is not
always same with GOPATH/bin

Fix below error:
$ hack/testExamplesAgainstKustomize.sh HEAD
Installing kustomize HEAD
On linux, and not on remote CI.  Running expensive tests.
make: Nothing to be done for '/home/lizj/gosrc/bin/helm'.
Removing kustomize HEAD
rm: cannot remove '/home/lizj/gosrc/bin/kustomize': No such file or directory

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>