### PR TITLE
Remove debug fmt.Println breaking kpt Starlark output

### DIFF
--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -496,7 +496,6 @@ func (r *RunFns) ffp(spec runtimeutil.FunctionSpec, api *yaml.RNode, currentUser
 			}
 			p = filepath.ToSlash(filepath.Join(r.Path, filepath.Dir(p), spec.Starlark.Path))
 		}
-		fmt.Println(p)
 
 		sf := &starlark.Filter{Name: spec.Starlark.Name, Path: p, URL: spec.Starlark.URL}
 


### PR DESCRIPTION
This line causes `kpt fn run --enable-star --star-path something.star` to output the path to the Starlark source as the first line, i.e. not valid function output. I can't see any reason for it existing other than being a forgotten debug line.