### PR TITLE
Change paths for krusty tests to relative, and have top level be '.'

### DIFF
--- a/api/krusty/accumulation_test.go
+++ b/api/krusty/accumulation_test.go
@@ -15,19 +15,19 @@ import (
 
 func TestTargetMustHaveKustomizationFile(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/service.yaml", `
+	th.WriteF("service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
   name: aService
 `)
-	th.WriteF("/app/deeper/service.yaml", `
+	th.WriteF("deeper/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
   name: anotherService
 `)
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -39,27 +39,27 @@ metadata:
 func TestTargetMustHaveOnlyOneKustomizationFile(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	for _, n := range konfig.RecognizedKustomizationFileNames() {
-		th.WriteF(filepath.Join("/app", n), `
+		th.WriteF(filepath.Join(".", n), `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 `)
 	}
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
-	if !strings.Contains(err.Error(), "Found multiple kustomization files under: /app") {
+	if !strings.Contains(err.Error(), "Found multiple kustomization files") {
 		t.Fatalf("unexpected error: %q", err)
 	}
 }
 
 func TestBaseMustHaveKustomizationFile(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - base
 `)
-	th.WriteF("/app/base/service.yaml", `
+	th.WriteF("base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -70,7 +70,7 @@ spec:
   ports:
     - port: 7002
 `)
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -81,11 +81,11 @@ spec:
 
 func TestResourceNotFound(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 `)
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected an error")
 	}
@@ -96,11 +96,11 @@ resources:
 
 func TestResourceHasAnchor(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - ingress.yaml
 `)
-	th.WriteF("/app/ingress.yaml", `
+	th.WriteF("ingress.yaml", `
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -125,7 +125,7 @@ spec:
   - host: www.xyz.me
     http: *xxx_rules
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func writeMediumBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: baseprefix-
 commonLabels:
   foo: bar
@@ -20,7 +20,7 @@ resources:
 - deployment/deployment.yaml
 - service/service.yaml
 `)
-	th.WriteF("/app/base/service/service.yaml", `
+	th.WriteF("base/service/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,7 +33,7 @@ spec:
   selector:
     app: mungebot
 `)
-	th.WriteF("/app/base/deployment/deployment.yaml", `
+	th.WriteF("base/deployment/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,7 +61,7 @@ spec:
 func TestMediumBase(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeMediumBase(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -115,7 +115,7 @@ spec:
 func TestMediumOverlay(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeMediumBase(th)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 namePrefix: test-infra-
 commonLabels:
   app: mungebot
@@ -140,24 +140,24 @@ images:
 - name: nginx
   newTag: 1.8.0`)
 
-	th.WriteF("/app/overlay/configmap/db.env", `
+	th.WriteF("overlay/configmap/db.env", `
 DB_USERNAME=admin
 DB_PASSWORD=somepw
 `)
-	th.WriteF("/app/overlay/configmap/units.ini", `
+	th.WriteF("overlay/configmap/units.ini", `
 LENGTH=kilometer
 ENERGY=electronvolt
 `)
-	th.WriteF("/app/overlay/configmap/food.ini", `
+	th.WriteF("overlay/configmap/food.ini", `
 FRUIT=banana
 LEGUME=chickpea
 `)
-	th.WriteF("/app/overlay/configmap/dummy.txt",
+	th.WriteF("overlay/configmap/dummy.txt",
 		`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. 
 `)
-	th.WriteF("/app/overlay/deployment/deployment.yaml", `
+	th.WriteF("overlay/deployment/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -190,7 +190,7 @@ spec:
           name: app-env
         name: app-env
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/basereusenameprefix_test.go
+++ b/api/krusty/basereusenameprefix_test.go
@@ -41,37 +41,37 @@ import (
 
 func TestBaseReuseNameConflict(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/component1/base", `
+	th.WriteK("component1/base", `
 resources:
   - ../../shared
 
 namePrefix: component1-
 `)
-	th.WriteK("/app/component1/overlay", `
+	th.WriteK("component1/overlay", `
 resources:
   - ../base
 
 namePrefix: overlay-
 `)
 
-	th.WriteK("/app/component2/base", `
+	th.WriteK("component2/base", `
 resources:
   - ../../shared
 
 namePrefix: component2-
 `)
-	th.WriteK("/app/component2/overlay", `
+	th.WriteK("component2/overlay", `
 resources:
   - ../base
 
 namePrefix: overlay-
 `)
 
-	th.WriteK("/app/shared", `
+	th.WriteK("shared", `
 resources:
   - resources.yaml
 `)
-	th.WriteF("/app/shared/resources.yaml", `
+	th.WriteF("shared/resources.yaml", `
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -111,13 +111,13 @@ spec:
             claimName: postgres
 `)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
   - component1/overlay
   - component2/overlay
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/api/krusty/chartinflatorplugin_test.go
+++ b/api/krusty/chartinflatorplugin_test.go
@@ -32,13 +32,13 @@ func TestChartInflatorPlugin(t *testing.T) {
 		PrepExecPlugin("someteam.example.com", "v1", "ChartInflator")
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 generators:
 - chartInflator.yaml
 namePrefix: LOOOOOOOONG-
 `)
 
-	th.WriteF("/app/chartInflator.yaml", `
+	th.WriteF("./chartInflator.yaml", `
 apiVersion: someteam.example.com/v1
 kind: ChartInflator
 metadata:
@@ -46,7 +46,7 @@ metadata:
 chartName: minecraft
 `)
 
-	m := th.Run("/app", th.MakeOptionsPluginsEnabled())
+	m := th.Run(".", th.MakeOptionsPluginsEnabled())
 	chartName := regexp.MustCompile("chart: minecraft-[0-9.]+")
 	th.AssertActualEqualsExpectedWithTweak(m,
 		func(x []byte) []byte {

--- a/api/krusty/complexcomposition_test.go
+++ b/api/krusty/complexcomposition_test.go
@@ -27,11 +27,11 @@ spec:
 `
 
 func writeStatefulSetBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - statefulset.yaml
 `)
-	th.WriteF("/app/base/statefulset.yaml", `
+	th.WriteF("base/statefulset.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -56,15 +56,15 @@ spec:
 }
 
 func writeHTTPSOverlay(th kusttest_test.Harness) {
-	th.WriteK("/app/https", `
+	th.WriteK("https", `
 resources:
 - ../base
 - https-svc.yaml
 patchesStrategicMerge:
 - sts-patch.yaml
 `)
-	th.WriteF("/app/https/https-svc.yaml", httpsService)
-	th.WriteF("/app/https/sts-patch.yaml", `
+	th.WriteF("https/https-svc.yaml", httpsService)
+	th.WriteF("https/sts-patch.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -75,8 +75,8 @@ spec:
 }
 
 func writeHTTPSTransformerRaw(th kusttest_test.Harness) {
-	th.WriteF("/app/https/service/https-svc.yaml", httpsService)
-	th.WriteF("/app/https/transformer/transformer.yaml", `
+	th.WriteF("https/service/https-svc.yaml", httpsService)
+	th.WriteF("https/transformer/transformer.yaml", `
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
@@ -97,11 +97,11 @@ patch: |-
 }
 
 func writeHTTPSTransformerBase(th kusttest_test.Harness) {
-	th.WriteK("/app/https/service", `
+	th.WriteK("https/service", `
 resources:
 - https-svc.yaml
 `)
-	th.WriteK("/app/https/transformer", `
+	th.WriteK("https/transformer", `
 resources:
 - transformer.yaml
 `)
@@ -109,7 +109,7 @@ resources:
 }
 
 func writeConfigFromEnvOverlay(th kusttest_test.Harness) {
-	th.WriteK("/app/config", `
+	th.WriteK("config", `
 resources:
 - ../base
 configMapGenerator:
@@ -121,7 +121,7 @@ generatorOptions:
 patchesStrategicMerge:
 - sts-patch.yaml
 `)
-	th.WriteF("/app/config/sts-patch.yaml", `
+	th.WriteF("config/sts-patch.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -138,7 +138,7 @@ spec:
 }
 
 func writeConfigFromEnvTransformerRaw(th kusttest_test.Harness) {
-	th.WriteF("/app/config/map/generator.yaml", `
+	th.WriteF("config/map/generator.yaml", `
 apiVersion: builtin
 kind: ConfigMapGenerator
 metadata:
@@ -148,7 +148,7 @@ options:
 literals:
 - MY_ENV=foo
 `)
-	th.WriteF("/app/config/transformer/transformer.yaml", `
+	th.WriteF("config/transformer/transformer.yaml", `
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
@@ -174,11 +174,11 @@ patch: |-
 `)
 }
 func writeConfigFromEnvTransformerBase(th kusttest_test.Harness) {
-	th.WriteK("/app/config/map", `
+	th.WriteK("config/map", `
 resources:
 - generator.yaml
 `)
-	th.WriteK("/app/config/transformer", `
+	th.WriteK("config/transformer", `
 resources:
 - transformer.yaml
 `)
@@ -186,13 +186,13 @@ resources:
 }
 
 func writeTolerationsOverlay(th kusttest_test.Harness) {
-	th.WriteK("/app/tolerations", `
+	th.WriteK("tolerations", `
 resources:
 - ../base
 patchesStrategicMerge:
 - sts-patch.yaml
 `)
-	th.WriteF("/app/tolerations/sts-patch.yaml", `
+	th.WriteF("tolerations/sts-patch.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -208,7 +208,7 @@ spec:
 }
 
 func writeTolerationsTransformerRaw(th kusttest_test.Harness) {
-	th.WriteF("/app/tolerations/transformer.yaml", `
+	th.WriteF("tolerations/transformer.yaml", `
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
@@ -234,7 +234,7 @@ patch: |-
 }
 
 func writeTolerationsTransformerBase(th kusttest_test.Harness) {
-	th.WriteK("/app/tolerations", `
+	th.WriteK("tolerations", `
 resources:
 - transformer.yaml
 `)
@@ -242,7 +242,7 @@ resources:
 }
 
 func writeStorageOverlay(th kusttest_test.Harness) {
-	th.WriteK("/app/storage", `
+	th.WriteK("storage", `
 resources:
 - ../base
 patchesJson6902:
@@ -253,13 +253,13 @@ patchesJson6902:
     name: my-sts
   path: sts-patch.json
 `)
-	th.WriteF("/app/storage/sts-patch.json", `
+	th.WriteF("storage/sts-patch.json", `
 [{"op": "replace", "path": "/spec/volumeClaimTemplates/0/spec/storageClassName", "value": "my-sc"}]
 `)
 }
 
 func writeStorageTransformerRaw(th kusttest_test.Harness) {
-	th.WriteF("/app/storage/transformer.yaml", `
+	th.WriteF("storage/transformer.yaml", `
 apiVersion: builtin
 kind: PatchTransformer
 metadata:
@@ -275,7 +275,7 @@ patch: |-
 }
 
 func writeStorageTransformerBase(th kusttest_test.Harness) {
-	th.WriteK("/app/storage", `
+	th.WriteK("storage", `
 resources:
 - transformer.yaml
 `)
@@ -358,12 +358,12 @@ func TestComplexComposition_Dev_Failure(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingOverlays(th)
-	th.WriteK("/app/dev", `
+	th.WriteK("dev", `
 resources:
 - ../storage
 - ../config
 `)
-	err := th.RunWithErr("/app/dev", th.MakeDefaultOptions())
+	err := th.RunWithErr("dev", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("Expected resource accumulation error")
 	}
@@ -410,7 +410,7 @@ func TestComplexComposition_Dev_SuccessWithRawTransformers(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingTransformersRaw(th)
-	th.WriteK("/app/dev", `
+	th.WriteK("dev", `
 resources:
 - ../base
 generators:
@@ -419,7 +419,7 @@ transformers:
 - ../config/transformer/transformer.yaml
 - ../storage/transformer.yaml
 `)
-	m := th.Run("/app/dev", func() Options {
+	m := th.Run("dev", func() Options {
 		o := th.MakeDefaultOptions()
 		o.LoadRestrictions = types.LoadRestrictionsNone
 		return o
@@ -431,7 +431,7 @@ func TestComplexComposition_Dev_SuccessWithBaseTransformers(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingTransformerBases(th)
-	th.WriteK("/app/dev", `
+	th.WriteK("dev", `
 resources:
 - ../base
 generators:
@@ -440,7 +440,7 @@ transformers:
 - ../config/transformer
 - ../storage
 `)
-	m := th.Run("/app/dev", th.MakeDefaultOptions())
+	m := th.Run("dev", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, devDesiredResult)
 }
 
@@ -448,13 +448,13 @@ func TestComplexComposition_Prod_Failure(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingOverlays(th)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 resources:
 - ../config
 - ../tolerations
 - ../https
 `)
-	err := th.RunWithErr("/app/prod", th.MakeDefaultOptions())
+	err := th.RunWithErr("prod", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("Expected resource accumulation error")
 	}
@@ -517,7 +517,7 @@ func TestComplexComposition_Prod_SuccessWithRawTransformers(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingTransformersRaw(th)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 resources:
 - ../base
 - ../https/service/https-svc.yaml
@@ -528,7 +528,7 @@ transformers:
 - ../https/transformer/transformer.yaml
 - ../tolerations/transformer.yaml
 `)
-	m := th.Run("/app/prod", func() Options {
+	m := th.Run("prod", func() Options {
 		o := th.MakeDefaultOptions()
 		o.LoadRestrictions = types.LoadRestrictionsNone
 		return o
@@ -540,7 +540,7 @@ func TestComplexComposition_Prod_SuccessWithBaseTransformers(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeStatefulSetBase(th)
 	writePatchingTransformerBases(th)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 resources:
 - ../base
 - ../https/service
@@ -551,6 +551,6 @@ transformers:
 - ../https/transformer
 - ../tolerations
 `)
-	m := th.Run("/app/prod", th.MakeDefaultOptions())
+	m := th.Run("prod", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, prodDesiredResult)
 }

--- a/api/krusty/crd_test.go
+++ b/api/krusty/crd_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func writeBaseWithCrd(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 crds:
@@ -23,7 +23,7 @@ resources:
 
 namePrefix: x-
 `)
-	th.WriteF("/app/base/bee.yaml", `
+	th.WriteF("base/bee.yaml", `
 apiVersion: v1beta1
 kind: Bee
 metadata:
@@ -31,7 +31,7 @@ metadata:
 spec:
   action: fly
 `)
-	th.WriteF("/app/base/mykind.yaml", `
+	th.WriteF("base/mykind.yaml", `
 apiVersion: jingfang.example.com/v1
 kind: MyKind
 metadata:
@@ -42,7 +42,7 @@ spec:
   beeRef:
     name: bee
 `)
-	th.WriteF("/app/base/secret.yaml", `
+	th.WriteF("base/secret.yaml", `
 apiVersion: v1
 kind: Secret
 metadata:
@@ -50,7 +50,7 @@ metadata:
 data:
   PATH: yellowBrickRoad
 `)
-	th.WriteF("/app/base/mycrd.json", `
+	th.WriteF("base/mycrd.json", `
 {
   "github.com/example/pkg/apis/jingfang/v1beta1.Bee": {
     "Schema": {
@@ -227,7 +227,7 @@ data:
 func TestCrdBase(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeBaseWithCrd(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -258,7 +258,7 @@ spec:
 func TestCrdWithOverlay(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeBaseWithCrd(th)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: prod-
@@ -267,7 +267,7 @@ resources:
 patchesStrategicMerge:
 - bee.yaml
 `)
-	th.WriteF("/app/overlay/bee.yaml", `
+	th.WriteF("overlay/bee.yaml", `
 apiVersion: v1beta1
 kind: Bee
 metadata:
@@ -275,7 +275,7 @@ metadata:
 spec:
   action: makehoney
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
@@ -306,7 +306,7 @@ spec:
 
 func TestCrdWithContainers(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/crd/containers", `
+	th.WriteK("crd/containers", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -316,7 +316,7 @@ images:
     newName: registry.gitlab.com/test
     newTag: latest
 `)
-	th.WriteF("/app/crd/containers/crd.yaml", `
+	th.WriteF("crd/containers/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -337,7 +337,7 @@ spec:
           containers:
             description: Containers allows injecting additional containers
   `)
-	m := th.Run("/app/crd/containers", th.MakeDefaultOptions())
+	m := th.Run("crd/containers", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/api/krusty/customconfig_test.go
+++ b/api/krusty/customconfig_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func makeBaseReferencingCustomConfig(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: x-
 commonLabels:
   app: myApp
@@ -35,7 +35,7 @@ configurations:
 - config/defaults.yaml
 - config/custom.yaml
 `)
-	th.WriteF("/app/base/giraffes.yaml", `
+	th.WriteF("base/giraffes.yaml", `
 kind: Giraffe
 metadata:
   name: april
@@ -50,7 +50,7 @@ spec:
   diet: acacia
   location: SE
 `)
-	th.WriteF("/app/base/gorilla.yaml", `
+	th.WriteF("base/gorilla.yaml", `
 kind: Gorilla
 metadata:
   name: koko
@@ -58,7 +58,7 @@ spec:
   diet: bambooshoots
   location: SW
 `)
-	th.WriteF("/app/base/animalPark.yaml", `
+	th.WriteF("base/animalPark.yaml", `
 apiVersion: foo
 kind: AnimalPark
 metadata:
@@ -77,8 +77,8 @@ spec:
 func TestCustomConfig(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeBaseReferencingCustomConfig(th)
-	th.WriteLegacyConfigs("/app/base/config/defaults.yaml")
-	th.WriteF("/app/base/config/custom.yaml", `
+	th.WriteLegacyConfigs("base/config/defaults.yaml")
+	th.WriteF("base/config/custom.yaml", `
 nameReference:
 - kind: Gorilla
   fieldSpecs:
@@ -92,7 +92,7 @@ varReference:
 - path: spec/food
   kind: AnimalPark
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: foo
 kind: AnimalPark
@@ -141,11 +141,11 @@ spec:
 func TestCustomConfigWithDefaultOverspecification(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeBaseReferencingCustomConfig(th)
-	th.WriteLegacyConfigs("/app/base/config/defaults.yaml")
+	th.WriteLegacyConfigs("base/config/defaults.yaml")
 	// Specifying namePrefix here conflicts with (is the same as)
 	// the defaults written above.  This is intentional in the
 	// test to assure duplicate config doesn't cause problems.
-	th.WriteF("/app/base/config/custom.yaml", `
+	th.WriteF("base/config/custom.yaml", `
 namePrefix:
 - path: metadata/name
 nameReference:
@@ -161,7 +161,7 @@ varReference:
 - path: spec/food
   kind: AnimalPark
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: foo
 kind: AnimalPark
@@ -210,8 +210,8 @@ spec:
 func TestFixedBug605_BaseCustomizationAvailableInOverlay(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeBaseReferencingCustomConfig(th)
-	th.WriteLegacyConfigs("/app/base/config/defaults.yaml")
-	th.WriteF("/app/base/config/custom.yaml", `
+	th.WriteLegacyConfigs("base/config/defaults.yaml")
+	th.WriteF("base/config/custom.yaml", `
 nameReference:
 - kind: Gorilla
   fieldSpecs:
@@ -228,7 +228,7 @@ varReference:
   apiVersion: foo
   kind: AnimalPark
 `)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 namePrefix: o-
 commonLabels:
   movie: planetOfTheApes
@@ -238,7 +238,7 @@ resources:
 - ../base
 - ursus.yaml
 `)
-	th.WriteF("/app/overlay/ursus.yaml", `
+	th.WriteF("overlay/ursus.yaml", `
 kind: Gorilla
 metadata:
   name: ursus
@@ -247,7 +247,7 @@ spec:
   location: Arizona
 `)
 	// The following replaces the gorillaRef in the AnimalPark.
-	th.WriteF("/app/overlay/animalPark.yaml", `
+	th.WriteF("overlay/animalPark.yaml", `
 apiVersion: foo
 kind: AnimalPark
 metadata:
@@ -256,7 +256,7 @@ spec:
   gorillaRef:
     name: ursus
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: foo
 kind: AnimalPark

--- a/api/krusty/customconfigofbuiltinplugin_test.go
+++ b/api/krusty/customconfigofbuiltinplugin_test.go
@@ -17,7 +17,7 @@ func TestCustomNamePrefixer(t *testing.T) {
 		PrepBuiltin("PrefixSuffixTransformer")
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 - role.yaml
@@ -25,7 +25,7 @@ resources:
 transformers:
 - prefixer.yaml
 `)
-	th.WriteF("/app/prefixer.yaml", `
+	th.WriteF("prefixer.yaml", `
 apiVersion: builtin
 kind: PrefixSuffixTransformer
 metadata:
@@ -37,7 +37,7 @@ fieldSpecs:
 - kind: Service
   path: metadata/name
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,20 +52,20 @@ spec:
       - name: whatever
         image: whatever
 `)
-	th.WriteF("/app/role.yaml", `
+	th.WriteF("role.yaml", `
 apiVersion: v1
 kind: Role
 metadata:
   name: myRole
 `)
-	th.WriteF("/app/service.yaml", `
+	th.WriteF("service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
   name: myService
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/customconfigreusable_test.go
+++ b/api/krusty/customconfigreusable_test.go
@@ -23,7 +23,7 @@ func TestReusableCustomTransformers(t *testing.T) {
 	// First write three custom configurations for builtin plugins.
 
 	// A custom name prefixer that only touches Deployments and Services.
-	th.WriteF("/app/mytransformers/deploymentServicePrefixer.yaml", `
+	th.WriteF("mytransformers/deploymentServicePrefixer.yaml", `
 apiVersion: builtin
 kind: PrefixSuffixTransformer
 metadata:
@@ -37,7 +37,7 @@ fieldSpecs:
 `)
 
 	// A custom annotator exclusively annotating Roles.
-	th.WriteF("/app/mytransformers/roleAnnotator.yaml", `
+	th.WriteF("mytransformers/roleAnnotator.yaml", `
 apiVersion: builtin
 kind: AnnotationsTransformer
 metadata:
@@ -55,7 +55,7 @@ fieldSpecs:
 	// and only labels them at their top metadata level
 	// exclusively.  It does not modify selectors or
 	// add labels to pods in the template.
-	th.WriteF("/app/mytransformers/deploymentLabeller.yaml", `
+	th.WriteF("mytransformers/deploymentLabeller.yaml", `
 apiVersion: builtin
 kind: LabelTransformer
 metadata:
@@ -73,7 +73,7 @@ fieldSpecs:
 	// all happen to be plugin configurations. This makes
 	// these plugins re-usable as a group in any number of other
 	// kustomizations.
-	th.WriteK("/app/mytransformers", `
+	th.WriteK("mytransformers", `
 resources:
 - deploymentServicePrefixer.yaml
 - roleAnnotator.yaml
@@ -82,7 +82,7 @@ resources:
 
 	// Finally, define the kustomization for the (arbitrarily named)
 	// staging environment.
-	th.WriteK("/app/staging", `
+	th.WriteK("staging", `
 
 # Bring in the custom transformers.
 transformers:
@@ -104,7 +104,7 @@ resources:
 - role.yaml
 - service.yaml
 `)
-	th.WriteF("/app/staging/deployment.yaml", `
+	th.WriteF("staging/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -119,20 +119,20 @@ spec:
       - name: whatever
         image: whatever
 `)
-	th.WriteF("/app/staging/role.yaml", `
+	th.WriteF("staging/role.yaml", `
 apiVersion: v1
 kind: Role
 metadata:
   name: myRole
 `)
-	th.WriteF("/app/staging/service.yaml", `
+	th.WriteF("staging/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
   name: myService
 `)
 
-	m := th.Run("/app/staging", th.MakeDefaultOptions())
+	m := th.Run("staging", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/diamonds_test.go
+++ b/api/krusty/diamonds_test.go
@@ -31,11 +31,11 @@ import (
 //             base
 //
 func writeDiamondBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deploy.yaml
 `)
-	th.WriteF("/app/base/deploy.yaml", `
+	th.WriteF("base/deploy.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -46,7 +46,7 @@ spec:
 }
 
 func writeKirk(th kusttest_test.Harness) {
-	th.WriteK("/app/kirk", `
+	th.WriteK("kirk", `
 namePrefix: kirk-
 resources:
 - ../base
@@ -54,7 +54,7 @@ resources:
 patchesStrategicMerge:
 - dep-patch.yaml
 `)
-	th.WriteF("/app/kirk/dep-patch.yaml", `
+	th.WriteF("kirk/dep-patch.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -62,7 +62,7 @@ metadata:
 spec:
   type: Confident
 `)
-	th.WriteF("/app/kirk/configmap.yaml", `
+	th.WriteF("kirk/configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -73,14 +73,14 @@ data:
 }
 
 func writeSpock(th kusttest_test.Harness) {
-	th.WriteK("/app/spock", `
+	th.WriteK("spock", `
 namePrefix: spock-
 resources:
 - ../base
 patchesStrategicMerge:
 - dep-patch.yaml
 `)
-	th.WriteF("/app/spock/dep-patch.yaml", `
+	th.WriteF("spock/dep-patch.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -91,14 +91,14 @@ spec:
 }
 
 func writeBones(th kusttest_test.Harness) {
-	th.WriteK("/app/bones", `
+	th.WriteK("bones", `
 namePrefix: bones-
 resources:
 - ../base
 patchesStrategicMerge:
 - dep-patch.yaml
 `)
-	th.WriteF("/app/bones/dep-patch.yaml", `
+	th.WriteF("bones/dep-patch.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -109,7 +109,7 @@ spec:
 }
 
 func writeTenants(th kusttest_test.Harness) {
-	th.WriteK("/app/tenants", `
+	th.WriteK("tenants", `
 namePrefix: t-
 resources:
 - ../kirk
@@ -119,7 +119,7 @@ resources:
 patchesStrategicMerge:
 - bones-patch.yaml
 `)
-	th.WriteF("/app/tenants/bones-patch.yaml", `
+	th.WriteF("tenants/bones-patch.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -127,7 +127,7 @@ metadata:
 spec:
   mood: Cantankerous
 `)
-	th.WriteF("/app/tenants/configMap.yaml", `
+	th.WriteF("tenants/configMap.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -145,7 +145,7 @@ func TestBasicDiamond(t *testing.T) {
 	writeSpock(th)
 	writeBones(th)
 	writeTenants(th)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 namePrefix: prod-
 resources:
 - ../tenants
@@ -154,7 +154,7 @@ patchesStrategicMerge:
 `)
 	// The patch only has to be specific enough
 	// to match the item.
-	th.WriteF("/app/prod/patches.yaml", `
+	th.WriteF("prod/patches.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -177,7 +177,7 @@ data:
   zone: twilight
 `)
 
-	m := th.Run("/app/prod", th.MakeDefaultOptions())
+	m := th.Run("prod", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Deployment

--- a/api/krusty/directoryarrangement_test.go
+++ b/api/krusty/directoryarrangement_test.go
@@ -11,19 +11,19 @@ import (
 
 func TestIssue596AllowDirectoriesThatAreSubstringsOfEachOther(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", "")
-	th.WriteK("/app/overlays/aws", `
+	th.WriteK("base", "")
+	th.WriteK("overlays/aws", `
 resources:
 - ../../base
 `)
-	th.WriteK("/app/overlays/aws-nonprod", `
+	th.WriteK("overlays/aws-nonprod", `
 resources:
 - ../aws
 `)
-	th.WriteK("/app/overlays/aws-sandbox2.us-east-1", `
+	th.WriteK("overlays/aws-sandbox2.us-east-1", `
 resources:
 - ../aws-nonprod
 `)
-	m := th.Run("/app/overlays/aws-sandbox2.us-east-1", th.MakeDefaultOptions())
+	m := th.Run("overlays/aws-sandbox2.us-east-1", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, "")
 }

--- a/api/krusty/extendedpatch_test.go
+++ b/api/krusty/extendedpatch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func makeCommonFileForExtendedPatchTest(th kusttest_test.Harness) {
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,7 +61,7 @@ spec:
           name: configmap-in-base
         name: configmap-in-base
 `)
-	th.WriteF("/app/base/service.yaml", `
+	th.WriteF("base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -91,7 +91,7 @@ spec:
 func TestExtendedPatchNameSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -100,7 +100,7 @@ patches:
   target:
     name: busybox
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -108,7 +108,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -193,7 +193,7 @@ spec:
 func TestExtendedPatchGvkSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -202,7 +202,7 @@ patches:
   target:
     kind: Deployment
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -210,7 +210,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -295,7 +295,7 @@ spec:
 func TestExtendedPatchLabelSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -304,7 +304,7 @@ patches:
   target:
     labelSelector: app=nginx
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -312,7 +312,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -397,7 +397,7 @@ spec:
 func TestExtendedPatchNameGvkSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -407,7 +407,7 @@ patches:
     name: busybox
     kind: Deployment
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -415,7 +415,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -498,7 +498,7 @@ spec:
 func TestExtendedPatchNameLabelSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -508,7 +508,7 @@ patches:
     name: .*
     labelSelector: app=busybox
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -516,7 +516,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -601,7 +601,7 @@ spec:
 func TestExtendedPatchGvkLabelSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -611,7 +611,7 @@ patches:
     kind: Deployment
     labelSelector: app=busybox
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -619,7 +619,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -702,7 +702,7 @@ spec:
 func TestExtendedPatchNameGvkLabelSelector(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -713,7 +713,7 @@ patches:
     kind: Deployment
     labelSelector: app=busybox
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -721,7 +721,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -804,7 +804,7 @@ spec:
 func TestExtendedPatchNoMatch(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -813,7 +813,7 @@ patches:
   target:
     name: no-match
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -821,7 +821,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -902,14 +902,14 @@ spec:
 func TestExtendedPatchWithoutTarget(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
 patches:
 - path: patch.yaml
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -917,7 +917,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -1000,7 +1000,7 @@ spec:
 func TestExtendedPatchNoMatchMultiplePatch(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -1013,7 +1013,7 @@ patches:
     name: busybox
     kind: Job
 `)
-	th.WriteF("/app/base/patch.yaml", `
+	th.WriteF("base/patch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1021,7 +1021,7 @@ metadata:
   annotations:
     new-key: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -1102,7 +1102,7 @@ spec:
 func TestExtendedPatchMultiplePatchOverlapping(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForExtendedPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - service.yaml
@@ -1115,7 +1115,7 @@ patches:
     name: busybox
     kind: Deployment
 `)
-	th.WriteF("/app/base/patch1.yaml", `
+	th.WriteF("base/patch1.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1123,7 +1123,7 @@ metadata:
   annotations:
     new-key-from-patch1: new-value
 `)
-	th.WriteF("/app/base/patch2.yaml", `
+	th.WriteF("base/patch2.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1131,7 +1131,7 @@ metadata:
   annotations:
     new-key-from-patch2: new-value
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/generatormergeandreplace_test.go
+++ b/api/krusty/generatormergeandreplace_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSimpleBase(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: team-foo-
@@ -27,7 +27,7 @@ resources:
   - deployment.yaml
   - networkpolicy.yaml
 `)
-	th.WriteF("/app/base/service.yaml", `
+	th.WriteF("app/base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,7 +40,7 @@ spec:
   selector:
     app: nginx
 `)
-	th.WriteF("/app/base/networkpolicy.yaml", `
+	th.WriteF("app/base/networkpolicy.yaml", `
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -55,7 +55,7 @@ spec:
             matchLabels:
               app: nginx
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("app/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,7 +72,7 @@ spec:
       - name: nginx
         image: nginx
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("app/base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Service
@@ -149,7 +149,7 @@ spec:
 }
 
 func makeBaseWithGenerators(th kusttest_test.Harness) {
-	th.WriteK("/app", `
+	th.WriteK("app", `
 namePrefix: team-foo-
 commonLabels:
   app: mynginx
@@ -170,7 +170,7 @@ secretGenerator:
   - username=admin
   - password=somepw
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("app/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -196,7 +196,7 @@ spec:
           name: configmap-in-base
         name: configmap-in-base
 `)
-	th.WriteF("/app/service.yaml", `
+	th.WriteF("app/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -214,7 +214,7 @@ spec:
 func TestBaseWithGeneratorsAlone(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeBaseWithGenerators(th)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run("app", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -305,7 +305,7 @@ type: Opaque
 func TestMergeAndReplaceGenerators(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeBaseWithGenerators(th)
-	th.WriteF("/overlay/deployment.yaml", `
+	th.WriteF("overlay/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -322,7 +322,7 @@ spec:
           name: configmap-in-overlay
         name: configmap-in-overlay
 `)
-	th.WriteK("/overlay", `
+	th.WriteK("overlay", `
 namePrefix: staging-
 commonLabels:
   env: staging
@@ -345,7 +345,7 @@ secretGenerator:
   literals:
   - proxy=haproxy
 `)
-	m := th.Run("/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -457,7 +457,7 @@ metadata:
 
 func TestGeneratingIntoNamespaces(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK("app", `
 configMapGenerator:
 - name: test
   namespace: default
@@ -479,7 +479,7 @@ secretGenerator:
   - username=admin
   - password=somepw
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run("app", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -523,7 +523,7 @@ type: Opaque
 // and namespace left to default
 func TestConfigMapGeneratingIntoSameNamespace(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK("app", `
 configMapGenerator:
 - name: test
   namespace: default
@@ -533,7 +533,7 @@ configMapGenerator:
   literals:
   - key=value
 `)
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr("app", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -546,7 +546,7 @@ configMapGenerator:
 // and namespace left to default
 func TestSecretGeneratingIntoSameNamespace(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK("app", `
 secretGenerator:
 - name: test
   namespace: default
@@ -558,7 +558,7 @@ secretGenerator:
   - username=admin
   - password=somepw
 `)
-	err := th.RunWithErr("/app", th.MakeDefaultOptions())
+	err := th.RunWithErr("app", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/api/krusty/generatoroptions_test.go
+++ b/api/krusty/generatoroptions_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSecretGenerator(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 secretGenerator:
 - name: bob
   literals:
@@ -23,12 +23,12 @@ secretGenerator:
   envs:
   - foo.env
 `)
-	th.WriteF("/app/foo.env", `
+	th.WriteF("foo.env", `
 MOUNTAIN=everest
 OCEAN=pacific
 `)
-	th.WriteF("/app/phrase.dat", "dat phrase")
-	m := th.Run("/app", th.MakeDefaultOptions())
+	th.WriteF("phrase.dat", "dat phrase")
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -47,7 +47,7 @@ type: Opaque
 
 func TestGeneratorOptionsWithBases(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 generatorOptions:
@@ -59,7 +59,7 @@ configMapGenerator:
   literals:
   - foo=bar
 `)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -73,7 +73,7 @@ configMapGenerator:
   literals:
   - fruit=apple
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:

--- a/api/krusty/gvknpatch_test.go
+++ b/api/krusty/gvknpatch_test.go
@@ -15,8 +15,8 @@ import (
 func TestKeepOriginalGVKN(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteF("apps/deployment.yaml", `
-apiVersion: apps/v1
+	th.WriteF("deployment.yaml", `
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -28,14 +28,14 @@ spec:
           image: nginx
 `)
 
-	th.WriteF("apps/patch.yaml", `
-apiVersion: apps/v1
+	th.WriteF("patch.yaml", `
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
 `)
 
-	th.WriteK("apps", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -45,9 +45,9 @@ patches:
     kind: Deployment
 `)
 
-	m := th.Run("apps", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -65,8 +65,8 @@ spec:
 func TestChangeName(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteF("apps/deployment.yaml", `
-apiVersion: apps/v1
+	th.WriteF("deployment.yaml", `
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -78,14 +78,14 @@ spec:
           image: nginx
 `)
 
-	th.WriteF("apps/patch.yaml", `
-apiVersion: apps/v1
+	th.WriteF("patch.yaml", `
+apiVersion: v1
 kind: Deployment
 metadata:
   name: new-name
 `)
 
-	th.WriteK("apps", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -99,9 +99,9 @@ patches:
 	options.AllowResourceIdChanges = true
 
 	// name should become `new-name`
-	m := th.Run("apps", options)
+	m := th.Run(".", options)
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -117,8 +117,8 @@ spec:
 func TestChangeKind(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteF("apps/deployment.yaml", `
-apiVersion: apps/v1
+	th.WriteF("deployment.yaml", `
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -130,14 +130,14 @@ spec:
           image: nginx
 `)
 
-	th.WriteF("apps/patch.yaml", `
-apiVersion: apps/v1
+	th.WriteF("patch.yaml", `
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: old-name
 `)
 
-	th.WriteK("apps", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -151,9 +151,9 @@ patches:
 	options.AllowResourceIdChanges = true
 
 	// kind should become `StatefulSet`
-	m := th.Run("apps", options)
+	m := th.Run(".", options)
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -169,8 +169,8 @@ spec:
 func TestChangeNameAndKind(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteF("apps/deployment.yaml", `
-apiVersion: apps/v1
+	th.WriteF("deployment.yaml", `
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -182,14 +182,14 @@ spec:
           image: nginx
 `)
 
-	th.WriteF("apps/patch.yaml", `
-apiVersion: apps/v1
+	th.WriteF("patch.yaml", `
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
 `)
 
-	th.WriteK("apps", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -204,9 +204,9 @@ patches:
 
 	// kind should become `StatefulSet`
 	// name should become `new-name`
-	m := th.Run("apps", options)
+	m := th.Run(".", options)
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -226,7 +226,7 @@ func TestPatchOriginalName(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteF("base/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -238,7 +238,7 @@ spec:
           image: nginx
 `)
 	th.WriteF("base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: new-name
@@ -260,7 +260,7 @@ patchesStrategicMerge:
 - depPatch.yaml
 `)
 	th.WriteF("overlay/depPatch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -274,7 +274,7 @@ spec:
 	// name should become `new-name`
 	m := th.Run("overlay", options)
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -292,7 +292,7 @@ func TestPatchNewName(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteF("base/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -304,7 +304,7 @@ spec:
           image: nginx
 `)
 	th.WriteF("base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: new-name
@@ -326,7 +326,7 @@ patchesStrategicMerge:
 - depPatch.yaml
 `)
 	th.WriteF("overlay/depPatch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: new-name
@@ -346,7 +346,7 @@ func TestPatchOriginalNameAndKind(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteF("base/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -358,7 +358,7 @@ spec:
           image: nginx
 `)
 	th.WriteF("base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
@@ -380,7 +380,7 @@ patchesStrategicMerge:
 - depPatch.yaml
 `)
 	th.WriteF("overlay/depPatch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -395,7 +395,7 @@ spec:
 	// name should become `new-name`
 	m := th.Run("overlay", options)
 	th.AssertActualEqualsExpected(m, `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -413,7 +413,7 @@ func TestPatchNewNameAndKind(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteF("base/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -425,7 +425,7 @@ spec:
           image: nginx
 `)
 	th.WriteF("base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
@@ -447,7 +447,7 @@ patchesStrategicMerge:
 - depPatch.yaml
 `)
 	th.WriteF("overlay/depPatch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
@@ -469,7 +469,7 @@ func TestPatchOriginalNameAndNewKind(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	th.WriteF("base/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: old-name
@@ -481,7 +481,7 @@ spec:
           image: nginx
 `)
 	th.WriteF("base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: new-name
@@ -503,7 +503,7 @@ patchesStrategicMerge:
 - depPatch.yaml
 `)
 	th.WriteF("overlay/depPatch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: new-name
@@ -558,7 +558,7 @@ resources:
   - deployment.yaml
 `)
 	th.WriteF("/app/shared/deployment.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: Deployment
 metadata:
   name: my-deploy
@@ -592,7 +592,7 @@ patches:
     name: my-deploy
 `)
 	th.WriteF("/app/component2/base/patch.yaml", `
-apiVersion: apps/v1
+apiVersion: v1
 kind: StatefulSet
 metadata:
   name: my-stateful-set

--- a/api/krusty/inlinepatch_test.go
+++ b/api/krusty/inlinepatch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func makeResourcesForPatchTest(th kusttest_test.Harness) {
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,7 +41,7 @@ spec:
 func TestStrategicMergePatchInline(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeResourcesForPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 
@@ -58,7 +58,7 @@ patchesStrategicMerge:
           - name: nginx
             image: image1
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -90,7 +90,7 @@ spec:
 func TestJSONPatchInline(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeResourcesForPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 
@@ -105,7 +105,7 @@ patchesJson6902:
       path: /spec/template/spec/containers/0/image
       value: image1
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -137,7 +137,7 @@ spec:
 func TestExtendedPatchInlineJSON(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeResourcesForPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 
@@ -150,7 +150,7 @@ patches:
       path: /spec/template/spec/containers/0/image
       value: image1
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -182,7 +182,7 @@ spec:
 func TestExtendedPatchInlineYAML(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeResourcesForPatchTest(th)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 
@@ -202,7 +202,7 @@ patches:
             - name: nginx
               image: image1
 `)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/inlinetransformer_test.go
+++ b/api/krusty/inlinetransformer_test.go
@@ -13,14 +13,14 @@ func TestInlineTransformer(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
 
-	th.WriteF("/app/resource.yaml", `
+	th.WriteF("resource.yaml", `
 apiVersion: apps/v1
 kind: ConfigMap
 metadata:
   name: whatever
 data: {}
 `)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - resource.yaml
 transformers:
@@ -44,7 +44,7 @@ metadata:
   namespace: test
 `
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, expected)
 }
 
@@ -52,7 +52,7 @@ func TestInlineGenerator(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 generators:
 - |-
   apiVersion: builtin
@@ -74,6 +74,6 @@ metadata:
   name: mymap-kfd8tf729k
 `
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, expected)
 }

--- a/api/krusty/intermediateresourceid_test.go
+++ b/api/krusty/intermediateresourceid_test.go
@@ -13,14 +13,14 @@ import (
 // Ref: Issue #3455
 func TestIntermediateName(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/gcp", `
+	th.WriteK("gcp", `
 namePrefix: gcp-
 resources:
 - ../emea
 patchesStrategicMerge:
 - depPatch.yaml
 `)
-	th.WriteF("/app/gcp/depPatch.yaml", `
+	th.WriteF("gcp/depPatch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,21 +28,21 @@ metadata:
 spec:
   replicas: 999
 `)
-	th.WriteK("/app/emea", `
+	th.WriteK("emea", `
 namePrefix: emea-
 resources:
 - ../prod
 `)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 namePrefix: prod-
 resources:
 - ../base
 `)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,7 +53,7 @@ spec:
       containers:
       - image: whatever
 `)
-	m := th.Run("/app/gcp", th.MakeDefaultOptions())
+	m := th.Run("gcp", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -72,14 +72,14 @@ spec:
 // transformations) have the same name, there is no conflict
 func TestIntermediateNameSameNameDifferentLayer(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/gcp", `
+	th.WriteK("gcp", `
 namePrefix: gcp-
 resources:
 - ../emea
 patchesStrategicMerge:
 - depPatch.yaml
 `)
-	th.WriteF("/app/gcp/depPatch.yaml", `
+	th.WriteF("gcp/depPatch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,13 +87,13 @@ metadata:
 spec:
   replicas: 999
 `)
-	th.WriteK("/app/emea", `
+	th.WriteK("emea", `
 namePrefix: emea-
 resources:
 - ../prod
 - deployment.yaml
 `)
-	th.WriteF("/app/emea/deployment.yaml", `
+	th.WriteF("emea/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -104,16 +104,16 @@ spec:
       containers:
       - image: whatever
 `)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 namePrefix: prod-
 resources:
 - ../base
 `)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -124,7 +124,7 @@ spec:
       containers:
       - image: whatever
 `)
-	m := th.Run("/app/gcp", th.MakeDefaultOptions())
+	m := th.Run("gcp", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -153,14 +153,14 @@ spec:
 // instead of prod-foo
 func TestIntermediateNameAmbiguous(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/gcp", `
+	th.WriteK("gcp", `
 namePrefix: gcp-
 resources:
 - ../emea
 patchesStrategicMerge:
 - depPatch.yaml
 `)
-	th.WriteF("/app/gcp/depPatch.yaml", `
+	th.WriteF("gcp/depPatch.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -168,13 +168,13 @@ metadata:
 spec:
   replicas: 999
 `)
-	th.WriteK("/app/emea", `
+	th.WriteK("emea", `
 namePrefix: emea-
 resources:
 - ../prod
 - deployment.yaml
 `)
-	th.WriteF("/app/emea/deployment.yaml", `
+	th.WriteF("emea/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,16 +185,16 @@ spec:
       containers:
       - image: whatever
 `)
-	th.WriteK("/app/prod", `
+	th.WriteK("prod", `
 namePrefix: prod-
 resources:
 - ../base
 `)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -205,7 +205,7 @@ spec:
       containers:
       - image: whatever
 `)
-	err := th.RunWithErr("/app/gcp", th.MakeDefaultOptions())
+	err := th.RunWithErr("gcp", th.MakeDefaultOptions())
 	assert.Error(t, err)
 }
 
@@ -220,13 +220,13 @@ namePrefix: project-
 resources:
 - app`)
 
-	th.WriteK("/app", `
+	th.WriteK("app", `
 resources:
 - resources/deployment.yaml
 - resources/xql
 `)
 
-	th.WriteK("/app/resources/xql", `
+	th.WriteK("app/resources/xql", `
 resources:
 - xql-zero
 - xql-one
@@ -234,12 +234,12 @@ configurations:
 - ./kustomizeconfig.yaml
 `)
 
-	th.WriteF("/app/resources/xql/kustomizeconfig.yaml", `
+	th.WriteF("app/resources/xql/kustomizeconfig.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/valueFrom/secretKeyRef/name
 `)
 
-	th.WriteK("/app/resources/xql/xql-one", `
+	th.WriteK("app/resources/xql/xql-one", `
 namePrefix: xql-one-
 resources:
 - ../../../../bases/xql
@@ -258,11 +258,11 @@ vars:
     fieldpath: metadata.name
 `)
 
-	th.WriteF("/app/resources/xql/xql-one/config/xql-one-secret.env", `
+	th.WriteF("app/resources/xql/xql-one/config/xql-one-secret.env", `
 arg=1
 `)
 
-	th.WriteK("/app/resources/xql/xql-zero", `
+	th.WriteK("app/resources/xql/xql-zero", `
 namePrefix: xql-zero-
 resources:
 - ../../../../bases/xql
@@ -281,7 +281,7 @@ vars:
     fieldpath: metadata.name
 `)
 
-	th.WriteF("/app/resources/xql/xql-zero/config/xql-zero-secret.env", `
+	th.WriteF("app/resources/xql/xql-zero/config/xql-zero-secret.env", `
 arg=0
 `)
 
@@ -320,7 +320,7 @@ spec:
               key: password
 `)
 
-	th.WriteK("/bases/xql", `
+	th.WriteK("bases/xql", `
 secretGenerator:
 - name: xql-secret
   envs:

--- a/api/krusty/keepemptyarray_test.go
+++ b/api/krusty/keepemptyarray_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestKeepEmptyArray(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/resources.yaml", `
+	th.WriteF("resources.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,11 +24,11 @@ spec:
         imagePullPolicy: IfNotPresent
       imagePullSecrets: []`)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - resources.yaml`)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/managedbylabel_test.go
+++ b/api/krusty/managedbylabel_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAddManagedbyLabel(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/service.yaml", `
+	th.WriteF("service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,7 +20,7 @@ spec:
   ports:
   - port: 7002
 `)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -28,7 +28,7 @@ resources:
 `)
 	options := th.MakeDefaultOptions()
 	options.AddManagedbyLabel = true
-	m := th.Run("/app", options)
+	m := th.Run(".", options)
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Service

--- a/api/krusty/mergeenvfrom_test.go
+++ b/api/krusty/mergeenvfrom_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func makeCommonFileForMergeEnvFromTest(th kusttest_test.Harness) {
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +33,7 @@ spec:
 func TestMergeEnvFrom(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForMergeEnvFromTest(th)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -52,7 +52,7 @@ patchesStrategicMerge:
           - configMapRef:
               name: another-config
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -73,7 +73,7 @@ spec:
 func TestMergeEnvFromViaJsonInline(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFileForMergeEnvFromTest(th)
-	th.WriteK("app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 patches:
@@ -87,7 +87,7 @@ patches:
         configMapRef:
           name: another-config
 `)
-	m := th.Run("app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/multiplepatch_test.go
+++ b/api/krusty/multiplepatch_test.go
@@ -506,7 +506,7 @@ metadata:
 }
 
 func makeCommonFilesForMultiplePatchTests(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: team-foo-
 commonLabels:
   app: mynginx
@@ -522,7 +522,7 @@ configMapGenerator:
   literals:
   - foo=bar
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -548,7 +548,7 @@ spec:
           name: configmap-in-base
         name: configmap-in-base
 `)
-	th.WriteF("/app/base/service.yaml", `
+	th.WriteF("base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -561,7 +561,7 @@ spec:
   selector:
     app: nginx
 `)
-	th.WriteK("/app/overlay/staging", `
+	th.WriteK("overlay/staging", `
 namePrefix: staging-
 commonLabels:
   env: staging
@@ -580,7 +580,7 @@ configMapGenerator:
 func TestMultiplePatchesNoConflict(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFilesForMultiplePatchTests(th)
-	th.WriteF("/app/overlay/staging/deployment-patch1.yaml", `
+	th.WriteF("overlay/staging/deployment-patch1.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -602,7 +602,7 @@ spec:
           name: configmap-in-overlay
         name: configmap-in-overlay
 `)
-	th.WriteF("/app/overlay/staging/deployment-patch2.yaml", `
+	th.WriteF("overlay/staging/deployment-patch2.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -616,7 +616,7 @@ spec:
         - name: ANOTHERENV
           value: FOO
 `)
-	m := th.Run("/app/overlay/staging", th.MakeDefaultOptions())
+	m := th.Run("overlay/staging", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -718,7 +718,7 @@ metadata:
 func TestMultiplePatchesWithConflict(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFilesForMultiplePatchTests(th)
-	th.WriteF("/app/overlay/staging/deployment-patch1.yaml", `
+	th.WriteF("overlay/staging/deployment-patch1.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -739,7 +739,7 @@ spec:
           name: configmap-in-overlay
         name: configmap-in-overlay
 `)
-	th.WriteF("/app/overlay/staging/deployment-patch2.yaml", `
+	th.WriteF("overlay/staging/deployment-patch2.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -757,7 +757,7 @@ spec:
 	if opts.UseKyaml {
 		// kyaml doesn't try to detect conflicts in patches
 		// (so ENABLE_FEATURE_FOO FALSE wins).
-		m := th.Run("/app/overlay/staging", opts)
+		m := th.Run("overlay/staging", opts)
 		th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -853,7 +853,7 @@ metadata:
   name: staging-configmap-in-overlay-dc6fm46dhm
 `)
 	} else {
-		err := th.RunWithErr("/app/overlay/staging", opts)
+		err := th.RunWithErr("overlay/staging", opts)
 		if err == nil {
 			t.Fatalf("expected conflict")
 		}
@@ -910,9 +910,9 @@ spec:
 		t.Run(c.name, func(t *testing.T) {
 			th := kusttest_test.MakeHarness(t)
 			makeCommonFilesForMultiplePatchTests(th)
-			th.WriteF("/app/overlay/staging/deployment-patch1.yaml", c.patch1)
-			th.WriteF("/app/overlay/staging/deployment-patch2.yaml", c.patch2)
-			m := th.Run("/app/overlay/staging", th.MakeDefaultOptions())
+			th.WriteF("overlay/staging/deployment-patch1.yaml", c.patch1)
+			th.WriteF("overlay/staging/deployment-patch2.yaml", c.patch2)
+			m := th.Run("overlay/staging", th.MakeDefaultOptions())
 			th.AssertActualEqualsExpected(m, `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1005,7 +1005,7 @@ metadata:
 func TestMultiplePatchesBothWithPatchDeleteDirective(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeCommonFilesForMultiplePatchTests(th)
-	th.WriteF("/app/overlay/staging/deployment-patch1.yaml", `
+	th.WriteF("overlay/staging/deployment-patch1.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1017,7 +1017,7 @@ spec:
       - $patch: delete
         name: sidecar
 `)
-	th.WriteF("/app/overlay/staging/deployment-patch2.yaml", `
+	th.WriteF("overlay/staging/deployment-patch2.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1033,7 +1033,7 @@ spec:
 	if opt.UseKyaml {
 		// kyaml doesn't fail on conflicts in patches; both containers
 		// (nginx and sidecar) are deleted per this patching instruction.
-		m := th.Run("/app/overlay/staging", opt)
+		m := th.Run("overlay/staging", opt)
 		th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -1114,7 +1114,7 @@ metadata:
 `)
 	} else {
 		// No kyaml means error on a patch conflict.
-		err := th.RunWithErr("/app/overlay/staging", opt)
+		err := th.RunWithErr("overlay/staging", opt)
 		if err == nil {
 			t.Fatalf("Expected error")
 		}

--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -514,13 +514,13 @@ type: Opaque
 
 func TestEmptyFieldSpecValue(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 generators:
 - generators.yaml
 configurations:
 - kustomizeconfig.yaml
 `)
-	th.WriteF("/app/generators.yaml", `
+	th.WriteF("generators.yaml", `
 apiVersion: builtin
 kind: ConfigMapGenerator
 metadata:
@@ -530,7 +530,7 @@ labels:
 literals:
 - this_is_a_secret_name=
 `)
-	th.WriteF("/app/kustomizeconfig.yaml", `
+	th.WriteF("kustomizeconfig.yaml", `
 nameReference:
 - kind: Secret
   version: v1
@@ -538,7 +538,7 @@ nameReference:
   - path: data/this_is_a_secret_name
     kind: ConfigMap
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:

--- a/api/krusty/namespacedgenerators_test.go
+++ b/api/krusty/namespacedgenerators_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNamespacedGenerator(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
@@ -34,7 +34,7 @@ secretGenerator:
   literals:
   - password.txt=anotherSecret
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -74,7 +74,7 @@ type: Opaque
 
 func TestNamespacedGeneratorWithOverlays(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namespace: base
 
 configMapGenerator:
@@ -82,7 +82,7 @@ configMapGenerator:
   literals:
     - base=apple
 `)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 resources:
   - ../base
 
@@ -94,7 +94,7 @@ configMapGenerator:
     literals:
       - overlay=peach
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:

--- a/api/krusty/namespaces_test.go
+++ b/api/krusty/namespaces_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNamespacedSecrets(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/secrets.yaml", `
+	th.WriteF("secrets.yaml", `
 apiVersion: v1
 kind: Secret
 metadata:
@@ -33,7 +33,7 @@ data:
 `)
 
 	// This should find the proper secret.
-	th.WriteF("/app/role.yaml", `
+	th.WriteF("role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -45,7 +45,7 @@ rules:
   verbs: ["get"]
 `)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - secrets.yaml
 - role.yaml
@@ -55,7 +55,7 @@ resources:
 	// The ClusterRole (by def) is not in a namespace,
 	// and in this case applies to *any* Secret resource
 	// named "dummy"
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 data:
@@ -722,14 +722,14 @@ func TestVariablesDisambiguatedWithNamespace(t *testing.T) {
 func TestAddNamePrefixWithNamespace(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
-	th.WriteF("/app/serviceaccount.yaml", `
+	th.WriteF("serviceaccount.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
 `)
 
-	th.WriteF("/app/clusterrolebinding.yaml", `
+	th.WriteF("clusterrolebinding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -744,7 +744,7 @@ subjects:
   namespace: iter8-monitoring
 `)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 namePrefix: iter8-
 namespace: iter8-monitoring
 resources:
@@ -752,7 +752,7 @@ resources:
 - serviceaccount.yaml
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/api/krusty/nameupdateinroleref_test.go
+++ b/api/krusty/nameupdateinroleref_test.go
@@ -9,7 +9,7 @@ import (
 // https://github.com/kubernetes-sigs/kustomize/issues/2640
 func TestNameUpdateInRoleRef(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/rbac.yaml", `
+	th.WriteF("rbac.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -61,7 +61,7 @@ subjects:
   name: default
 `)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 namespace: foo
 resources:
 - rbac.yaml
@@ -78,7 +78,7 @@ patches:
     name: my-role
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -138,7 +138,7 @@ subjects:
 // https://github.com/kubernetes-sigs/kustomize/issues/3073
 func TestNameUpdateInRoleRef2(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/workloads.yaml", `
+	th.WriteF("workloads.yaml", `
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -198,7 +198,7 @@ subjects:
   name: myapp
 `)
 
-	th.WriteF("/app/suffixTransformer.yaml", `
+	th.WriteF("suffixTransformer.yaml", `
 apiVersion: builtin
 kind: PrefixSuffixTransformer
 metadata:
@@ -213,7 +213,7 @@ fieldSpecs:
   name: myapp
 `)
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -224,7 +224,7 @@ namespace: test
 
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount

--- a/api/krusty/nullvalues_test.go
+++ b/api/krusty/nullvalues_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNullValues1(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,13 +32,13 @@ spec:
         image: image
         name: example
 `)
-	th.WriteF("/app/kustomization.yaml", `
+	th.WriteF("kustomization.yaml", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1

--- a/api/krusty/numericcommonlabels_test.go
+++ b/api/krusty/numericcommonlabels_test.go
@@ -14,7 +14,7 @@ func TestNumericCommonLabels(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	// A basic deployment just used to put labels into
-	th.WriteF("/app/default/deployment.yaml", `
+	th.WriteF("default/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,14 +24,14 @@ metadata:
 	// Combine these custom transformers in one kustomization file.
 	// This kustomization file has a string-valued commonLabel that
 	// should always be quoted to remain a string
-	th.WriteK("/app/default", `
+	th.WriteK("default", `
 commonLabels:
   version: "1"
 resources:
 - deployment.yaml
 `)
 
-	m := th.Run("/app/default", th.MakeDefaultOptions())
+	m := th.Run("default", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/openapicustomschema_test.go
+++ b/api/krusty/openapicustomschema_test.go
@@ -35,13 +35,13 @@ spec:
 }
 
 func writeTestComponentWithCustomSchema(th kusttest_test.Harness) {
-	writeTestSchema(th, "/comp/")
+	writeTestSchema(th, "comp/")
 	openapi.ResetOpenAPI()
-	th.WriteC("/comp", `
+	th.WriteC("comp", `
 openapi:
   path: mycrd_schema.json
 `)
-	th.WriteF("/comp/stub.yaml", `
+	th.WriteF("comp/stub.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -93,7 +93,7 @@ resources:
 openapi:
   path: mycrd_schema.json
 `+customSchemaPatch)
-	writeCustomResource(th, "/mycrd.yaml")
+	writeCustomResource(th, "mycrd.yaml")
 	writeTestSchema(th, "./")
 	openapi.ResetOpenAPI()
 	m := th.Run(".", th.MakeDefaultOptions())
@@ -111,7 +111,7 @@ openapi:
   version: v1.18.8
   path: mycrd_schema.json
 `+customSchemaPatch)
-	writeCustomResource(th, "/mycrd.yaml")
+	writeCustomResource(th, "mycrd.yaml")
 	writeTestSchema(th, "./")
 	openapi.ResetOpenAPI()
 	err := th.RunWithErr(".", th.MakeDefaultOptions())
@@ -130,7 +130,7 @@ resources:
 openapi:
   path: mycrd_schema.json
 `+customSchemaPatch)
-	writeCustomResource(th, "/mycrd.yaml")
+	writeCustomResource(th, "mycrd.yaml")
 	openapi.ResetOpenAPI()
 	err := th.RunWithErr(".", th.MakeDefaultOptions())
 	assert.Error(t, err)
@@ -152,7 +152,7 @@ resources:
 - ../base
 `+customSchemaPatch)
 	writeCustomResource(th, "base/mycrd.yaml")
-	writeTestSchema(th, "/base/")
+	writeTestSchema(th, "base/")
 	openapi.ResetOpenAPI()
 	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, patchedCustomResource)
@@ -173,7 +173,7 @@ openapi:
   path: mycrd_schema.json
 `+customSchemaPatch)
 	writeCustomResource(th, "base/mycrd.yaml")
-	writeTestSchema(th, "/overlay/")
+	writeTestSchema(th, "overlay/")
 	openapi.ResetOpenAPI()
 	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, patchedCustomResource)
@@ -196,7 +196,7 @@ openapi:
   version: v1.19.1
 `+customSchemaPatch)
 	writeCustomResource(th, "base/mycrd.yaml")
-	writeTestSchema(th, "/base/")
+	writeTestSchema(th, "base/")
 	openapi.ResetOpenAPI()
 	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `

--- a/api/krusty/openapiversion_test.go
+++ b/api/krusty/openapiversion_test.go
@@ -17,7 +17,7 @@ openapi:
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +52,7 @@ openapi:
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -76,7 +76,7 @@ func TestOpenApiFieldDefaultVersion(t *testing.T) {
 resources:
 - deployment.yaml
 `)
-	th.WriteF("/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -260,7 +260,7 @@ spec:
 
 func TestOpenAPIFieldFromComponentDefault(t *testing.T) {
 	input := []FileGen{writeTestBase, writeTestComponent, writeOverlayProd}
-	runPath := "/prod"
+	runPath := "prod"
 
 	th := kusttest_test.MakeHarness(t)
 	for _, f := range input {
@@ -271,11 +271,11 @@ func TestOpenAPIFieldFromComponentDefault(t *testing.T) {
 }
 
 func writeTestComponentWithOlderOpenAPIVersion(th kusttest_test.Harness) {
-	th.WriteC("/comp", `
+	th.WriteC("comp", `
 openapi:
   version: v1.18.8
 `)
-	th.WriteF("/comp/stub.yaml", `
+	th.WriteF("comp/stub.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:

--- a/api/krusty/resourceconflict_test.go
+++ b/api/krusty/resourceconflict_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func writeBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - serviceaccount.yaml
 - rolebinding.yaml
@@ -20,13 +20,13 @@ resources:
 namePrefix: pfx-
 nameSuffix: -sfx
 `)
-	th.WriteF("/app/base/serviceaccount.yaml", `
+	th.WriteF("base/serviceaccount.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: serviceaccount
 `)
-	th.WriteF("/app/base/rolebinding.yaml", `
+	th.WriteF("base/rolebinding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -39,7 +39,7 @@ subjects:
 - kind: ServiceAccount
   name: serviceaccount
 `)
-	th.WriteF("/app/base/clusterrolebinding.yaml", `
+	th.WriteF("base/clusterrolebinding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -52,7 +52,7 @@ subjects:
 - kind: ServiceAccount
   name: serviceaccount
 `)
-	th.WriteF("/app/base/clusterrole.yaml", `
+	th.WriteF("base/clusterrole.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -66,13 +66,13 @@ rules:
 
 func writeMidOverlays(th kusttest_test.Harness) {
 	// Mid-level overlays
-	th.WriteK("/app/overlays/a", `
+	th.WriteK("overlays/a", `
 resources:
 - ../../base
 namePrefix: a-
 nameSuffix: -suffixA
 `)
-	th.WriteK("/app/overlays/b", `
+	th.WriteK("overlays/b", `
 resources:
 - ../../base
 namePrefix: b-
@@ -82,7 +82,7 @@ nameSuffix: -suffixB
 
 func writeTopOverlay(th kusttest_test.Harness) {
 	// Top overlay, combining the mid-level overlays
-	th.WriteK("/app/combined", `
+	th.WriteK("combined", `
 resources:
 - ../overlays/a
 - ../overlays/b
@@ -92,7 +92,7 @@ resources:
 func TestBase(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeBase(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -143,7 +143,7 @@ func TestMidLevelA(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeBase(th)
 	writeMidOverlays(th)
-	m := th.Run("/app/overlays/a", th.MakeDefaultOptions())
+	m := th.Run("overlays/a", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -194,7 +194,7 @@ func TestMidLevelB(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	writeBase(th)
 	writeMidOverlays(th)
-	m := th.Run("/app/overlays/b", th.MakeDefaultOptions())
+	m := th.Run("overlays/b", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -246,7 +246,7 @@ func TestMultibasesNoConflict(t *testing.T) {
 	writeBase(th)
 	writeMidOverlays(th)
 	writeTopOverlay(th)
-	m := th.Run("/app/combined", th.MakeDefaultOptions())
+	m := th.Run("combined", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -342,7 +342,7 @@ func TestMultibasesWithConflict(t *testing.T) {
 	writeMidOverlays(th)
 	writeTopOverlay(th)
 
-	th.WriteK("/app/overlays/a", `
+	th.WriteK("overlays/a", `
 namePrefix: a-
 nameSuffix: -suffixA
 resources:
@@ -351,14 +351,14 @@ resources:
 `)
 	// Expect an error because this resource in the overlay
 	// matches a resource in the base.
-	th.WriteF("/app/overlays/a/serviceaccount.yaml", `
+	th.WriteF("overlays/a/serviceaccount.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: serviceaccount
 `)
 
-	err := th.RunWithErr("/app/combined", th.MakeDefaultOptions())
+	err := th.RunWithErr("combined", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/api/krusty/rolebindingacrossnamespace_test.go
+++ b/api/krusty/rolebindingacrossnamespace_test.go
@@ -10,12 +10,12 @@ func TestRoleBindingAcrossNamespace(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - resource.yaml
 nameSuffix: -ns2
 `)
-	th.WriteF("/app/resource.yaml", `
+	th.WriteF("resource.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -77,7 +77,7 @@ subjects:
     namespace: ns1
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -145,12 +145,12 @@ func TestRoleBindingAcrossNamespaceWoSubjects(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - resource.yaml
 nameSuffix: -ns2
 `)
-	th.WriteF("/app/resource.yaml", `
+	th.WriteF("resource.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -181,7 +181,7 @@ roleRef:
   name: my-role
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -219,18 +219,18 @@ roleRef:
 func TestRoleBindingWhenSubjectsAcrossNamespace(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - ./ns1
 - ./ns2
 `)
-	th.WriteK("/app/ns1", `
+	th.WriteK("ns1", `
 namespace: namespace-1
 resources:
 - role-ns1.yaml
 - rolebinding-ns1.yaml
 `)
-	th.WriteF("/app/ns1/role-ns1.yaml", `
+	th.WriteF("ns1/role-ns1.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -240,7 +240,7 @@ rules:
     resources: ["pods"]
     verbs: ["get"]
 `)
-	th.WriteF("/app/ns1/rolebinding-ns1.yaml", `
+	th.WriteF("ns1/rolebinding-ns1.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -254,13 +254,13 @@ subjects:
     name: testAccount
     namespace: namespace-2
 `)
-	th.WriteK("/app/ns2", `
+	th.WriteK("ns2", `
 namespace: namespace-2
 resources:
 - role-ns2.yaml
 - rolebinding-ns2.yaml
 `)
-	th.WriteF("/app/ns2/role-ns2.yaml", `
+	th.WriteF("ns2/role-ns2.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -270,7 +270,7 @@ rules:
     resources: ["pods"]
     verbs: ["get"]
 `)
-	th.WriteF("/app/ns2/rolebinding-ns2.yaml", `
+	th.WriteF("ns2/rolebinding-ns2.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -285,7 +285,7 @@ subjects:
     namespace: namespace-1
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/api/krusty/simple_test.go
+++ b/api/krusty/simple_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSimple1(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/dep.yaml", `
+	th.WriteF("dep.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -19,7 +19,7 @@ metadata:
 spec:
   numReplicas: 1
 `)
-	th.WriteF("/patch.yaml", `
+	th.WriteF("patch.yaml", `
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -28,13 +28,13 @@ spec:
   numReplicas: 999
 `)
 
-	th.WriteK("/", `
+	th.WriteK(".", `
 resources:
 - dep.yaml
 patchesStrategicMerge:
 - patch.yaml
 `)
-	m := th.Run("/", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1

--- a/api/krusty/stringquoteblank_test.go
+++ b/api/krusty/stringquoteblank_test.go
@@ -13,7 +13,7 @@ import (
 // is invalid as plain style.
 func TestLongLineBreaks(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -42,11 +42,11 @@ spec:
         - name: INVALID_PLAIN_STYLE_STRING
           value: ': test'
 `)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/api/krusty/transformerplugin_test.go
+++ b/api/krusty/transformerplugin_test.go
@@ -24,12 +24,12 @@ func TestPluginsNotEnabled(t *testing.T) {
 		BuildGoPlugin("someteam.example.com", "v1", "StringPrefixer")
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 transformers:
 - stringPrefixer.yaml
 `)
-	writeStringPrefixer(th, "/app/stringPrefixer.yaml", "apple")
-	err := th.RunWithErr("/app", th.MakeOptionsPluginsDisabled())
+	writeStringPrefixer(th, "stringPrefixer.yaml", "apple")
+	err := th.RunWithErr(".", th.MakeOptionsPluginsDisabled())
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -43,7 +43,7 @@ func TestSedTransformer(t *testing.T) {
 		PrepExecPlugin("someteam.example.com", "v1", "SedTransformer")
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - configmap.yaml
 
@@ -56,19 +56,19 @@ configMapGenerator:
   - FOO=$FOO
   - BAR=$BAR
 `)
-	th.WriteF("/app/sed-transformer.yaml", `
+	th.WriteF("sed-transformer.yaml", `
 apiVersion: someteam.example.com/v1
 kind: SedTransformer
 metadata:
   name: some-random-name
 argsFromFile: sed-input.txt
 `)
-	th.WriteF("/app/sed-input.txt", `
+	th.WriteF("sed-input.txt", `
 s/$FOO/foo/g
 s/$BAR/bar/g
 `)
 
-	th.WriteF("/app/configmap.yaml", `
+	th.WriteF("configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -79,7 +79,7 @@ data:
   foo: $FOO
 `)
 
-	m := th.Run("/app", th.MakeOptionsPluginsEnabled())
+	m := th.Run(".", th.MakeOptionsPluginsEnabled())
 	th.AssertActualEqualsExpectedNoIdAnnotations(m, `
 apiVersion: v1
 data:
@@ -140,7 +140,7 @@ func TestOrderedTransformers(t *testing.T) {
 		BuildGoPlugin("someteam.example.com", "v1", "DatePrefixer")
 	defer th.Reset()
 
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 transformers:
@@ -149,12 +149,12 @@ transformers:
 - applePrefixer.yaml
 - date2Prefixer.yaml
 `)
-	writeDeployment(th, "/app/deployment.yaml")
-	writeStringPrefixer(th, "/app/applePrefixer.yaml", "apple")
-	writeStringPrefixer(th, "/app/peachPrefixer.yaml", "peach")
-	writeDatePrefixer(th, "/app/date1Prefixer.yaml", "date1")
-	writeDatePrefixer(th, "/app/date2Prefixer.yaml", "date2")
-	m := th.Run("/app", th.MakeOptionsPluginsEnabled())
+	writeDeployment(th, "deployment.yaml")
+	writeStringPrefixer(th, "applePrefixer.yaml", "apple")
+	writeStringPrefixer(th, "peachPrefixer.yaml", "peach")
+	writeDatePrefixer(th, "date1Prefixer.yaml", "date1")
+	writeDatePrefixer(th, "date2Prefixer.yaml", "date2")
+	m := th.Run(".", th.MakeOptionsPluginsEnabled())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -178,24 +178,24 @@ func TestTransformedTransformers(t *testing.T) {
 		BuildGoPlugin("someteam.example.com", "v1", "DatePrefixer")
 	defer th.Reset()
 
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - stringPrefixer.yaml
 transformers:
 - datePrefixer.yaml
 `)
-	writeStringPrefixer(th, "/app/base/stringPrefixer.yaml", "apple")
-	writeDatePrefixer(th, "/app/base/datePrefixer.yaml", "date")
+	writeStringPrefixer(th, "base/stringPrefixer.yaml", "apple")
+	writeDatePrefixer(th, "base/datePrefixer.yaml", "date")
 
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 resources:
 - deployment.yaml
 transformers:
 - ../base
 `)
-	writeDeployment(th, "/app/overlay/deployment.yaml")
+	writeDeployment(th, "overlay/deployment.yaml")
 
-	m := th.Run("/app/overlay", th.MakeOptionsPluginsEnabled())
+	m := th.Run("overlay", th.MakeOptionsPluginsEnabled())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment

--- a/api/krusty/transformersarrays_test.go
+++ b/api/krusty/transformersarrays_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func makeStatefulSetKustomization(th kusttest_test.Harness) {
-	th.WriteK("/app", `
+	th.WriteK(".", `
 commonLabels:
   notIn: arrays
 resources:
 - statefulset.yaml
 - statefulset-with-template.yaml
 `)
-	th.WriteF("/app/statefulset.yaml", `
+	th.WriteF("statefulset.yaml", `
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -42,7 +42,7 @@ spec:
         - containerPort: 80
           name: web
 `)
-	th.WriteF("/app/statefulset-with-template.yaml", `
+	th.WriteF("statefulset-with-template.yaml", `
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -94,7 +94,7 @@ spec:
 func TestTransformersNoCreateArrays(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeStatefulSetKustomization(th)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: StatefulSet

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func makeTransfomersImageBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deploy1.yaml
 - random.yaml
@@ -34,7 +34,7 @@ images:
   newName: my-docker
   digest: sha256:25a0d4b4
 `)
-	th.WriteF("/app/base/deploy1.yaml", `
+	th.WriteF("base/deploy1.yaml", `
 group: apps
 apiVersion: v1
 kind: Deployment
@@ -56,7 +56,7 @@ spec:
       - name: postgresdb
         image: postgres:1.8.0
 `)
-	th.WriteF("/app/base/random.yaml", `
+	th.WriteF("base/random.yaml", `
 kind: randomKind
 metadata:
   name: random
@@ -95,7 +95,7 @@ spec3:
 
 func TestIssue1281_JsonPatchAndImageTag(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 resources:
 - deployment.yaml
 
@@ -113,7 +113,7 @@ patchesJson6902:
     name: ben
   path: patch.json
 `)
-	th.WriteF("/app/deployment.yaml", `
+	th.WriteF("deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -138,7 +138,7 @@ spec:
         image: abbott
 `)
 
-	th.WriteF("/app/patch.json", `
+	th.WriteF("patch.json", `
 [ {"op": "add",
    "path": "/spec/replica", "value": "3"},
   {"op": "replace",
@@ -146,7 +146,7 @@ spec:
    "value": { "image": "costello" } } ]
 `)
 
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -179,7 +179,7 @@ spec:
 func TestTransfomersImageDefaultConfig(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeTransfomersImageBase(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 group: apps
@@ -239,7 +239,7 @@ spec3:
 }
 
 func makeTransfomersImageCustomBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - custom.yaml
 configurations:
@@ -264,7 +264,7 @@ images:
   newName: my-docker
   digest: sha256:25a0d4b4
 `)
-	th.WriteF("/app/base/custom.yaml", `
+	th.WriteF("base/custom.yaml", `
 kind: customKind
 metadata:
   name: custom
@@ -299,7 +299,7 @@ spec3:
       - name: my-cool-app
         image: gcr.io:8080/my-project/my-cool-app:latest
 `)
-	th.WriteF("/app/base/config/custom.yaml", `
+	th.WriteF("base/config/custom.yaml", `
 images:
 - kind: Custom
   path: spec/template/spec/myContainers[]/image
@@ -313,7 +313,7 @@ images:
 func TestTransfomersImageCustomConfig(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeTransfomersImageCustomBase(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 kind: customKind
 metadata:
@@ -352,7 +352,7 @@ spec3:
 }
 
 func makeTransfomersImageKnativeBase(th kusttest_test.Harness) {
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - knative.yaml
 configurations:
@@ -361,7 +361,7 @@ images:
 - name: solsa-echo
   newTag: foo
 `)
-	th.WriteF("/app/base/knative.yaml", `
+	th.WriteF("base/knative.yaml", `
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
@@ -374,7 +374,7 @@ spec:
           container:
             image: solsa-echo
 `)
-	th.WriteF("/app/base/config/knative.yaml", `
+	th.WriteF("base/config/knative.yaml", `
 images:
 - path: spec/runLatest/configuration/revisionTemplate/spec/container/image
   apiVersion: serving.knative.dev/v1alpha1
@@ -385,7 +385,7 @@ images:
 func TestTransfomersImageKnativeConfig(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	makeTransfomersImageKnativeBase(th)
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBasicVariableRef(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app", `
+	th.WriteK(".", `
 namePrefix: base-
 resources:
 - pod.yaml
@@ -26,7 +26,7 @@ vars:
     fieldpath: metadata.name
 `)
 
-	th.WriteF("/app/pod.yaml", `
+	th.WriteF("pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -42,7 +42,7 @@ spec:
       - name: FOO
         value: "$(POD_NAME)"
 `)
-	m := th.Run("/app", th.MakeDefaultOptions())
+	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -63,7 +63,7 @@ spec:
 
 func TestBasicVarCollision(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base1", `
+	th.WriteK("base1", `
 namePrefix: base1-
 resources:
 - pod.yaml
@@ -76,7 +76,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base1/pod.yaml", `
+	th.WriteF("base1/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -93,7 +93,7 @@ spec:
         value: "$(POD_NAME)"
 `)
 
-	th.WriteK("/app/base2", `
+	th.WriteK("base2", `
 namePrefix: base2-
 resources:
 - pod.yaml
@@ -106,7 +106,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base2/pod.yaml", `
+	th.WriteF("base2/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -123,12 +123,12 @@ spec:
         value: "$(POD_NAME)"
 `)
 
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 resources:
 - ../base1
 - ../base2
 `)
-	err := th.RunWithErr("/app/overlay", th.MakeDefaultOptions())
+	err := th.RunWithErr("overlay", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("should have an error")
 	}
@@ -139,7 +139,7 @@ resources:
 
 func TestVarPropagatesUp(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base1", `
+	th.WriteK("base1", `
 namePrefix: base1-
 resources:
 - pod.yaml
@@ -152,7 +152,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base1/pod.yaml", `
+	th.WriteF("base1/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -169,7 +169,7 @@ spec:
         value: "$(POD_NAME1)"
 `)
 
-	th.WriteK("/app/base2", `
+	th.WriteK("base2", `
 namePrefix: base2-
 resources:
 - pod.yaml
@@ -182,7 +182,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base2/pod.yaml", `
+	th.WriteF("base2/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -199,13 +199,13 @@ spec:
         value: "$(POD_NAME2)"
 `)
 
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 resources:
 - pod.yaml
 - ../base1
 - ../base2
 `)
-	th.WriteF("/app/overlay/pod.yaml", `
+	th.WriteF("overlay/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -224,7 +224,7 @@ spec:
       - name: P2
         value: "$(POD_NAME2)"
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Pod
@@ -282,7 +282,7 @@ spec:
 // twice, it's a collision, so it's denied.
 func TestBug506(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: base-
 resources:
 - pod.yaml
@@ -295,7 +295,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base/pod.yaml", `
+	th.WriteF("base/pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -308,17 +308,17 @@ spec:
         - name: POD_NAME
           value: $(POD_NAME)
 `)
-	th.WriteK("/app/o1", `
+	th.WriteK("o1", `
 nameprefix: p1-
 resources:
 - ../base
 `)
-	th.WriteK("/app/o2", `
+	th.WriteK("o2", `
 nameprefix: p2-
 resources:
 - ../base
 `)
-	th.WriteK("/app/top", `
+	th.WriteK("top", `
 resources:
 - ../o1
 - ../o2
@@ -351,7 +351,7 @@ resources:
 	       name: myServer
 	   `
 	*/
-	err := th.RunWithErr("/app/top", th.MakeDefaultOptions())
+	err := th.RunWithErr("top", th.MakeDefaultOptions())
 	if err == nil {
 		t.Fatalf("should have an error")
 	}
@@ -543,7 +543,7 @@ metadata:
 
 func TestVarRefBig(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: base-
 resources:
 - role-stuff.yaml
@@ -593,7 +593,7 @@ vars:
         apiVersion: v1
    fieldref:
         fieldpath: metadata.name`)
-	th.WriteF("/app/base/cronjob.yaml", `
+	th.WriteF("base/cronjob.yaml", `
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -616,7 +616,7 @@ spec:
               - name: CDB_PUBLIC_SVC
                 value: "$(CDB_PUBLIC_SVC)"
 `)
-	th.WriteF("/app/base/services.yaml", `
+	th.WriteF("base/services.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -663,7 +663,7 @@ spec:
   selector:
     app: cockroachdb
 `)
-	th.WriteF("/app/base/role-stuff.yaml", `
+	th.WriteF("base/role-stuff.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -732,7 +732,7 @@ subjects:
   name: cockroachdb
   namespace: default
 `)
-	th.WriteF("/app/base/pdb.yaml", `
+	th.WriteF("base/pdb.yaml", `
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -745,7 +745,7 @@ spec:
       app: cockroachdb
   maxUnavailable: 1
 `)
-	th.WriteF("/app/base/statefulset.yaml", `
+	th.WriteF("base/statefulset.yaml", `
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -854,12 +854,12 @@ spec:
         requests:
           storage: 1Gi
 `)
-	th.WriteK("/app/overlay/staging", `
+	th.WriteK("overlay/staging", `
 namePrefix: dev-
 resources:
 - ../../base
 `)
-	m := th.Run("/app/overlay/staging", th.MakeDefaultOptions())
+	m := th.Run("overlay/staging", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -1165,7 +1165,7 @@ metadata:
 
 func TestVariableRefIngressOverlay(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - service.yaml
 - deployment.yaml
@@ -1180,7 +1180,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1203,7 +1203,7 @@ spec:
         - name: http
           containerPort: 80
 `)
-	th.WriteF("/app/base/ingress.yaml", `
+	th.WriteF("base/ingress.yaml", `
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -1224,7 +1224,7 @@ spec:
     - $(DEPLOYMENT_NAME).example.com
     secretName: $(DEPLOYMENT_NAME).example.com-tls
 `)
-	th.WriteF("/app/base/service.yaml", `
+	th.WriteF("base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -1238,12 +1238,12 @@ spec:
     protocol: TCP
     targetPort: http
 `)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 nameprefix: kustomized-
 resources:
 - ../base
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: Service
@@ -1304,7 +1304,7 @@ spec:
 
 func TestVariableRefMountPath(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - namespace.yaml
@@ -1317,7 +1317,7 @@ vars:
     name: my-namespace
 
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
   apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -1338,14 +1338,14 @@ vars:
         - name: my-volume
           emptyDir: {}
 `)
-	th.WriteF("/app/base/namespace.yaml", `
+	th.WriteF("base/namespace.yaml", `
   apiVersion: v1
   kind: Namespace
   metadata:
     name: my-namespace
 `)
 
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -1376,7 +1376,7 @@ metadata:
 
 func TestVariableRefMaps(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - deployment.yaml
 - namespace.yaml
@@ -1387,7 +1387,7 @@ vars:
     kind: Namespace
     name: my-namespace
 `)
-	th.WriteF("/app/base/deployment.yaml", `
+	th.WriteF("base/deployment.yaml", `
   apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -1403,14 +1403,14 @@ vars:
         - name: app
           image: busybox
 `)
-	th.WriteF("/app/base/namespace.yaml", `
+	th.WriteF("base/namespace.yaml", `
   apiVersion: v1
   kind: Namespace
   metadata:
     name: my-namespace
 `)
 
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: Deployment
@@ -1436,14 +1436,14 @@ metadata:
 
 func TestVaribaleRefDifferentPrefix(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 namePrefix: base-
 resources:
 - dev
 - test
 `)
 
-	th.WriteK("/app/base/dev", `
+	th.WriteK("base/dev", `
 namePrefix: dev-
 resources:
 - elasticsearch-dev-service.yml
@@ -1457,7 +1457,7 @@ vars:
     fieldpath: metadata.name
 
 `)
-	th.WriteF("/app/base/dev/elasticsearch-dev-service.yml", `
+	th.WriteF("base/dev/elasticsearch-dev-service.yml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -1483,7 +1483,7 @@ spec:
   clusterIP: None
 `)
 
-	th.WriteK("/app/base/test", `
+	th.WriteK("base/test", `
 namePrefix: test-
 resources:
 - elasticsearch-test-service.yml
@@ -1496,7 +1496,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base/test/elasticsearch-test-service.yml", `
+	th.WriteF("base/test/elasticsearch-test-service.yml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -1522,7 +1522,7 @@ spec:
   clusterIP: None
 `)
 
-	m := th.Run("/app/base", th.MakeDefaultOptions())
+	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1576,7 +1576,7 @@ spec:
 
 func TestVariableRefNFSServer(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("/app/base", `
+	th.WriteK("base", `
 resources:
 - pv_pvc.yaml
 - nfs_deployment.yaml
@@ -1599,7 +1599,7 @@ vars:
   fieldref:
     fieldpath: metadata.name
 `)
-	th.WriteF("/app/base/pv_pvc.yaml", `
+	th.WriteF("base/pv_pvc.yaml", `
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -1611,7 +1611,7 @@ spec:
     requests:
       storage: 10Gi
 `)
-	th.WriteF("/app/base/nfs_deployment.yaml", `
+	th.WriteF("base/nfs_deployment.yaml", `
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -1643,7 +1643,7 @@ spec:
           persistentVolumeClaim:
             claimName: shared-volume-claim
 `)
-	th.WriteF("/app/base/nfs_service.yaml", `
+	th.WriteF("base/nfs_service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -1659,7 +1659,7 @@ spec:
   selector:
     role: nfs-server
 `)
-	th.WriteF("/app/base/Deployment.yaml", `
+	th.WriteF("base/Deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1682,7 +1682,7 @@ spec:
         - name: http
           containerPort: 80
         volumeMounts:
-          - mountPath: /app/shared-files
+          - mountPath: shared-files
             name: nfs-files-vol
       volumes:
         - name: nfs-files-vol
@@ -1691,7 +1691,7 @@ spec:
             path: /
             readOnly: false
 `)
-	th.WriteF("/app/base/CronJob.yaml", `
+	th.WriteF("base/CronJob.yaml", `
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -1711,7 +1711,7 @@ spec:
             - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure
           volumeMounts:
-          - mountPath: /app/shared-files
+          - mountPath: shared-files
             name: nfs-files-vol
         volumes:
         - name: nfs-files-vol
@@ -1720,7 +1720,7 @@ spec:
             path: /
             readOnly: false
 `)
-	th.WriteF("/app/base/DaemonSet.yaml", `
+	th.WriteF("base/DaemonSet.yaml", `
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -1755,7 +1755,7 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       terminationGracePeriodSeconds: 30
       volumes:
@@ -1771,7 +1771,7 @@ spec:
           path: /
           readOnly: false
 `)
-	th.WriteF("/app/base/ReplicaSet.yaml", `
+	th.WriteF("base/ReplicaSet.yaml", `
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
@@ -1794,7 +1794,7 @@ spec:
       - name: php-redis
         image: gcr.io/google_samples/gb-frontend:v3
         volumeMounts:
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       volumes:
       - name: nfs-files-vol
@@ -1804,7 +1804,7 @@ spec:
           readOnly: false
 `)
 
-	th.WriteF("/app/base/Job.yaml", `
+	th.WriteF("base/Job.yaml", `
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -1817,7 +1817,7 @@ spec:
         image: perl
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
         volumeMounts:
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       restartPolicy: Never
       volumes:
@@ -1828,7 +1828,7 @@ spec:
           readOnly: false
   backoffLimit: 4
 `)
-	th.WriteF("/app/base/StatefulSet.yaml", `
+	th.WriteF("base/StatefulSet.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -1864,7 +1864,7 @@ spec:
         path: /
         readOnly: false
 `)
-	th.WriteF("/app/base/Pod.yaml", `
+	th.WriteF("base/Pod.yaml", `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1880,7 +1880,7 @@ spec:
       containerPort: 80
   volumeMounts:
   - name: nfs-files-vol
-    mountPath: /app/shared-files
+    mountPath: shared-files
   volumes:
   - name: nfs-files-vol
     nfs:
@@ -1888,7 +1888,7 @@ spec:
       path: /
       readOnly: false
 `)
-	th.WriteF("/app/base/nfs_pv.yaml", `
+	th.WriteF("base/nfs_pv.yaml", `
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -1903,12 +1903,12 @@ spec:
     path: /
     readOnly: false
 `)
-	th.WriteK("/app/overlay", `
+	th.WriteK("overlay", `
 nameprefix: kustomized-
 resources:
 - ../base
 `)
-	m := th.Run("/app/overlay", th.MakeDefaultOptions())
+	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -1989,7 +1989,7 @@ spec:
         - containerPort: 80
           name: http
         volumeMounts:
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       volumes:
       - name: nfs-files-vol
@@ -2016,7 +2016,7 @@ spec:
             name: hello
           restartPolicy: OnFailure
           volumeMounts:
-          - mountPath: /app/shared-files
+          - mountPath: shared-files
             name: nfs-files-vol
         volumes:
         - name: nfs-files-vol
@@ -2057,7 +2057,7 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       terminationGracePeriodSeconds: 30
       tolerations:
@@ -2097,7 +2097,7 @@ spec:
       - image: gcr.io/google_samples/gb-frontend:v3
         name: php-redis
         volumeMounts:
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       volumes:
       - name: nfs-files-vol
@@ -2156,7 +2156,7 @@ spec:
     - containerPort: 80
       name: http
   volumeMounts:
-  - mountPath: /app/shared-files
+  - mountPath: shared-files
     name: nfs-files-vol
   volumes:
   - name: nfs-files-vol
@@ -2182,7 +2182,7 @@ spec:
         image: perl
         name: pi
         volumeMounts:
-        - mountPath: /app/shared-files
+        - mountPath: shared-files
           name: nfs-files-vol
       restartPolicy: Never
       volumes:


### PR DESCRIPTION
@monopole mentioned wanting to do this eventually, so here is a PR for it

This changes krusty tests to have "." at the top level instead of "app" and have relative paths instead of absolute ones