### PR TITLE
Make dir optional for tree command

### DIFF
--- a/cmd/config/internal/commands/tree.go
+++ b/cmd/config/internal/commands/tree.go
@@ -20,7 +20,7 @@ import (
 func GetTreeRunner(name string) *TreeRunner {
 	r := &TreeRunner{}
 	c := &cobra.Command{
-		Use:     "tree DIR",
+		Use:     "tree [DIR]",
 		Short:   commands.TreeShort,
 		Long:    commands.TreeLong,
 		Example: commands.TreeExamples,
@@ -83,11 +83,14 @@ func (r *TreeRunner) getMatchFilesGlob() []string {
 func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 	var input kio.Reader
 	var root = "."
-	if len(args) == 1 {
+	if len(args) == 0 {
+		args = append(args, root)
+	}
+	if args[0] == "-" {
+		input = &kio.ByteReader{Reader: c.InOrStdin()}
+	} else {
 		root = filepath.Clean(args[0])
 		input = kio.LocalPackageReader{PackagePath: args[0], MatchFilesGlob: r.getMatchFilesGlob()}
-	} else {
-		input = &kio.ByteReader{Reader: c.InOrStdin()}
 	}
 
 	var fields []kio.TreeWriterField

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -15,6 +15,84 @@ import (
 	"sigs.k8s.io/kustomize/cmd/config/internal/commands"
 )
 
+func TestTreeCommandDefaultCurDir_files(t *testing.T) {
+	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	defer os.RemoveAll(d)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = os.Chdir(d)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+apiVersion: v1
+kind: Abstraction
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/example/reconciler:v1
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  replicas: 1
+---
+kind: Deployment
+metadata:
+  labels:
+    app: nginx2
+  name: foo
+  annotations:
+    app: nginx2
+spec:
+  replicas: 1
+---
+kind: Service
+metadata:
+  name: foo
+  annotations:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: bar
+  annotations:
+    app: nginx
+spec:
+  replicas: 3
+`), 0600)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// fmt the files
+	b := &bytes.Buffer{}
+	r := commands.GetTreeRunner("")
+	r.Command.SetArgs([]string{})
+	r.Command.SetOut(b)
+	if !assert.NoError(t, r.Command.Execute()) {
+		return
+	}
+
+	if !assert.Equal(t, fmt.Sprintf(`.
+├── [f1.yaml]  Deployment foo
+├── [f1.yaml]  Service foo
+└── [f2.yaml]  Deployment bar
+`), b.String()) {
+		return
+	}
+}
+
 // TestCmd_files verifies fmt reads the files and filters them
 func TestTreeCommand_files(t *testing.T) {
 	d, err := ioutil.TempDir("", "kustomize-tree-test")
@@ -244,7 +322,7 @@ func TestTreeCommand_stdin(t *testing.T) {
 	// fmt the files
 	b := &bytes.Buffer{}
 	r := commands.GetTreeRunner("")
-	r.Command.SetArgs([]string{})
+	r.Command.SetArgs([]string{"-"})
 	r.Command.SetIn(bytes.NewBufferString(`apiVersion: extensions/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR is to make DIR argument optional and default to current working directory. This also makes `-` to be passed as an argument to accept STDIN.