### PR TITLE
migrate build annotations to internal prefix

### DIFF
--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -1514,9 +1514,9 @@ kind: Deployment
 metadata:
   name: pre-deploy
   annotations: 
-    config.kubernetes.io/previousNames: deploy,deploy
-    config.kubernetes.io/previousKinds: CronJob,Deployment
-    config.kubernetes.io/previousNamespaces: default,default
+    internal.config.kubernetes.io/previousNames: deploy,deploy
+    internal.config.kubernetes.io/previousKinds: CronJob,Deployment
+    internal.config.kubernetes.io/previousNamespaces: default,default
 spec:
   template:
     spec:
@@ -1543,9 +1543,9 @@ kind: Deployment
 metadata:
   name: pre-deploy
   annotations:
-    config.kubernetes.io/previousNames: deploy,deploy
-    config.kubernetes.io/previousKinds: CronJob,Deployment
-    config.kubernetes.io/previousNamespaces: default,default
+    internal.config.kubernetes.io/previousNames: deploy,deploy
+    internal.config.kubernetes.io/previousKinds: CronJob,Deployment
+    internal.config.kubernetes.io/previousNamespaces: default,default
 spec:
   template:
     spec:

--- a/api/internal/accumulator/resaccumulator_test.go
+++ b/api/internal/accumulator/resaccumulator_test.go
@@ -362,10 +362,10 @@ func TestResolveVarsWithNoambiguation(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "sub-backendOne",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/previousKinds":      "Service",
-					"config.kubernetes.io/previousNames":      "backendOne",
-					"config.kubernetes.io/previousNamespaces": "default",
-					"config.kubernetes.io/prefixes":           "sub-",
+					"internal.config.kubernetes.io/previousKinds":      "Service",
+					"internal.config.kubernetes.io/previousNames":      "backendOne",
+					"internal.config.kubernetes.io/previousNamespaces": "default",
+					"internal.config.kubernetes.io/prefixes":           "sub-",
 				},
 			}}).ResMap()
 

--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -10,17 +10,17 @@ import (
 )
 
 const (
-	BuildAnnotationPreviousKinds      = konfig.ConfigAnnoDomain + "/previousKinds"
-	BuildAnnotationPreviousNames      = konfig.ConfigAnnoDomain + "/previousNames"
-	BuildAnnotationPrefixes           = konfig.ConfigAnnoDomain + "/prefixes"
-	BuildAnnotationSuffixes           = konfig.ConfigAnnoDomain + "/suffixes"
-	BuildAnnotationPreviousNamespaces = konfig.ConfigAnnoDomain + "/previousNamespaces"
-	BuildAnnotationsRefBy             = konfig.ConfigAnnoDomain + "/refBy"
+	BuildAnnotationPreviousKinds      = konfig.InternalConfigAnnoDomain + "/previousKinds"
+	BuildAnnotationPreviousNames      = konfig.InternalConfigAnnoDomain + "/previousNames"
+	BuildAnnotationPreviousNamespaces = konfig.InternalConfigAnnoDomain + "/previousNamespaces"
+	BuildAnnotationPrefixes           = konfig.InternalConfigAnnoDomain + "/prefixes"
+	BuildAnnotationSuffixes           = konfig.InternalConfigAnnoDomain + "/suffixes"
+	BuildAnnotationsRefBy             = konfig.InternalConfigAnnoDomain + "/refBy"
 
 	// the following are only for patches, to specify whether they can change names
 	// and kinds of their targets
-	BuildAnnotationAllowNameChange = konfig.ConfigAnnoDomain + "/allowNameChange"
-	BuildAnnotationAllowKindChange = konfig.ConfigAnnoDomain + "/allowKindChange"
+	BuildAnnotationAllowNameChange = konfig.InternalConfigAnnoDomain + "/allowNameChange"
+	BuildAnnotationAllowKindChange = konfig.InternalConfigAnnoDomain + "/allowKindChange"
 	Allowed                        = "allowed"
 )
 

