### PR TITLE
remove metadata field from resourceRef schema

### DIFF
--- a/kyaml/fn/framework/command/example_test.go
+++ b/kyaml/fn/framework/command/example_test.go
@@ -320,9 +320,12 @@ func ExampleBuild_validate() {
 				continue
 			}
 			validationResults = append(validationResults, framework.ResultItem{
-				Severity:    framework.Error,
-				Message:     "field is required",
-				ResourceRef: meta,
+				Severity: framework.Error,
+				Message:  "field is required",
+				ResourceRef: yaml.ResourceIdentifier{
+					TypeMeta: meta.TypeMeta,
+					NameMeta: meta.ObjectMeta.NameMeta,
+				},
 				Field: framework.Field{
 					Path:           "spec.replicas",
 					SuggestedValue: "1",
@@ -374,8 +377,7 @@ items:
 	//     resourceRef:
 	//       apiVersion: apps/v1
 	//       kind: Deployment
-	//       metadata:
-	//         name: foo
+	//       name: foo
 	//     field:
 	//       path: spec.replicas
 	//       suggestedValue: "1"

--- a/kyaml/fn/framework/framework_test.go
+++ b/kyaml/fn/framework/framework_test.go
@@ -22,11 +22,9 @@ func TestExecute_Result(t *testing.T) {
 				{
 					Message:  "bad value for replicas",
 					Severity: framework.Error,
-					ResourceRef: yaml.ResourceMeta{
+					ResourceRef: yaml.ResourceIdentifier{
 						TypeMeta: yaml.TypeMeta{APIVersion: "v1", Kind: "Deployment"},
-						ObjectMeta: yaml.ObjectMeta{
-							NameMeta: yaml.NameMeta{Name: "tester", Namespace: "default"},
-						},
+						NameMeta: yaml.NameMeta{Name: "tester", Namespace: "default"},
 					},
 					Field: framework.Field{
 						Path:           ".spec.Replicas",
@@ -83,9 +81,8 @@ results:
     resourceRef:
       apiVersion: v1
       kind: Deployment
-      metadata:
-        name: tester
-        namespace: default
+      name: tester
+      namespace: default
     field:
       path: .spec.Replicas
       currentValue: "0"

--- a/kyaml/fn/framework/result.go
+++ b/kyaml/fn/framework/result.go
@@ -31,7 +31,7 @@ type ResultItem struct {
 	Severity Severity `yaml:"severity,omitempty"`
 
 	// ResourceRef is a reference to a resource
-	ResourceRef yaml.ResourceMeta `yaml:"resourceRef,omitempty"`
+	ResourceRef yaml.ResourceIdentifier `yaml:"resourceRef,omitempty"`
 
 	// Field is a reference to the field in a resource this result refers to
 	Field Field `yaml:"field,omitempty"`
@@ -42,7 +42,7 @@ type ResultItem struct {
 
 // String provides a human-readable message for the result item
 func (i ResultItem) String() string {
-	identifier := i.ResourceRef.GetIdentifier()
+	identifier := i.ResourceRef
 	var idStringList []string
 	if identifier.APIVersion != "" {
 		idStringList = append(idStringList, identifier.APIVersion)


### PR DESCRIPTION
In a function result item, the resourceRef schema is currently:
```
resourceRef:
    apiVersion: apps/v1
    kind: Deployment
    metadata: 
      namespace: ''
      name: nginx-deployment
```

We want it to be:
```
resourceRef:
    apiVersion: apps/v1
    kind: Deployment
    namespace: ''
    name: nginx-deployment
```

so that it aligns with the schema in the function specification described here: https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md