### PR TITLE
Reinstate configmap/secret generator 'env' field.

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -132,6 +132,7 @@ configMapGenerator:
   - vegetable=broccoli
   envs:
   - foo.env
+  env: bar.env
   files:
   - passphrase=phrase.dat
   - forces.txt
@@ -153,10 +154,14 @@ secretGenerator:
   files:
   - passphrase=phrase.dat
   - forces.txt
+  env: bar.env
 `)
 	th.WriteF("foo.env", `
 MOUNTAIN=everest
 OCEAN=pacific
+`)
+	th.WriteF("bar.env", `
+BIRD=falcon
 `)
 	th.WriteF("phrase.dat", `
 Life is short.
@@ -173,6 +178,7 @@ weak nuclear
 	m := th.Run(".", opts)
 	expFmt := `apiVersion: v1
 data:
+  BIRD: falcon
   MOUNTAIN: everest
   OCEAN: pacific
   forces.txt: |2
@@ -190,7 +196,7 @@ data:
   vegetable: broccoli
 kind: ConfigMap
 metadata:
-  name: blah-bob-d87t8m8tgm
+  name: blah-bob-g9df72cd5b
 ---
 apiVersion: v1
 data:
@@ -203,6 +209,7 @@ metadata:
 ---
 apiVersion: v1
 data:
+  BIRD: ZmFsY29u
   MOUNTAIN: ZXZlcmVzdA==
   OCEAN: cGFjaWZpYw==
   forces.txt: %s
@@ -230,7 +237,7 @@ type: Opaque
     CmdyYXZpdGF0aW9uYWwKZWxlY3Ryb21hZ25ldGljCnN0cm9uZyBudWNsZWFyCndlYWsgbn
     VjbGVhcgo=`, `|
     CkxpZmUgaXMgc2hvcnQuCkJ1dCB0aGUgeWVhcnMgYXJlIGxvbmcuCk5vdCB3aGlsZSB0aG
-    UgZXZpbCBkYXlzIGNvbWUgbm90Lgo=`, `9t25t44gg4`)))
+    UgZXZpbCBkYXlzIGNvbWUgbm90Lgo=`, `58g62h555c`)))
 }
 
 // TODO: These should be errors instead.

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -155,7 +155,6 @@ type Kustomization struct {
 // moving content of deprecated fields to newer
 // fields.
 func (k *Kustomization) FixKustomizationPostUnmarshalling() {
-
 	if k.Kind == "" {
 		k.Kind = KustomizationKind
 	}
@@ -168,6 +167,20 @@ func (k *Kustomization) FixKustomizationPostUnmarshalling() {
 	}
 	k.Resources = append(k.Resources, k.Bases...)
 	k.Bases = nil
+	for i, g := range k.ConfigMapGenerator {
+		if g.EnvSource != "" {
+			k.ConfigMapGenerator[i].EnvSources =
+				append(g.EnvSources, g.EnvSource)
+			k.ConfigMapGenerator[i].EnvSource = ""
+		}
+	}
+	for i, g := range k.SecretGenerator {
+		if g.EnvSource != "" {
+			k.SecretGenerator[i].EnvSources =
+				append(g.EnvSources, g.EnvSource)
+			k.SecretGenerator[i].EnvSource = ""
+		}
+	}
 }
 
 // FixKustomizationPreMarshalling fixes things

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -15,6 +16,12 @@ func fixKustomizationPostUnmarshallingCheck(k, e *Kustomization) bool {
 func TestFixKustomizationPostUnmarshalling(t *testing.T) {
 	var k Kustomization
 	k.Bases = append(k.Bases, "foo")
+	k.ConfigMapGenerator = []ConfigMapArgs{{GeneratorArgs{
+		KvPairSources: KvPairSources{
+			EnvSources: []string{"a", "b"},
+			EnvSource:  "c",
+		},
+	}}}
 	k.FixKustomizationPostUnmarshalling()
 
 	expected := Kustomization{
@@ -23,8 +30,15 @@ func TestFixKustomizationPostUnmarshalling(t *testing.T) {
 			APIVersion: KustomizationVersion,
 		},
 		Resources: []string{"foo"},
+		ConfigMapGenerator: []ConfigMapArgs{{GeneratorArgs{
+			KvPairSources: KvPairSources{
+				EnvSources: []string{"a", "b", "c"},
+			},
+		}}},
 	}
-
+	if !reflect.DeepEqual(k, expected) {
+		t.Fatalf("unexpected output: %v", k)
+	}
 	if !fixKustomizationPostUnmarshallingCheck(&k, &expected) {
 		t.Fatalf("unexpected output: %v", k)
 	}

--- a/api/types/kvpairsources.go
+++ b/api/types/kvpairsources.go
@@ -28,4 +28,9 @@ type KvPairSources struct {
 	// or npm ".env" file or a ".ini" file
 	// (wikipedia.org/wiki/INI_file)
 	EnvSources []string `json:"envs,omitempty" yaml:"envs,omitempty"`
+
+	// Older, singular form of EnvSources.
+	// On edits (e.g. `kustomize fix`) this is merged into the plural form
+	// for consistency with LiteralSources and FileSources.
+	EnvSource string `json:"env,omitempty" yaml:"env,omitempty"`
 }


### PR DESCRIPTION
Fixes #2205 
This field was overzealously deprecated.