--- a/api/konfig/general.go
+++ b/api/konfig/general.go
@@ -34,6 +34,9 @@ const (
 	// ConfigAnnoDomain is configuration-related annotation namespace.
 	ConfigAnnoDomain = "config.kubernetes.io"
 
+	// InternalConfigAnnoDomain is internal configuration-related annotation namespace.
+	InternalConfigAnnoDomain = "internal.config.kubernetes.io"
+
 	// If a resource has this annotation, kustomize will drop it.
 	IgnoredByKustomizeAnnotation = ConfigAnnoDomain + "/local-config"
 

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -343,9 +343,9 @@ func TestGetMatchingResourcesByAnyId(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "new-alice",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/previousKinds":      "ConfigMap",
-					"config.kubernetes.io/previousNames":      "alice",
-					"config.kubernetes.io/previousNamespaces": "default",
+					"internal.config.kubernetes.io/previousKinds":      "ConfigMap",
+					"internal.config.kubernetes.io/previousNames":      "alice",
+					"internal.config.kubernetes.io/previousNamespaces": "default",
 				},
 			},
 		})
@@ -356,9 +356,9 @@ func TestGetMatchingResourcesByAnyId(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "new-bob",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/previousKinds":      "ConfigMap,ConfigMap",
-					"config.kubernetes.io/previousNames":      "bob,bob2",
-					"config.kubernetes.io/previousNamespaces": "default,default",
+					"internal.config.kubernetes.io/previousKinds":      "ConfigMap,ConfigMap",
+					"internal.config.kubernetes.io/previousNames":      "bob,bob2",
+					"internal.config.kubernetes.io/previousNamespaces": "default,default",
 				},
 			},
 		})
@@ -370,9 +370,9 @@ func TestGetMatchingResourcesByAnyId(t *testing.T) {
 				"name":      "new-bob",
 				"namespace": "new-happy",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/previousKinds":      "ConfigMap",
-					"config.kubernetes.io/previousNames":      "bob",
-					"config.kubernetes.io/previousNamespaces": "happy",
+					"internal.config.kubernetes.io/previousKinds":      "ConfigMap",
+					"internal.config.kubernetes.io/previousNames":      "bob",
+					"internal.config.kubernetes.io/previousNamespaces": "happy",
 				},
 			},
 		})
@@ -384,9 +384,9 @@ func TestGetMatchingResourcesByAnyId(t *testing.T) {
 				"name":      "charlie",
 				"namespace": "happy",
 				"annotations": map[string]interface{}{
-					"config.kubernetes.io/previousKinds":      "ConfigMap",
-					"config.kubernetes.io/previousNames":      "charlie",
-					"config.kubernetes.io/previousNamespaces": "default",
+					"internal.config.kubernetes.io/previousKinds":      "ConfigMap",
+					"internal.config.kubernetes.io/previousNames":      "charlie",
+					"internal.config.kubernetes.io/previousNamespaces": "default",
 				},
 			},
 		})

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -717,9 +717,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret
-    config.kubernetes.io/previousNames: oldName
-    config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/previousKinds: Secret
+    internal.config.kubernetes.io/previousNames: oldName
+    internal.config.kubernetes.io/previousNamespaces: default
   name: newName
 `,
 		},
@@ -729,9 +729,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret
-    config.kubernetes.io/previousNames: oldName
-    config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/previousKinds: Secret
+    internal.config.kubernetes.io/previousNames: oldName
+    internal.config.kubernetes.io/previousNamespaces: default
   name: oldName2
 `,
 			newName: "newName",
@@ -740,9 +740,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret,Secret
-    config.kubernetes.io/previousNames: oldName,oldName2
-    config.kubernetes.io/previousNamespaces: default,default
+    internal.config.kubernetes.io/previousKinds: Secret,Secret
+    internal.config.kubernetes.io/previousNames: oldName,oldName2
+    internal.config.kubernetes.io/previousNamespaces: default,default
   name: newName
 `,
 		},
@@ -752,9 +752,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret
-    config.kubernetes.io/previousNames: oldName
-    config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/previousKinds: Secret
+    internal.config.kubernetes.io/previousNames: oldName
+    internal.config.kubernetes.io/previousNamespaces: default
   name: oldName2
   namespace: oldNamespace
 `,
