### PR TITLE
Preserve order of original elements when applying patches

### DIFF
--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -284,6 +284,253 @@ spec:
 `, string(bytes))
 }
 
+func TestApplySmPatchShouldOutputListItemsInCorrectOrder(t *testing.T) {
+	cases := []struct {
+		name           string
+		patch          string
+		expectedOutput string
+	}{
+		{
+			name: "Order should not change when patch has foo only",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: foo
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+  - name: foo
+  - name: bar
+`,
+		},
+		{
+			name: "Order should not change when patch has bar only",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: bar
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+  - name: foo
+  - name: bar
+`,
+		},
+		{
+			name: "Order should not change and should include a new item at the beginning when patch has a new list item",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: baz
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+  - name: baz
+  - name: foo
+  - name: bar
+`,
+		},
+		{
+			name: "Order should not change when patch has foo and bar in same order",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: foo
+    - name: bar
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+  - name: foo
+  - name: bar
+`,
+		},
+		{
+			name: "Order should change when patch has foo and bar in different order",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: bar
+    - name: foo
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+  - name: bar
+  - name: foo
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, err := factory.FromBytes([]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  initContainers:
+    - name: foo
+    - name: bar
+`))
+			assert.NoError(t, err)
+
+			patch, err := factory.FromBytes([]byte(tc.patch))
+			assert.NoError(t, err)
+			assert.NoError(t, resource.ApplySmPatch(patch))
+			bytes, err := resource.AsYAML()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedOutput, string(bytes))
+		})
+	}
+}
+
+func TestApplySmPatchShouldOutputPrimitiveListItemsInCorrectOrder(t *testing.T) {
+	cases := []struct {
+		name           string
+		patch          string
+		expectedOutput string
+	}{
+		{
+			name: "Order should not change when patch has foo only",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["foo"]
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  finalizers:
+  - foo
+  - bar
+  name: test
+`,
+		},
+		{
+			name: "Order should not change when patch has bar only",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["bar"]
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  finalizers:
+  - foo
+  - bar
+  name: test
+`,
+		},
+		{
+			name: "Order should not change and should include a new item at the beginning when patch has a new list item",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["baz"]
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  finalizers:
+  - baz
+  - foo
+  - bar
+  name: test
+`,
+		},
+		{
+			name: "Order should not change when patch has foo and bar in same order",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["foo", "bar"]
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  finalizers:
+  - foo
+  - bar
+  name: test
+`,
+		},
+		{
+			name: "Order should change when patch has foo and bar in different order",
+			patch: `apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["bar", "foo"]
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  finalizers:
+  - bar
+  - foo
+  name: test
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, err := factory.FromBytes([]byte(`
+kind: Pod
+metadata:
+  name: test
+  finalizers: ["foo", "bar"]
+`))
+			assert.NoError(t, err)
+
+			patch, err := factory.FromBytes([]byte(tc.patch))
+			assert.NoError(t, err)
+			assert.NoError(t, resource.ApplySmPatch(patch))
+			bytes, err := resource.AsYAML()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedOutput, string(bytes))
+		})
+	}
+}
+
 func TestMergeDataMapFrom(t *testing.T) {
 	resource, err := factory.FromBytes([]byte(`
 apiVersion: v1

--- a/kyaml/yaml/merge3/element_test.go
+++ b/kyaml/yaml/merge3/element_test.go
@@ -1469,11 +1469,11 @@ spec:
           protocol: UDP
           name: original
         - containerPort: 8080
-          protocol: HTTP
-          name: local
-        - containerPort: 8080
           name: updated
           protocol: TCP
+        - containerPort: 8080
+          protocol: HTTP
+          name: local
 `},
 
 	{


### PR DESCRIPTION
The original issue is https://github.com/kubernetes-sigs/kustomize/issues/3912

It was discussed in this PR's comments: https://github.com/kubernetes-sigs/kustomize/pull/4046#discussion_r675214868 and https://github.com/kubernetes-sigs/kustomize/pull/4046#discussion_r675234083 and decided that the original issue reported is not actually a bug, based on comparing its behavior with how strategic merge patch works in k/k.  But @knVerey pointed out that there **is in fact a related bug where a patch that has a subset of list items can cause the output list to be incorrectly rearranged**.

This PR changes `elementValues()` and `elementPrimitiveValues()` in **associative_sequence.go** to preserve the order of the values when only a subset of the original values are patched.

Below is an illustration of the bug this fixes:

#### Base:
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  initContainers:
    - name: foo
    - name: bar
```
#### Patch:
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  initContainers:
    - name: bar
```
#### Output:
```
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  initContainers:
  - name: bar
  - name: foo
```

BUG: initContainers should still have `foo` first, and `bar` second because the patch only has `bar` and is not asking for the order to be changed.