### PR TITLE
feat(imagetag): Allow regex submatch in newName from name string

### DIFF
--- a/api/filters/imagetag/imagetag_test.go
+++ b/api/filters/imagetag/imagetag_test.go
@@ -658,6 +658,52 @@ spec:
 				},
 			},
 		},
+		"newNameWithRegex": {
+			input: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: some.registry.io/image-one:1.0
+        name: image-one
+      - image: some.registry.io/image-two:2.0
+        name: image-two
+`,
+			expectedOutput: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploy1
+spec:
+  template:
+    spec:
+      containers:
+      - image: other.registry.io/namespace/image-one:1.0
+        name: image-one
+      - image: other.registry.io/namespace/image-two:2.0
+        name: image-two
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					Name:    "some.registry.io/(.*)",
+					NewName: "other.registry.io/namespace/$1",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/template/spec/containers[]/image",
+				},
+				{
+					Path: "spec/template/spec/initContainers[]/image",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -18,6 +18,8 @@ type imageTagUpdater struct {
 }
 
 func (u imageTagUpdater) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	// FIXME for some reason, the fuction is invoked twice for each image
+	//       with the value in yamlRNode already modified
 	if err := yaml.ErrorIfInvalid(rn, yaml.ScalarNode); err != nil {
 		return nil, err
 	}
@@ -30,7 +32,7 @@ func (u imageTagUpdater) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 
 	name, tag := image.Split(value)
 	if u.ImageTag.NewName != "" {
-		name = u.ImageTag.NewName
+		name = image.NewImageName(u.ImageTag.Name, name, u.ImageTag.NewName)
 	}
 	if u.ImageTag.NewTag != "" {
 		tag = ":" + u.ImageTag.NewTag

--- a/api/image/image.go
+++ b/api/image/image.go
@@ -18,6 +18,14 @@ func IsImageMatched(s, t string) bool {
 	return pattern.MatchString(s)
 }
 
+// NewImageName creates new image name with name used as pattern for
+// replacement of original image name and newName as a replacement
+// that accepts subMatch (capture groups)
+func NewImageName(pattern, name, newName string) string {
+	re, _ := regexp.Compile("^" + pattern + ".*$")
+	return re.ReplaceAllString(name, newName)
+}
+
 // Split separates and returns the name and tag parts
 // from the image string using either colon `:` or at `@` separators.
 // Note that the returned tag keeps its separator.


### PR DESCRIPTION
It is already possible to reference the name of Image subjected to change using regular expression. See [api/image/image.go#L17](https://github.com/kubernetes-sigs/kustomize/blob/master/api/image/image.go#L17)
```go
	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.{}-]*)?$")
```


This PR adds the feature to reference submatch (capture groups) used in the name field for newName field.

This way you can change the registry for all images matching other registry, or change repository namespace with multiple repositories in there.

## example:

resource
```yaml
image: myregistry/customer/app01:0.1
---
image: myregistry/customer/app02:0.1
```
kustomization.yaml
```yaml
images:
  - name: "myregistry/customer/(.+)"
    newName: "customerregistry/stage/$1"
```
should produce
```yaml
image: customerregistry/stage/app01:0.1
---
image: customerregistry/stage/app02:0.1
```

## known issues
Even the current implementation allows to have more name regexes in images list written in a way the signle image hits the rule twice. I am not sure how clearly reproduce it.