### PR TITLE
added `kustomize openapi fetch` command to get schema from local cluster

### DIFF
--- a/kustomize/commands/openapi/fetch/fetch.go
+++ b/kustomize/commands/openapi/fetch/fetch.go
@@ -1,0 +1,73 @@
+package fetch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdFetch makes a new fetch command.
+func NewCmdFetch(w io.Writer) *cobra.Command {
+	infoCmd := cobra.Command{
+		Use: "fetch",
+		Short: `Fetches the OpenAPI specification from the current kubernetes cluster specified 
+in the user's kubeconfig`,
+		Example: `kustomize openapi fetch`,
+		Run: func(cmd *cobra.Command, args []string) {
+			printSchema(w)
+		},
+		Hidden: true,
+	}
+
+	return &infoCmd
+}
+
+func printSchema(w io.Writer) {
+	fmt.Fprintln(w, "Fetching schema from cluster")
+	errMsg := `
+Error fetching schema from cluster.
+Please make sure port 8081 is available, kubectl is installed, and its context is set correctly.
+Installation and setup instructions: https://kubernetes.io/docs/tasks/tools/install-kubectl/`
+
+	command := exec.Command("kubectl", []string{"proxy", "--port=8081", "&"}...)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	err := command.Start()
+	defer killProcess(command)
+
+	// give the proxy a second to start up
+	time.Sleep(time.Second)
+
+	if err != nil || stderr.String() != "" {
+		fmt.Fprintln(w, err, stderr.String()+errMsg)
+		return
+	}
+
+	commandCurl := exec.Command("curl", []string{"http://localhost:8081/openapi/v2"}...)
+	var stdout bytes.Buffer
+	commandCurl.Stdout = &stdout
+	commandCurl.Stderr = &stderr
+	err = commandCurl.Run()
+	if err != nil || stdout.String() == "" {
+		fmt.Fprintln(w, err, stderr.String()+errMsg)
+		return
+	}
+
+	// format and output
+	var jsonSchema map[string]interface{}
+	output := stdout.Bytes()
+	json.Unmarshal(output, &jsonSchema)
+	output, _ = json.MarshalIndent(jsonSchema, "", "  ")
+	fmt.Fprintln(w, string(output))
+}
+
+func killProcess(command *exec.Cmd) {
+	if command.Process != nil {
+		command.Process.Kill()
+	}
+}

--- a/kustomize/commands/openapi/openapi.go
+++ b/kustomize/commands/openapi/openapi.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/configcobra"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi/fetch"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi/info"
 )
 
@@ -22,6 +23,7 @@ func NewCmdOpenAPI(w io.Writer) *cobra.Command {
 	}
 
 	openApiCmd.AddCommand(info.NewCmdInfo(w))
+	openApiCmd.AddCommand(fetch.NewCmdFetch(w))
 	configcobra.AddCommands(openApiCmd, "openapi")
 
 	return openApiCmd

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -23,3 +23,5 @@ replace sigs.k8s.io/kustomize/api => ../api
 replace sigs.k8s.io/kustomize/cmd/config => ../cmd/config
 
 replace sigs.k8s.io/kustomize/kyaml => ../kyaml
+
+replace sigs.k8s.io/kustomize/kustomize/v4/commands => ./commands


### PR DESCRIPTION
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2206-openapi-features-in-kustomize
KEP issue: https://github.com/kubernetes/enhancements/issues/2206

Had a few options

1) The easiest way would have been to use kubectl's util.Factory's RESTClient (https://pkg.go.dev/k8s.io/kubectl/pkg/cmd/util#Factory) to hit the OpenAPI endpoint, but this would have made kustomize have a dependency on kubectl (which is not ideal, but correct me if I'm wrong).

2) Use kpt live fetch-k8s-schema, but that would expect the user to have kpt installed.

3) The solution that I've opted for, which is to run the kubectl proxy command and then curl.

I have heard there are plans for kubectl to have a similar command to fetch the schema, at which point this code should probably change to use that. 