### PR TITLE
Undo kyaml/go.mod lint replacements.

### DIFF
--- a/kyaml/Makefile
+++ b/kyaml/Makefile
@@ -11,6 +11,7 @@ $(MYGOBIN)/addlicense:
 
 # TODO: Issue #3663
 # Update this version of golangci-lint
+# Ideally use same version as in {REPO}/hack/go.mod
 $(MYGOBIN)/golangci-lint:
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.0
 
@@ -20,7 +21,7 @@ $(MYGOBIN)/k8scopy:
 $(MYGOBIN)/stringer:
 	go get golang.org/x/tools/cmd/stringer
 
-all: license fix vet fmt test lint tidy
+all: license fix vet fmt test tidy
 
 k8sGenDir := yaml/internal/k8sgen/pkg
 

--- a/kyaml/go.mod
+++ b/kyaml/go.mod
@@ -23,16 +23,12 @@ require (
 )
 
 // These can be removed after upgrading golangci-lint (Issue #3663)
-replace github.com/go-critic/go-critic v0.0.0-20181204210945-c3db6069acc5 => github.com/go-critic/go-critic v0.0.0-20190422201921-c3db6069acc5
+// 07 Mar 2021 commenting these out to perform a release.
 
-replace github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
-
-replace github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196 => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
-
-replace github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
-
-replace github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547 => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
-
-replace github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
-
-replace mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34 => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
+// replace github.com/go-critic/go-critic v0.0.0-20181204210945-c3db6069acc5 => github.com/go-critic/go-critic v0.0.0-20190422201921-c3db6069acc5
+// replace github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
+// replace github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196 => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
+// replace github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
+// replace github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547 => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
+// replace github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
+// replace mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34 => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34


### PR DESCRIPTION
The old linter is now blocking releases.