### PR TITLE
Type alias for spec.Schema

### DIFF
--- a/api/internal/accumulator/loadconfigfromcrds.go
+++ b/api/internal/accumulator/loadconfigfromcrds.go
@@ -25,7 +25,7 @@ type OpenAPIDefinition struct {
 	Dependencies []string
 }
 
-type myProperties map[string]spec.Schema
+type myProperties = map[string]spec.Schema
 type nameToApiMap map[string]OpenAPIDefinition
 
 // LoadConfigFromCRDs parse CRD schemas from paths into a TransformerConfig


### PR DESCRIPTION
Presumably Fix #3443, copy of #3444
(unfortunately #3444 doesn't have a signed CLA).


This seems to be a harmless change, but a better fix is to avoid
transitive deps that bring in multiple versions of kustomize.

