### PR TITLE
Remove label value validation from annotationSelector

### DIFF
--- a/api/resmap/selector_test.go
+++ b/api/resmap/selector_test.go
@@ -186,6 +186,12 @@ func TestFindPatchTargets(t *testing.T) {
 			},
 			count: 1,
 		},
+		"select_20": {
+			target: types.Selector{
+				AnnotationSelector: "foo=bar,bar=baz",
+			},
+			count: 0,
+		},
 	}
 	for n, testcase := range testcases {
 		actual, err := rm.Select(testcase.target)

--- a/api/resmap/selector_test.go
+++ b/api/resmap/selector_test.go
@@ -23,6 +23,7 @@ metadata:
     app: name1
   annotations:
     foo: bar
+    cert-manager.io/inject-ca-from: capi-webhook-system/capi-serving-cert
 ---
 apiVersion: group1/v1
 kind: Kind1
@@ -176,6 +177,12 @@ func TestFindPatchTargets(t *testing.T) {
 		"select_18": {
 			target: types.Selector{
 				ResId: resid.ResId{Namespace: "ns1"},
+			},
+			count: 1,
+		},
+		"select_19": {
+			target: types.Selector{
+				AnnotationSelector: "cert-manager.io/inject-ca-from=capi-webhook-system/capi-serving-cert",
 			},
 			count: 1,
 		},

--- a/api/types/selector.go
+++ b/api/types/selector.go
@@ -17,7 +17,7 @@ type Selector struct {
 	// ResId refers to a GVKN/Ns of a resource.
 	resid.ResId `json:",inline,omitempty" yaml:",inline,omitempty"`
 
-	// AnnotationSelector is a string that follows the label selection expression
+	// AnnotationSelector is a string that follows equality-based label selection requirements.
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
 	// It matches with the resource annotations.
 	AnnotationSelector string `json:"annotationSelector,omitempty" yaml:"annotationSelector,omitempty"`

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -1029,26 +1029,19 @@ func TestRNodeMatchesAnnotationSelector(t *testing.T) {
 		"select_01": {
 			selector: ".*",
 			matches:  false,
-			errMsg:   "name part must consist of alphanumeric character",
+			errMsg:   "invalid selector:",
 		},
 		"select_02": {
+			selector: "invalid/annotation/name=fail",
+			matches:  false,
+			errMsg:   "Invalid value:",
+		},
+		"select_03": {
 			selector: "area=51",
 			matches:  true,
 		},
-		"select_03": {
-			selector: "area=florida",
-			matches:  false,
-		},
 		"select_04": {
-			selector: "area in (disneyland, 51, iowa)",
-			matches:  true,
-		},
-		"select_05": {
-			selector: "area in (disneyland, iowa)",
-			matches:  false,
-		},
-		"select_06": {
-			selector: "area notin (disneyland, 51, iowa)",
+			selector: "area=florida",
 			matches:  false,
 		},
 	}


### PR DESCRIPTION
Fixes  #3887

This change allows valid annotation values, that happen to be invalid label values, to be used in `annotationSelector`.

As-is, this may break some users if they use a set-based selector string instead of equality-based.

ALLOW_MODULE_SPAN