### PR TITLE
add test for multibyte string

### DIFF
--- a/api/krusty/multibytecharacter_test.go
+++ b/api/krusty/multibytecharacter_test.go
@@ -1,0 +1,32 @@
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestMultibyteCharInConfigMap(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+  - resources.yaml
+`)
+	th.WriteF("resources.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: game-config
+data:
+  key: あ 
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  key: あ
+kind: ConfigMap
+metadata:
+  name: game-config
+`)
+}


### PR DESCRIPTION
Reference to #https://github.com/kubernetes-sigs/kustomize/issues/3358

Regression test to demonstrate that using a multibyte character as data in a ConfigMap doesn't panic. While we will need to look into #3358, it appears that using kustomize can parse multibyte characters as data.