### PR TITLE
change marshal indent to 2

### DIFF
--- a/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
+++ b/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
@@ -1133,7 +1133,7 @@ metadata:
 `,
 			expectedFn: `
 container:
-    image: foo:v1.0.0`,
+  image: foo:v1.0.0`,
 		},
 
 		{
@@ -1150,16 +1150,16 @@ metadata:
 `,
 			expectedFn: `
 container:
-    image: foo:v1.0.0
-    mounts:
-      - type: bind
-        src: /mount/path
-        dst: /local/
-      - type: volume
-        src: myvol
-        dst: /local/
-      - type: tmpfs
-        dst: /local/
+  image: foo:v1.0.0
+  mounts:
+  - type: bind
+    src: /mount/path
+    dst: /local/
+  - type: volume
+    src: myvol
+    dst: /local/
+  - type: tmpfs
+    dst: /local/
 `,
 		},
 
@@ -1185,16 +1185,16 @@ metadata:
 `,
 			expectedFn: `
 container:
-    image: foo:v1.0.0
-    mounts:
-      - type: bind
-        src: /mount/path
-        dst: /local/
-      - type: volume
-        src: myvol
-        dst: /local/
-      - type: tmpfs
-        dst: /local/
+  image: foo:v1.0.0
+  mounts:
+  - type: bind
+    src: /mount/path
+    dst: /local/
+  - type: volume
+    src: myvol
+    dst: /local/
+  - type: tmpfs
+    dst: /local/
 `,
 		},
 
@@ -1212,8 +1212,8 @@ metadata:
 `,
 			expectedFn: `
 container:
-    image: foo:v1.0.0
-    network: true
+  image: foo:v1.0.0
+  network: true
 `,
 		},
 
@@ -1232,7 +1232,7 @@ metadata:
 			// path should be erased
 			expectedFn: `
 container:
-    image: foo:v1.0.0
+  image: foo:v1.0.0
 `,
 		},
 
@@ -1251,7 +1251,7 @@ metadata:
 			// network should be erased
 			expectedFn: `
 container:
-    image: foo:v1.0.0
+  image: foo:v1.0.0
 `,
 		},
 
@@ -1267,7 +1267,7 @@ metadata:
 `,
 			expectedFn: `
 container:
-    image: foo:v1.0.0
+  image: foo:v1.0.0
 `,
 		},
 

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -4,6 +4,7 @@
 package yaml
 
 import (
+	"bytes"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -20,8 +21,14 @@ type Node = yaml.Node
 type Style = yaml.Style
 type TypeError = yaml.TypeError
 type Unmarshaler = yaml.Unmarshaler
-
-var Marshal = yaml.Marshal
+var Marshal = func (in interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	err := NewEncoder(&buf).Encode(in)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
 var Unmarshal = yaml.Unmarshal
 var NewDecoder = yaml.NewDecoder
 var NewEncoder = func(w io.Writer) *yaml.Encoder {

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -1171,88 +1171,88 @@ const (
 `
 	bigMapYaml = `Kind: Service
 complextree:
-  - field1:
-      - boolfield: true
-        floatsubfield: 1.01
-        intsubfield: 1010
-        stringsubfield: idx1010
-      - boolfield: false
-        floatsubfield: 1.011
-        intsubfield: 1011
-        stringsubfield: idx1011
-    field2:
-      - boolfield: true
-        floatsubfield: 1.02
-        intsubfield: 1020
-        stringsubfield: idx1020
-      - boolfield: false
-        floatsubfield: 1.021
-        intsubfield: 1021
-        stringsubfield: idx1021
-  - field1:
-      - boolfield: true
-        floatsubfield: 1.11
-        intsubfield: 1110
-        stringsubfield: idx1110
-      - boolfield: false
-        floatsubfield: 1.111
-        intsubfield: 1111
-        stringsubfield: idx1111
-    field2:
-      - boolfield: true
-        floatsubfield: 1.112
-        intsubfield: 1120
-        stringsubfield: idx1120
-      - boolfield: false
-        floatsubfield: 1.1121
-        intsubfield: 1121
-        stringsubfield: idx1121
+- field1:
+  - boolfield: true
+    floatsubfield: 1.01
+    intsubfield: 1010
+    stringsubfield: idx1010
+  - boolfield: false
+    floatsubfield: 1.011
+    intsubfield: 1011
+    stringsubfield: idx1011
+  field2:
+  - boolfield: true
+    floatsubfield: 1.02
+    intsubfield: 1020
+    stringsubfield: idx1020
+  - boolfield: false
+    floatsubfield: 1.021
+    intsubfield: 1021
+    stringsubfield: idx1021
+- field1:
+  - boolfield: true
+    floatsubfield: 1.11
+    intsubfield: 1110
+    stringsubfield: idx1110
+  - boolfield: false
+    floatsubfield: 1.111
+    intsubfield: 1111
+    stringsubfield: idx1111
+  field2:
+  - boolfield: true
+    floatsubfield: 1.112
+    intsubfield: 1120
+    stringsubfield: idx1120
+  - boolfield: false
+    floatsubfield: 1.1121
+    intsubfield: 1121
+    stringsubfield: idx1121
 metadata:
-    labels:
-        app: application-name
-    name: service-name
+  labels:
+    app: application-name
+  name: service-name
 spec:
-    ports:
-        port: 80
+  ports:
+    port: 80
 that:
-  - idx0
-  - idx1
-  - idx2
-  - idx3
+- idx0
+- idx1
+- idx2
+- idx3
 these:
-  - field1:
-      - idx010
-      - idx011
-    field2:
-      - idx020
-      - idx021
-  - field1:
-      - idx110
-      - idx111
-    field2:
-      - idx120
-      - idx121
-  - field1:
-      - idx210
-      - idx211
-    field2:
-      - idx220
-      - idx221
+- field1:
+  - idx010
+  - idx011
+  field2:
+  - idx020
+  - idx021
+- field1:
+  - idx110
+  - idx111
+  field2:
+  - idx120
+  - idx121
+- field1:
+  - idx210
+  - idx211
+  field2:
+  - idx220
+  - idx221
 this:
-    is:
-        aBool: true
-        aFloat: 1.001
-        aNilValue: null
-        aNumber: 1000
-        anEmptyMap: {}
-        anEmptySlice: []
+  is:
+    aBool: true
+    aFloat: 1.001
+    aNilValue: null
+    aNumber: 1000
+    anEmptyMap: {}
+    anEmptySlice: []
 those:
-  - field1: idx0foo
-    field2: idx0bar
-  - field1: idx1foo
-    field2: idx1bar
-  - field1: idx2foo
-    field2: idx2bar
+- field1: idx0foo
+  field2: idx0bar
+- field1: idx1foo
+  field2: idx1bar
+- field1: idx2foo
+  field2: idx2bar
 `
 )
 


### PR DESCRIPTION
change kyaml/yaml.Marshal to use 2 spaces for indent instead of 4

This may affect users of kyaml libraries. Is that okay? I'm guessing if they really need this they can use yaml.Marshal directly.