### PR TITLE
Deprecate some cfg commands

### DIFF
--- a/cmd/config/internal/commands/annotate.go
+++ b/cmd/config/internal/commands/annotate.go
@@ -27,6 +27,8 @@ func NewAnnotateRunner(parent string) *AnnotateRunner {
 		Long:    commands.AnnotateLong,
 		Example: commands.AnnotateExamples,
 		RunE:    r.runE,
+		Deprecated:
+			"use the `commonAnnotations` field in your kustomization file.",
 	}
 	runner.FixDocs(parent, c)
 	r.Command = c

--- a/cmd/config/internal/commands/annotate_test.go
+++ b/cmd/config/internal/commands/annotate_test.go
@@ -559,7 +559,7 @@ added annotations in the package
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, expectedNormalized, actualNormalized) {
+			if !assert.Contains(t, actualNormalized, expectedNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -32,6 +32,8 @@ func NewCreateSetterRunner(parent string) *CreateSetterRunner {
 		Example: commands.CreateSetterExamples,
 		PreRunE: r.preRunE,
 		RunE:    r.runE,
+		Deprecated: "setter commands will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	set.Flags().StringVar(&r.FieldValue, "value", "",
 		"optional flag, alternative to specifying the value as an argument. e.g. used to specify values that start with '-'")

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -869,7 +869,7 @@ setter with name "namespace" already exists, if you want to modify it, please de
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, expectedNormalized, actualNormalized) {
+			if !assert.Contains(t, actualNormalized, expectedNormalized) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdcreatesubstitution.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution.go
@@ -23,6 +23,8 @@ func NewCreateSubstitutionRunner(parent string) *CreateSubstitutionRunner {
 		Args:   cobra.ExactArgs(2),
 		PreRun: r.preRun,
 		RunE:   r.runE,
+		Deprecated: "imperative substitutions will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	cs.Flags().StringVar(&r.CreateSubstitution.FieldName, "field", "",
 		"name of the field to set -- e.g. --field image")

--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -506,7 +506,7 @@ created substitution "image-tag"`,
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, strings.TrimSpace(actualNormalized), strings.TrimSpace(expectedNormalized), ) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdinit.go
+++ b/cmd/config/internal/commands/cmdinit.go
@@ -26,6 +26,8 @@ func GetInitRunner(name string) *InitRunner {
 		Long:    commands.InitLong,
 		Example: commands.InitExamples,
 		RunE:    r.runE,
+		Deprecated: "setter commands and substitutions will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	runner.FixDocs(name, c)
 	r.Command = c

--- a/cmd/config/internal/commands/cmdlistsetters.go
+++ b/cmd/config/internal/commands/cmdlistsetters.go
@@ -31,6 +31,8 @@ func NewListSettersRunner(parent string) *ListSettersRunner {
 		Example: commands.ListSettersExamples,
 		PreRunE: r.preRunE,
 		RunE:    r.runE,
+		Deprecated: "setter commands will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	c.Flags().BoolVar(&r.Markdown, "markdown", false,
 		"output as github markdown")

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -525,7 +525,7 @@ test/testdata/dataset-with-setters/mysql/
 			// normalize path format for windows
 			actualNormalized := strings.Replace(actual.String(), "\\", "/", -1)
 
-			if !assert.Equal(t, strings.TrimSpace(test.expected), strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, strings.TrimSpace(actualNormalized), strings.TrimSpace(test.expected)) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/cmdset.go
+++ b/cmd/config/internal/commands/cmdset.go
@@ -27,6 +27,8 @@ func NewSetRunner(parent string) *SetRunner {
 		Example: commands.SetExamples,
 		PreRunE: r.preRunE,
 		RunE:    r.runE,
+		Deprecated: "setter commands will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	runner.FixDocs(parent, c)
 	r.Command = c

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -1137,7 +1137,7 @@ set 1 field(s) of setter "namespace" to value "otherspace"
 			expectedNormalized := strings.Replace(
 				strings.Replace(expected, "\\", "/", -1),
 				"//", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, strings.TrimSpace(actualNormalized), strings.TrimSpace(expectedNormalized)) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/fmt.go
+++ b/cmd/config/internal/commands/fmt.go
@@ -25,6 +25,8 @@ func GetFmtRunner(name string) *FmtRunner {
 		Example: commands.FmtExamples,
 		RunE:    r.runE,
 		PreRunE: r.preRunE,
+		Deprecated: "imperative formatting will no longer be available in kustomize v5.\n" +
+			"Declare a formatting transformer in your kustomization instead.",
 	}
 	runner.FixDocs(name, c)
 	c.Flags().StringVar(&r.FilenamePattern, "pattern", filters.DefaultFilenamePattern,

--- a/cmd/config/internal/commands/fmt_test.go
+++ b/cmd/config/internal/commands/fmt_test.go
@@ -78,7 +78,7 @@ func TestFmtCommand_stdin(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the output
-	assert.Equal(t, string(testyaml.FormattedYaml1), out.String())
+	assert.Contains(t, out.String(), string(testyaml.FormattedYaml1))
 }
 
 // TestCmd_filesAndstdin verifies that if both files and stdin input are provided, only
@@ -238,7 +238,7 @@ formatted resource files in the package
 
 			expected := strings.Replace(test.expected, "${baseDir}", baseDir, -1)
 			expectedNormalized := strings.Replace(expected, "\\", "/", -1)
-			if !assert.Equal(t, strings.TrimSpace(expectedNormalized), strings.TrimSpace(actualNormalized)) {
+			if !assert.Contains(t, strings.TrimSpace(actualNormalized), strings.TrimSpace(expectedNormalized), ) {
 				t.FailNow()
 			}
 		})

--- a/cmd/config/internal/commands/init_test.go
+++ b/cmd/config/internal/commands/init_test.go
@@ -43,7 +43,9 @@ kind: Krmfile
 		t.FailNow()
 	}
 
-	if !assert.Equal(t, "", b.String()) {
+	if !assert.Equal(t, `Command "init" is deprecated, setter commands and substitutions will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.
+`, b.String()) {
 		t.FailNow()
 	}
 }
@@ -78,7 +80,9 @@ kind: Krmfile
 		t.FailNow()
 	}
 
-	if !assert.Equal(t, "", b.String()) {
+	if !assert.Equal(t, `Command "init" is deprecated, setter commands and substitutions will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.
+`, b.String()) {
 		t.FailNow()
 	}
 }

--- a/cmd/config/internal/commands/merge.go
+++ b/cmd/config/internal/commands/merge.go
@@ -19,6 +19,8 @@ func GetMergeRunner(name string) *MergeRunner {
 		Long:    commands.MergeLong,
 		Example: commands.MergeExamples,
 		RunE:    r.runE,
+		Deprecated: "this will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	runner.FixDocs(name, c)
 	r.Command = c

--- a/cmd/config/internal/commands/merge3.go
+++ b/cmd/config/internal/commands/merge3.go
@@ -18,6 +18,8 @@ func GetMerge3Runner(name string) *Merge3Runner {
 		Long:    commands.Merge3Long,
 		Example: commands.Merge3Examples,
 		RunE:    r.runE,
+		Deprecated: "this will no longer be available in kustomize v5.\n" +
+			"See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.",
 	}
 	runner.FixDocs(name, c)
 	c.Flags().StringVar(&r.ancestor, "ancestor", "",


### PR DESCRIPTION
This PR marks some `cfg` commands as deprecated as described in https://github.com/kubernetes-sigs/kustomize/issues/3953, and would be a first step toward https://github.com/kubernetes-sigs/kustomize/issues/4045.

Some questions:
1. Can we do this now? There is some discussion in the #3953 about having setters as a transformer - do we need to wait for that to be done before deprecating the setters commands? Or is a release note pointing to the KRM functions enough?
2. I haven't seen any discussion about the command `create-subst` - this PR marks it as deprecated, but is that what we want to do?
3. Some of the wording for the deprecation messages can probably be improved, I would appreciate some feedback for that. 

Sample output:
```
$ kustomize cfg annotate
Command "annotate" is deprecated, use `commonAnnotations` field in kustomization instead.
```