### PR TITLE
Fix some gofmt warnings

### DIFF
--- a/kyaml/openapi/kubernetesapi/v1204/swagger.go
+++ b/kyaml/openapi/kubernetesapi/v1204/swagger.go
@@ -196,9 +196,9 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"kubernetesapi": &bintree{nil, map[string]*bintree{
-		"v1204": &bintree{nil, map[string]*bintree{
-			"swagger.json": &bintree{kubernetesapiV1204SwaggerJson, map[string]*bintree{}},
+	"kubernetesapi": {nil, map[string]*bintree{
+		"v1204": {nil, map[string]*bintree{
+			"swagger.json": {kubernetesapiV1204SwaggerJson, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/kyaml/openapi/kustomizationapi/swagger.go
+++ b/kyaml/openapi/kustomizationapi/swagger.go
@@ -196,8 +196,8 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"kustomizationapi": &bintree{nil, map[string]*bintree{
-		"swagger.json": &bintree{kustomizationapiSwaggerJson, map[string]*bintree{}},
+	"kustomizationapi": {nil, map[string]*bintree{
+		"swagger.json": {kustomizationapiSwaggerJson, map[string]*bintree{}},
 	}},
 }}
 


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

Warning: redundant type from array, slice, or map composite literal