### PR TITLE
Preserve order of original elements when applying patches

### DIFF
--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -224,6 +224,16 @@ spec:
         repo: test-infra
     spec:
       containers:
+      - envFrom:
+        - configMapRef:
+            name: someConfigMap
+        - configMapRef:
+            name: test-infra-app-env-8h5mh7f7ch
+        image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/env
+          name: app-env
       - env:
         - name: FOO
           valueFrom:
@@ -236,16 +246,6 @@ spec:
         name: nginx
         ports:
         - containerPort: 80
-      - envFrom:
-        - configMapRef:
-            name: someConfigMap
-        - configMapRef:
-            name: test-infra-app-env-8h5mh7f7ch
-        image: busybox
-        name: busybox
-        volumeMounts:
-        - mountPath: /tmp/env
-          name: app-env
       volumes:
       - configMap:
           name: test-infra-app-env-8h5mh7f7ch

--- a/api/krusty/generatormergeandreplace_test.go
+++ b/api/krusty/generatormergeandreplace_test.go
@@ -382,12 +382,12 @@ spec:
         - mountPath: /tmp/ps
           name: nginx-persistent-storage
       volumes:
-      - gcePersistentDisk:
-          pdName: nginx-persistent-storage
-        name: nginx-persistent-storage
       - configMap:
           name: staging-configmap-in-overlay-dc6fm46dhm
         name: configmap-in-overlay
+      - gcePersistentDisk:
+          pdName: nginx-persistent-storage
+        name: nginx-persistent-storage
       - configMap:
           name: staging-team-foo-configmap-in-base-hc6g9dk6g9
         name: configmap-in-base

--- a/api/krusty/multiplepatch_test.go
+++ b/api/krusty/multiplepatch_test.go
@@ -519,12 +519,12 @@ spec:
         - mountPath: /tmp/ps
           name: fancyDisk
       volumes:
-      - gcePersistentDisk:
-          pdName: fancyDisk
-        name: fancyDisk
       - configMap:
           name: overlayCm-dc6fm46dhm
         name: overlayCm
+      - gcePersistentDisk:
+          pdName: fancyDisk
+        name: fancyDisk
       - configMap:
           name: baseCm-798k5k7g9f
         name: baseCm

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -311,17 +311,11 @@ func (l Walker) elementKey() (string, error) {
 // elements missing from earlier sources appear later.
 func (l Walker) elementValues(keys []string) [][]string {
 	// use slice to to keep elements in the original order
-	var returnValues [][]string
+	var existingValues [][]string
+	var newValues [][]string
 	var seen sets.StringList
 
-	// if we are doing append, dest node should be the first.
-	// otherwise dest node should be the last.
-	beginIdx := 0
-	if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
-		beginIdx = 1
-	}
-	for i := range l.Sources {
-		src := l.Sources[(i+beginIdx)%len(l.Sources)]
+	for i, src := range l.Sources {
 		if src == nil {
 			continue
 		}
@@ -333,11 +327,19 @@ func (l Walker) elementValues(keys []string) [][]string {
 			if len(s) == 0 || seen.Has(s) {
 				continue
 			}
-			returnValues = append(returnValues, s)
+			if i == 0 {
+				existingValues = append(existingValues, s)
+			} else {
+				newValues = append(newValues, s)
+			}
 			seen = seen.Insert(s)
 		}
 	}
-	return returnValues
+
+	if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
+		return append(newValues, existingValues...)
+	}
+	return append(existingValues, newValues...)
 }
 
 // elementPrimitiveValues returns the primitive values in an associative list -- eg. finalizers


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/3912

The bug was in `elementValues()` function of `associated_sequence.go`.

Handling of MergeOptionsListPrepend is currently wrong because it handles prepend only by processing dest (index 0) last. That is not sufficient. To preserve the order of elements, `elementValues()` needs to maintain two separate slices (existingValues and newValues) and combine them at the end (or maybe some other approach, but this is a straighforward way)

NOTE TO REVIEWER:
You may notice I had to change the expected output of four existing unit tests (this may be a red flag for you when you are reviewing this!).  I believe it is correct to make this change as the expected output was assuming the element order would be changed by the patch, assuming it is agreed that the current behavior is wrong. This PR fixes the order of the elements in the expected output of those tests. **This may be considered a breaking change** if someone is depending on the order to be altered by patching, but it seems that depending on this behavior would be a mistake if someone is doing that currently.

I also added a new unit test (TestApplySmPatchShouldPreserveInitContainerOrder) using the example YAML provided in the issue that this PR fixes.