### PR TITLE
Enhance the enhanced test harness.

### DIFF
--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -319,7 +319,6 @@ func (fl *fileLoader) Load(path string) ([]byte, error) {
 		}
 		return body, nil
 	}
-
 	if !filepath.IsAbs(path) {
 		path = fl.root.Join(path)
 	}

--- a/api/loader/fileloader_test.go
+++ b/api/loader/fileloader_test.go
@@ -54,7 +54,6 @@ func MakeFakeFs(td []testData) filesys.FileSystem {
 
 func makeLoader() *fileLoader {
 	return NewFileLoaderAtRoot(MakeFakeFs(testCases))
-
 }
 
 func TestLoaderLoad(t *testing.T) {

--- a/api/types/pluginconfig.go
+++ b/api/types/pluginconfig.go
@@ -15,8 +15,10 @@ type PluginConfig struct {
 	FnpLoadingOptions FnPluginLoadingOptions
 }
 
-func EnabledPluginConfig(b BuiltinPluginLoadingOptions) *PluginConfig {
-	return MakePluginConfig(PluginRestrictionsNone, b)
+func EnabledPluginConfig(b BuiltinPluginLoadingOptions) (pc *PluginConfig) {
+	pc = MakePluginConfig(PluginRestrictionsNone, b)
+	pc.FnpLoadingOptions.EnableStar = true
+	return
 }
 
 func DisabledPluginConfig() *PluginConfig {


### PR DESCRIPTION
Add a MakeEnhancedHarnessWithTmpRoot which provides a tmp dir to plugin tests that need it (helm needs it).

https://www.youtube.com/watch?v=Vxq9yj2pVWk
