### PR TITLE
Update supported URLs in remoteBuild.md

### DIFF
--- a/examples/zh/remoteBuild.md
+++ b/examples/zh/remoteBuild.md
@@ -9,7 +9,7 @@
 <!-- @remoteOverlayBuild @test -->
 
 ```bash
-target="github.com/kubernetes-sigs/kustomize/examples/multibases/dev/?ref=v1.0.6"
+target="https://github.com/kubernetes-sigs/kustomize//examples/multibases/dev/?ref=v1.0.6"
 test 1 == \
   $(kustomize build $target | grep dev-myapp-pod | wc -l); \
   echo $?
@@ -19,7 +19,7 @@ test 1 == \
 
 <!-- @remoteBuild @test -->
 ```bash
-target="https://github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6"
+target="https://github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6"
 test 3 == \
   $(kustomize build $target | grep cluster-a-.*-myapp-pod | wc -l); \
   echo $?
@@ -33,7 +33,7 @@ DEMO_HOME=$(mktemp -d)
 
 cat <<EOF >$DEMO_HOME/kustomization.yaml
 resources:
-- github.com/kubernetes-sigs/kustomize/examples/multibases?ref=v1.0.6
+- https://github.com/kubernetes-sigs/kustomize//examples/multibases?ref=v1.0.6
 namePrefix: remote-
 EOF
 ```
@@ -47,7 +47,7 @@ test 3 == \
   echo $?
 ```
 
-## URL format
+## Legacy URL format
 
 URL 需要遵循 [hashicorp/go-getter URL 格式](https://github.com/hashicorp/go-getter#url-format) 。下面是一些遵循此约定的 Github repos 示例url。
 


### PR DESCRIPTION
Since kustomize no longer bundles `go-getter`, I've updated the documentation to reflect that. I also took the liberty of more narrowly defining what the supported URL format is. The goal is to minimize confusion for users and to have a potential avenue to remove the "go-getter" format.

I only updated the file in the `examples/` directory as I presume the `docs/` directory is deprecated in favor of https://github.com/kubernetes-sigs/cli-experimental if this looks good I can submit a PR for updating those docs too.