### PR TITLE
Handle null values while formatting

### DIFF
--- a/kyaml/yaml/compatibility.go
+++ b/kyaml/yaml/compatibility.go
@@ -45,6 +45,14 @@ func FormatNonStringStyle(node *Node, schema spec.Schema) {
 	default:
 		return
 	}
+
+	// if the node tag is null, make sure we don't add any non-null tags
+	// https://github.com/GoogleContainerTools/kpt/issues/2321
+	if node.Tag == NodeTagNull {
+		// must NOT quote null values
+		node.Style = 0
+		return
+	}
 	if tag, found := typeToTag[t]; found {
 		// make sure the right tag is set
 		node.Tag = tag


### PR DESCRIPTION
This PR is to make sure we don't add non-null tags to null values as it makes yaml invalid.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/2321