### PR TITLE
Introduce Validate Data Map Function

### DIFF
--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -555,6 +555,9 @@ func (rn *RNode) GetValidatedDataMap(expectedKeys []string) (map[string]string, 
 }
 
 func (rn *RNode) validateDataMap(dataMap map[string]string, expectedKeys []string) error {
+	if dataMap == nil {
+		return fmt.Errorf("The datamap is unassigned")
+	}
 	for key := range dataMap {
 		found := false
 		for _, expected := range expectedKeys {

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -546,6 +546,27 @@ func (rn *RNode) GetBinaryDataMap() map[string]string {
 	return result
 }
 
+func (rn *RNode) GetValidatedDataMap(expected []string) (map[string]string, error) {
+	dataMap := rn.GetDataMap()
+	err := rn.validateDataMap(dataMap, expected)
+	return dataMap, err
+}
+
+func (rn *RNode) validateDataMap(dataMap map[string]string, expectedKeys []string) error {
+	for key := range dataMap {
+		found := false
+		for _, expected := range expectedKeys {
+			if expected == key {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("an unexpected key (%v) was found", key)
+		}
+	}
+	return nil
+}
+
 func (rn *RNode) SetDataMap(m map[string]string) {
 	if rn == nil {
 		log.Fatal("cannot set data map on nil Rnode")

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -547,10 +547,10 @@ func (rn *RNode) GetBinaryDataMap() map[string]string {
 }
 
 // GetValidatedDataMap retrieves the data map and returns an error if the data
-// map contains entries which are not included in the expected set
-func (rn *RNode) GetValidatedDataMap(expected []string) (map[string]string, error) {
+// map contains entries which are not included in the expectedKeys set.
+func (rn *RNode) GetValidatedDataMap(expectedKeys []string) (map[string]string, error) {
 	dataMap := rn.GetDataMap()
-	err := rn.validateDataMap(dataMap, expected)
+	err := rn.validateDataMap(dataMap, expectedKeys)
 	return dataMap, err
 }
 

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -546,6 +546,8 @@ func (rn *RNode) GetBinaryDataMap() map[string]string {
 	return result
 }
 
+// GetValidatedDataMap retrieves the data map and returns an error if the data
+// map contains entries which are not included in the expected set
 func (rn *RNode) GetValidatedDataMap(expected []string) (map[string]string, error) {
 	dataMap := rn.GetDataMap()
 	err := rn.validateDataMap(dataMap, expected)

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -4,6 +4,7 @@
 package yaml
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -179,6 +180,105 @@ func TestRNodeGetDataMap(t *testing.T) {
 			}
 			m := rn.GetDataMap()
 			if !assert.Equal(t, tc.expected, m) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func TestRNodeGetValidatedDataMap(t *testing.T) {
+	emptyMap := map[string]string{}
+	testCases := map[string]struct {
+		theMap         map[string]interface{}
+		theAllowedKeys []string
+		expected       map[string]string
+		expectedError  error
+	}{
+		"nilResultEmptyKeys": {
+			theMap:         nil,
+			theAllowedKeys: []string{},
+			expected:       emptyMap,
+			expectedError:  nil,
+		},
+		"empty": {
+			theMap:         map[string]interface{}{},
+			theAllowedKeys: []string{},
+			expected:       emptyMap,
+			expectedError:  nil,
+		},
+		"expectedKeysMatch": {
+			theMap: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "winnie",
+				},
+				"data": map[string]string{
+					"wine":   "cabernet",
+					"truck":  "ford",
+					"rocket": "falcon9",
+					"planet": "mars",
+					"city":   "brownsville",
+				},
+			},
+			theAllowedKeys: []string{
+				"wine",
+				"truck",
+				"rocket",
+				"planet",
+				"city",
+				"plane",
+				"country",
+			},
+			// order irrelevant, because assert.Equals is smart about maps.
+			expected: map[string]string{
+				"city":   "brownsville",
+				"wine":   "cabernet",
+				"planet": "mars",
+				"rocket": "falcon9",
+				"truck":  "ford",
+			},
+			expectedError: nil,
+		},
+		"unexpectedKeyInConfigMap": {
+			theMap: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "winnie",
+				},
+				"data": map[string]string{
+					"wine":   "cabernet",
+					"truck":  "ford",
+					"rocket": "falcon9",
+				},
+			},
+			theAllowedKeys: []string{
+				"wine",
+				"truck",
+			},
+			// order irrelevant, because assert.Equals is smart about maps.
+			expected: map[string]string{
+				"wine":   "cabernet",
+				"rocket": "falcon9",
+				"truck":  "ford",
+			},
+			expectedError: fmt.Errorf("an unexpected key (rocket) was found"),
+		},
+	}
+
+	for n := range testCases {
+		tc := testCases[n]
+		t.Run(n, func(t *testing.T) {
+			rn, err := FromMap(tc.theMap)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			m, err := rn.GetValidatedDataMap(tc.theAllowedKeys)
+			if !assert.Equal(t, tc.expected, m) {
+				t.FailNow()
+			}
+			if !assert.Equal(t, tc.expectedError, err) {
 				t.FailNow()
 			}
 		})


### PR DESCRIPTION
This introduces a new function to `rnode` that allows for validation of the results against a set of allowed keys. If a key in the data map is not in the expected set of keys then an error will be returned.

The data map should contain a subset of the keys provided.

This is intended to help identify misspellings in configuration that might otherwise just be ignored.

```yaml
data:
  city: New York
  action: swimming
```

would be matched for a set of `["city", "action"]` and will also match for a set of `["city", "action", "car", "spaceship"]`. An expected map of `["action"]` would result in an error that an unexpected key "city" was found. Other examples are included in the tests.


In both cases the results of `GetDataMap` are returned.