### PR TITLE
Kustomize file should be ignored when adding resources and components

### DIFF
--- a/kustomize/commands/edit/add/addcomponent.go
+++ b/kustomize/commands/edit/add/addcomponent.go
@@ -68,11 +68,13 @@ func (o *addComponentOptions) RunAddComponent(fSys filesys.FileSystem) error {
 	}
 
 	for _, component := range components {
-		if kustfile.StringInSlice(component, m.Components) {
-			log.Printf("component %s already in kustomization file", component)
-			continue
+		if mf.GetPath() != component {
+			if kustfile.StringInSlice(component, m.Components) {
+				log.Printf("component %s already in kustomization file", component)
+				continue
+			}
+			m.Components = append(m.Components, component)
 		}
-		m.Components = append(m.Components, component)
 	}
 
 	return mf.Write(m)

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -62,6 +62,28 @@ func TestAddComponentAlreadyThere(t *testing.T) {
 	}
 }
 
+func TestAddKustomizationFileAsComponent(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	fSys.WriteFile(componentFileName, []byte(componentFileContent))
+	testutils_test.WriteTestKustomization(fSys)
+
+	cmd := newCmdAddComponent(fSys)
+	args := []string{componentFileName}
+	err := cmd.RunE(cmd, args)
+	if err != nil {
+		t.Fatalf("unexpected cmd error: %v", err)
+	}
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	if err != nil {
+		t.Errorf("unexpected read error: %v", err)
+	}
+
+	if strings.Contains(string(content), componentFileName) {
+		t.Errorf("%v shouldn't be in the list of the components", componentFileName)
+	}
+}
+
 func TestAddComponentNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 

--- a/kustomize/commands/edit/add/addresource.go
+++ b/kustomize/commands/edit/add/addresource.go
@@ -68,11 +68,13 @@ func (o *addResourceOptions) RunAddResource(fSys filesys.FileSystem) error {
 	}
 
 	for _, resource := range resources {
-		if kustfile.StringInSlice(resource, m.Resources) {
-			log.Printf("resource %s already in kustomization file", resource)
-			continue
+		if mf.GetPath() != resource {
+			if kustfile.StringInSlice(resource, m.Resources) {
+				log.Printf("resource %s already in kustomization file", resource)
+				continue
+			}
+			m.Resources = append(m.Resources, resource)
 		}
-		m.Resources = append(m.Resources, resource)
 	}
 
 	return mf.Write(m)

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -62,6 +62,28 @@ func TestAddResourceAlreadyThere(t *testing.T) {
 	}
 }
 
+func TestAddKustomizationFileAsResource(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	fSys.WriteFile(resourceFileName, []byte(resourceFileContent))
+	testutils_test.WriteTestKustomization(fSys)
+
+	cmd := newCmdAddResource(fSys)
+	args := []string{resourceFileName}
+	err := cmd.RunE(cmd, args)
+	if err != nil {
+		t.Fatalf("unexpected cmd error: %v", err)
+	}
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	if err != nil {
+		t.Errorf("unexpected read error: %v", err)
+	}
+
+	if strings.Contains(string(content), resourceFileName) {
+		t.Errorf("%v shouldn't be in the list of the resources", resourceFileName)
+	}
+}
+
 func TestAddResourceNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 

--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -117,6 +117,13 @@ func NewKustomizationFile(fSys filesys.FileSystem) (*kustomizationFile, error) {
 	return mf, nil
 }
 
+func (mf *kustomizationFile) GetPath() string {
+	if mf == nil {
+		return ""
+	}
+	return mf.path
+}
+
 func (mf *kustomizationFile) validate() error {
 	match := 0
 	var path []string

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -80,6 +80,18 @@ func TestWriteAndRead(t *testing.T) {
 	}
 }
 
+func TestGetPath(t *testing.T) {
+	fSys := filesys.MakeEmptyDirInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	mf, err := NewKustomizationFile(fSys)
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	if mf.GetPath() != "kustomization.yaml" {
+		t.Fatalf("Path expected: kustomization.yaml. Actual path: %v", mf.GetPath())
+	}
+}
+
 func TestNewNotExist(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 	_, err := NewKustomizationFile(fSys)


### PR DESCRIPTION
As described in issue #3575 both `kustomize edit add resource *.yaml` and `kustomize edit add component *.yaml` commands will add the kustomization file itself. So, kustomize file should be ignored when adding resources and components.