### PR TITLE
add openapi/path field to use custom openapi schema document

### DIFF
--- a/api/krusty/component_test.go
+++ b/api/krusty/component_test.go
@@ -33,7 +33,7 @@ func writeK(path string, content string) FileGen {
 }
 
 func writeTestBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("/base", `
 resources:
 - deploy.yaml
 configMapGenerator:
@@ -42,7 +42,7 @@ configMapGenerator:
   - testValue=purple
   - otherValue=green
 `)
-	th.WriteF("/app/base/deploy.yaml", `
+	th.WriteF("/base/deploy.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -53,7 +53,7 @@ spec:
 }
 
 func writeTestComponent(th kusttest_test.Harness) {
-	th.WriteC("/app/comp", `
+	th.WriteC("/comp", `
 namePrefix: comp-
 replicas:
 - name: storefront
@@ -67,7 +67,7 @@ configMapGenerator:
   - testValue=blue
   - compValue=red
 `)
-	th.WriteF("/app/comp/stub.yaml", `
+	th.WriteF("/comp/stub.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -78,7 +78,7 @@ spec:
 }
 
 func writeOverlayProd(th kusttest_test.Harness) {
-	th.WriteK("/app/prod", `
+	th.WriteK("/prod", `
 resources:
 - ../base
 - db
@@ -90,7 +90,7 @@ components:
 }
 
 func writeDB(th kusttest_test.Harness) {
-	deployment("db", "/app/prod/db")(th)
+	deployment("db", "/prod/db")(th)
 }
 
 func deployment(name string, path string) FileGen {
@@ -114,7 +114,7 @@ func TestComponent(t *testing.T) {
 		// resources that come before it in the resources list of the parent Kustomization.
 		"basic-component": {
 			input:   []FileGen{writeTestBase, writeTestComponent, writeOverlayProd},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -149,14 +149,14 @@ spec:
 		},
 		"multiple-components": {
 			input: []FileGen{writeTestBase, writeTestComponent, writeDB,
-				writeC("/app/additionalcomp", `
+				writeC("/additionalcomp", `
 configMapGenerator:
 - name: my-configmap
   behavior: merge
   literals:	
   - otherValue=orange
 `),
-				writeK("/app/prod", `
+				writeK("/prod", `
 resources:
 - ../base
 - db
@@ -166,7 +166,7 @@ components:
 - ../additionalcomp
 `),
 			},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -201,7 +201,7 @@ spec:
 		},
 		"nested-components": {
 			input: []FileGen{writeTestBase, writeTestComponent, writeDB,
-				writeC("/app/additionalcomp", `
+				writeC("/additionalcomp", `
 components:
 - ../comp
 configMapGenerator:
@@ -210,7 +210,7 @@ configMapGenerator:
   literals:
   - otherValue=orange
 `),
-				writeK("/app/prod", `
+				writeK("/prod", `
 resources:
 - ../base
 - db
@@ -219,7 +219,7 @@ components:
 - ../additionalcomp
 `),
 			},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -256,13 +256,13 @@ spec:
 		// without being affected by the component in another branch of the resource tree
 		"basic-component-with-repeated-base": {
 			input: []FileGen{writeTestBase, writeTestComponent, writeOverlayProd,
-				writeK("/app/repeated", `
+				writeK("/repeated", `
 resources:
 - ../base
 - ../prod
 `),
 			},
-			runPath: "/app/repeated",
+			runPath: "/repeated",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -312,7 +312,7 @@ spec:
 		},
 		"applying-component-directly-should-be-same-as-kustomization": {
 			input: []FileGen{writeTestBase, writeTestComponent,
-				writeC("/app/direct-component", `
+				writeC("/direct-component", `
 resources:
 - ../base
 configMapGenerator:
@@ -323,7 +323,7 @@ configMapGenerator:
   - testValue=blue
 `),
 			},
-			runPath: "/app/direct-component",
+			runPath: "/direct-component",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -344,7 +344,7 @@ metadata:
 		},
 		"missing-optional-component-api-version": {
 			input: []FileGen{writeTestBase, writeOverlayProd,
-				writeF("/app/comp/"+konfig.DefaultKustomizationFileName(), `
+				writeF("/comp/"+konfig.DefaultKustomizationFileName(), `
 kind: Component
 configMapGenerator:
 - name: my-configmap
@@ -353,7 +353,7 @@ configMapGenerator:
   - otherValue=orange
 `),
 			},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -382,25 +382,25 @@ spec:
 		// accumulator when "comp-b" is accumulated.  In practice we could use simple Kustomizations for this example.
 		"components-can-add-the-same-base-if-the-first-renames-resources": {
 			input: []FileGen{writeTestBase,
-				deployment("proxy", "/app/comp-a/proxy.yaml"),
-				writeC("/app/comp-a", `
+				deployment("proxy", "/comp-a/proxy.yaml"),
+				writeC("/comp-a", `
 resources:
 - ../base
 
 nameSuffix: "-a"
 `),
-				writeC("/app/comp-b", `
+				writeC("/comp-b", `
 resources:
 - ../base
 
 nameSuffix: "-b"
 `),
-				writeK("/app/prod", `
+				writeK("/prod", `
 components:
 - ../comp-a
 - ../comp-b`),
 			},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			expectedOutput: `
 apiVersion: v1
 kind: Deployment
@@ -436,34 +436,34 @@ metadata:
 
 		"multiple-bases-can-add-the-same-component-if-it-doesn-not-define-named-entities": {
 			input: []FileGen{
-				writeC("/app/comp", `
+				writeC("/comp", `
 namespace: prod
 `),
-				writeK("/app/base-a", `
+				writeK("/base-a", `
 resources:
 - proxy.yaml
 
 components:
 - ../comp
 `),
-				deployment("proxy-a", "/app/base-a/proxy.yaml"),
-				writeK("/app/base-b", `
+				deployment("proxy-a", "/base-a/proxy.yaml"),
+				writeK("/base-b", `
 resources:
 - proxy.yaml
 
 components:
 - ../comp
 `),
-				deployment("proxy-b", "/app/base-b/proxy.yaml"),
-				writeK("/app/prod", `
+				deployment("proxy-b", "/base-b/proxy.yaml"),
+				writeK("/prod", `
 resources:
 - proxy.yaml
 - ../base-a
 - ../base-b
 `),
-				deployment("proxy-prod", "/app/prod/proxy.yaml"),
+				deployment("proxy-prod", "/prod/proxy.yaml"),
 			},
-			runPath: "/app/prod",
+			runPath: "/prod",
 			// Note that the namepsace has not been applied to proxy-prod because it was not in scope when the
 			// component was applied
 			expectedOutput: `
@@ -513,30 +513,30 @@ func TestComponentErrors(t *testing.T) {
 	}{
 		"components-cannot-be-added-to-resources": {
 			input: []FileGen{writeTestBase, writeTestComponent,
-				writeK("/app/compinres", `
+				writeK("/compinres", `
 resources:
 - ../base
 - ../comp
 `),
 			},
-			runPath:       "app/compinres",
-			expectedError: "expected kind != 'Component' for path '/app/comp'",
+			runPath:       "compinres",
+			expectedError: "expected kind != 'Component' for path '/comp'",
 		},
 		"kustomizations-cannot-be-added-to-components": {
 			input: []FileGen{writeTestBase, writeTestComponent,
-				writeK("/app/kustincomponents", `
+				writeK("/kustincomponents", `
 components:
 - ../base
 - ../comp
 `),
 			},
-			runPath: "/app/kustincomponents",
+			runPath: "/kustincomponents",
 			expectedError: "accumulating components: accumulateDirectory: \"expected kind 'Component' for path " +
-				"'/app/base' but got 'Kustomization'",
+				"'/base' but got 'Kustomization'",
 		},
 		"files-cannot-be-added-to-components-list": {
 			input: []FileGen{writeTestBase,
-				writeF("/app/filesincomponents/stub.yaml", `
+				writeF("/filesincomponents/stub.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -544,18 +544,18 @@ metadata:
 spec:
   replicas: 1
 `),
-				writeK("/app/filesincomponents", `
+				writeK("/filesincomponents", `
 components:
 - stub.yaml
 - ../comp
 `),
 			},
-			runPath:       "/app/filesincomponents",
-			expectedError: "'/app/filesincomponents/stub.yaml' must be a directory to be a root",
+			runPath:       "/filesincomponents",
+			expectedError: "'/filesincomponents/stub.yaml' must be a directory to be a root",
 		},
 		"invalid-component-api-version": {
 			input: []FileGen{writeTestBase, writeOverlayProd,
-				writeF("/app/comp/"+konfig.DefaultKustomizationFileName(), `
+				writeF("/comp/"+konfig.DefaultKustomizationFileName(), `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Component
 configMapGenerator:
@@ -565,22 +565,22 @@ configMapGenerator:
   - otherValue=orange
 `),
 			},
-			runPath:       "/app/prod",
+			runPath:       "/prod",
 			expectedError: "apiVersion for Component should be kustomize.config.k8s.io/v1alpha1",
 		},
 		"components-cannot-add-the-same-resource": {
 			input: []FileGen{writeTestBase,
-				writeC("/app/comp-a", `
+				writeC("/comp-a", `
 resources:
 - proxy.yaml
 `),
-				deployment("proxy", "/app/comp-a/proxy.yaml"),
-				writeC("/app/comp-b", `
+				deployment("proxy", "/comp-a/proxy.yaml"),
+				writeC("/comp-b", `
 resources:
 - proxy.yaml
 `),
-				deployment("proxy", "/app/comp-b/proxy.yaml"),
-				writeK("/app/prod", `
+				deployment("proxy", "/comp-b/proxy.yaml"),
+				writeK("/prod", `
 resources:
 - ../base
 
@@ -588,49 +588,49 @@ components:
 - ../comp-a
 - ../comp-b`),
 			},
-			runPath:       "/app/prod",
+			runPath:       "/prod",
 			expectedError: "may not add resource with an already registered id: ~G_v1_Deployment|~X|proxy",
 		},
 		"components-cannot-add-the-same-base": {
 			input: []FileGen{writeTestBase,
-				deployment("proxy", "/app/comp-a/proxy.yaml"),
-				writeC("/app/comp-a", `
+				deployment("proxy", "/comp-a/proxy.yaml"),
+				writeC("/comp-a", `
 resources:
 - ../base
 `),
-				writeC("/app/comp-b", `
+				writeC("/comp-b", `
 resources:
 - ../base
 `),
-				writeK("/app/prod", `
+				writeK("/prod", `
 components:
 - ../comp-a
 - ../comp-b`),
 			},
-			runPath:       "/app/prod",
+			runPath:       "/prod",
 			expectedError: "may not add resource with an already registered id: ~G_v1_Deployment|~X|storefront",
 		},
 		"components-cannot-add-bases-containing-the-same-resource": {
 			input: []FileGen{writeTestBase,
-				writeC("/app/comp-a", `
+				writeC("/comp-a", `
 resources:
 - ../base-a
 `),
-				writeK("/app/base-a", `
+				writeK("/base-a", `
 resources:
 - proxy.yaml
 `),
-				deployment("proxy", "/app/base-a/proxy.yaml"),
-				writeC("/app/comp-b", `
+				deployment("proxy", "/base-a/proxy.yaml"),
+				writeC("/comp-b", `
 resources:
 - ../base-b
 `),
-				writeK("/app/base-b", `
+				writeK("/base-b", `
 resources:
 - proxy.yaml
 `),
-				deployment("proxy", "/app/base-b/proxy.yaml"),
-				writeK("/app/prod", `
+				deployment("proxy", "/base-b/proxy.yaml"),
+				writeK("/prod", `
 resources:
 - ../base
 
@@ -638,7 +638,7 @@ components:
 - ../comp-a
 - ../comp-b`),
 			},
-			runPath:       "/app/prod",
+			runPath:       "/prod",
 			expectedError: "may not add resource with an already registered id: ~G_v1_Deployment|~X|proxy",
 		},
 	}

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -5,6 +5,7 @@ package krusty
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/filesys"
@@ -73,7 +74,14 @@ func (b *Kustomizer) Run(
 	if err != nil {
 		return nil, err
 	}
-	err = openapi.SetSchemaVersion(kt.Kustomization().OpenAPI, true)
+	var bytes []byte
+	if openApiPath, exists := kt.Kustomization().OpenAPI["path"]; exists {
+		bytes, err = ldr.Load(filepath.Join(ldr.Root(), openApiPath))
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = openapi.SetSchema(kt.Kustomization().OpenAPI, bytes, true)
 	if err != nil {
 		return nil, err
 	}

--- a/api/krusty/openapicustomschema_test.go
+++ b/api/krusty/openapicustomschema_test.go
@@ -1,0 +1,403 @@
+package krusty_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+)
+
+func writeTestSchema(th kusttest_test.Harness, filepath string) {
+	bytes, _ := ioutil.ReadFile("testdata/customschema.json")
+	th.WriteF(filepath+"mycrd_schema.json", string(bytes))
+}
+
+func writeTestComponentWithCustomSchema(th kusttest_test.Harness) {
+	writeTestSchema(th, "/app/comp/")
+	openapi.ResetOpenAPI()
+	th.WriteC("/app/comp", `
+openapi:
+  path: mycrd_schema.json
+`)
+	th.WriteF("/app/comp/stub.yaml", `
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: stub
+spec:
+  replicas: 1
+`)
+}
+
+// Test for issue #2825
+func TestCustomOpenApiFieldBasicUsage(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("/app", `
+resources:
+- mycrd.yaml
+
+openapi:
+  path: mycrd_schema.json
+
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	th.WriteF("/app/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	writeTestSchema(th, "/app/")
+	openapi.ResetOpenAPI()
+
+	m := th.Run("/app", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - command: example
+        image: nginx
+        name: server
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+`)
+}
+
+// Error if user tries to specify both builtin version
+// and custom schema
+func TestCustomOpenApiFieldBothPathAndVersion(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("/app", `
+resources:
+- mycrd.yaml
+
+openapi:
+  version: v1.18.8
+  path: mycrd_schema.json
+
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	th.WriteF("/app/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	writeTestSchema(th, "/app/")
+	openapi.ResetOpenAPI()
+	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	assert.Error(t, err)
+	assert.Equal(t,
+		"builtin version and custom schema provided, cannot use both",
+		err.Error())
+}
+
+// Test for if the filepath specified is not found
+func TestCustomOpenApiFieldFileNotFound(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("/app", `
+resources:
+- mycrd.yaml
+
+openapi:
+  path: mycrd_schema.json
+
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	th.WriteF("/app/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	openapi.ResetOpenAPI()
+	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	assert.Error(t, err)
+	assert.Equal(t,
+		"'/app/mycrd_schema.json' doesn't exist",
+		err.Error())
+}
+
+func TestCustomOpenApiFieldFromBase(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+resources:
+- mycrd.yaml
+
+openapi:
+  path: mycrd_schema.json
+`)
+	th.WriteF("base/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	writeTestSchema(th, "/base/")
+	openapi.ResetOpenAPI()
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - command: example
+        image: nginx
+        name: server
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+`)
+	assert.Equal(t, "using custom schema from file provided",
+		openapi.GetSchemaVersion())
+}
+
+func TestCustomOpenApiFieldFromOverlay(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+resources:
+- mycrd.yaml
+`)
+	th.WriteF("base/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+openapi:
+  path: mycrd_schema.json
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	writeTestSchema(th, "/overlay/")
+	openapi.ResetOpenAPI()
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - command: example
+        image: nginx
+        name: server
+        ports:
+        - containerPort: 8080
+          name: grpc
+          protocol: TCP
+`)
+	assert.Equal(t, "using custom schema from file provided",
+		openapi.GetSchemaVersion())
+}
+
+func TestCustomOpenApiFieldOverlayTakesPrecedence(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+resources:
+- mycrd.yaml
+openapi:
+  path: mycrd_schema.json
+`)
+	th.WriteF("base/mycrd.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        image: server
+        command: example
+        ports:
+        - name: grpc
+          protocol: TCP
+          containerPort: 8080
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+openapi:
+  version: v1.19.1
+patchesStrategicMerge:
+- |-
+  apiVersion: example.com/v1alpha1
+  kind: MyCRD
+  metadata:
+    name: service
+  spec:
+    template:
+      spec:
+        containers:
+        - name: server
+          image: nginx
+`)
+	writeTestSchema(th, "/base/")
+	openapi.ResetOpenAPI()
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyCRD
+metadata:
+  name: service
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx
+        name: server
+`)
+	assert.Equal(t, "v1191",
+		openapi.GetSchemaVersion())
+}
+
+func TestCustomOpenAPIFieldFromComponent(t *testing.T) {
+	input := []FileGen{
+		writeTestBase,
+		writeTestComponentWithCustomSchema,
+		writeOverlayProd}
+
+	th := kusttest_test.MakeHarness(t)
+	for _, f := range input {
+		f(th)
+	}
+	openapi.ResetOpenAPI()
+	th.Run(runPath, th.MakeDefaultOptions())
+	assert.Equal(t, "using custom schema from file provided", openapi.GetSchemaVersion())
+}

--- a/api/krusty/openapiversion_test.go
+++ b/api/krusty/openapiversion_test.go
@@ -285,12 +285,13 @@ spec:
 `)
 }
 
+const runPath = "/app/prod"
+
 func TestOpenAPIFieldFromComponent(t *testing.T) {
 	input := []FileGen{
 		writeTestBase,
 		writeTestComponentWithOlderOpenAPIVersion,
 		writeOverlayProd}
-	runPath := "/app/prod"
 
 	th := kusttest_test.MakeHarness(t)
 	for _, f := range input {

--- a/api/krusty/openapiversion_test.go
+++ b/api/krusty/openapiversion_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestOpenApiFieldBasicUsage(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 openapi:
   version: v1.18.8
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,7 +29,7 @@ spec:
       - image: whatever
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -46,13 +46,13 @@ spec:
 
 func TestOpenApiFieldNotBuiltin(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 openapi:
   version: v1.14.1
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,7 +64,7 @@ spec:
       - image: whatever
 `)
 
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -72,11 +72,11 @@ spec:
 
 func TestOpenApiFieldDefaultVersion(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -88,7 +88,7 @@ spec:
       - image: whatever
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -260,7 +260,7 @@ spec:
 
 func TestOpenAPIFieldFromComponentDefault(t *testing.T) {
 	input := []FileGen{writeTestBase, writeTestComponent, writeOverlayProd}
-	runPath := "/app/prod"
+	runPath := "/prod"
 
 	th := kusttest_test.MakeHarness(t)
 	for _, f := range input {
@@ -271,11 +271,11 @@ func TestOpenAPIFieldFromComponentDefault(t *testing.T) {
 }
 
 func writeTestComponentWithOlderOpenAPIVersion(th kusttest_test.Harness) {
-	th.WriteC("/app/comp", `
+	th.WriteC("/comp", `
 openapi:
   version: v1.18.8
 `)
-	th.WriteF("/app/comp/stub.yaml", `
+	th.WriteF("/comp/stub.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -285,7 +285,7 @@ spec:
 `)
 }
 
-const runPath = "/app/prod"
+const runPath = "prod"
 
 func TestOpenAPIFieldFromComponent(t *testing.T) {
 	input := []FileGen{

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -481,7 +481,7 @@ func initSchema() {
 		ResetOpenAPI()
 		err := parse(customSchema)
 		if err != nil {
-			panic(err)
+			panic("invalid schema file")
 		}
 		return
 	}


### PR DESCRIPTION
solution for #2825 
implements part of KEP: https://github.com/kubernetes/enhancements/issues/2206

allow users to specify their own custom openapi schema files to use with kustomize, to support strategic merge patching with CRDs

ALLOW_MODULE_SPAN