### PR TITLE
add starlark.SimpleFilter that doesn't use runtimeutil.FunctionFilter 

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	ResourceListKind       = "ResourceList"
-	ResourceListAPIVersion = "config.kubernetes.io/v1alpha1"
+	ResourceListKind       = kioutil.ResourceListKind
+	ResourceListAPIVersion = kioutil.ResourceListAPIVersion
 )
 
 // ByteReadWriter reads from an input and writes to an output.


### PR DESCRIPTION
Currently, `starlark.Filter` uses [`runtimeutil.FunctionFilter`](https://github.com/kubernetes-sigs/kustomize/blob/259fcfcef8795a794d76bc811f978fb5dac4d5a2/kyaml/fn/runtime/starlark/starlark.go#L49) which go through [serialization and deserialization](https://github.com/kubernetes-sigs/kustomize/blob/259fcfcef8795a794d76bc811f978fb5dac4d5a2/kyaml/fn/runtime/runtimeutil/runtimeutil.go#L157) Serialization copies the comments and drops the id annotations.
This behavior makes sense when starlark is built-in in kpt.

In kpt v1, copying comments is done by the orchestrator. A function should NOT mess with the id annotations.
This PR adds `starlark.SimpleFilter` that doesn't go through serialization and deserialization.

ref: https://github.com/GoogleContainerTools/kpt/issues/2382

Tests will be added soon.