### PR TITLE
Feature: Allow both tag and digest

### DIFF
--- a/api/image/image.go
+++ b/api/image/image.go
@@ -14,7 +14,7 @@ func IsImageMatched(s, t string) bool {
 	// Tag values are limited to [a-zA-Z0-9_.{}-].
 	// Some tools like Bazel rules_k8s allow tag patterns with {} characters.
 	// More info: https://github.com/bazelbuild/rules_k8s/pull/423
-	pattern, _ := regexp.Compile("^" + t + "(@sha256)?(:[a-zA-Z0-9_.{}-]*)?$")
+	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]+)?(@sha256:[a-zA-Z0-9_.{}-]+)?$")
 	return pattern.MatchString(s)
 }
 
@@ -22,25 +22,35 @@ func IsImageMatched(s, t string) bool {
 // from the image string using either colon `:` or at `@` separators.
 // Note that the returned tag keeps its separator.
 func Split(imageName string) (name string, tag string) {
+	ic := -1
+	ia := strings.LastIndex(imageName, "@")
 	// check if image name contains a domain
 	// if domain is present, ignore domain and check for `:`
-	ic := -1
 	if slashIndex := strings.Index(imageName, "/"); slashIndex < 0 {
-		ic = strings.LastIndex(imageName, ":")
+		if ia > 0 {
+			ic = strings.LastIndex(imageName[:ia], ":")
+		} else {
+			ic = strings.LastIndex(imageName, ":")
+		}
+
 	} else {
-		lastIc := strings.LastIndex(imageName[slashIndex:], ":")
+		lastIc := -1
+		if ia > 0 {
+			lastIc = strings.LastIndex(imageName[slashIndex:ia], ":")
+		} else {
+			lastIc = strings.LastIndex(imageName[slashIndex:], ":")
+		}
 		// set ic only if `:` is present
 		if lastIc > 0 {
 			ic = slashIndex + lastIc
 		}
 	}
-	ia := strings.LastIndex(imageName, "@")
+
 	if ic < 0 && ia < 0 {
 		return imageName, ""
 	}
-
 	i := ic
-	if ia > 0 {
+	if ic < 0 || (ia > 0 && ia < ic) {
 		i = ia
 	}
 

--- a/api/image/image_test.go
+++ b/api/image/image_test.go
@@ -29,6 +29,18 @@ func TestIsImageMatched(t *testing.T) {
 			isMatched: true,
 		},
 		{
+			testName:  "name is match",
+			value:     "nginx@sha256:12345",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
+			testName:  "name is match",
+			value:     "nginx:1.2.3@sha256:12345",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
 			testName:  "name is not a match",
 			value:     "apache:12345",
 			name:      "nginx",
@@ -67,6 +79,12 @@ func TestSplit(t *testing.T) {
 			value:    "nginx@12345",
 			name:     "nginx",
 			tag:      "@12345",
+		},
+		{
+			testName: "with tag and digest",
+			value:    "nginx:1.2.3@sha256:12345",
+			name:     "nginx",
+			tag:      ":1.2.3@sha256:12345",
 		},
 	}
 

--- a/kustomize/commands/edit/set/setimage.go
+++ b/kustomize/commands/edit/set/setimage.go
@@ -31,6 +31,7 @@ var (
 	errImageInvalidArgs = errors.New(`invalid format of image, use one of the following options:
 - <image>=<newimage>:<newtag>
 - <image>=<newimage>@<digest>
+- <image>=<newimage>:<newtag>@<digest>
 - <image>=<newimage>
 - <image>:<newtag>
 - <image>@<digest>`)
@@ -210,7 +211,8 @@ func parse(arg string) (types.Image, error) {
 
 	// matches if there is an image name to overwrite
 	// <image>=<new-image><:|@><new-tag>
-	if s := strings.Split(arg, separator); len(s) == 2 {
+	s := strings.Split(arg, separator)
+	if len(s) == 2 {
 		p, err := parseOverwrite(s[1], true)
 		return types.Image{
 			Name:    s[0],
@@ -235,10 +237,21 @@ func parse(arg string) (types.Image, error) {
 func parseOverwrite(arg string, overwriteImage bool) (overwrite, error) {
 	// match <image>@<digest>
 	if d := strings.Split(arg, "@"); len(d) > 1 {
+		if t := pattern.FindStringSubmatch(d[0]); len(t) == 3 {
+			name := t[1]
+			tag := t[2]
+
+			return overwrite{
+				name:   name,
+				digest: d[1],
+				tag:    tag,
+			}, nil
+		}
 		return overwrite{
 			name:   d[0],
 			digest: d[1],
 		}, nil
+
 	}
 
 	// match <image>:<tag>

--- a/kustomize/commands/edit/set/setimage_test.go
+++ b/kustomize/commands/edit/set/setimage_test.go
@@ -64,6 +64,19 @@ func TestSetImage(t *testing.T) {
 		},
 		{
 			given: given{
+				args: []string{"image1=my-image1:my-tag@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- digest: sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3",
+					"  name: image1",
+					"  newName: my-image1",
+					"  newTag: my-tag",
+				}},
+		},
+		{
+			given: given{
 				args: []string{"image1=my-image1@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
 			},
 			expected: expected{


### PR DESCRIPTION
Hello,

I have the same issue with issue #2234. So I create a patch to solve my problem. Hope it is useful! 

## My case

- base/kustomization.yaml
```
images:
- name: test
  newTag: 1.0@sha256:1234
```
- dev/kustomization.yaml
```
images:
- name: test
  newTag: 2.2-date@sha256:7890
```

### Current behavior
```
kustomize build dev | grep -E 'image: test'
      - image: test:1.0@sha256:1234
```

### Expected behavior
```
kustomize build dev | grep -E 'image: test'
      - image: test: 2.2-date@sha256:7890
```
