### PR TITLE
modify Error log info

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -228,7 +228,7 @@ func demandOneMatch(
 	if len(r) > 1 {
 		return nil, fmt.Errorf("multiple matches for %s %s", s, id)
 	}
-	return nil, fmt.Errorf("no matches for %sId %s", s, id)
+	return nil, fmt.Errorf("no matches for %s %s", s, id)
 }
 
 // GroupedByCurrentNamespace implements ResMap.GroupByCurrentNamespace


### PR DESCRIPTION
I received an error report like this:
```
Error: no matches for IdId ~G_v1_xxxxxx|xxxxxx|xxxxxxx;
```
I think it needs to be modified here.