### PR TITLE
Make seq indent configurable and add retain seq indent functionality

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -114,7 +114,7 @@ type ByteReader struct {
 	Reader io.Reader
 
 	// OmitReaderAnnotations will configures Read to skip setting the config.kubernetes.io/index
-	// annotation on Resources as they are Read.
+	// and internal.config.kubernetes.io/seqindent annotations on Resources as they are Read.
 	OmitReaderAnnotations bool
 
 	// AddSeqIndentAnnotation if true adds kioutil.SeqIndentAnnotation to each resource
@@ -314,20 +314,14 @@ func seqIndentAnno(node *yaml.Node, originalYAML string) string {
 	}
 
 	// marshal the node with 2 space sequence indentation and calculate the diff
-	out, err := yaml.MarshalWithOptions(rNode.Document(), &yaml.EncoderOptions{
-		MapIndent: yaml.DefaultMapIndent,
-		SeqIndent: yaml.WideSeqIndent,
-	})
+	out, err := yaml.MarshalWithOptions(rNode.Document(), &yaml.EncoderOptions{SeqIndent: yaml.WideSeqIndent})
 	if err != nil {
 		return ""
 	}
 	twoSpaceIndentDiff := copyutil.PrettyFileDiff(string(out), originalYAML)
 
 	// marshal the node with 0 space sequence indentation and calculate the diff
-	out, err = yaml.MarshalWithOptions(rNode.Document(), &yaml.EncoderOptions{
-		MapIndent: yaml.DefaultMapIndent,
-		SeqIndent: yaml.CompactSeqIndent,
-	})
+	out, err = yaml.MarshalWithOptions(rNode.Document(), &yaml.EncoderOptions{SeqIndent: yaml.CompactSeqIndent})
 	if err != nil {
 		return ""
 	}

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -806,7 +806,7 @@ items:
 	}
 }
 
-func TestByteReader_RetainSeqIndent(t *testing.T) {
+func TestByteReader_AddSeqIndent(t *testing.T) {
 	type testCase struct {
 		name           string
 		err            string

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -832,7 +832,8 @@ spec:
 - baz
 metadata:
   annotations:
-    internal.config.kubernetes.io/seqindent: wide
+    config.kubernetes.io/index: '0'
+    internal.config.kubernetes.io/seqindent: 'wide'
 `,
 		},
 		{
@@ -852,7 +853,8 @@ spec:
 - baz
 metadata:
   annotations:
-    internal.config.kubernetes.io/seqindent: compact
+    config.kubernetes.io/index: '0'
+    internal.config.kubernetes.io/seqindent: 'compact'
 `,
 		},
 		{
@@ -878,7 +880,8 @@ env:
 - bar
 metadata:
   annotations:
-    internal.config.kubernetes.io/seqindent: wide
+    config.kubernetes.io/index: '0'
+    internal.config.kubernetes.io/seqindent: 'wide'
 `,
 		},
 		{
@@ -904,7 +907,8 @@ env:
 - bar
 metadata:
   annotations:
-    internal.config.kubernetes.io/seqindent: compact
+    config.kubernetes.io/index: '0'
+    internal.config.kubernetes.io/seqindent: 'compact'
 `,
 		},
 	}
@@ -913,7 +917,7 @@ metadata:
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			rNodes, err := (&ByteReader{
-				OmitReaderAnnotations:  true,
+				OmitReaderAnnotations:  false,
 				AddSeqIndentAnnotation: true,
 				Reader:                 bytes.NewBuffer([]byte(tc.input)),
 			}).Read()

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -289,47 +289,6 @@ functionConfig:
 `,
 			instance: kio.ByteReadWriter{FunctionConfig: yaml.MustParse(`c: d`)},
 		},
-		{
-			name: "ResourceList indentation doesn't matter",
-			input: `
-apiVersion: config.kubernetes.io/v1alpha1
-kind: ResourceList
-items:
-  - kind: Deployment
-    metadata:
-      annotations:
-        internal.config.kubernetes.io/seqindent: "compact"
-    spec:
-      - foo
-      - bar
-  - kind: Service
-    metadata:
-      annotations:
-        internal.config.kubernetes.io/seqindent: "wide"
-    spec:
-      - foo
-      - bar
-`,
-			expectedOutput: `
-apiVersion: config.kubernetes.io/v1alpha1
-kind: ResourceList
-items:
-- kind: Deployment
-  metadata:
-    annotations:
-      internal.config.kubernetes.io/seqindent: "compact"
-  spec:
-  - foo
-  - bar
-- kind: Service
-  metadata:
-    annotations:
-      internal.config.kubernetes.io/seqindent: "wide"
-  spec:
-  - foo
-  - bar
-`,
-		},
 	}
 
 	for i := range testCases {

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -425,7 +425,7 @@ spec:
 `,
 		},
 		{
-			name: "round_trip with mixed indentations in same resource, least diff wins",
+			name: "round_trip with mixed indentations in same resource, wide wins",
 			input: `
 apiVersion: apps/v1
 kind: Deployment
@@ -450,7 +450,7 @@ env:
 `,
 		},
 		{
-			name: "round_trip with mixed indentations in same resource, least diff wins",
+			name: "round_trip with mixed indentations in same resource, compact wins",
 			input: `
 apiVersion: apps/v1
 kind: Deployment

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -289,6 +289,47 @@ functionConfig:
 `,
 			instance: kio.ByteReadWriter{FunctionConfig: yaml.MustParse(`c: d`)},
 		},
