### PR TITLE
allow most recent release with specific path

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -1,12 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If no argument is given -> Downloads the most recently released
 # kustomize binary to your current working directory.
 # (e.g. 'install_kustomize.sh')
 #
-# If an argument is given -> Downloads the specified version of the
-# kustomize binary to your current working directory.
-# (e.g. 'install_kustomize.sh 3.8.2')
+# If one argument is given -> 
+# If that argument is in the format of #.#.#, downloads the specified
+# version of the kustomize binary to your current working directory.
+# If that argument is something else, downloads the most recently released
+# kustomize binary to the specified directory.
+# (e.g. 'install_kustomize.sh 3.8.2' or 'install_kustomize.sh $(go env GOPATH)/bin')
 #
 # If two arguments are given -> Downloads the specified version of the
 # kustomize binary to the specified directory.
@@ -14,22 +17,39 @@
 #
 # Fails if the file already exists.
 
+set -e
+
 curl_timeout=600
+
+where=$PWD
 
 version=""
 release_url=https://api.github.com/repos/kubernetes-sigs/kustomize/releases
 if [ -n "$1" ]; then
-  version=v$1
-  release_url=${release_url}/tags/kustomize%2F$version
+  if [[ "$1" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
+    version=v$1
+    release_url=${release_url}/tags/kustomize%2F$version
+  elif [ -n "$2" ]; then
+    echo "The first argument should be the requested version."
+    exit 1
+  else
+    where="$1"
+  fi
 fi
 
-where=$PWD
 if [ -n "$2" ]; then
-  where=$2
+  where="$2"
 fi
 
-if [ -f $where/kustomize ]; then
-  echo "A file named $where/kustomize already exists (remove it first)."
+if ! test -d "$where"; then
+  echo "$where does not exist. Create it first."
+  exit 1
+fi
+
+where="$(readlink -f $where)/"
+
+if [ -f "${where}kustomize" ]; then
+  echo "A file named ${where}kustomize already exists (remove it first)."
   exit 1
 fi
 
@@ -43,9 +63,9 @@ function cleanup {
   rm -rf "$tmpDir"
 }
 
-trap cleanup EXIT
+trap cleanup EXIT ERR
 
-pushd $tmpDir >& /dev/null
+pushd "$tmpDir" >& /dev/null
 
 opsys=windows
 arch=amd64
@@ -68,10 +88,10 @@ else
     exit 1
 fi
 
-cp ./kustomize $where
+cp ./kustomize "$where"
 
 popd >& /dev/null
 
-$where/kustomize version
+${where}kustomize version
 
-echo kustomize installed to $where
+echo "kustomize installed to ${where}kustomize"


### PR DESCRIPTION
Wanted to install the most recent version to a specific path, but wasn't able to. Now we can!

Also fixed some edge cases:
- quotes after cp to allow paths with spaces
- allow bash elsewhere on PATH
- fixed double slash in message when installing to `/`
- don't proceed on uncaught errors, but on error do the cleanup
- Check if the given directory exists, else ask the user to create it