### PR TITLE
Avoid aliasing in fsnode by forcing copies for file contents

### DIFF
--- a/kyaml/filesys/fsnode.go
+++ b/kyaml/filesys/fsnode.go
@@ -123,11 +123,11 @@ func (n *fsNode) addFile(name string, c []byte) (result *fsNode, err error) {
 		if result.offset != nil {
 			return nil, fmt.Errorf("cannot add already opened file '%s'", n.Path())
 		}
-		result.content = c
+		result.content = append(result.content[:0], c...)
 		return result, nil
 	}
 	result = &fsNode{
-		content: c,
+		content: append([]byte(nil), c...),
 		parent:  parent,
 	}
 	parent.dir[fileName] = result

--- a/kyaml/filesys/fsnode_test.go
+++ b/kyaml/filesys/fsnode_test.go
@@ -157,9 +157,13 @@ func runBasicOperations(
 		if string(stuff) != both {
 			t.Fatalf("%s; unexpected content '%s', expected '%s'", c.what, stuff, both)
 		}
-		if err := fSys.WriteFile(c.path, []byte(shortContent)); err != nil {
+
+		content := []byte(shortContent)
+		if err := fSys.WriteFile(c.path, content); err != nil {
 			t.Fatalf("%s; unexpected error: %v", c.what, err)
 		}
+		// This ensures that modifying the original slice does not change the contents of the file.
+		content[0] = '@'
 		stuff, err = fSys.ReadFile(c.path)
 		if err != nil {
 			t.Fatalf("%s; unexpected error: %v", c.what, err)


### PR DESCRIPTION
While developing other PRs, I found a subtle bug in the filesys.FileSystem in-memory implementation.

This PR fixes it and updates a test to check for the right behavior.
