### PR TITLE
expose --as-current-user flag to kustomize build command

### DIFF
--- a/api/internal/plugins/fnplugin/fnplugin.go
+++ b/api/internal/plugins/fnplugin/fnplugin.go
@@ -78,6 +78,7 @@ func NewFnPlugin(o *types.FnPluginLoadingOptions) *FnPlugin {
 			EnableExec:     o.EnableExec,
 			StorageMounts:  toStorageMounts(o.Mounts),
 			Env:            o.Env,
+			AsCurrentUser:  o.AsCurrentUser,
 		},
 	}
 }

--- a/api/types/pluginrestrictions.go
+++ b/api/types/pluginrestrictions.go
@@ -42,7 +42,7 @@ const (
 	BploLoadFromFileSys
 )
 
-// FnPluginLoadingOptions set way functions-based pluing are restricted
+// FnPluginLoadingOptions set way functions-based plugins are restricted
 type FnPluginLoadingOptions struct {
 	// Allow to run executables
 	EnableExec bool
@@ -55,4 +55,6 @@ type FnPluginLoadingOptions struct {
 	Mounts []string
 	// list of env variables to pass to fn
 	Env []string
+	// Run as uid and gid of the command executor
+	AsCurrentUser bool
 }

--- a/cmd/config/internal/commands/run-fns.go
+++ b/cmd/config/internal/commands/run-fns.go
@@ -72,7 +72,7 @@ func GetRunFnRunner(name string) *RunFnRunner {
 		&r.Env, "env", "e", []string{},
 		"a list of environment variables to be used by functions")
 	r.Command.Flags().BoolVar(
-		&r.AsCurrentUser, "as-current-user", false, "use the uid and gid that kpt is running with to run the function in the container")
+		&r.AsCurrentUser, "as-current-user", false, "use the uid and gid of the command executor to run the function in the container")
 	return r
 }
 

--- a/kustomize/commands/build/flagsforfunctions.go
+++ b/kustomize/commands/build/flagsforfunctions.go
@@ -20,6 +20,9 @@ func AddFunctionBasicsFlags(set *pflag.FlagSet) {
 	set.StringArrayVarP(
 		&theFlags.fnOptions.Env, "env", "e", []string{},
 		"a list of environment variables to be used by functions")
+	set.BoolVar(
+		&theFlags.fnOptions.AsCurrentUser, "as-current-user", false,
+		"use the uid and gid of the command executor to run the function in the container")
 }
 
 func AddFunctionAlphaEnablementFlags(set *pflag.FlagSet) {


### PR DESCRIPTION
Support setting UID and GID of command executor in KRM functions.