### PR TITLE
Sink: Force JSON encoding for .json files

### DIFF
--- a/cmd/config/internal/commands/e2e/e2e_test.go
+++ b/cmd/config/internal/commands/e2e/e2e_test.go
@@ -87,8 +87,18 @@ metadata:
 			expectedFiles: func(d string) map[string]string {
 				return map[string]string{
 					"deployment.json": `
-{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "foo", annotations: {
-      a-string-value: '', a-int-value: '0', a-bool-value: 'false'}}}
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "a-bool-value": "false",
+      "a-int-value": "0",
+      "a-string-value": ""
+    },
+    "name": "foo"
+  }
+}
 `,
 				}
 			},

--- a/kyaml/kio/byteio_writer.go
+++ b/kyaml/kio/byteio_writer.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// Writer writes ResourceNodes to bytes.
+// ByteWriter writes ResourceNodes to bytes.
 type ByteWriter struct {
 	// Writer is where ResourceNodes are encoded.
 	Writer io.Writer
@@ -55,24 +55,24 @@ func (w ByteWriter) Write(nodes []*yaml.RNode) error {
 		}
 	}
 
-	encoder := yaml.NewEncoder(w.Writer)
-	// keep
-	hasJSONPathExt := make([]bool, len(nodes))
-	defer encoder.Close()
-	for i := range nodes {
-		// Check if the output file is a JSON file so we can force JSON encoding in that case.
-		// YAML flow style encoding may not be compatible because of newlines introduced by the
-		// YAML marshaller in long double quoted string values. These newlines are insignificant
-		// when interpreted as YAML but invalid when interpreted as JSON.
-		if path, _, _ := kioutil.GetFileAnnotations(nodes[i]); path != "" {
+	// Check if the output is a single JSON file so we can force JSON encoding in that case.
+	// YAML flow style encoding may not be compatible because of unquoted strings and newlines
+	// introduced by the YAML marshaller in long string values. These newlines are insignificant
+	// when interpreted as YAML but invalid when interpreted as JSON.
+	jsonEncodeSingleNode := false
+	if w.WrappingKind == "" && len(nodes) == 1 {
+		if path, _, _ := kioutil.GetFileAnnotations(nodes[0]); path != "" {
 			filename := filepath.Base(path)
 			for _, glob := range JSONMatch {
 				if match, _ := filepath.Match(glob, filename); match {
-					hasJSONPathExt[i] = true
+					jsonEncodeSingleNode = true
 					break
 				}
 			}
 		}
+	}
+
+	for i := range nodes {
 		// clean resources by removing annotations set by the Reader
 		if !w.KeepReaderAnnotations {
 			_, err := nodes[i].Pipe(yaml.ClearAnnotation(kioutil.IndexAnnotation))
@@ -96,10 +96,18 @@ func (w ByteWriter) Write(nodes []*yaml.RNode) error {
 		}
 	}
 
+	if jsonEncodeSingleNode {
+		encoder := json.NewEncoder(w.Writer)
+		encoder.SetIndent("", "  ")
+		return errors.Wrap(encoder.Encode(nodes[0]))
+	}
+
+	encoder := yaml.NewEncoder(w.Writer)
+	defer encoder.Close()
 	// don't wrap the elements
 	if w.WrappingKind == "" {
 		for i := range nodes {
-			if err := w.encode(encoder, hasJSONPathExt[i], nodes[i].Document()); err != nil {
+			if err := encoder.Encode(nodes[i].Document()); err != nil {
 				return err
 			}
 		}
@@ -133,27 +141,7 @@ func (w ByteWriter) Write(nodes []*yaml.RNode) error {
 	for i := range nodes {
 		items.Content = append(items.Content, nodes[i].YNode())
 	}
-	err := w.encode(encoder, false, doc)
+	err := encoder.Encode(doc)
 	yaml.UndoSerializationHacksOnNodes(nodes)
 	return err
-}
-
-// encode encodes the input document node to appropriate node format
-func (w ByteWriter) encode(encoder *yaml.Encoder, forceJSON bool, doc *yaml.Node) error {
-	rNode := &yaml.RNode{}
-	rNode.SetYNode(doc)
-	useJSONEncoder := forceJSON
-	if !forceJSON {
-		str, err := rNode.String()
-		if err != nil {
-			return errors.Wrap(err)
-		}
-		useJSONEncoder = json.Valid([]byte(str))
-	}
-	if useJSONEncoder {
-		je := json.NewEncoder(w.Writer)
-		je.SetIndent("", "  ")
-		return errors.Wrap(je.Encode(rNode))
-	}
-	return encoder.Encode(doc)
 }

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -194,7 +194,7 @@ metadata:
 		// Test Case
 		//
 		{
-			name:     "encode_valid_json",
+			name: "encode_valid_json",
 			items: []string{
 				`{
   "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
@@ -220,7 +220,7 @@ metadata:
 		// Test Case
 		//
 		{
-			name:     "encode_wrapped_json_as_yaml",
+			name: "encode_wrapped_json_as_yaml",
 			instance: ByteWriter{
 				Sort:               true,
 				WrappingKind:       ResourceListKind,
@@ -248,7 +248,7 @@ items:
 		// Test Case
 		//
 		{
-			name:     "encode_multi_doc_json_as_yaml",
+			name: "encode_multi_doc_json_as_yaml",
 			items: []string{
 				`{
   "a": "b",

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -26,7 +26,7 @@ func TestByteWriter(t *testing.T) {
 
 	testCases := []testCase{
 		//
-		//
+		// Test Case
 		//
 		{
 			name: "wrap_resource_list",
@@ -60,7 +60,7 @@ functionConfig:
 		},
 
 		//
-		//
+		// Test Case
 		//
 		{
 			name: "multiple_items",
@@ -188,6 +188,32 @@ metadata:
   annotations:
     config.kubernetes.io/path: "a/b/a_test.yaml"
 `,
+		},
+
+		//
+		// Test Case
+		//
+		{
+			name:     "encode_valid_json",
+			items: []string{
+				`{
+  "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test.json"
+    }
+  }
+}`,
+			},
+
+			expectedOutput: `{
+  "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test.json"
+    }
+  }
+}`,
 		},
 	}
 

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -220,6 +220,25 @@ metadata:
 		// Test Case
 		//
 		{
+			name: "encode_unformatted_valid_json",
+			items: []string{
+				`{ "a": "b", metadata: { annotations: { config.kubernetes.io/path: test.json } } }`,
+			},
+
+			expectedOutput: `{
+  "a": "b",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test.json"
+    }
+  }
+}`,
+		},
+
+		//
+		// Test Case
+		//
+		{
 			name: "encode_wrapped_json_as_yaml",
 			instance: ByteWriter{
 				Sort:               true,

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -198,9 +198,9 @@ metadata:
 			items: []string{
 				`{
   "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
-  "metadata": {
-    "annotations": {
-      "config.kubernetes.io/path": "test.json"
+  metadata: {
+    annotations: {
+      config.kubernetes.io/path: test.json
     }
   }
 }`,
@@ -214,6 +214,65 @@ metadata:
     }
   }
 }`,
+		},
+
+		//
+		// Test Case
+		//
+		{
+			name:     "encode_wrapped_json_as_yaml",
+			instance: ByteWriter{
+				Sort:               true,
+				WrappingKind:       ResourceListKind,
+				WrappingAPIVersion: ResourceListAPIVersion,
+			},
+			items: []string{
+				`{
+  "a": "b",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test.json"
+    }
+  }
+}`,
+			},
+
+			expectedOutput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- {"a": "b", "metadata": {"annotations": {"config.kubernetes.io/path": "test.json"}}}
+`,
+		},
+
+		//
+		// Test Case
+		//
+		{
+			name:     "encode_multi_doc_json_as_yaml",
+			items: []string{
+				`{
+  "a": "b",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test-1.json"
+    }
+  }
+}`,
+				`{
+  "c": "d",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test-2.json"
+    }
+  }
+}`,
+			},
+
+			expectedOutput: `
+{"a": "b", "metadata": {"annotations": {"config.kubernetes.io/path": "test-1.json"}}}
+---
+{"c": "d", "metadata": {"annotations": {"config.kubernetes.io/path": "test-2.json"}}}
+`,
 		},
 	}
 

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -743,6 +743,46 @@ func TestFormatFileOrDirectory_ymlExtFile(t *testing.T) {
 	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
 }
 
+// TestFormatFileOrDirectory_YamlExtFileWithJson verifies that the JSON compatible flow style
+// YAML content is formatted as such.
+func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
+	// write the unformatted JSON file contents
+	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
+	assert.NoError(t, err)
+
+	// format the file
+	err = FormatFileOrDirectory(f.Name())
+	assert.NoError(t, err)
+
+	// check the result is formatted as yaml
+	b, err := ioutil.ReadFile(f.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, string(testyaml.FormattedFlowYAML1), string(b))
+}
+
+// TestFormatFileOrDirectory_JsonExtFileWithNotModified verifies that a file with .json extensions
+// and JSON contents won't be modified.
+func TestFormatFileOrDirectory_JsonExtFileWithNotModified(t *testing.T) {
+	// write the unformatted JSON file contents
+	f, err := ioutil.TempFile("", "yamlfmt*.json")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
+	assert.NoError(t, err)
+
+	// format the file
+	err = FormatFileOrDirectory(f.Name())
+	assert.NoError(t, err)
+
+	// check the result is formatted as yaml
+	b, err := ioutil.ReadFile(f.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, string(testyaml.UnformattedJSON1), string(b))
+}
+
 // TestFormatFileOrDirectory_partialKubernetesYamlFile verifies that if a yaml file contains both
 // Kubernetes and non-Kubernetes documents, it will only format the Kubernetes documents
 func TestFormatFileOrDirectory_partialKubernetesYamlFile(t *testing.T) {

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -743,26 +743,6 @@ func TestFormatFileOrDirectory_ymlExtFile(t *testing.T) {
 	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
 }
 
-// TestFormatFileOrDirectory_skipYamlExtFileWithJson verifies that the json content is formatted
-// as yaml
-func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
-	// write the unformatted JSON file contents
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
-	assert.NoError(t, err)
-	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
-	assert.NoError(t, err)
-
-	// format the file
-	err = FormatFileOrDirectory(f.Name())
-	assert.NoError(t, err)
-
-	// check the result is formatted as yaml
-	b, err := ioutil.ReadFile(f.Name())
-	assert.NoError(t, err)
-	assert.Equal(t, string(testyaml.FormattedJSON1), string(b))
-}
-
 // TestFormatFileOrDirectory_partialKubernetesYamlFile verifies that if a yaml file contains both
 // Kubernetes and non-Kubernetes documents, it will only format the Kubernetes documents
 func TestFormatFileOrDirectory_partialKubernetesYamlFile(t *testing.T) {

--- a/kyaml/kio/filters/testyaml/testyaml.go
+++ b/kyaml/kio/filters/testyaml/testyaml.go
@@ -68,15 +68,6 @@ metadata:
   selfLink: ""
 `)
 
-var UnformattedJSON1 = []byte(`
-{
-  "spec": "a",
-  "status": {"conditions": [3, 1, 2]},
-  "apiVersion": "example.com/v1beta1",
-  "kind": "MyType"
-}
-`)
-
 var FormattedYaml1 = []byte(`apiVersion: example.com/v1beta1
 kind: MyType
 spec: a
@@ -95,20 +86,6 @@ status2:
   - 3
   - 1
   - 2
-`)
-
-var FormattedJSON1 = []byte(`{
-  "apiVersion": "example.com/v1beta1",
-  "kind": "MyType",
-  "spec": "a",
-  "status": {
-    "conditions": [
-      3,
-      1,
-      2
-    ]
-  }
-}
 `)
 
 var FormattedYaml3 = []byte(`apiVersion: v1

--- a/kyaml/kio/filters/testyaml/testyaml.go
+++ b/kyaml/kio/filters/testyaml/testyaml.go
@@ -68,6 +68,15 @@ metadata:
   selfLink: ""
 `)
 
+var UnformattedJSON1 = []byte(`
+{
+  "spec": "a",
+  "status": {"conditions": [3, 1, 2]},
+  "apiVersion": "example.com/v1beta1",
+  "kind": "MyType"
+}
+`)
+
 var FormattedYaml1 = []byte(`apiVersion: example.com/v1beta1
 kind: MyType
 spec: a
@@ -86,6 +95,11 @@ status2:
   - 3
   - 1
   - 2
+`)
+
+var FormattedFlowYAML1 = []byte(
+	`{"apiVersion": "example.com/v1beta1", "kind": "MyType", "spec": "a", "status": {"conditions": [
+      3, 1, 2]}}
 `)
 
 var FormattedYaml3 = []byte(`apiVersion: v1

--- a/plugin/builtin/iampolicygenerator/go.sum
+++ b/plugin/builtin/iampolicygenerator/go.sum
@@ -126,7 +126,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
The main issue this PR addresses is when a `.json` file containing long strings is read by `kpt fn source` and then, potentially after passing through some functions, get written back to a `.json` file by `kpt fn sink` as invalid JSON because of newlines added to the long strings. This PR could maybe be seen as the followup mentioned in #2546.

As a side note, it looks a bit problematic to get this change into kpt because it's at kyaml v0.10.17 and v0.10.20 comes with breaking changes. I could easily address all but one that was inside kustomize v2.0.3 which gets pulled in transitively via kubectl. Not sure how to deal with that.