### PR TITLE
add an option to include local configs

### DIFF
--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -23,9 +23,10 @@ import (
 type Factory struct {
 	hasher ifc.KustHasher
 
-	// IncludeLocalConfigs indicates should resource factory ignore
-	// the resources which have annotation 'config.kubernetes.io/local-config'.
-	// By default it's false.
+	// When set to true, IncludeLocalConfigs indicates
+	// that Factory should include resources with the
+	// annotation 'config.kubernetes.io/local-config'.
+	// By default these resources are ignored.
 	IncludeLocalConfigs bool
 }
 

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -22,6 +22,11 @@ import (
 // Factory makes instances of Resource.
 type Factory struct {
 	hasher ifc.KustHasher
+
+	// IncludeLocalConfigs indicates should resource factory ignore
+	// the resources which have annotation 'config.kubernetes.io/local-config'.
+	// By default it's false.
+	IncludeLocalConfigs bool
 }
 
 // NewFactory makes an instance of Factory.
@@ -221,13 +226,15 @@ func (rf *Factory) shouldIgnore(n *yaml.RNode) (bool, error) {
 	if n.IsNilOrEmpty() {
 		return true, nil
 	}
-	md, err := n.GetValidatedMetadata()
-	if err != nil {
-		return true, err
-	}
-	_, ignore := md.ObjectMeta.Annotations[konfig.IgnoredByKustomizeAnnotation]
-	if ignore {
-		return true, nil
+	if !rf.IncludeLocalConfigs {
+		md, err := n.GetValidatedMetadata()
+		if err != nil {
+			return true, err
+		}
+		_, ignore := md.ObjectMeta.Annotations[konfig.IgnoredByKustomizeAnnotation]
+		if ignore {
+			return true, nil
+		}
 	}
 	if foundNil, path := n.HasNilEntryInList(); foundNil {
 		return true, fmt.Errorf("empty item at %v in object %v", path, n)

--- a/plugin/builtin/iampolicygenerator/go.sum
+++ b/plugin/builtin/iampolicygenerator/go.sum
@@ -126,7 +126,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
https://github.com/GoogleContainerTools/kpt/issues/1933

This PR adds an option to resource factory to explicitly include resources which have `config.kubernetes.io/local-config` annotation.