### PR TITLE
List setters default false for recurse-subpackages

### DIFF
--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -36,7 +36,7 @@ func NewListSettersRunner(parent string) *ListSettersRunner {
 		"output as github markdown")
 	c.Flags().BoolVar(&r.IncludeSubst, "include-subst", false,
 		"include substitutions in the output")
-	c.Flags().BoolVarP(&r.RecurseSubPackages, "recurse-subpackages", "R", true,
+	c.Flags().BoolVarP(&r.RecurseSubPackages, "recurse-subpackages", "R", false,
 		"list setters recursively in all the nested subpackages")
 	runner.FixDocs(parent, c)
 	r.Command = c

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -472,7 +472,7 @@ func TestListSettersSubPackages(t *testing.T) {
 		{
 			name:    "list-replicas",
 			dataset: "dataset-with-setters",
-			args:    []string{"--include-subst"},
+			args:    []string{"--include-subst", "-R"},
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/
@@ -495,7 +495,6 @@ test/testdata/dataset-with-setters/mysql/storage/
 		{
 			name:    "list-replicas",
 			dataset: "dataset-with-setters/mysql",
-			args:    []string{"--recurse-subpackages=false"},
 			expected: `
 
 test/testdata/dataset-with-setters/mysql/


### PR DESCRIPTION
This PR is to address the issue https://github.com/GoogleContainerTools/kpt/issues/1113 . list-setters will have the default for --recurse-subpackage=false making the behavior consistent with all the other setter commands.