### PR TITLE
use assert statements for kustomize edit tests

### DIFF
--- a/kustomize/commands/edit/add/addbase_test.go
+++ b/kustomize/commands/edit/add/addbase_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
@@ -26,19 +27,12 @@ func TestAddBaseHappyPath(t *testing.T) {
 
 	cmd := newCmdAddBase(fSys)
 	args := []string{baseDirectoryPaths}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
+	assert.NoError(t, err)
 
 	for _, base := range bases {
-		if !strings.Contains(string(content), base) {
-			t.Errorf("expected base name in kustomization")
-		}
+		assert.Contains(t, string(content), base)
 	}
 }
 
@@ -53,22 +47,14 @@ func TestAddBaseAlreadyThere(t *testing.T) {
 
 	cmd := newCmdAddBase(fSys)
 	args := []string{baseDirectoryPaths}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 	// adding an existing base should return an error
-	err = cmd.RunE(cmd, args)
-	if err == nil {
-		t.Errorf("expected already there problem")
-	}
+	assert.Error(t, cmd.RunE(cmd, args))
 	var expectedErrors []string
 	for _, base := range bases {
 		msg := "base " + base + " already in kustomization file"
 		expectedErrors = append(expectedErrors, msg)
-		if !kustfile.StringInSlice(msg, expectedErrors) {
-			t.Errorf("unexpected error %v", err)
-		}
+		assert.True(t, kustfile.StringInSlice(msg, expectedErrors))
 	}
 }
 
