### PR TITLE
api/internal/git: handle .git suffix in repospec

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -125,7 +125,7 @@ func parseGitUrl(n string) (
 		index := strings.Index(n, gitSuffix)
 		orgRepo = n[0:index]
 		n = n[index+len(gitSuffix):]
-		if n[0] == '/' {
+		if len(n) > 0 && n[0] == '/' {
 			n = n[1:]
 		}
 		path, gitRef, gitTimeout, gitSubmodules = peelQuery(n)

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -182,6 +182,12 @@ func TestNewRepoSpecFromUrl_CloneSpecs(t *testing.T) {
 			absPath:   notCloned.String(),
 			ref:       "",
 		},
+		"t12": {
+			input:     "https://bitbucket.example.com/scm/project/repository.git",
+			cloneSpec: "https://bitbucket.example.com/scm/project/repository.git",
+			absPath:   notCloned.String(),
+			ref:       "",
+		},
 	}
 	for tn, tc := range testcases {
 		t.Run(tn, func(t *testing.T) {


### PR DESCRIPTION
This change adds a new test case for parsing url with `.git` suffix. In
that case, we should have the full url as clone spec with an empty
abspath.

This fixes #4011.