### PR TITLE
iampolicygenerator: update module name

### DIFF
--- a/plugin/builtin/iampolicygenerator/go.mod
+++ b/plugin/builtin/iampolicygenerator/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/kustomize/plugin/builtin/configmapgenerator
+module sigs.k8s.io/kustomize/plugin/builtin/iampolicypgenerator
 
 go 1.16
 


### PR DESCRIPTION
The previous module name is incorrect and seems to be copied from
another builtin plugin. This change fixes the name.

The error log when I open this project in vscode:

```
Error loading workspace: found module "sigs.k8s.io/kustomize/plugin/builtin/configmapgenerator" twice in the workspace
```