### PR TITLE
Run e2e tests against 4.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ verify-kustomize: \
 	lint-kustomize \
 	test-unit-kustomize-all \
 	test-examples-kustomize-against-HEAD \
-	test-examples-kustomize-against-4.0
+	test-examples-kustomize-against-4.1
 
 # The following target referenced by a file in
 # https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kustomize
@@ -41,7 +41,7 @@ prow-presubmit-check: \
 	test-unit-cmd-all \
 	test-go-mod \
 	test-examples-kustomize-against-HEAD \
-	test-examples-kustomize-against-4.0
+	test-examples-kustomize-against-4.1
 
 .PHONY: verify-kustomize-e2e
 verify-kustomize-e2e: test-examples-e2e-kustomize
@@ -284,8 +284,8 @@ test-examples-kustomize-against-HEAD: $(MYGOBIN)/kustomize $(MYGOBIN)/mdrip
 	./hack/testExamplesAgainstKustomize.sh HEAD
 
 .PHONY:
-test-examples-kustomize-against-4.0: $(MYGOBIN)/mdrip
-	./hack/testExamplesAgainstKustomize.sh v4@v4.0.5
+test-examples-kustomize-against-4.1: $(MYGOBIN)/mdrip
+	./hack/testExamplesAgainstKustomize.sh v4@v4.1.2
 
 # linux only.
 # This is for testing an example plugin that

--- a/hack/testExamplesAgainstKustomize.sh
+++ b/hack/testExamplesAgainstKustomize.sh
@@ -35,11 +35,8 @@ mdrip --mode test --blockTimeOut 15m \
 # TODO: make work for non-linux
 if onLinuxAndNotOnRemoteCI; then
   echo "On linux, and not on remote CI.  Running expensive tests."
-  # TODO: remove the HEAD check once --enable-helm flag released.
-  if [ "$version" == "HEAD" ]; then
-    make $MYGOBIN/helmV3
-    mdrip --mode test --label testHelm examples/chart.md
-  fi
+  make $MYGOBIN/helmV3
+  mdrip --mode test --label testHelm examples/chart.md
 fi
 
 # Force outside logic to rebuild kustomize rather than


### PR DESCRIPTION
Also run helm checks against both HEAD and 4.1.2 on local machines