### PR TITLE
Expand documentation of annotations used in manifests and KRM functions API

### DIFF
--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -327,16 +327,22 @@ A function SHOULD preserve comments when input serialization format is YAML.
 This allows for human authoring of configuration to coexist with changes made by
 functions.
 
-### Annotations
+### Internal Annotations
 
-The orchestrator annotates resources in the wire format with annotation prefix
-`config.kubernetes.io`. These annotations are not persisted when the
-orchestrator writes the resources to the filesystem. The orchestrator sets this
-annotation when reading files from the local filesystem and removes the
-annotation when writing the output of functions back to the filesystem.
+For orchestration purposes, the orchestrator will use a set of annotations,
+referred to as _internal annotations_, on resources in `Resources.items`. These
+annotations are not persisted to resource manifests on the filesystem: The
+orchestrator sets this annotation when reading files from the local filesystem
+and removes the annotation when writing the output of functions back to the
+filesystem.
 
-In general, a function MUST NOT modify these annotations except the ones
-explicitly listed below.
+Annotation prefix `internal.config.kubernetes.io` is reserved for use for
+internal annotations. In general, a function MUST NOT modify these annotations.
+This enables orchestrator to add additional internal annotations in the future,
+without requiring changes to existing functions.
+
+For legacy reasons, a few internal annotations do not use this annotation
+prefix. These are listed below:
 
 #### `config.kubernetes.io/path`
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -337,7 +337,7 @@ and removes the annotation when writing the output of functions back to the
 filesystem.
 
 Annotation prefix `internal.config.kubernetes.io` is reserved for use for
-internal annotations. In general, a function MUT NOT modify these annotations with
+internal annotations. In general, a function MUST NOT modify these annotations with
 exceptions of specific annotation listed below. This enables orchestrator to add additional internal annotations, without requiring changes to existing functions.
 
 #### `internal.config.kubernetes.io/path`

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -337,17 +337,16 @@ and removes the annotation when writing the output of functions back to the
 filesystem.
 
 Annotation prefix `internal.config.kubernetes.io` is reserved for use for
-internal annotations. In general, a function SHOULD NOT modify these annotations.
-This enables orchestrator to add additional internal annotations,
-without requiring changes to existing functions.
-
-Specific internal annotations is discussed below:
+internal annotations. In general, a function MUT NOT modify these annotations with
+exceptions of specific annotation listed below. This enables orchestrator to add additional internal annotations, without requiring changes to existing functions.
 
 #### `internal.config.kubernetes.io/path`
 
 Records the slash-delimited, OS-agnostic, relative file path to a resource. The
 path is relative to a fix location on the filesystem. Different orchestrator
 implementations can choose different fixed points.
+
+A function SHOULD NOT modify these annotations.
 
 Example:
 
@@ -363,6 +362,8 @@ Records the index of a Resource in file. In a multi-object YAML file, resources
 are separated by three dashes (`---`), and the index represents the position of
 the Resource starting from zero. When this annotation is not specified, it
 implies a value of `0`.
+
+A function SHOULD NOT modify these annotations.
 
 Example:
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -338,7 +338,7 @@ filesystem.
 
 Annotation prefix `internal.config.kubernetes.io` is reserved for use for
 internal annotations. In general, a function MUST NOT modify these annotations with
-exceptions of specific annotation listed below. This enables orchestrator to add additional internal annotations, without requiring changes to existing functions.
+the exception of the specific annotations listed below. This enables orchestrators to add additional internal annotations, without requiring changes to existing functions.
 
 #### `internal.config.kubernetes.io/path`
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -337,45 +337,40 @@ and removes the annotation when writing the output of functions back to the
 filesystem.
 
 Annotation prefix `internal.config.kubernetes.io` is reserved for use for
-internal annotations. In general, a function MUST NOT modify these annotations.
-This enables orchestrator to add additional internal annotations in the future,
+internal annotations. In general, a function SHOULD NOT modify these annotations.
+This enables orchestrator to add additional internal annotations,
 without requiring changes to existing functions.
 
-For legacy reasons, a few internal annotations do not use this annotation
-prefix. These are listed below:
+Specific internal annotations is discussed below:
 
