### PR TITLE
Fix init command in wordpress example

### DIFF
--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -86,9 +86,8 @@ The patch has following content
 >       initContainers:
 >       - name: init-command
 >         image: debian
->         command:
->         - "echo $(WORDPRESS_SERVICE)"
->         - "echo $(MYSQL_SERVICE)"
+>         command: ["/bin/sh"]
+>         args: ["-c", "echo $(WORDPRESS_SERVICE); echo $(MYSQL_SERVICE)"]
 >       containers:
 >       - name: wordpress
 >         env:
@@ -138,11 +137,13 @@ Expect this in the output:
 > ```
 > (truncated)
 > ...
->      initContainers:
->      - command:
->        - echo demo-wordpress
->        - echo demo-mysql
->        image: debian
->        name: init-command
+>     initContainers:
+>     - args:
+>       - -c
+>       - echo demo-wordpress; echo demo-mysql
+>       command:
+>       - /bin/sh
+>       image: debian
+>       name: init-command
 >
 > ```

--- a/examples/wordpress/patch.yaml
+++ b/examples/wordpress/patch.yaml
@@ -8,9 +8,8 @@ spec:
       initContainers:
       - name: init-command
         image: debian
-        command:
-        - "echo $(WORDPRESS_SERVICE)"
-        - "echo $(MYSQL_SERVICE)"
+        command: ["/bin/sh"]
+        args: ["-c", "echo $(WORDPRESS_SERVICE); echo $(MYSQL_SERVICE)"]
       containers:
       - name: wordpress
         env:

--- a/examples/zh/vars.md
+++ b/examples/zh/vars.md
@@ -86,9 +86,8 @@ curl -s -o "$DEMO_HOME/#1.yaml" \
 >       initContainers:
 >       - name: init-command
 >         image: debian
->         command:
->         - "echo $(WORDPRESS_SERVICE)"
->         - "echo $(MYSQL_SERVICE)"
+>         command: ["/bin/sh"]
+>         args: ["-c", "echo $(WORDPRESS_SERVICE); echo $(MYSQL_SERVICE)"]
 >       containers:
 >       - name: wordpress
 >         env:
@@ -138,11 +137,13 @@ kustomize build $DEMO_HOME
 > ```yaml
 > (truncated)
 > ...
->      initContainers:
->      - command:
->        - echo demo-wordpress
->        - echo demo-mysql
->        image: debian
->        name: init-command
+>     initContainers:
+>     - args:
+>       - -c
+>       - echo demo-wordpress; echo demo-mysql
+>       command:
+>       - /bin/sh
+>       image: debian
+>       name: init-command
 >
 > ```


### PR DESCRIPTION
Fix the init-command that cannot be executed in the wordpress example, and update the docs.

Describe Init container:

```console
    State:          Waiting
      Reason:       RunContainerError
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "echo demo-wordpress": executable file not found in $PATH: unknown
      Exit Code:    128
```

> "echo demo-wordpress" is not an executable file.
