### PR TITLE
Fix a mistake in hello-world example - metadata key in kustomization

### DIFF
--- a/examples/helloWorld/kustomization.yaml
+++ b/examples/helloWorld/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-metadata:
-  name: arbitrary
 
 # Example configuration for the webserver
 # at https://github.com/monopole/hello


### PR DESCRIPTION
According to docs and schema, metadata key on root level of kustomization.yaml is not allowed:
https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/

```
Property metadata is not allowed.yaml-schema: https://json.schemastore.org/kustomization
```

Hence it errors while running `kustomize` command:
```
$ kustomize build $BASE
Error: json: unknown field "metadata"
```

This PR removes that property allowing example to work correctly without any changes from end user.