### PR TITLE
Fix api tests on MacOS

### DIFF
--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -102,7 +102,10 @@ func (th *HarnessEnhanced) MkDir(path string) string {
 
 func (th *HarnessEnhanced) Reset() {
 	if th.shouldWipeLdrRoot {
-		if !strings.HasPrefix(th.ldr.Root(), os.TempDir()) {
+		root, _ := filepath.EvalSymlinks(th.ldr.Root())
+		tmpdir, _ := filepath.EvalSymlinks(os.TempDir())
+
+		if !strings.HasPrefix(root, tmpdir) {
 			// sanity check.
 			panic("something strange about th.ldr.Root() = " + th.ldr.Root())
 		}


### PR DESCRIPTION
On MacOS /var is a symlink for /private/var and we can end up with the
loader having a `/private/var` path while the TMPDIR has a `/var` path which
triggers a panic.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>