### PR TITLE
Update fork updater script

### DIFF
--- a/kyaml/internal/forked/README.md
+++ b/kyaml/internal/forked/README.md
@@ -6,6 +6,6 @@ This code is used by the starlark runtime. We copied it in to reduce the depende
 
 ## go-yaml/yaml
 
-This code is used extensively by kyaml. It is a copy of upstream at a particular revision that kubectl is using, with [a change we need](https://github.com/go-yaml/yaml/pull/753) cherry-picked on top. For background information on this problem, see https://github.com/kubernetes-sigs/kustomize/issues/3946.
+This code is used extensively by kyaml. It is a copy of upstream at a particular revision that kubectl is using, with fixes we need cherry-picked on top ([#753](https://github.com/go-yaml/yaml/pull/753), [#766](https://github.com/go-yaml/yaml/pull/766)). For background information on this problem, see https://github.com/kubernetes-sigs/kustomize/issues/3946.
 
-This copy was created using the [git subtree technique](https://medium.com/@porteneuve/mastering-git-subtrees-943d29a798ec) and can be recreated on top of a new version of go-yaml v3 using the [update-go-yaml.sh](update-go-yaml.sh) script. Please note that there is nothing special about the fork directory, so copy-paste with manual edits will work just fine if you prefer.
+This copy was created using the [git subtree technique](https://medium.com/@porteneuve/mastering-git-subtrees-943d29a798ec) and can be recreated on top of a new version of go-yaml v3 using the [update-go-yaml.sh](update-go-yaml.sh) script. To add an additional go-yaml PR to be cherry-picked, simply update the script's `GO_YAML_PRS` variable. Please note that there is nothing special about the fork directory, so copy-paste with manual edits will work just fine if you prefer.

--- a/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go
+++ b/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go
@@ -47,6 +47,9 @@ var unmarshalTests = []struct {
 	}, {
 		"v: hi", map[string]interface{}{"v": "hi"},
 	}, {
+		"v: 'hi\nthis is a\nmultiline string\n'",
+		map[string]interface {}{"v":"hi\nthis is a\nmultiline string\n"},
+	}, {
 		"v: true",
 		map[string]string{"v": "true"},
 	}, {


### PR DESCRIPTION
- Support cherry-picking multiple PRs into the fork
- Fix a bug in the deletion part of the fork replacement
- Remove commented out code (it is in fact no longer necessary)

Confirmed that this works by running it. It successfully recreates the fork, and `git diff master kyaml/internal/forked/github.com/go-yaml/` correctly shows that the upstream PRs contain a test change that is not currently in the internal fork:

```diff
diff --git a/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go b/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go
index 7b34fade2..cd7157958 100644
--- a/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go
+++ b/kyaml/internal/forked/github.com/go-yaml/yaml/decode_test.go
@@ -46,6 +46,9 @@ var unmarshalTests = []struct {
                map[string]string{"v": "hi"},
        }, {
                "v: hi", map[string]interface{}{"v": "hi"},
+       }, {
+               "v: 'hi\nthis is a\nmultiline string\n'",
+               map[string]interface {}{"v":"hi\nthis is a\nmultiline string\n"},
        }, {
                "v: true",
                map[string]string{"v": "true"},
```