### PR TITLE
Add failing test for replacements when using an overlay with a namePrefix

### DIFF
--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -344,7 +344,7 @@ spec:
 }
 
 // TODO: Address namePrefix in overlay not applying to replacement targets
-// The name in the target deployment should end up being `prefix-source` instead of `source`
+// The property `data.blue-name` should end up being `overlay-blue` instead of `blue`
 // https://github.com/kubernetes-sigs/kustomize/issues/4034
 func TestReplacementTransformerWithNamePrefixOverlay(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
@@ -391,6 +391,9 @@ metadata:
 `)
 }
 
+// TODO: Address namespace in overlay not applying to replacement targets
+// The property `data.blue-namespace` should end up being `overlay-namespace` instead of `base-namespace`
+// https://github.com/kubernetes-sigs/kustomize/issues/4034
 func TestReplacementTransformerWithNamespaceOverlay(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
@@ -439,6 +442,9 @@ metadata:
 `)
 }
 
+// TODO: Address configMapGenerator suffix not applying to replacement targets
+// The property `data.blue-name` should end up being `blue-6ct58987ht` instead of `blue`
+// https://github.com/kubernetes-sigs/kustomize/issues/4034
 func TestReplacementTransformerWithConfigMapGenerator(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()

--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -343,6 +343,9 @@ spec:
 `)
 }
 
+// TODO: Address namePrefix in overlay not applying to replacement targets
+// The image in the target deployment should end up being `prefix-source` instead of `source`
+// https://github.com/kubernetes-sigs/kustomize/issues/4034
 func TestReplacementTransformerWithNamePrefixOverlay(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t)
 	defer th.Reset()
@@ -402,7 +405,7 @@ spec:
   template:
     spec:
       containers:
-      - image: prefix-source
+      - image: source
         name: nginx
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
When using an simple overlay with a namePrefix on a base that contains replacements the prefix does not end up on the target values. 

cc @natasha41575 