@@ -764,9 +764,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret,Secret
-    config.kubernetes.io/previousNames: oldName,oldName2
-    config.kubernetes.io/previousNamespaces: default,oldNamespace
+    internal.config.kubernetes.io/previousKinds: Secret,Secret
+    internal.config.kubernetes.io/previousNames: oldName,oldName2
+    internal.config.kubernetes.io/previousNamespaces: default,oldNamespace
   name: newName
   namespace: newNamespace
 `,
@@ -814,9 +814,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret
-    config.kubernetes.io/previousNames: oldName
-    config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/previousKinds: Secret
+    internal.config.kubernetes.io/previousNames: oldName
+    internal.config.kubernetes.io/previousNamespaces: default
   name: newName
 `,
 			expected: []resid.ResId{
@@ -833,9 +833,9 @@ metadata:
 kind: Secret
 metadata:
   annotations:
-    config.kubernetes.io/previousKinds: Secret,Secret
-    config.kubernetes.io/previousNames: oldName,oldName2
-    config.kubernetes.io/previousNamespaces: default,oldNamespace
+    internal.config.kubernetes.io/previousKinds: Secret,Secret
+    internal.config.kubernetes.io/previousNames: oldName,oldName2
+    internal.config.kubernetes.io/previousNamespaces: default,oldNamespace
   name: newName
   namespace: newNamespace
 `,
@@ -1150,7 +1150,7 @@ kind: Deployment
 metadata:
   name: clown
   annotations:
-    config.kubernetes.io/refBy: gr1_ver1_knd1|ns1|name1
+    internal.config.kubernetes.io/refBy: gr1_ver1_knd1|ns1|name1
 spec:
   numReplicas: 1
 `)
@@ -1162,7 +1162,7 @@ kind: Deployment
 metadata:
   name: clown
   annotations:
-    config.kubernetes.io/refBy: gr1_ver1_knd1|ns1|name1,gr2_ver2_knd2|ns2|name2
+    internal.config.kubernetes.io/refBy: gr1_ver1_knd1|ns1|name1,gr2_ver2_knd2|ns2|name2
 spec:
   numReplicas: 1
 `)

--- a/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
+++ b/plugin/builtin/prefixsuffixtransformer/PrefixSuffixTransformer_test.go
@@ -63,11 +63,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    config.kubernetes.io/prefixes: baked-
-    config.kubernetes.io/previousKinds: Service
-    config.kubernetes.io/previousNames: apple
-    config.kubernetes.io/previousNamespaces: default
-    config.kubernetes.io/suffixes: -pie
+    internal.config.kubernetes.io/prefixes: baked-
+    internal.config.kubernetes.io/previousKinds: Service
+    internal.config.kubernetes.io/previousNames: apple
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -pie
   name: baked-apple-pie
 spec:
   ports:
@@ -87,11 +87,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    config.kubernetes.io/prefixes: baked-
-    config.kubernetes.io/previousKinds: ConfigMap
-    config.kubernetes.io/previousNames: cm
-    config.kubernetes.io/previousNamespaces: default
-    config.kubernetes.io/suffixes: -pie
+    internal.config.kubernetes.io/prefixes: baked-
+    internal.config.kubernetes.io/previousKinds: ConfigMap
+    internal.config.kubernetes.io/previousNames: cm
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -pie
   name: baked-cm-pie
 `)
 
@@ -139,10 +139,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    config.kubernetes.io/prefixes: test-
-    config.kubernetes.io/previousKinds: Deployment
-    config.kubernetes.io/previousNames: deployment
-    config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/prefixes: test-
+    internal.config.kubernetes.io/previousKinds: Deployment
+    internal.config.kubernetes.io/previousNames: deployment
+    internal.config.kubernetes.io/previousNamespaces: default
   name: test-deployment
 spec:
   template:


### PR DESCRIPTION
In the spirit of aligning with https://github.com/kubernetes-sigs/kustomize/pull/3995/files - 

"For orchestration purposes, the orchestrator will use a set of annotations,
referred to as _internal annotations_." This PR updates the annotation prefixes of resource build annotations (which are used solely by the kustomize orchestrator) to have the internal prefix.

See discussion in https://github.com/kubernetes-sigs/kustomize/pull/4061#issuecomment-881058172