### PR TITLE
imagetag filter support regexpName

### DIFF
--- a/api/filters/imagetag/imagetag_test.go
+++ b/api/filters/imagetag/imagetag_test.go
@@ -658,6 +658,42 @@ spec:
 				},
 			},
 		},
+
+		"multiple matches by regexpName": {
+			input: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: instance
+spec:
+  containers:
+  - image: hub.my.com/nginx:1.2.1
+  - image: not_nginx@54321
+  - image: hub.my.com/redis:2.3.4
+`,
+			expectedOutput: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: instance
+spec:
+  containers:
+  - image: hub.you.com/ci/nginx:1.2.1
+  - image: not_nginx@54321
+  - image: hub.you.com/ci/redis:2.3.4
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					RegexpName:    "hub.my.com/",
+					NewRegexpName: "hub.you.com/ci/",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/containers/image",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/types/image.go
+++ b/api/types/image.go
@@ -18,4 +18,10 @@ type Image struct {
 	// Digest is the value used to replace the original image tag.
 	// If digest is present NewTag value is ignored.
 	Digest string `json:"digest,omitempty" yaml:"digest,omitempty"`
+
+	// RegexpName is a regexp string match image name.
+	RegexpName string `json:"regexpName,omitempty" yaml:"regexpName,omitempty"`
+
+	// NewRegexpName is the value used to regexp replace the original name.
+	NewRegexpName string `json:"newRegexpName,omitempty" yaml:"newRegexpName,omitempty"`
 }


### PR DESCRIPTION
The existing imagetag filter does not support batch replacement of name prefixes, so the regexpName field is added.

eg:
```yaml
# input
spec:
  containers:
  - image: hub.my.com/nginx:1.2.1
  - image: not_nginx@54321
  - image: hub.my.com/redis:2.3.4
```
use filter:
```yaml
# kustomization.yaml
images:
- regexpName: hub.my.com/
  newRegexpName: hub.you.com/ci/
```
will output:
```yaml
# output
spec:
  containers:
  - image: hub.you.com/ci/nginx:1.2.1
  - image: not_nginx@54321
  - image: hub.you.com/ci/redis:2.3.4
```
