### PR TITLE
Increment major version from v3 to v4

### DIFF
--- a/kustomize/commands/commands.go
+++ b/kustomize/commands/commands.go
@@ -14,11 +14,11 @@ import (
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/cmd/config/completion"
 	"sigs.k8s.io/kustomize/cmd/config/configcobra"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/build"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/create"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/openapi"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/version"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/build"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/create"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/version"
 )
 
 // NewDefaultCommand returns the default (aka root) command for kustomize command.

--- a/kustomize/commands/create/create.go
+++ b/kustomize/commands/create/create.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 type createFlags struct {

--- a/kustomize/commands/create/create_test.go
+++ b/kustomize/commands/create/create_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 var factory = provider.NewDefaultDepProvider().GetKunstructuredFactory()

--- a/kustomize/commands/edit/add/addbase.go
+++ b/kustomize/commands/edit/add/addbase.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type addBaseOptions struct {

--- a/kustomize/commands/edit/add/addbase_test.go
+++ b/kustomize/commands/edit/add/addbase_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/add/addcomponent.go
+++ b/kustomize/commands/edit/add/addcomponent.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 type addComponentOptions struct {

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 // kindOfAdd is the kind of metadata being added: label or annotation

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func makeKustomization(t *testing.T) *types.Kustomization {

--- a/kustomize/commands/edit/add/addpatch.go
+++ b/kustomize/commands/edit/add/addpatch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type addPatchOptions struct {

--- a/kustomize/commands/edit/add/addpatch_test.go
+++ b/kustomize/commands/edit/add/addpatch_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/add/addresource.go
+++ b/kustomize/commands/edit/add/addresource.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 type addResourceOptions struct {

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/add/addtransformer.go
+++ b/kustomize/commands/edit/add/addtransformer.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 type addTransformerOptions struct {

--- a/kustomize/commands/edit/add/addtransformer_test.go
+++ b/kustomize/commands/edit/add/addtransformer_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/add/configmap.go
+++ b/kustomize/commands/edit/add/configmap.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 // newCmdAddConfigMap returns a new command.

--- a/kustomize/commands/edit/add/flagsandargs.go
+++ b/kustomize/commands/edit/add/flagsandargs.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 // flagsAndArgs encapsulates the options for add secret/configmap commands.

--- a/kustomize/commands/edit/add/secret.go
+++ b/kustomize/commands/edit/add/secret.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 // newCmdAddSecret returns a new command.

--- a/kustomize/commands/edit/all.go
+++ b/kustomize/commands/edit/all.go
@@ -9,11 +9,11 @@ import (
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/add"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/fix"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/listbuiltin"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/remove"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/set"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/add"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/fix"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/listbuiltin"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/remove"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/set"
 )
 
 // NewCmdEdit returns an instance of 'edit' subcommand.

--- a/kustomize/commands/edit/fix/fix.go
+++ b/kustomize/commands/edit/fix/fix.go
@@ -6,7 +6,7 @@ package fix
 import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 // NewCmdFix returns an instance of 'fix' subcommand.

--- a/kustomize/commands/edit/fix/fix_test.go
+++ b/kustomize/commands/edit/fix/fix_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func TestFix(t *testing.T) {

--- a/kustomize/commands/edit/remove/removemetadata.go
+++ b/kustomize/commands/edit/remove/removemetadata.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 // kindOfAdd is the kind of metadata being added: label or annotation

--- a/kustomize/commands/edit/remove/removemetadata_test.go
+++ b/kustomize/commands/edit/remove/removemetadata_test.go
@@ -11,8 +11,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func makeKustomizationFS() filesys.FileSystem {

--- a/kustomize/commands/edit/remove/removepatch.go
+++ b/kustomize/commands/edit/remove/removepatch.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type removePatchOptions struct {

--- a/kustomize/commands/edit/remove/removepatch_test.go
+++ b/kustomize/commands/edit/remove/removepatch_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/remove/removeresource.go
+++ b/kustomize/commands/edit/remove/removeresource.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type removeResourceOptions struct {

--- a/kustomize/commands/edit/remove/removeresource_test.go
+++ b/kustomize/commands/edit/remove/removeresource_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"testing"
 
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/remove_test"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/remove_test"
 )
 
 func TestRemoveResources(t *testing.T) {

--- a/kustomize/commands/edit/remove/removetransformer.go
+++ b/kustomize/commands/edit/remove/removetransformer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type removeTransformerOptions struct {

--- a/kustomize/commands/edit/remove/removetransformer_test.go
+++ b/kustomize/commands/edit/remove/removetransformer_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/edit/remove_test"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/edit/remove_test"
 )
 
 func TestRemoveTransformer(t *testing.T) {

--- a/kustomize/commands/edit/remove_test/removetest.go
+++ b/kustomize/commands/edit/remove_test/removetest.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 // Given represents the provided inputs for the test case.

--- a/kustomize/commands/edit/set/set_name_prefix.go
+++ b/kustomize/commands/edit/set/set_name_prefix.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type setNamePrefixOptions struct {

--- a/kustomize/commands/edit/set/set_name_prefix_test.go
+++ b/kustomize/commands/edit/set/set_name_prefix_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/set/set_name_suffix.go
+++ b/kustomize/commands/edit/set/set_name_suffix.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type setNameSuffixOptions struct {

--- a/kustomize/commands/edit/set/set_name_suffix_test.go
+++ b/kustomize/commands/edit/set/set_name_suffix_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/set/setimage.go
+++ b/kustomize/commands/edit/set/setimage.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type setImageOptions struct {

--- a/kustomize/commands/edit/set/setimage_test.go
+++ b/kustomize/commands/edit/set/setimage_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func TestSetImage(t *testing.T) {

--- a/kustomize/commands/edit/set/setlabel.go
+++ b/kustomize/commands/edit/set/setlabel.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/util"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 )
 
 type setLabelOptions struct {

--- a/kustomize/commands/edit/set/setlabel_test.go
+++ b/kustomize/commands/edit/set/setlabel_test.go
@@ -9,8 +9,8 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func makeKustomization(t *testing.T) *types.Kustomization {

--- a/kustomize/commands/edit/set/setnamespace.go
+++ b/kustomize/commands/edit/set/setnamespace.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/ifc"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type setNamespaceOptions struct {

--- a/kustomize/commands/edit/set/setnamespace_test.go
+++ b/kustomize/commands/edit/set/setnamespace_test.go
@@ -10,7 +10,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/filesys"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 const (

--- a/kustomize/commands/edit/set/setreplicas.go
+++ b/kustomize/commands/edit/set/setreplicas.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 )
 
 type setReplicasOptions struct {

--- a/kustomize/commands/edit/set/setreplicas_test.go
+++ b/kustomize/commands/edit/set/setreplicas_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/filesys"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func TestSetReplicas(t *testing.T) {

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v3/commands/internal/testutils"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
 
 func TestFieldOrder(t *testing.T) {

--- a/kustomize/commands/openapi/openapi.go
+++ b/kustomize/commands/openapi/openapi.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/configcobra"
-	"sigs.k8s.io/kustomize/kustomize/v3/commands/openapi/info"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi/info"
 )
 
 // NewCmdOpenAPI makes a new openapi command.

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kustomize/kustomize/v3
+module sigs.k8s.io/kustomize/kustomize/v4
 
 go 1.15
 

--- a/kustomize/main.go
+++ b/kustomize/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"os"
 
-	"sigs.k8s.io/kustomize/kustomize/v3/commands"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands"
 )
 
 func main() {


### PR DESCRIPTION
Due to #3578, and the fix (drop go-getter) in #3586, the set of URLs accepted by `kustomize build` is reduced
to only file system paths or values compatible with `git clone` (so, for example, mercurial and S3 no longer supported).
This backward incompatibility triggers a major version increment.

The same goes for elements of the `resources` field in `kustomization.yaml`  (details in #3578).

Users that rely on special URLs in `resource` fields may use [v3.10.0] or earlier.

We hope someone will [write a plugin] to restore this option, albeit with a new syntax.

Alternatively, we can refactor code to accept a new loader that would have to live outside `kustomize/kustomize` and outside `kustomize/api` (i.e. not on any path imported by kubectl or someone else).


[v3.10.0]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.10.0
[write a plugin]: https://github.com/kubernetes-sigs/kustomize/issues/3585
