### PR TITLE
fix openapi command help page

### DIFF
--- a/kustomize/commands/openapi/fetch/fetch.go
+++ b/kustomize/commands/openapi/fetch/fetch.go
@@ -20,9 +20,7 @@ in the user's kubeconfig`,
 		Run: func(cmd *cobra.Command, args []string) {
 			printSchema(w)
 		},
-		Hidden: true,
 	}
-
 	return &infoCmd
 }
 

--- a/kustomize/commands/openapi/info/info.go
+++ b/kustomize/commands/openapi/info/info.go
@@ -13,7 +13,6 @@ import (
 
 // NewCmdInfo makes a new info command.
 func NewCmdInfo(w io.Writer) *cobra.Command {
-
 	infoCmd := cobra.Command{
 		Use:     "info",
 		Short:   "Prints the `info` field from the kubernetes OpenAPI data",
@@ -21,8 +20,6 @@ func NewCmdInfo(w io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintln(w, kubernetesapi.Info)
 		},
-		Hidden: true,
 	}
-
 	return &infoCmd
 }

--- a/kustomize/commands/openapi/openapi.go
+++ b/kustomize/commands/openapi/openapi.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/kustomize/cmd/config/configcobra"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi/fetch"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/openapi/info"
 )
@@ -24,7 +23,5 @@ func NewCmdOpenAPI(w io.Writer) *cobra.Command {
 
 	openApiCmd.AddCommand(info.NewCmdInfo(w))
 	openApiCmd.AddCommand(fetch.NewCmdFetch(w))
-	configcobra.AddCommands(openApiCmd, "openapi")
-
 	return openApiCmd
 }


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/kustomize/issues/3897

before:
```
$ kustomize openapi
Commands for interacting with the OpenAPI data

Usage:
  kustomize openapi [command]

Examples:
kustomize openapi info

Available Commands:
  cfg                       Commands for reading and writing configuration.
  fn                        Commands for running functions against configuration.

Flags:
  -h, --help   help for openapi

Global Flags:
      --stack-trace   print a stack-trace on error

Additional help topics:
  kustomize openapi docs-fn         [Alpha] Documentation for developing and invoking Configuration Functions.
  kustomize openapi docs-fn-spec    [Alpha] Documentation for Configuration Functions Specification.
  kustomize openapi docs-io-annotations [Alpha] Documentation for annotations used by io.
  kustomize openapi docs-merge      [Alpha] Documentation for merging Resources (2-way merge).
  kustomize openapi docs-merge3     [Alpha] Documentation for merging Resources (3-way merge).
  kustomize openapi tutorials-command-basics [Alpha] Tutorials for using basic config commands.
  kustomize openapi tutorials-function-basics [Alpha] Tutorials for using functions.
```

After:
```
$ kustomize openapi
Commands for interacting with the OpenAPI data

Usage:
  kustomize openapi [command]

Examples:
kustomize openapi info

Available Commands:
  fetch       Fetches the OpenAPI specification from the current kubernetes cluster specified 
in the user's kubeconfig
  info        Prints the `info` field from the kubernetes OpenAPI data

Flags:
  -h, --help   help for openapi

Global Flags:
      --stack-trace   print a stack-trace on error
```
