### PR TITLE
Don't print Krmfile file in tree output

### DIFF
--- a/cmd/config/internal/commands/tree.go
+++ b/cmd/config/internal/commands/tree.go
@@ -75,11 +75,6 @@ type TreeRunner struct {
 	structure       string
 }
 
-func (r *TreeRunner) getMatchFilesGlob() []string {
-	matchFilesGlob := append([]string{ext.KRMFileName()}, kio.DefaultMatch...)
-	return append(matchFilesGlob, "Kustomization")
-}
-
 func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 	var input kio.Reader
 	var root = "."
@@ -90,7 +85,7 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 		input = &kio.ByteReader{Reader: c.InOrStdin()}
 	} else {
 		root = filepath.Clean(args[0])
-		input = kio.LocalPackageReader{PackagePath: args[0], MatchFilesGlob: r.getMatchFilesGlob()}
+		input = kio.LocalPackageReader{PackagePath: args[0]}
 	}
 
 	var fields []kio.TreeWriterField

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -208,7 +208,6 @@ resources:
 	}
 
 	if !assert.Equal(t, fmt.Sprintf(`%s
-├── [Kustomization]  Kustomization 
 └── [f2.yaml]  Deployment bar
 `, d), b.String()) {
 		return
@@ -307,11 +306,9 @@ openAPI:
 	}
 
 	if !assert.Equal(t, fmt.Sprintf(`%s
-├── [Krmfile]  Krmfile mainpkg
 ├── [f1.yaml]  Deployment foo
 ├── [f1.yaml]  Service foo
 └── Pkg: subpkg
-    ├── [Krmfile]  Krmfile subpkg
     └── [f2.yaml]  Deployment bar
 `, d), b.String()) {
 		return


### PR DESCRIPTION
This PR is to avoid printing Krmfile as part of `tree` command output.