### PR TITLE
Add check of UpdateExpectedFromActual before skipping test

### DIFF
--- a/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
+++ b/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
@@ -111,8 +111,8 @@ func (rc *CommandResultsChecker) compare(t *testing.T, path string) {
 	args := []string{rc.ConfigInputFilename}
 
 	expectedOutput, expectedError := getExpected(t, rc.ExpectedOutputFilename, rc.ExpectedErrorFilename)
-	if expectedError == "" && expectedOutput == "" {
-		// missing expected
+	if expectedError == "" && expectedOutput == "" && !rc.UpdateExpectedFromActual {
+		// missing expected and UpdateExpectedFromActual == false, return and skip this test
 		return
 	}
 	require.NoError(t, err)
@@ -251,8 +251,8 @@ func (rc *ProcessorResultsChecker) compare(t *testing.T, path string) {
 	require.NoError(t, err)
 
 	expectedOutput, expectedError := getExpected(t, rc.ExpectedOutputFilename, rc.ExpectedErrorFilename)
-	if expectedError == "" && expectedOutput == "" {
-		// missing expected
+	if expectedError == "" && expectedOutput == "" && !rc.UpdateExpectedFromActual {
+		// missing expected and UpdateExpectedFromActual == false, return and skip this test
 		return
 	}
 


### PR DESCRIPTION
Currently, the `compare` functions on `CommandResultsChecker` and `ProcessorResultsChecker` return and skip the test case if the expected error and expected result files are empty, even when `UpdateExpectedFromActual` is true. This leads to a somewhat confusing experience because the test cases are more or less silently skipped. I noticed this by dropping all other test cases but one and getting the error message that no complete test cases were found. I had assumed that setting `UpdateExpectedFromActual` would generate the results in this case, not just when there was some other value in the file.  


This PR adds a third condition to the check before returning early from the function, allowing the test case to run IF `UpdateExpectedFromActual` is true. 

 



Signed-off-by: Jeremy <jeremyrrickard@gmail.com>