### PR TITLE
Support immutable attribute on generators

### DIFF
--- a/api/internal/generators/configmap.go
+++ b/api/internal/generators/configmap.go
@@ -41,5 +41,6 @@ func MakeConfigMap(
 		return nil, err
 	}
 	copyLabelsAndAnnotations(rn, args.Options)
+	setImmutable(rn, args.Options)
 	return rn, nil
 }

--- a/api/internal/generators/configmap_test.go
+++ b/api/internal/generators/configmap_test.go
@@ -163,6 +163,7 @@ data:
 							"river": "Missouri",
 							"city":  "Iowa City",
 						},
+						Immutable: true,
 					},
 				},
 			},
@@ -183,6 +184,7 @@ data:
   b: y
   c: Hello World
   d: "true"
+immutable: true
 `,
 			},
 		},

--- a/api/internal/generators/secret.go
+++ b/api/internal/generators/secret.go
@@ -54,5 +54,6 @@ func MakeSecret(
 		return nil, err
 	}
 	copyLabelsAndAnnotations(rn, args.Options)
+	setImmutable(rn, args.Options)
 	return rn, nil
 }

--- a/api/internal/generators/secret_test.go
+++ b/api/internal/generators/secret_test.go
@@ -170,6 +170,7 @@ data:
 							"river": "Missouri",
 							"city":  "Iowa City",
 						},
+						Immutable: true,
 					},
 				},
 			},
@@ -191,6 +192,7 @@ data:
   b: eQ==
   c: SGVsbG8gV29ybGQ=
   d: dHJ1ZQ==
+immutable: true
 `,
 			},
 		},

--- a/api/internal/generators/utils.go
+++ b/api/internal/generators/utils.go
@@ -76,3 +76,16 @@ func copyLabelsAndAnnotations(
 	}
 	return nil
 }
+
+func setImmutable(
+	rn *yaml.RNode, opts *types.GeneratorOptions) error {
+	if opts == nil {
+		return nil
+	}
+	if opts.Immutable {
+		if _, err := rn.Pipe(yaml.SetField("immutable", yaml.NewScalarRNode("true"))); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/api/types/generatoroptions.go
+++ b/api/types/generatoroptions.go
@@ -15,6 +15,9 @@ type GeneratorOptions struct {
 	// suffix to the names of generated resources that is a hash of the
 	// resource contents.
 	DisableNameSuffixHash bool `json:"disableNameSuffixHash,omitempty" yaml:"disableNameSuffixHash,omitempty"`
+
+	// Immutable if true add to all generated resources.
+	Immutable bool `json:"immutable,omitempty" yaml:"immutable,omitempty"`
 }
 
 // MergeGlobalOptionsIntoLocal merges two instances of GeneratorOptions.
@@ -41,6 +44,9 @@ func MergeGlobalOptionsIntoLocal(
 	overrideMap(&localOpts.Annotations, globalOpts.Annotations)
 	if globalOpts.DisableNameSuffixHash {
 		localOpts.DisableNameSuffixHash = true
+	}
+	if globalOpts.Immutable {
+		localOpts.Immutable = true
 	}
 	return localOpts
 }

--- a/api/types/generatoroptions_test.go
+++ b/api/types/generatoroptions_test.go
@@ -34,6 +34,7 @@ func TestMergeGlobalOptionsIntoLocal(t *testing.T) {
 				Labels:                map[string]string{"pet": "dog"},
 				Annotations:           map[string]string{"fruit": "apple"},
 				DisableNameSuffixHash: false,
+				Immutable:             false,
 			},
 		},
 		{
@@ -47,6 +48,7 @@ func TestMergeGlobalOptionsIntoLocal(t *testing.T) {
 				Labels:                map[string]string{"pet": "dog"},
 				Annotations:           map[string]string{"fruit": "apple"},
 				DisableNameSuffixHash: false,
+				Immutable:             false,
 			},
 		},
 		{
@@ -76,42 +78,52 @@ func TestMergeGlobalOptionsIntoLocal(t *testing.T) {
 					"tesla": "Y",
 				},
 				DisableNameSuffixHash: false,
+				Immutable:             false,
 			},
 		},
 		{
 			name: "global disable trumps local",
 			local: &GeneratorOptions{
 				DisableNameSuffixHash: false,
+				Immutable:             false,
 			},
 			global: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 			expected: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 		},
 		{
 			name: "local disable works",
 			local: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 			global: &GeneratorOptions{
 				DisableNameSuffixHash: false,
+				Immutable:             false,
 			},
 			expected: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 		},
 		{
 			name: "everyone wants disable",
 			local: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 			global: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 			expected: &GeneratorOptions{
 				DisableNameSuffixHash: true,
+				Immutable:             true,
 			},
 		},
 	}


### PR DESCRIPTION
Close #2895

Add `Immutable` field to`GeneratorOptions`.
If true, generate ConfigMap and Secret with `immutable: true`