### PR TITLE
deprecate fn wrap, xargs, sink, source commands

### DIFF
--- a/cmd/config/internal/commands/cmdwrap.go
+++ b/cmd/config/internal/commands/cmdwrap.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -47,6 +48,7 @@ Environment Variables:
 
 `,
 		RunE:               r.runE,
+		PreRunE:            r.preRunE,
 		SilenceUsage:       true,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Args:               cobra.MinimumNArgs(1),
@@ -76,6 +78,12 @@ const (
 
 func WrapCommand() *cobra.Command {
 	return GetWrapRunner().Command
+}
+
+func (r *WrapRunner) preRunE(_ *cobra.Command, _ []string) error {
+	_, err := fmt.Fprintln(os.Stderr, `Command "wrap" is deprecated, this will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.`)
+	return err
 }
 
 func (r *WrapRunner) runE(c *cobra.Command, args []string) error {

--- a/cmd/config/internal/commands/cmdxargs.go
+++ b/cmd/config/internal/commands/cmdxargs.go
@@ -60,6 +60,7 @@ $ kyaml cat pkg/ --function-config config.yaml --wrap-kind ResourceList | kyaml 
 
 `,
 		RunE:               r.runE,
+		PreRunE:            r.preRunE,
 		SilenceUsage:       true,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		Args:               cobra.MinimumNArgs(1),
@@ -82,6 +83,12 @@ type XArgsRunner struct {
 
 func XArgsCommand() *cobra.Command {
 	return GetXArgsRunner().Command
+}
+
+func (r *XArgsRunner) preRunE(_ *cobra.Command, _ []string) error {
+	_, err := fmt.Fprintln(os.Stderr, `Command "xargs" is deprecated, this will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.`)
+	return err
 }
 
 func (r *XArgsRunner) runE(c *cobra.Command, _ []string) error {

--- a/cmd/config/internal/commands/sink.go
+++ b/cmd/config/internal/commands/sink.go
@@ -4,6 +4,9 @@
 package commands
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/internal/generateddocs/commands"
 	"sigs.k8s.io/kustomize/cmd/config/runner"
@@ -20,6 +23,7 @@ func GetSinkRunner(name string) *SinkRunner {
 		Long:    commands.SinkLong,
 		Example: commands.SinkExamples,
 		RunE:    r.runE,
+		PreRunE: r.preRunE,
 		Args:    cobra.MaximumNArgs(1),
 	}
 	runner.FixDocs(name, c)
@@ -34,6 +38,12 @@ func SinkCommand(name string) *cobra.Command {
 // SinkRunner contains the run function
 type SinkRunner struct {
 	Command *cobra.Command
+}
+
+func (r *SinkRunner) preRunE(c *cobra.Command, args []string) error {
+	_, err := fmt.Fprintln(os.Stderr, `Command "sink" is deprecated, this will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.`)
+	return err
 }
 
 func (r *SinkRunner) runE(c *cobra.Command, args []string) error {

--- a/cmd/config/internal/commands/source.go
+++ b/cmd/config/internal/commands/source.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/internal/generateddocs/commands"
@@ -22,6 +23,7 @@ func GetSourceRunner(name string) *SourceRunner {
 		Long:    commands.SourceLong,
 		Example: commands.SourceExamples,
 		RunE:    r.runE,
+		PreRunE: r.preRunE,
 	}
 	runner.FixDocs(name, c)
 	c.Flags().StringVar(&r.WrapKind, "wrap-kind", kio.ResourceListKind,
@@ -45,6 +47,12 @@ type SourceRunner struct {
 	WrapApiVersion string
 	FunctionConfig string
 	Command        *cobra.Command
+}
+
+func (r *SourceRunner) preRunE(c *cobra.Command, args []string) error {
+	_, err := fmt.Fprintln(os.Stderr, `Command "source" is deprecated, this will no longer be available in kustomize v5.
+See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.`)
+	return err
 }
 
 func (r *SourceRunner) runE(c *cobra.Command, args []string) error {


### PR DESCRIPTION
Deprecate

```
kustomize fn xargs
kustomize fn source
kustomize fn sink
kustomize fn wrap
```

as discussed in https://github.com/kubernetes-sigs/kustomize/issues/3953