-#### `config.kubernetes.io/path`
+#### `internal.config.kubernetes.io/path`
 
 Records the slash-delimited, OS-agnostic, relative file path to a resource. The
 path is relative to a fix location on the filesystem. Different orchestrator
 implementations can choose different fixed points.
-
-A function SHOULD NOT modify this annotation.
 
 Example:
 
 ```yaml
 metadata:
   annotations:
-    config.kubernetes.io/path: "relative/file/path.yaml"
+    internal.config.kubernetes.io/path: "relative/file/path.yaml"
 ```
 
-#### `config.kubernetes.io/index`
+#### `internal.config.kubernetes.io/index`
 
 Records the index of a Resource in file. In a multi-object YAML file, resources
 are separated by three dashes (`---`), and the index represents the position of
 the Resource starting from zero. When this annotation is not specified, it
 implies a value of `0`.
 
-A function SHOULD NOT modify this annotation.
-
 Example:
 
 ```yaml
 metadata:
   annotations:
-    config.kubernetes.io/path: "relative/file/path.yaml"
-    config.kubernetes.io/index: 2
+    internal.config.kubernetes.io/path: "relative/file/path.yaml"
+    internal.config.kubernetes.io/index: 2
 ```
 
 This represents the third resource in the file.

--- a/cmd/config/docs/api-conventions/manifest-annotations.md
+++ b/cmd/config/docs/api-conventions/manifest-annotations.md
@@ -4,18 +4,8 @@ This document lists the annotations that can be declared in resource manifests.
 
 ### `config.kubernetes.io/local-config`
 
-A value of `"true"` for this annotation declares that the configuration is to
-local tools rather than a remote Resource. e.g. The `Kustomization` config in a
-`kustomization.yaml` **SHOULD** contain this annotation so that tools know it is
-not intended to be sent to the Kubernetes API server.
-
-Example:
-
-```yaml
-metadata:
-  annotations:
-    config.kubernetes.io/local-config: "true"
-```
+A value of `"true"` for this annotation declares that the resource is only consumed by
+client-side tooling and should not be applied to the API server.
 
 A value of `"false"` can be used to declare that a resource should be applied to
-the cluster in situations where the tool assumes the resource is local.
+the API server even when it is assumed to be local.

--- a/cmd/config/docs/api-conventions/manifest-annotations.md
+++ b/cmd/config/docs/api-conventions/manifest-annotations.md
@@ -7,7 +7,7 @@ This document lists the annotations that can be declared in resource manifests.
 A value of `"true"` for this annotation declares that the configuration is to
 local tools rather than a remote Resource. e.g. The `Kustomization` config in a
 `kustomization.yaml` **SHOULD** contain this annotation so that tools know it is
-not intended to be sent to the Kubernetes api server.
+not intended to be sent to the Kubernetes API server.
 
 Example:
 

--- a/cmd/config/docs/api-conventions/manifest-annotations.md
+++ b/cmd/config/docs/api-conventions/manifest-annotations.md
@@ -1,0 +1,21 @@
+# Manifest Annotations
+
+This document lists the annotations that can be declared in resource manifests.
+
+### `config.kubernetes.io/local-config`
+
+A value of `"true"` for this annotation declares that the configuration is to
+local tools rather than a remote Resource. e.g. The `Kustomization` config in a
+`kustomization.yaml` **SHOULD** contain this annotation so that tools know it is
+not intended to be sent to the Kubernetes api server.
+
+Example:
+
+```yaml
+metadata:
+  annotations:
+    config.kubernetes.io/local-config: "true"
+```
+
+A value of `"false"` can be used to declare that a resource should be applied to
+the cluster in situations where the tool assumes the resource is local.


### PR DESCRIPTION
- Reserve `internal.config.kubernetes.io` for internal annotations
- Document `local-config` annotation in a separate document (It's
  orthogonal to KRM functions).
- Follow up implementation changes: https://github.com/kubernetes-sigs/kustomize/issues/4024


[1]: https://github.com/kubernetes-sigs/kustomize/blob/7e8ba62e9fd9c9b9635598008b933f30f988452f/kyaml/fn/runtime/runtimeutil/runtimeutil.go#L195
[2]: https://github.com/kubernetes-sigs/kustomize/pull/2465