+		{
+			name: "ResourceList indentation doesn't matter",
+			input: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+  - kind: Deployment
+    metadata:
+      annotations:
+        internal.config.kubernetes.io/seqindent: "compact"
+    spec:
+      - foo
+      - bar
+  - kind: Service
+    metadata:
+      annotations:
+        internal.config.kubernetes.io/seqindent: "wide"
+    spec:
+      - foo
+      - bar
+`,
+			expectedOutput: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- kind: Deployment
+  metadata:
+    annotations:
+      internal.config.kubernetes.io/seqindent: "compact"
+  spec:
+  - foo
+  - bar
+- kind: Service
+  metadata:
+    annotations:
+      internal.config.kubernetes.io/seqindent: "wide"
+  spec:
+  - foo
+  - bar
+`,
+		},
 	}
 
 	for i := range testCases {
@@ -305,6 +346,249 @@ functionConfig:
 				t.FailNow()
 			}
 
+			err = w.Write(nodes)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			if tc.err != "" {
+				if !assert.EqualError(t, err, tc.err) {
+					t.FailNow()
+				}
+				return
+			}
+
+			if !assert.Equal(t,
+				strings.TrimSpace(tc.expectedOutput), strings.TrimSpace(out.String())) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func TestByteReadWriter_RetainSeqIndent(t *testing.T) {
+	type testCase struct {
+		name           string
+		err            string
+		input          string
+		expectedOutput string
+		instance       kio.ByteReadWriter
+	}
+
+	testCases := []testCase{
+		{
+			name: "round_trip with 2 space seq indent",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+---
+apiVersion: v1
+kind: Service
+spec:
+  - foo
+  - bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+---
+apiVersion: v1
+kind: Service
+spec:
+  - foo
+  - bar
+`,
+		},
+		{
+			name: "round_trip with 0 space seq indent",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+---
+apiVersion: v1
+kind: Service
+spec:
+- foo
+- bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+---
+apiVersion: v1
+kind: Service
+spec:
+- foo
+- bar
+`,
+		},
+		{
+			name: "round_trip with different indentations",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+---
+apiVersion: v1
+kind: Service
+spec:
+- foo
+- bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+---
+apiVersion: v1
+kind: Service
+spec:
+- foo
+- bar
+`,
+		},
+		{
+			name: "round_trip with mixed indentations in same resource, least diff wins",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+env:
+- foo
+- bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+env:
+  - foo
+  - bar
+`,
+		},
+		{
+			name: "round_trip with mixed indentations in same resource, least diff wins",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+- baz
+env:
+  - foo
+  - bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+- baz
+env:
+- foo
+- bar
+`,
+		},
+		{
+			name: "round_trip with mixed indentations in same resource, compact in case of a tie",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+env:
+  - foo
+  - bar
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+env:
+- foo
+- bar
+`,
+		},
+		{
+			name: "unwrap ResourceList with annotations",
+			input: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+  - kind: Deployment
+    metadata:
+      annotations:
+        internal.config.kubernetes.io/seqindent: "compact"
+    spec:
+      - foo
+      - bar
+  - kind: Service
+    metadata:
+      annotations:
+        internal.config.kubernetes.io/seqindent: "wide"
+    spec:
+      - foo
+      - bar
+`,
+			expectedOutput: `
+kind: Deployment
+spec:
+- foo
+- bar
+---
+kind: Service
+spec:
+  - foo
+  - bar
+`,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			var in, out bytes.Buffer
+			in.WriteString(tc.input)
+			w := tc.instance
+			w.Writer = &out
+			w.Reader = &in
+			w.RetainSeqIndent = true
+
+			nodes, err := w.Read()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			w.WrappingKind = ""
 			err = w.Write(nodes)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -540,7 +540,7 @@ spec:
 			w := tc.instance
 			w.Writer = &out
 			w.Reader = &in
-			w.AddSeqIndentAnnotation = true
+			w.PreserveSeqIndent = true
 
 			nodes, err := w.Read()
 			if !assert.NoError(t, err) {

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -530,6 +530,31 @@ spec:
   - bar
 `,
 		},
+		{
+			name: "round_trip with mixed indentations in same resource, wide wins as it is first",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+env:
+- foo
+- bar
+- baz
+`,
+			expectedOutput: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+env:
+  - foo
+  - bar
+  - baz
+`,
+		},
 	}
 
 	for i := range testCases {

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -425,14 +425,12 @@ spec:
 `,
 		},
 		{
-			name: "round_trip with mixed indentations in same resource, wide wins",
+			name: "round_trip with mixed indentations in same resource, wide wins as it is first",
 			input: `
 apiVersion: apps/v1
 kind: Deployment
 spec:
   - foo
-  - bar
-  - baz
 env:
 - foo
 - bar
@@ -442,22 +440,18 @@ apiVersion: apps/v1
 kind: Deployment
 spec:
   - foo
-  - bar
-  - baz
 env:
   - foo
   - bar
 `,
 		},
 		{
-			name: "round_trip with mixed indentations in same resource, compact wins",
+			name: "round_trip with mixed indentations in same resource, compact wins as it is first",
 			input: `
 apiVersion: apps/v1
 kind: Deployment
 spec:
 - foo
-- bar
-- baz
 env:
   - foo
   - bar
@@ -467,31 +461,6 @@ apiVersion: apps/v1
 kind: Deployment
 spec:
 - foo
-- bar
-- baz
-env:
-- foo
-- bar
-`,
-		},
-		{
-			name: "round_trip with mixed indentations in same resource, compact in case of a tie",
-			input: `
-apiVersion: apps/v1
-kind: Deployment
-spec:
-- foo
-- bar
-env:
-  - foo
-  - bar
-`,
-			expectedOutput: `
-apiVersion: apps/v1
-kind: Deployment
-spec:
-- foo
-- bar
 env:
 - foo
 - bar

--- a/kyaml/kio/byteio_readwriter_test.go
+++ b/kyaml/kio/byteio_readwriter_test.go
@@ -581,7 +581,7 @@ spec:
 			w := tc.instance
 			w.Writer = &out
 			w.Reader = &in
-			w.RetainSeqIndent = true
+			w.AddSeqIndentAnnotation = true
 
 			nodes, err := w.Read()
 			if !assert.NoError(t, err) {

--- a/kyaml/kio/byteio_writer.go
+++ b/kyaml/kio/byteio_writer.go
@@ -108,7 +108,7 @@ func (w ByteWriter) Write(inputNodes []*yaml.RNode) error {
 	// don't wrap the elements
 	if w.WrappingKind == "" {
 		for i := range nodes {
-			if seqIndentsForNodes[i] == string(yaml.WideSeqIndent) {
+			if seqIndentsForNodes[i] == string(yaml.WideSequenceStyle) {
 				encoder.DefaultSeqIndent()
 			} else {
 				encoder.CompactSeqIndent()

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -315,6 +315,67 @@ metadata:
 		// Test Case
 		//
 		{
+			name:     "keep_annotation_seqindent",
+			instance: ByteWriter{KeepReaderAnnotations: true},
+			items: []string{
+				`a: b #first
+metadata:
+  annotations:
+    config.kubernetes.io/index: 0
+    config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/index: "compact"
+`,
+				`e: f
+g:
+  h:
+  - i # has a list
+  - j
+metadata:
+  annotations:
+    config.kubernetes.io/index: 0
+    config.kubernetes.io/path: "a/b/b_test.yaml"
+    internal.config.kubernetes.io/seqindent: "wide"
+`,
+				`c: d # second
+metadata:
+  annotations:
+    config.kubernetes.io/index: 1
+    config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/seqindent: "compact"
+`,
+			},
+
+			expectedOutput: `a: b #first
+metadata:
+  annotations:
+    config.kubernetes.io/index: 0
+    config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/index: "compact"
+---
+e: f
+g:
+  h:
+    - i # has a list
+    - j
+metadata:
+  annotations:
+    config.kubernetes.io/index: 0
+    config.kubernetes.io/path: "a/b/b_test.yaml"
+    internal.config.kubernetes.io/seqindent: "wide"
+---
+c: d # second
+metadata:
+  annotations:
+    config.kubernetes.io/index: 1
+    config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/seqindent: "compact"
+`,
+		},
+
+		//
+		// Test Case
+		//
+		{
 			name: "encode_valid_json",
 			items: []string{
 				`{
@@ -322,6 +383,34 @@ metadata:
   metadata: {
     annotations: {
       config.kubernetes.io/path: test.json
+    }
+  }
+}`,
+			},
+
+			expectedOutput: `{
+  "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
+  "metadata": {
+    "annotations": {
+      "config.kubernetes.io/path": "test.json"
+    }
+  }
+}`,
+		},
+
+		//
+		// Test Case
+		//
+		{
+			name: "encode_valid_json_remove_seqindent_annotation",
+			items: []string{
+				`{
+  "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
+  metadata: {
+    annotations: {
+      "internal.config.kubernetes.io/seqindent": "compact",
+      "config.kubernetes.io/index": "0",
+      "config.kubernetes.io/path": "test.json"
     }
   }
 }`,

--- a/kyaml/kio/kioutil/kioutil.go
+++ b/kyaml/kio/kioutil/kioutil.go
@@ -23,7 +23,7 @@ const (
 	// PathAnnotation records the path to the file the Resource was read from
 	PathAnnotation AnnotationKey = "config.kubernetes.io/path"
 
-	// SeqIndentAnnotation records the path to the file the Resource was read from
+	// SeqIndentAnnotation records the sequence nodes indentation of the input resource
 	SeqIndentAnnotation AnnotationKey = "internal.config.kubernetes.io/seqindent"
 )
 

--- a/kyaml/kio/kioutil/kioutil.go
+++ b/kyaml/kio/kioutil/kioutil.go
@@ -22,6 +22,9 @@ const (
 
 	// PathAnnotation records the path to the file the Resource was read from
 	PathAnnotation AnnotationKey = "config.kubernetes.io/path"
+
+	// SeqIndentAnnotation records the path to the file the Resource was read from
+	SeqIndentAnnotation AnnotationKey = "internal.config.kubernetes.io/seqindent"
 )
 
 func GetFileAnnotations(rn *yaml.RNode) (string, string, error) {

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -177,6 +177,8 @@ type LocalPackageReader struct {
 	// FileSkipFunc is a function which returns true if reader should ignore
 	// the file
 	FileSkipFunc LocalPackageSkipFileFunc
+
+	RetainSeqIndent bool
 }
 
 var _ Reader = LocalPackageReader{}
@@ -263,10 +265,11 @@ func (r *LocalPackageReader) readFile(path string, _ os.FileInfo) ([]*yaml.RNode
 	defer f.Close()
 
 	rr := &ByteReader{
-		DisableUnwrapping:     true,
-		Reader:                f,
-		OmitReaderAnnotations: r.OmitReaderAnnotations,
-		SetAnnotations:        r.SetAnnotations,
+		DisableUnwrapping:      true,
+		Reader:                 f,
+		OmitReaderAnnotations:  r.OmitReaderAnnotations,
+		SetAnnotations:         r.SetAnnotations,
+		AddSeqIndentAnnotation: r.RetainSeqIndent,
 	}
 	return rr.Read()
 }

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -40,8 +40,8 @@ type LocalPackageReadWriter struct {
 
 	KeepReaderAnnotations bool `yaml:"keepReaderAnnotations,omitempty"`
 
-	// AddSeqIndentAnnotation if true adds kioutil.SeqIndentAnnotation to each resource
-	AddSeqIndentAnnotation bool
+	// PreserveSeqIndent if true adds kioutil.SeqIndentAnnotation to each resource
+	PreserveSeqIndent bool
 
 	// PackagePath is the path to the package directory.
 	PackagePath string `yaml:"path,omitempty"`
@@ -82,14 +82,14 @@ type LocalPackageReadWriter struct {
 
 func (r *LocalPackageReadWriter) Read() ([]*yaml.RNode, error) {
 	nodes, err := LocalPackageReader{
-		PackagePath:            r.PackagePath,
-		MatchFilesGlob:         r.MatchFilesGlob,
-		IncludeSubpackages:     r.IncludeSubpackages,
-		ErrorIfNonResources:    r.ErrorIfNonResources,
-		SetAnnotations:         r.SetAnnotations,
-		PackageFileName:        r.PackageFileName,
-		FileSkipFunc:           r.FileSkipFunc,
-		AddSeqIndentAnnotation: r.AddSeqIndentAnnotation,
+		PackagePath:         r.PackagePath,
+		MatchFilesGlob:      r.MatchFilesGlob,
+		IncludeSubpackages:  r.IncludeSubpackages,
+		ErrorIfNonResources: r.ErrorIfNonResources,
+		SetAnnotations:      r.SetAnnotations,
+		PackageFileName:     r.PackageFileName,
+		FileSkipFunc:        r.FileSkipFunc,
+		PreserveSeqIndent:   r.PreserveSeqIndent,
 	}.Read()
 	if err != nil {
 		return nil, errors.Wrap(err)
@@ -182,8 +182,8 @@ type LocalPackageReader struct {
 	// the file
 	FileSkipFunc LocalPackageSkipFileFunc
 
-	// AddSeqIndentAnnotation if true adds kioutil.SeqIndentAnnotation to each resource
-	AddSeqIndentAnnotation bool
+	// PreserveSeqIndent if true adds kioutil.SeqIndentAnnotation to each resource
+	PreserveSeqIndent bool
 }
 
 var _ Reader = LocalPackageReader{}
@@ -270,11 +270,11 @@ func (r *LocalPackageReader) readFile(path string, _ os.FileInfo) ([]*yaml.RNode
 	defer f.Close()
 
 	rr := &ByteReader{
-		DisableUnwrapping:      true,
-		Reader:                 f,
-		OmitReaderAnnotations:  r.OmitReaderAnnotations,
-		SetAnnotations:         r.SetAnnotations,
-		AddSeqIndentAnnotation: r.AddSeqIndentAnnotation,
+		DisableUnwrapping:     true,
+		Reader:                f,
+		OmitReaderAnnotations: r.OmitReaderAnnotations,
+		SetAnnotations:        r.SetAnnotations,
+		PreserveSeqIndent:     r.PreserveSeqIndent,
 	}
 	return rr.Read()
 }

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -178,7 +178,8 @@ type LocalPackageReader struct {
 	// the file
 	FileSkipFunc LocalPackageSkipFileFunc
 
-	RetainSeqIndent bool
+	// AddSeqIndentAnnotation if true adds kioutil.SeqIndentAnnotation to each resource
+	AddSeqIndentAnnotation bool
 }
 
 var _ Reader = LocalPackageReader{}
@@ -269,7 +270,7 @@ func (r *LocalPackageReader) readFile(path string, _ os.FileInfo) ([]*yaml.RNode
 		Reader:                 f,
 		OmitReaderAnnotations:  r.OmitReaderAnnotations,
 		SetAnnotations:         r.SetAnnotations,
-		AddSeqIndentAnnotation: r.RetainSeqIndent,
+		AddSeqIndentAnnotation: r.AddSeqIndentAnnotation,
 	}
 	return rr.Read()
 }

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -40,6 +40,9 @@ type LocalPackageReadWriter struct {
 
 	KeepReaderAnnotations bool `yaml:"keepReaderAnnotations,omitempty"`
 
+	// AddSeqIndentAnnotation if true adds kioutil.SeqIndentAnnotation to each resource
+	AddSeqIndentAnnotation bool
+
 	// PackagePath is the path to the package directory.
 	PackagePath string `yaml:"path,omitempty"`
 
@@ -79,13 +82,14 @@ type LocalPackageReadWriter struct {
 
 func (r *LocalPackageReadWriter) Read() ([]*yaml.RNode, error) {
 	nodes, err := LocalPackageReader{
-		PackagePath:         r.PackagePath,
-		MatchFilesGlob:      r.MatchFilesGlob,
-		IncludeSubpackages:  r.IncludeSubpackages,
-		ErrorIfNonResources: r.ErrorIfNonResources,
-		SetAnnotations:      r.SetAnnotations,
-		PackageFileName:     r.PackageFileName,
-		FileSkipFunc:        r.FileSkipFunc,
+		PackagePath:            r.PackagePath,
+		MatchFilesGlob:         r.MatchFilesGlob,
+		IncludeSubpackages:     r.IncludeSubpackages,
+		ErrorIfNonResources:    r.ErrorIfNonResources,
+		SetAnnotations:         r.SetAnnotations,
+		PackageFileName:        r.PackageFileName,
+		FileSkipFunc:           r.FileSkipFunc,
+		AddSeqIndentAnnotation: r.AddSeqIndentAnnotation,
 	}.Read()
 	if err != nil {
 		return nil, errors.Wrap(err)

--- a/kyaml/kio/pkgio_reader_test.go
+++ b/kyaml/kio/pkgio_reader_test.go
@@ -337,7 +337,7 @@ g:
 	}
 }
 
-func TestLocalPackageReader_Read_addSeqIndentAnnotation(t *testing.T) {
+func TestLocalPackageReader_Read_PreserveSeqIndent(t *testing.T) {
 	s := SetupDirectories(t, filepath.Join("a", "b"), filepath.Join("a", "c"))
 	defer s.Clean()
 	s.WriteFile(t, filepath.Join("a_test.yaml"), readFileA)
@@ -351,7 +351,7 @@ func TestLocalPackageReader_Read_addSeqIndentAnnotation(t *testing.T) {
 	}
 	for _, p := range paths {
 		// empty path
-		rfr := LocalPackageReader{PackagePath: p.path, AddSeqIndentAnnotation: true}
+		rfr := LocalPackageReader{PackagePath: p.path, PreserveSeqIndent: true}
 		nodes, err := rfr.Read()
 		if !assert.NoError(t, err) {
 			return

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -11,19 +11,19 @@ import (
 )
 
 const (
-	WideSeqIndent    SeqIndentType = "wide"
-	CompactSeqIndent SeqIndentType = "compact"
-	DefaultIndent                  = 2
+	WideSequenceStyle    SequenceIndentStyle = "wide"
+	CompactSequenceStyle SequenceIndentStyle = "compact"
+	DefaultIndent                            = 2
 )
 
 // SeqIndentType holds the indentation style for sequence nodes
-type SeqIndentType string
+type SequenceIndentStyle string
 
 // EncoderOptions are options that can be used to configure the encoder,
 // do not expose new options without considerable justification
 type EncoderOptions struct {
 	// SeqIndent is the indentation style for YAML Sequence nodes
-	SeqIndent SeqIndentType
+	SeqIndent SequenceIndentStyle
 }
 
 // Expose the yaml.v3 functions so this package can be used as a replacement
@@ -69,7 +69,7 @@ func MarshalWithOptions(in interface{}, opts *EncoderOptions) ([]byte, error) {
 func NewEncoderWithOptions(w io.Writer, opts *EncoderOptions) *yaml.Encoder {
 	encoder := NewEncoder(w)
 	encoder.SetIndent(DefaultIndent)
-	if opts.SeqIndent == WideSeqIndent {
+	if opts.SeqIndent == WideSequenceStyle {
 		encoder.DefaultSeqIndent()
 	} else {
 		encoder.CompactSeqIndent()

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -13,17 +13,15 @@ import (
 const (
 	WideSeqIndent    SeqIndentType = "wide"
 	CompactSeqIndent SeqIndentType = "compact"
-	DefaultMapIndent               = 2
+	DefaultIndent                  = 2
 )
 
 // SeqIndentType holds the indentation style for sequence nodes
 type SeqIndentType string
 
-// EncoderOptions are options that can be used to configure the encoder
+// EncoderOptions are options that can be used to configure the encoder,
+// do not expose new options without considerable justification
 type EncoderOptions struct {
-	// MapIndent is the indentation for YAML Mapping nodes
-	MapIndent int
-
 	// SeqIndent is the indentation style for YAML Sequence nodes
 	SeqIndent SeqIndentType
 }
@@ -52,7 +50,7 @@ var Unmarshal = yaml.Unmarshal
 var NewDecoder = yaml.NewDecoder
 var NewEncoder = func(w io.Writer) *yaml.Encoder {
 	e := yaml.NewEncoder(w)
-	e.SetIndent(DefaultMapIndent)
+	e.SetIndent(DefaultIndent)
 	e.CompactSeqIndent()
 	return e
 }
@@ -70,7 +68,7 @@ func MarshalWithOptions(in interface{}, opts *EncoderOptions) ([]byte, error) {
 // NewEncoderWithOptions returns the encoder with provided options
 func NewEncoderWithOptions(w io.Writer, opts *EncoderOptions) *yaml.Encoder {
 	encoder := NewEncoder(w)
-	encoder.SetIndent(opts.MapIndent)
+	encoder.SetIndent(DefaultIndent)
 	if opts.SeqIndent == WideSeqIndent {
 		encoder.DefaultSeqIndent()
 	} else {

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -19,6 +19,15 @@ const (
 // SeqIndentType holds the indentation style for sequence nodes
 type SeqIndentType string
 
+// EncoderOptions are options that can be used to configure the encoder
+type EncoderOptions struct {
+	// MapIndent is the indentation for YAML Mapping nodes
+	MapIndent int
+
+	// SeqIndent is the indentation style for YAML Sequence nodes
+	SeqIndent SeqIndentType
+}
+
 // Expose the yaml.v3 functions so this package can be used as a replacement
 
 type Decoder = yaml.Decoder
@@ -48,21 +57,21 @@ var NewEncoder = func(w io.Writer) *yaml.Encoder {
 	return e
 }
 
-// MarshalWithIndent marshals the input interface with provided indents
-func MarshalWithIndent(in interface{}, mapIndent int, seqIndent SeqIndentType) ([]byte, error) {
+// MarshalWithOptions marshals the input interface with provided options
+func MarshalWithOptions(in interface{}, opts *EncoderOptions) ([]byte, error) {
 	var buf bytes.Buffer
-	err := NewEncoderWithIndent(&buf, mapIndent, seqIndent).Encode(in)
+	err := NewEncoderWithOptions(&buf, opts).Encode(in)
 	if err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
 }
 
-// NewEncoderWithIndent returns the encoder with configurable indents
-func NewEncoderWithIndent(w io.Writer, mapIndent int, seqIndent SeqIndentType) *yaml.Encoder {
+// NewEncoderWithOptions returns the encoder with provided options
+func NewEncoderWithOptions(w io.Writer, opts *EncoderOptions) *yaml.Encoder {
 	encoder := NewEncoder(w)
-	encoder.SetIndent(mapIndent)
-	if seqIndent == WideSeqIndent {
+	encoder.SetIndent(opts.MapIndent)
+	if opts.SeqIndent == WideSeqIndent {
 		encoder.DefaultSeqIndent()
 	} else {
 		encoder.CompactSeqIndent()

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -19,6 +19,16 @@ const DefaultSequenceStyle = CompactSequenceStyle
 var sequenceIndentationStyle = DefaultSequenceStyle
 var indent = DefaultIndent
 
+// SetSequenceIndentationStyle sets the sequenceIndentationStyle variable
+func SetSequenceIndentationStyle(style string) {
+	sequenceIndentationStyle = style
+}
+
+// SequenceIndentationStyle returns the value of sequenceIndentationStyle
+func SequenceIndentationStyle() string {
+	return sequenceIndentationStyle
+}
+
 // Expose the yaml.v3 functions so this package can be used as a replacement
 
 type Decoder = yaml.Decoder

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -505,14 +505,6 @@ func (rn *RNode) SetAnnotations(m map[string]string) error {
 	return rn.setMapInMetadata(m, AnnotationsField)
 }
 
-// DeleteAnnotation tries to delete the annotation and clears the empty metadata field.
-func (rn *RNode) DeleteAnnotation(annotation string) error {
-	if err := rn.PipeE(ClearAnnotation(annotation)); err != nil {
-		return err
-	}
-	return ClearEmptyAnnotations(rn)
-}
-
 // GetLabels gets the metadata labels field.
 // If the field is missing, returns an empty map.
 // Use another method to check for missing metadata.

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -505,6 +505,14 @@ func (rn *RNode) SetAnnotations(m map[string]string) error {
 	return rn.setMapInMetadata(m, AnnotationsField)
 }
 
+// DeleteAnnotation tries to delete the annotation and clears the empty metadata field.
+func (rn *RNode) DeleteAnnotation(annotation string) error {
+	if err := rn.PipeE(ClearAnnotation(annotation)); err != nil {
+		return err
+	}
+	return ClearEmptyAnnotations(rn)
+}
+
 // GetLabels gets the metadata labels field.
 // If the field is missing, returns an empty map.
 // Use another method to check for missing metadata.

--- a/kyaml/yaml/util.go
+++ b/kyaml/yaml/util.go
@@ -29,20 +29,21 @@ func DeriveSeqIndentStyle(originalYAML string) string {
 
 		numSpacesBeforeKeyElem := len(keyLine) - len(strings.TrimLeft(keyLine, " "))
 		trimmedKeyLine := strings.Trim(keyLine, " ")
-		if strings.HasSuffix(trimmedKeyLine, "|") || strings.HasSuffix(trimmedKeyLine, "|-") {
+		if strings.Count(trimmedKeyLine, ":") != 1 || !strings.HasSuffix(trimmedKeyLine, ":") {
+			// if the key line doesn't contain only one : that too at the end,
 			// this is not a sequence node, it is a wrapped sequence node string
 			// ignore it
 			continue
 		}
 
 		if numSpacesBeforeSeqElem == numSpacesBeforeKeyElem {
-			return string(CompactSeqIndent)
+			return string(CompactSequenceStyle)
 		}
 
 		if numSpacesBeforeSeqElem-numSpacesBeforeKeyElem == 2 {
-			return string(WideSeqIndent)
+			return string(WideSequenceStyle)
 		}
 	}
 
-	return string(CompactSeqIndent)
+	return string(CompactSequenceStyle)
 }

--- a/kyaml/yaml/util.go
+++ b/kyaml/yaml/util.go
@@ -1,0 +1,48 @@
+package yaml
+
+import (
+	"strings"
+)
+
+// DeriveSeqIndentStyle derives the sequence indentation annotation value for the resource,
+// originalYAML is the input yaml string,
+// the style is decided by deriving the existing sequence indentation of first sequence node
+func DeriveSeqIndentStyle(originalYAML string) string {
+	lines := strings.Split(originalYAML, "\n")
+	for i, line := range lines {
+		elems := strings.SplitN(line, "- ", 2)
+		if len(elems) != 2 {
+			continue
+		}
+		// prefix of "- " must be sequence of spaces
+		if strings.Trim(elems[0], " ") != "" {
+			continue
+		}
+		numSpacesBeforeSeqElem := len(elems[0])
+
+		if i == 0 {
+			continue
+		}
+
+		// keyLine is the line before the first sequence element
+		keyLine := lines[i-1]
+
+		numSpacesBeforeKeyElem := len(keyLine) - len(strings.TrimLeft(keyLine, " "))
+		trimmedKeyLine := strings.Trim(keyLine, " ")
+		if strings.HasSuffix(trimmedKeyLine, "|") || strings.HasSuffix(trimmedKeyLine, "|-") {
+			// this is not a sequence node, it is a wrapped sequence node string
+			// ignore it
+			continue
+		}
+
+		if numSpacesBeforeSeqElem == numSpacesBeforeKeyElem {
+			return string(CompactSeqIndent)
+		}
+
+		if numSpacesBeforeSeqElem-numSpacesBeforeKeyElem == 2 {
+			return string(WideSeqIndent)
+		}
+	}
+
+	return string(CompactSeqIndent)
+}

--- a/kyaml/yaml/util_test.go
+++ b/kyaml/yaml/util_test.go
@@ -1,0 +1,143 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeriveSeqIndentStyle(t *testing.T) {
+	type testCase struct {
+		name           string
+		input          string
+		expectedOutput string
+	}
+
+	testCases := []testCase{
+		{
+			name: "detect simple wide indent",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+`,
+			expectedOutput: `wide`,
+		},
+		{
+			name: "detect simple compact indent",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+- baz
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "read with mixed indentation, wide first",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+env:
+- foo
+- bar
+`,
+			expectedOutput: `wide`,
+		},
+		{
+			name: "read with mixed indentation, compact first",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+- baz
+env:
+  - foo
+  - bar
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "read with mixed indentation, compact first with less elements",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+- foo
+- bar
+env:
+  - foo
+  - bar
+  - baz
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "skip wrapped sequence strings",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec: |-
+  - foo
+  - bar
+env:
+- foo
+- bar
+- baz
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "nested wide vs compact",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  foo:
+    bar:
+      baz:
+        bor:
+          - a
+          - b
+abc:
+- a
+- b
+`,
+			expectedOutput: `wide`,
+		},
+		{
+			name:           "invalid resource but valid yaml sequence",
+			input:          `  - foo`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "- within sequence element",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  foo:
+    - - a`,
+			expectedOutput: `wide`,
+		},
+		{
+			name: "- within non sequence element",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  foo:
+    a: - b`,
+			expectedOutput: `compact`,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, DeriveSeqIndentStyle(tc.input))
+		})
+	}
+}

--- a/kyaml/yaml/util_test.go
+++ b/kyaml/yaml/util_test.go
@@ -79,16 +79,42 @@ env:
 			expectedOutput: `compact`,
 		},
 		{
-			name: "skip wrapped sequence strings",
+			name: "skip wrapped sequence strings, pipe hyphen",
 			input: `apiVersion: apps/v1
 kind: Deployment
 spec: |-
   - foo
   - bar
-env:
-- foo
-- bar
-- baz
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "skip wrapped sequence strings, pipe",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec: |
+  - foo
+  - bar
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "skip wrapped sequence strings, right angle bracket",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec: >
+  - foo
+  - bar
+`,
+			expectedOutput: `compact`,
+		},
+		{
+			name: "skip wrapped sequence strings, plus",
+			input: `apiVersion: apps/v1
+kind: Deployment
+spec: +
+  - foo
+  - bar
 `,
 			expectedOutput: `compact`,
 		},


### PR DESCRIPTION
1. Make `sequenceIndentationStyle` in alias.go configurable by adding getter and setter
2. Add optional functionality to retain `SeqIndent`. This is purely an additional change and doesn't affect any of the existing tests. The motivation is to make `kio` package expose an option to downstream callers(like `kpt`) to retain the existing indentation of resources. This is done by adding a new internal annotation with name `internal.config.kubernetes.io/seqindent`. The byteio_reader adds this annotation so that byteio_write can encode the resources based on the indentation specified in the annotation.


Adding more tests. But want to confirm the direction.

@droot @KnVerey @natasha41575 