@@ -77,10 +63,6 @@ func TestAddBaseNoArgs(t *testing.T) {
 
 	cmd := newCmdAddBase(fSys)
 	err := cmd.Execute()
-	if err == nil {
-		t.Errorf("expected error: %v", err)
-	}
-	if err.Error() != "must specify a base directory" {
-		t.Errorf("incorrect error: %v", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "must specify a base directory", err.Error())
 }

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -4,9 +4,9 @@
 package add
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
@@ -27,20 +27,11 @@ func TestAddComponentHappyPath(t *testing.T) {
 
 	cmd := newCmdAddComponent(fSys)
 	args := []string{componentFileName + "*"}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), componentFileName) {
-		t.Errorf("expected component name in kustomization")
-	}
-	if !strings.Contains(string(content), componentFileName+"another") {
-		t.Errorf("expected component name in kustomization")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), componentFileName)
+	assert.Contains(t, string(content), componentFileName+"another")
 }
 
 func TestAddComponentAlreadyThere(t *testing.T) {
@@ -50,16 +41,10 @@ func TestAddComponentAlreadyThere(t *testing.T) {
 
 	cmd := newCmdAddComponent(fSys)
 	args := []string{componentFileName}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 
 	// adding an existing component doesn't return an error
-	err = cmd.RunE(cmd, args)
-	if err != nil {
-		t.Errorf("unexpected cmd error :%v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 }
 
 func TestAddKustomizationFileAsComponent(t *testing.T) {
@@ -69,19 +54,11 @@ func TestAddKustomizationFileAsComponent(t *testing.T) {
 
 	cmd := newCmdAddComponent(fSys)
 	args := []string{componentFileName}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-
-	if strings.Contains(string(content), componentFileName) {
-		t.Errorf("%v shouldn't be in the list of the components", componentFileName)
-	}
+	assert.NoError(t, err)
+	assert.NotContains(t, string(content), componentFileName)
 }
 
 func TestAddComponentNoArgs(t *testing.T) {
@@ -89,10 +66,6 @@ func TestAddComponentNoArgs(t *testing.T) {
 
 	cmd := newCmdAddComponent(fSys)
 	err := cmd.Execute()
-	if err == nil {
-		t.Errorf("expected error: %v", err)
-	}
-	if err.Error() != "must specify a component file" {
-		t.Errorf("incorrect error: %v", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "must specify a component file", err.Error())
 }

--- a/kustomize/commands/edit/add/addpatch_test.go
+++ b/kustomize/commands/edit/add/addpatch_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
@@ -42,18 +43,11 @@ func TestAddPatchWithFilePath(t *testing.T) {
 		"--label-selector", labelSelector,
 	}
 	cmd.SetArgs(args)
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.Execute())
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
+	assert.NoError(t, err)
 	for i := 1; i < len(args); i += 2 {
-		if !strings.Contains(string(content), args[i]) {
-			t.Errorf("expected flag value of %s in kustomization but got\n%s", args[i-1], content)
-		}
+		assert.Contains(t, string(content), args[i])
 	}
 }
 
@@ -74,18 +68,11 @@ func TestAddPatchWithPatchContent(t *testing.T) {
 		"--label-selector", labelSelector,
 	}
 	cmd.SetArgs(args)
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.Execute())
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
+	assert.NoError(t, err)
 	for i := 1; i < len(args); i += 2 {
-		if !strings.Contains(string(content), strings.Trim(args[i], " \n")) {
-			t.Errorf("expected flag value of %s in kustomization but got\n%s", args[i-1], content)
-		}
+		assert.Contains(t, string(content), strings.Trim(args[i], " \n"))
 	}
 }
 
@@ -106,16 +93,10 @@ func TestAddPatchAlreadyThere(t *testing.T) {
 		"--label-selector", labelSelector,
 	}
 	cmd.SetArgs(args)
-	err := cmd.Execute()
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.Execute())
 
 	// adding an existing patch shouldn't return an error
-	err = cmd.Execute()
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.Execute())
 }
 
 func TestAddPatchNoArgs(t *testing.T) {
@@ -123,10 +104,6 @@ func TestAddPatchNoArgs(t *testing.T) {
 
 	cmd := newCmdAddPatch(fSys)
 	err := cmd.Execute()
-	if err == nil {
-		t.Errorf("expected error: %v", err)
-	}
-	if err.Error() != "must provide either patch or path" {
-		t.Errorf("incorrect error: %v", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "must provide either patch or path", err.Error())
 }

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -4,9 +4,9 @@
 package add
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
@@ -27,20 +27,11 @@ func TestAddResourceHappyPath(t *testing.T) {
 
 	cmd := newCmdAddResource(fSys)
 	args := []string{resourceFileName + "*"}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), resourceFileName) {
-		t.Errorf("expected resource name in kustomization")
-	}
-	if !strings.Contains(string(content), resourceFileName+"another") {
-		t.Errorf("expected resource name in kustomization")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), resourceFileName)
+	assert.Contains(t, string(content), resourceFileName+"another")
 }
 
 func TestAddResourceAlreadyThere(t *testing.T) {
@@ -50,16 +41,10 @@ func TestAddResourceAlreadyThere(t *testing.T) {
 
 	cmd := newCmdAddResource(fSys)
 	args := []string{resourceFileName}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 
 	// adding an existing resource doesn't return an error
-	err = cmd.RunE(cmd, args)
-	if err != nil {
-		t.Errorf("unexpected cmd error :%v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 }
 
 func TestAddKustomizationFileAsResource(t *testing.T) {
@@ -69,19 +54,12 @@ func TestAddKustomizationFileAsResource(t *testing.T) {
 
 	cmd := newCmdAddResource(fSys)
 	args := []string{resourceFileName}
-	err := cmd.RunE(cmd, args)
-	if err != nil {
-		t.Fatalf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, args))
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
+	assert.NoError(t, err)
 
-	if strings.Contains(string(content), resourceFileName) {
-		t.Errorf("%v shouldn't be in the list of the resources", resourceFileName)
-	}
+	assert.NotContains(t, string(content), resourceFileName)
 }
 
 func TestAddResourceNoArgs(t *testing.T) {
@@ -89,10 +67,6 @@ func TestAddResourceNoArgs(t *testing.T) {
 
 	cmd := newCmdAddResource(fSys)
 	err := cmd.Execute()
-	if err == nil {
-		t.Errorf("expected error: %v", err)
-	}
-	if err.Error() != "must specify a resource file" {
-		t.Errorf("incorrect error: %v", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "must specify a resource file", err.Error())
 }

--- a/kustomize/commands/edit/add/configmap_test.go
+++ b/kustomize/commands/edit/add/configmap_test.go
@@ -6,6 +6,7 @@ package add
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
@@ -15,14 +16,12 @@ import (
 
 func TestNewAddConfigMapIsNotNil(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	if newCmdAddConfigMap(
+	assert.NotNil(t, newCmdAddConfigMap(
 		fSys,
 		kv.NewLoader(
 			loader.NewFileLoaderAtCwd(fSys),
 			valtest_test.MakeFakeValidator()),
-		nil) == nil {
-		t.Fatal("newCmdAddConfigMap shouldn't be nil")
-	}
+		nil))
 }
 
 func TestMakeConfigMapArgs(t *testing.T) {
@@ -36,28 +35,11 @@ func TestMakeConfigMapArgs(t *testing.T) {
 		t.Fatal("Initial kustomization should not have any configmaps")
 	}
 	args := findOrMakeConfigMapArgs(kustomization, cmName)
-
-	if args == nil {
-		t.Fatalf("args should always be non-nil")
-	}
-
-	if len(kustomization.ConfigMapGenerator) != 1 {
-		t.Fatalf("Kustomization should have newly created configmap")
-	}
-
-	if &kustomization.ConfigMapGenerator[len(kustomization.ConfigMapGenerator)-1] != args {
-		t.Fatalf("Pointer address for newly inserted configmap generator should be same")
-	}
-
-	args2 := findOrMakeConfigMapArgs(kustomization, cmName)
-
-	if args2 != args {
-		t.Fatalf("should have returned an existing args with name: %v", cmName)
-	}
-
-	if len(kustomization.ConfigMapGenerator) != 1 {
-		t.Fatalf("Should not insert configmap for an existing name: %v", cmName)
-	}
+	assert.NotNil(t, args)
+	assert.Equal(t, 1, len(kustomization.ConfigMapGenerator))
+	assert.Equal(t, &kustomization.ConfigMapGenerator[len(kustomization.ConfigMapGenerator)-1], args)
+	assert.Equal(t, args, findOrMakeConfigMapArgs(kustomization, cmName))
+	assert.Equal(t, 1, len(kustomization.ConfigMapGenerator))
 }
 
 func TestMergeFlagsIntoConfigMapArgs_LiteralSources(t *testing.T) {
@@ -69,12 +51,8 @@ func TestMergeFlagsIntoConfigMapArgs_LiteralSources(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{LiteralSources: []string{"k2=v2"}})
-	if k.ConfigMapGenerator[0].LiteralSources[0] != "k1=v1" {
-		t.Fatalf("expected v1")
-	}
-	if k.ConfigMapGenerator[0].LiteralSources[1] != "k2=v2" {
-		t.Fatalf("expected v2")
-	}
+	assert.Equal(t, "k1=v1", k.ConfigMapGenerator[0].LiteralSources[0])
+	assert.Equal(t, "k2=v2", k.ConfigMapGenerator[0].LiteralSources[1])
 }
 
 func TestMergeFlagsIntoConfigMapArgs_FileSources(t *testing.T) {
@@ -86,12 +64,8 @@ func TestMergeFlagsIntoConfigMapArgs_FileSources(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{FileSources: []string{"file2"}})
-	if k.ConfigMapGenerator[0].FileSources[0] != "file1" {
-		t.Fatalf("expected file1")
-	}
-	if k.ConfigMapGenerator[0].FileSources[1] != "file2" {
-		t.Fatalf("expected file2")
-	}
+	assert.Equal(t, "file1", k.ConfigMapGenerator[0].FileSources[0])
+	assert.Equal(t, "file2", k.ConfigMapGenerator[0].FileSources[1])
 }
 
 func TestMergeFlagsIntoConfigMapArgs_EnvSource(t *testing.T) {
@@ -103,12 +77,8 @@ func TestMergeFlagsIntoConfigMapArgs_EnvSource(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{EnvFileSource: "env2"})
-	if k.ConfigMapGenerator[0].EnvSources[0] != "env1" {
-		t.Fatalf("expected env1")
-	}
-	if k.ConfigMapGenerator[0].EnvSources[1] != "env2" {
-		t.Fatalf("expected env2")
-	}
+	assert.Equal(t, "env1", k.ConfigMapGenerator[0].EnvSources[0])
+	assert.Equal(t, "env2", k.ConfigMapGenerator[0].EnvSources[1])
 }
 
 func TestMergeFlagsIntoConfigMapArgs_Behavior(t *testing.T) {
@@ -122,9 +92,7 @@ func TestMergeFlagsIntoConfigMapArgs_Behavior(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		createBehaviorFlags)
-	if k.ConfigMapGenerator[0].Behavior != "create" {
-		t.Fatalf("expected create")
-	}
+	assert.Equal(t, "create", k.ConfigMapGenerator[0].Behavior)
 
 	mergeBehaviorFlags := flagsAndArgs{
 		Behavior:      "merge",
@@ -133,9 +101,7 @@ func TestMergeFlagsIntoConfigMapArgs_Behavior(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		mergeBehaviorFlags)
-	if k.ConfigMapGenerator[0].Behavior != "merge" {
-		t.Fatalf("expected merge")
-	}
+	assert.Equal(t, "merge", k.ConfigMapGenerator[0].Behavior)
 
 	replaceBehaviorFlags := flagsAndArgs{
 		Behavior:      "replace",
@@ -144,7 +110,5 @@ func TestMergeFlagsIntoConfigMapArgs_Behavior(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		replaceBehaviorFlags)
-	if k.ConfigMapGenerator[0].Behavior != "replace" {
-		t.Fatalf("expected replace")
-	}
+	assert.Equal(t, "replace", k.ConfigMapGenerator[0].Behavior)
 }

--- a/kustomize/commands/edit/add/flagsandargs_test.go
+++ b/kustomize/commands/edit/add/flagsandargs_test.go
@@ -7,23 +7,20 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"sigs.k8s.io/kustomize/api/filesys"
 )
 
 func TestDataValidation_NoName(t *testing.T) {
 	fa := flagsAndArgs{}
-
-	if fa.Validate([]string{}) == nil {
-		t.Fatal("Validation should fail if no name is specified")
-	}
+	assert.Error(t, fa.Validate([]string{}))
 }
 
 func TestDataValidation_MoreThanOneName(t *testing.T) {
 	fa := flagsAndArgs{}
 
-	if fa.Validate([]string{"name", "othername"}) == nil {
-		t.Fatal("Validation should fail if more than one name is specified")
-	}
+	assert.Error(t, fa.Validate([]string{"name", "othername"}))
 }
 
 func TestDataConfigValidation_Flags(t *testing.T) {
@@ -80,10 +77,11 @@ func TestDataConfigValidation_Flags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if test.fa.Validate([]string{"name"}) == nil && test.shouldFail {
-			t.Fatalf("Validation should fail if %s", test.name)
-		} else if test.fa.Validate([]string{"name"}) != nil && !test.shouldFail {
-			t.Fatalf("Validation should succeed if %s", test.name)
+		err := test.fa.Validate([]string{"name"})
+		if test.shouldFail {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 }

--- a/kustomize/commands/edit/add/secret_test.go
+++ b/kustomize/commands/edit/add/secret_test.go
@@ -6,24 +6,22 @@ package add
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/api/kv"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
-
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
+	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
 func TestNewCmdAddSecretIsNotNil(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	if newCmdAddSecret(
+	assert.NotNil(t, newCmdAddSecret(
 		fSys,
 		kv.NewLoader(
 			loader.NewFileLoaderAtCwd(fSys),
 			valtest_test.MakeFakeValidator()),
-		nil) == nil {
-		t.Fatal("newCmdAddSecret shouldn't be nil")
-	}
+		nil))
 }
 
 func TestMakeSecretArgs(t *testing.T) {
@@ -36,32 +34,13 @@ func TestMakeSecretArgs(t *testing.T) {
 
 	secretType := "Opaque"
 
-	if len(kustomization.SecretGenerator) != 0 {
-		t.Fatal("Initial kustomization should not have any secrets")
-	}
+	assert.Equal(t, 0, len(kustomization.SecretGenerator))
 	args := findOrMakeSecretArgs(kustomization, secretName, namespace, secretType)
-
-	if args == nil {
-		t.Fatalf("args should always be non-nil")
-	}
-
-	if len(kustomization.SecretGenerator) != 1 {
-		t.Fatalf("Kustomization should have newly created secret")
-	}
-
-	if &kustomization.SecretGenerator[len(kustomization.SecretGenerator)-1] != args {
-		t.Fatalf("Pointer address for newly inserted secret generator should be same")
-	}
-
-	args2 := findOrMakeSecretArgs(kustomization, secretName, namespace, secretType)
-
-	if args2 != args {
-		t.Fatalf("should have returned an existing args with name: %v", secretName)
-	}
-
-	if len(kustomization.SecretGenerator) != 1 {
-		t.Fatalf("Should not insert secret for an existing name: %v", secretName)
-	}
+	assert.NotNil(t, args)
+	assert.Equal(t, 1, len(kustomization.SecretGenerator))
+	assert.Equal(t, args, &kustomization.SecretGenerator[len(kustomization.SecretGenerator)-1])
+	assert.Equal(t, args, findOrMakeSecretArgs(kustomization, secretName, namespace, secretType))
+	assert.Equal(t, 1, len(kustomization.SecretGenerator))
 }
 
 func TestMergeFlagsIntoSecretArgs_LiteralSources(t *testing.T) {
@@ -73,12 +52,8 @@ func TestMergeFlagsIntoSecretArgs_LiteralSources(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{LiteralSources: []string{"k2=v2"}})
-	if k.SecretGenerator[0].LiteralSources[0] != "k1=v1" {
-		t.Fatalf("expected v1")
-	}
-	if k.SecretGenerator[0].LiteralSources[1] != "k2=v2" {
-		t.Fatalf("expected v2")
-	}
+	assert.Equal(t, "k1=v1", k.SecretGenerator[0].LiteralSources[0])
+	assert.Equal(t, "k2=v2", k.SecretGenerator[0].LiteralSources[1])
 }
 
 func TestMergeFlagsIntoSecretArgs_FileSources(t *testing.T) {
@@ -90,12 +65,8 @@ func TestMergeFlagsIntoSecretArgs_FileSources(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{FileSources: []string{"file2"}})
-	if k.SecretGenerator[0].FileSources[0] != "file1" {
-		t.Fatalf("expected file1")
-	}
-	if k.SecretGenerator[0].FileSources[1] != "file2" {
-		t.Fatalf("expected file2")
-	}
+	assert.Equal(t, "file1", k.SecretGenerator[0].FileSources[0])
+	assert.Equal(t, "file2", k.SecretGenerator[0].FileSources[1])
 }
 
 func TestMergeFlagsIntoSecretArgs_EnvSource(t *testing.T) {
@@ -107,12 +78,8 @@ func TestMergeFlagsIntoSecretArgs_EnvSource(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{EnvFileSource: "env2"})
-	if k.SecretGenerator[0].EnvSources[0] != "env1" {
-		t.Fatalf("expected env1")
-	}
-	if k.SecretGenerator[0].EnvSources[1] != "env2" {
-		t.Fatalf("expected env2")
-	}
+	assert.Equal(t, "env1", k.SecretGenerator[0].EnvSources[0])
+	assert.Equal(t, "env2", k.SecretGenerator[0].EnvSources[1])
 }
 
 func TestMergeFlagsIntoSecretArgs_DisableNameSuffixHash(t *testing.T) {
@@ -121,7 +88,5 @@ func TestMergeFlagsIntoSecretArgs_DisableNameSuffixHash(t *testing.T) {
 	mergeFlagsIntoGeneratorArgs(
 		&args.GeneratorArgs,
 		flagsAndArgs{DisableNameSuffixHash: true})
-	if k.SecretGenerator[0].Options.DisableNameSuffixHash != true {
-		t.Fatalf("expected true")
-	}
+	assert.True(t, k.SecretGenerator[0].Options.DisableNameSuffixHash)
 }

--- a/kustomize/commands/edit/fix/fix_test.go
+++ b/kustomize/commands/edit/fix/fix_test.go
@@ -4,10 +4,10 @@
 package fix
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filesys"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 )
@@ -17,20 +17,13 @@ func TestFix(t *testing.T) {
 	testutils_test.WriteTestKustomizationWith(fSys, []byte(`nameprefix: some-prefix-`))
 
 	cmd := NewCmdFix(fSys)
-	err := cmd.RunE(cmd, nil)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, nil))
+
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), "apiVersion: ") {
-		t.Errorf("expected apiVersion in kustomization")
-	}
-	if !strings.Contains(string(content), "kind: Kustomization") {
-		t.Errorf("expected kind in kustomization")
-	}
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(content), "apiVersion: ")
+	assert.Contains(t, string(content), "kind: Kustomization")
 }
 
 func TestFixOutdatedPatchesFieldTitle(t *testing.T) {
@@ -62,20 +55,12 @@ patches:
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomizationContentWithOutdatedPatchesFieldTitle)
 	cmd := NewCmdFix(fSys)
-	err := cmd.RunE(cmd, nil)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, nil))
+
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), "apiVersion: ") {
-		t.Errorf("expected apiVersion in kustomization")
-	}
-	if !strings.Contains(string(content), "kind: Kustomization") {
-		t.Errorf("expected kind in kustomization")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "apiVersion: ")
+	assert.Contains(t, string(content), "kind: Kustomization")
 
 	if diff := cmp.Diff(expected, content); diff != "" {
 		t.Errorf("Mismatch (-expected, +actual):\n%s", diff)
@@ -114,20 +99,12 @@ kind: Kustomization
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomizationContentWithOutdatedPatchesFieldTitle)
 	cmd := NewCmdFix(fSys)
-	err := cmd.RunE(cmd, nil)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, nil))
+
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), "apiVersion: ") {
-		t.Errorf("expected apiVersion in kustomization")
-	}
-	if !strings.Contains(string(content), "kind: Kustomization") {
-		t.Errorf("expected kind in kustomization")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "apiVersion: ")
+	assert.Contains(t, string(content), "kind: Kustomization")
 
 	if diff := cmp.Diff(expected, content); diff != "" {
 		t.Errorf("Mismatch (-expected, +actual):\n%s", diff)
@@ -156,20 +133,12 @@ kind: Kustomization
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomizationContentWithOutdatedCommonLabels)
 	cmd := NewCmdFix(fSys)
