### PR TITLE
Unset CDPATH in hack/install_kustomize.sh

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -19,6 +19,10 @@
 
 set -e
 
+# Unset CDPATH to restore default cd behavior. An exported CDPATH can
+# cause cd to output the current directory to STDOUT.
+unset CDPATH
+
 where=$PWD
 
 release_url=https://api.github.com/repos/kubernetes-sigs/kustomize/releases


### PR DESCRIPTION
`unset CDPATH` in `hack/install_kustomize.sh` for robustness. I encountered an issue where I had exported `CDPATH` in my environment prior to using the script which can cause `cd` (used in `readlink_f` implementation) to output the current directory to `STDOUT`.

See: https://bosker.wordpress.com/2012/02/12/bash-scripters-beware-of-the-cdpath/

Example with exported `CDPATH` outputs newline separated path from `cd` output joined with `echo "$RESULT"` from the `readlink_f` function:

```
➜  export CDPATH=.:~
➜  ./install_kustomize.sh 4.1.3 _output/tools/bin
cp: cannot create regular file '/home/abutcher/_output/tools'$'\n''/home/abutcher/_output/tools/bin/': No such file or directory

➜  unset CDPATH
➜  ./install_kustomize.sh 4.1.3 _output/tools/bin
{Version:kustomize/v4.1.3 GitCommit:0f614e92f72f1b938a9171b964d90b197ca8fb68 BuildDate:2021-05-20T20:52:40Z GoOs:linux GoArch:amd64}
kustomize installed to /home/abutcher/_output/tools/bin/kustomize
```
