### PR TITLE
Make UpdateExpectedFromActual work with hierarchical testdata directories

### DIFF
--- a/kyaml/fn/framework/frameworktestutil/frameworktestutil_test.go
+++ b/kyaml/fn/framework/frameworktestutil/frameworktestutil_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package frameworktestutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestProcessorResultsChecker_UpdateExpectedFromActual(t *testing.T) {
+	dir := filepath.FromSlash("testdata/update_expectations/processor")
+	checker := ProcessorResultsChecker{
+		TestDataDirectory:        dir,
+		UpdateExpectedFromActual: true,
+		Processor:                testProcessor,
+	}
+	// This should result in the test being skipped. If no tests are found, it will instead fail.
+	checker.Assert(t)
+	require.Contains(t, checker.TestCasesRun(), filepath.Join(dir, "important_subdir"))
+
+	checker.UpdateExpectedFromActual = false
+	// This time should inherently pass
+	checker.Assert(t)
+	require.Contains(t, checker.TestCasesRun(), filepath.Join(dir, "important_subdir"))
+}
+
+func TestCommandResultsChecker_UpdateExpectedFromActual(t *testing.T) {
+	dir := filepath.FromSlash("testdata/update_expectations/command")
+	checker := CommandResultsChecker{
+		TestDataDirectory:        dir,
+		UpdateExpectedFromActual: true,
+		Command:                  testCommand,
+	}
+	// This should result in the test being skipped. If no tests are found, it will instead fail.
+	checker.Assert(t)
+	require.Contains(t, checker.TestCasesRun(), filepath.Join(dir, "important_subdir"))
+
+	checker.UpdateExpectedFromActual = false
+	// This time should inherently pass
+	checker.Assert(t)
+	require.Contains(t, checker.TestCasesRun(), filepath.Join(dir, "important_subdir"))
+}
+
+func testCommand() *cobra.Command {
+	return command.Build(testProcessor(), command.StandaloneEnabled, false)
+}
+
+func testProcessor() framework.ResourceListProcessor {
+	return framework.SimpleProcessor{
+		Filter: kio.FilterFunc(func(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+			for _, node := range nodes {
+				err := node.SetAnnotations(map[string]string{"updated": "true"})
+				if err != nil {
+					return nil, err
+				}
+			}
+			return nodes, nil
+		}),
+	}
+}

--- a/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/config.yaml
+++ b/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/config.yaml
@@ -1,0 +1,7 @@
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: example.com/v1alpha1
+kind: Demo
+spec:
+  value: a

--- a/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/expected.yaml
+++ b/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/expected.yaml
@@ -1,0 +1,16 @@
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-1
+  annotations:
+    updated: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-2
+  annotations:
+    updated: "true"

--- a/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/input.yaml
+++ b/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/command/important_subdir/input.yaml
@@ -1,0 +1,16 @@
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-1
+  annotations:
+    baz: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-2
+  annotations:
+    foo: bar

--- a/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/processor/important_subdir/expected.yaml
+++ b/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/processor/important_subdir/expected.yaml
@@ -1,0 +1,20 @@
+apiVersion:
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-1
+    annotations:
+      updated: "true"
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-2
+    annotations:
+      updated: "true"
+functionConfig:
+  apiVersion: example.com/v1alpha1
+  kind: Demo
+  spec:
+    value: a

--- a/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/processor/important_subdir/input.yaml
+++ b/kyaml/fn/framework/frameworktestutil/testdata/update_expectations/processor/important_subdir/input.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-1
+    annotations:
+      baz: foo
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-2
+    annotations:
+      foo: bar
+functionConfig:
+  apiVersion: example.com/v1alpha1
+  kind: Demo
+  spec:
+    value: a


### PR DESCRIPTION
The core purpose of this PR is to fix a bug in `UpdateExpectedFromActual`: it didn't work if your test directories were nested at all. The regression test added fails as follows on master:

```
=== CONT  TestProcessorResultsChecker_UpdateExpectedFromActual
    frameworktestutil.go:179: Test case is missing input file
    frameworktestutil.go:181: 
        	Error Trace:	frameworktestutil.go:181
        	            				frameworktestutil.go:303
        	Error:      	Received unexpected error:
        	            	stat input.yaml: no such file or directory
        	Test:       	TestProcessorResultsChecker_UpdateExpectedFromActual
```

Whether or not a directory is a valid test case depends on three things: (1) necessary input files; (2) output fixture, if a success test case AND we're not updating it; (2) error fixture, if an error test case AND we're not updating it. Instead, when not updating, the code was previously checking if the contents of the output/error fixtures were blank, and skipping the directory if they were, even if the files were created or the input file existed. When updating, the code would assume that every directory encountered should be a test case, leading to the error above. The code doing that checking should have been referencing the input files, but those depend on the checker type. I ended up refactoring the helper yet again to fix this nicely. None of the code changed is in the public interface, but this PR does add a new method to it, for inspecting the list of directories identified as test case.