-	err := cmd.RunE(cmd, nil)
-	if err != nil {
-		t.Errorf("unexpected cmd error: %v", err)
-	}
+	assert.NoError(t, cmd.RunE(cmd, nil))
+
 	content, err := testutils_test.ReadTestKustomization(fSys)
-	if err != nil {
-		t.Errorf("unexpected read error: %v", err)
-	}
-	if !strings.Contains(string(content), "apiVersion: ") {
-		t.Errorf("expected apiVersion in kustomization")
-	}
-	if !strings.Contains(string(content), "kind: Kustomization") {
-		t.Errorf("expected kind in kustomization")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "apiVersion: ")
+	assert.Contains(t, string(content), "kind: Kustomization")
 
 	if diff := cmp.Diff(expected, content); diff != "" {
 		t.Errorf("Mismatch (-expected, +actual):\n%s", diff)
@@ -190,11 +159,6 @@ labels:
 	testutils_test.WriteTestKustomizationWith(fSys, kustomizationContentWithOutdatedCommonLabels)
 	cmd := NewCmdFix(fSys)
 	err := cmd.RunE(cmd, nil)
-	if err == nil {
-		t.Fatalf("expect error")
-	}
-	expectedErr := "label name 'foo' exists in both commonLabels and labels"
-	if err.Error() != expectedErr {
-		t.Fatalf("error message '%s' doesn't match expected", err.Error())
-	}
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "label name 'foo' exists in both commonLabels and labels")
 }

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	sigs.k8s.io/kustomize/api v0.8.9
 	sigs.k8s.io/kustomize/cmd/config v0.9.11
 	sigs.k8s.io/kustomize/kyaml v0.10.19

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -166,8 +166,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=


### PR DESCRIPTION
This PR is to use testify/assert for`kustomize edit add` and `kustomize edit fix` tests to simplify the test code a bit. 