### PR TITLE
Drop regeneration directives from copied code.

### DIFF
--- a/cmd/config/internal/commands/internal/k8sgen/pkg/api/resource/amount.go
+++ b/cmd/config/internal/commands/internal/k8sgen/pkg/api/resource/amount.go
@@ -57,7 +57,6 @@ var (
 
 // int64Amount represents a fixed precision numerator and arbitrary scale exponent. It is faster
 // than operations on inf.Dec for values that can be represented as int64.
-// +k8s:openapi-gen=true
 type int64Amount struct {
 	value int64
 	scale Scale

--- a/cmd/config/internal/commands/internal/k8sgen/pkg/api/resource/quantity.go
+++ b/cmd/config/internal/commands/internal/k8sgen/pkg/api/resource/quantity.go
@@ -86,8 +86,6 @@ import (
 // +protobuf.embed=string
 // +protobuf.options.marshal=false
 // +protobuf.options.(gogoproto.goproto_stringer)=false
-// +k8s:deepcopy-gen=true
-// +k8s:openapi-gen=true
 type Quantity struct {
 	// i is the quantity in int64 scaled form, if d.Dec == nil
 	i int64Amount

--- a/cmd/k8scopy/internal/copier.go
+++ b/cmd/k8scopy/internal/copier.go
@@ -92,10 +92,11 @@ func (c Copier) CopyFile(dir, name string) error {
 	for scanner.Scan() {
 		l := scanner.Text()
 		// Disallow recursive generation.
-		if strings.HasPrefix(l, "//go:generate") {
+		if strings.HasPrefix(l, "//go:generate") ||
+			strings.HasPrefix(l, "// +k8s:") {
 			continue
 		}
-		// Don't want it to appear double generated.
+		// When copying generated code, drop the old 'generated' message.
 		if strings.HasPrefix(l, "// Code generated") {
 			continue
 		}

--- a/kyaml/yaml/internal/k8sgen/pkg/labels/selector.go
+++ b/kyaml/yaml/internal/k8sgen/pkg/labels/selector.go
@@ -121,7 +121,6 @@ func (a ByKey) Less(i, j int) bool { return a[i].key < a[j].key }
 // The zero value of Requirement is invalid.
 // Requirement implements both set based match and exact match
 // Requirement should be initialized via NewRequirement constructor for creating a valid Requirement.
-// +k8s:deepcopy-gen=true
 type Requirement struct {
 	key      string
 	operator selection.Operator


### PR DESCRIPTION
ALLOW_MODULE_SPAN

k8s build scripts are reading these things, and we don't want them to (not in copied code).