### PR TITLE
fix: Allow custom MYGOBIN in mdrip invocations

### DIFF
--- a/examples/chart.md
+++ b/examples/chart.md
@@ -32,7 +32,7 @@ chart repository.
 This example defines the `helm` command as
 <!-- @defineHelmCommand @testHelm -->
 ```
-helmCommand=~/go/bin/helmV3
+helmCommand=${MYGOBIN:-~/go/bin}/helmV3
 ```
 
 This value is needed for testing this example in CI/CD.

--- a/hack/testExamplesAgainstKustomize.sh
+++ b/hack/testExamplesAgainstKustomize.sh
@@ -29,6 +29,7 @@ fi
 # We test against the latest release, and HEAD, and presumably
 # any branch using this label, so it should probably get
 # a new value.
+export MYGOBIN
 mdrip --mode test --blockTimeOut 15m \
     --label testAgainstLatestRelease examples
 


### PR DESCRIPTION
The mdrip had hardcoded path to helmV3, this PR fixes the issue when go binaries are not in ~/go/bin
MYGOBIN is defined in the ack script as well as in the Makefile.
