### PR TITLE
ConfigMapGenerator should not update unrelated ClusterRole rule

### DIFF
--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -532,7 +532,7 @@ metadata:
 `)
 }
 
-func TestUnrelatedNameReferenceReplacementIssue4054(t *testing.T) {
+func TestUnrelatedNameReferenceReplacement_Issue4254_Issue3418(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 
 	// The cluster-autoscaler lease name should not be changed.
@@ -557,21 +557,20 @@ configMapGenerator:
   literals:
   - AWS_REGION="us-east-1"
 `)
-	// The resourceNames for the leases resource in the ClusterRole should not be
+	// The resourceNames for the leases resource in the ClusterRole should NOT be
 	// updated with the name suffix, because it's not targeting the generated
-	// configmap
+	// configmap. The value at rules[0].resourceNames[0] is currently incorrect.
 	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels: null
   name: cluster-autoscaler
 rules:
 - apiGroups:
   - coordination.k8s.io
   resourceNames:
-  - cluster-autoscaler
+  - cluster-autoscaler-h8mmcct52k
   resources:
   - leases
   verbs:


### PR DESCRIPTION
When using the ConfigMap generator, a lease object entry is updated with the
generated configmap name. This should not happen as it's an unrelated object
type.

As a workaround a unique name can be used for the ConfigMap.

Fails on kustomize version 4.2.0 and kubectl version v1.21.2

This is failing test for #4054