### PR TITLE
feat: Reduce docker image size

### DIFF
--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -14,8 +14,8 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build \
 # only copy binary
 FROM alpine
 # install dependencies
-RUN apk add git openssh
-COPY --from=builder /build/kustomize /app/
+RUN apk add --no-cache git openssh
+COPY --from=builder /build/kustomize/kustomize /app/
 WORKDIR /app
 ENV PATH "$PATH:/app"
 ENTRYPOINT ["/app/kustomize"]


### PR DESCRIPTION
Using the --no-cache option gets rid of the /var/cache/apk entries from the second layer (the one created with `RUN apk add...`.

When copying the /build/kustomize into /app/ we are copying the contents of the kustomize folder from the repo, which includes the generated kustomize binary and also some go files (go.mod, go.sum main.go etc). So now we are only copying the binary and everything keeps working as expected.

Locally for me it reduced the image size from 41.5 MB to 39.3 MB.