### PR TITLE
Fix repospec test

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -78,6 +78,7 @@ func (x *RepoSpec) Cleaner(fSys filesys.FileSystem) func() error {
 	return func() error { return fSys.RemoveAll(x.Dir.String()) }
 }
 
+// NewRepoSpecFromUrl parses git-like urls.
 // From strings like git@github.com:someOrg/someRepo.git or
 // https://github.com/someOrg/someRepo?ref=someHash, extract
 // the parts.
@@ -85,7 +86,7 @@ func NewRepoSpecFromUrl(n string) (*RepoSpec, error) {
 	if filepath.IsAbs(n) {
 		return nil, fmt.Errorf("uri looks like abs path: %s", n)
 	}
-	host, orgRepo, path, gitRef, gitSubmodules, gitSuffix, gitTimeout := parseGitUrl(n)
+	host, orgRepo, path, gitRef, gitSubmodules, suffix, gitTimeout := parseGitUrl(n)
 	if orgRepo == "" {
 		return nil, fmt.Errorf("url lacks orgRepo: %s", n)
 	}
@@ -94,7 +95,7 @@ func NewRepoSpecFromUrl(n string) (*RepoSpec, error) {
 	}
 	return &RepoSpec{
 		raw: n, Host: host, OrgRepo: orgRepo,
-		Dir: notCloned, Path: path, Ref: gitRef, GitSuffix: gitSuffix,
+		Dir: notCloned, Path: path, Ref: gitRef, GitSuffix: suffix,
 		Submodules: gitSubmodules, Timeout: gitTimeout}, nil
 }
 
@@ -124,6 +125,9 @@ func parseGitUrl(n string) (
 		index := strings.Index(n, gitSuffix)
 		orgRepo = n[0:index]
 		n = n[index+len(gitSuffix):]
+		if n[0] == '/' {
+			n = n[1:]
+		}
 		path, gitRef, gitTimeout, gitSubmodules = peelQuery(n)
 		return
 	}


### PR DESCRIPTION
Repair a test broken in #3900 since the test infra was generally failing.
This change handles the case of URLs with a double slash before the path.
Also adjust table tests so that individual failures easier to diagnose.
