### PR TITLE
kustomization openapi data should be parsed for custom schema

### DIFF
--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -483,6 +483,10 @@ func initSchema() {
 		if err != nil {
 			panic("invalid schema file")
 		}
+		if err := parse(kustomizationapi.MustAsset(kustomizationAPIAssetName)); err != nil {
+			// this should never happen
+			panic(err)
+		}
 		return
 	}
 


### PR DESCRIPTION
Should have been part of https://github.com/kubernetes-sigs/kustomize/pull/3617, realized the mistake after it was merged

Custom schema only replaces the kubernetes openapi data, so kustomization openapi data still needs to be parsed