### PR TITLE
Support multiple implementations for IsSameResource

### DIFF
--- a/cmd/config/internal/commands/merge3.go
+++ b/cmd/config/internal/commands/merge3.go
@@ -46,12 +46,13 @@ type Merge3Runner struct {
 	path     bool
 }
 
-func (r *Merge3Runner) runE(c *cobra.Command, args []string) error {
+func (r *Merge3Runner) runE(_ *cobra.Command, _ []string) error {
+	matcher := filters.DefaultGVKNNMatcher{MergeOnPath: r.path}
 	err := filters.Merge3{
 		OriginalPath: r.ancestor,
 		UpdatedPath:  r.fromDir,
 		DestPath:     r.toDir,
-		MergeOnPath:  r.path,
+		Matcher:      &matcher,
 	}.Merge()
 	if err != nil {
 		return err

--- a/kyaml/kio/filters/merge3_test.go
+++ b/kyaml/kio/filters/merge3_test.go
@@ -44,6 +44,7 @@ func TestMerge3_Merge(t *testing.T) {
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),
+		Matcher:      &filters.DefaultGVKNNMatcher{MergeOnPath: false},
 	}.Merge()
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -89,7 +90,6 @@ func TestMerge3_Merge_path(t *testing.T) {
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),
-		MergeOnPath:  true,
 	}.Merge()
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -135,6 +135,7 @@ func TestMerge3_Merge_fail(t *testing.T) {
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),
+		Matcher:      &filters.DefaultGVKNNMatcher{MergeOnPath: false},
 	}.Merge()
 	if !assert.Error(t, err) {
 		t.FailNow()


### PR DESCRIPTION
This PR is to make the implementation of `IsSameResource` configurable so that it's implementation can be overridden by upstream tools.