### PR TITLE
HelmChartInflationGenerator: inherit environment variables to helm command

### DIFF
--- a/api/builtins/HelmChartInflationGenerator.go
+++ b/api/builtins/HelmChartInflationGenerator.go
@@ -76,7 +76,7 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 		cmd := exec.Command(p.HelmBin, args...)
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
-		cmd.Env = append(cmd.Env,
+		cmd.Env = append(os.Environ(),
 			fmt.Sprintf("HELM_CONFIG_HOME=%s", p.HelmHome),
 			fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", p.HelmHome),
 			fmt.Sprintf("HELM_DATA_HOME=%s/.data", p.HelmHome),

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -84,7 +84,7 @@ func (p *HelmChartInflationGeneratorPlugin) Config(h *resmap.PluginHelpers, conf
 		cmd := exec.Command(p.HelmBin, args...)
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
-		cmd.Env = append(cmd.Env,
+		cmd.Env = append(os.Environ(),
 			fmt.Sprintf("HELM_CONFIG_HOME=%s", p.HelmHome),
 			fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", p.HelmHome),
 			fmt.Sprintf("HELM_DATA_HOME=%s/.data", p.HelmHome),

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -12,6 +12,8 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
+//add tests for https://github.com/kubernetes-sigs/kustomize/pull/3713 if you plan to re-enable tests
+
 func TestHelmChartInflationGenerator(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
 		PrepBuiltin("HelmChartInflationGenerator")


### PR DESCRIPTION
Fixes #3712 

Taking this code fragment from the example here: https://golang.org/pkg/os/exec/#Command

Let me know if I forgot something. Not doing golang contribution every day.