### PR TITLE
allow kpt setters to set on kustomize inline patches

### DIFF
--- a/kyaml/go.sum
+++ b/kyaml/go.sum
@@ -107,7 +107,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -152,7 +151,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/kyaml/setters2/add_test.go
+++ b/kyaml/setters2/add_test.go
@@ -46,6 +46,41 @@ spec:
  `,
 		},
 		{
+			name: "add-to-inline-string",
+			add: Add{
+				FieldValue: "placeholder",
+				Ref:        "#/definitions/io.k8s.cli.setters.path",
+			},
+			input: `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- target:
+    kind: Something
+  patch: |
+    - op: add
+      path: placeholder
+      value: known
+    - op: replace
+      path: placeholder
+      value: known
+ `,
+			expected: `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- target:
+    kind: Something
+  patch: |
+    - op: add
+      path: placeholder # {"$openapi":"path"}
+      value: known
+    - op: replace
+      path: placeholder # {"$openapi":"path"}
+      value: known
+ `,
+		},
+		{
 			name: "add-replicas-annotations",
 			add: Add{
 				FieldValue: "3",

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -142,6 +143,35 @@ func NewMapRNode(values *map[string]string) *RNode {
 		})
 	}
 
+	return m
+}
+
+// NewMapListRNode returns a new List *RNode with Map *RNodes containing the provided values
+func NewMapListRNode(values *map[string]string) *RNode {
+	if values == nil || len(*values) == 0 {
+		return nil
+	}
+	m := &RNode{value: &yaml.Node{
+		Kind: yaml.SequenceNode,
+	}}
+
+	m.value.Content = append(m.value.Content, &yaml.Node{
+		Kind: yaml.MappingNode,
+	})
+	keys := make([]string, 0, len(*values))
+	for k := range *values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // needed for deterministic tests
+	for _, k := range keys {
+		m.value.Content[0].Content = append(m.value.Content[0].Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: k,
+		}, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: (*values)[k],
+		})
+	}
 	return m
 }
 


### PR DESCRIPTION
Close https://github.com/GoogleContainerTools/kpt/issues/1342

Request from users to allow kpt setters to work on kustomize patches. To do so the inline patches need additional parsing. 

Original request in comment here: https://github.com/GoogleContainerTools/kpt/issues/1218#issuecomment-756486462
