### PR TITLE
support for darwin and linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # Makefile for kustomize CLI and API.
 
 SHELL := /usr/bin/env bash
-UNAME := $(shell uname | tr [:upper:] [:lower:])
+GOOS = $(shell go env GOOS)
+GOARCH = $(shell go env GOARCH)
 MYGOBIN = $(shell go env GOBIN)
 ifeq ($(MYGOBIN),)
 MYGOBIN = $(shell go env GOPATH)/bin
@@ -290,8 +291,8 @@ $(MYGOBIN)/kubeval:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-$(UNAME)-amd64.tar.gz; \
-		tar xf kubeval-$(UNAME)-amd64.tar.gz; \
+		wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-$(GOOS)-$(GOARCH).tar.gz; \
+		tar xf kubeval-$(GOOS)-$(GOARCH).tar.gz; \
 		mv kubeval $(MYGOBIN); \
 		rm -rf $$d; \
 	)
@@ -305,10 +306,10 @@ $(MYGOBIN)/helmV2:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=helm-v2.13.1-$(UNAME)-amd64.tar.gz; \
+		tgzFile=helm-v2.13.1-$(GOOS)-$(GOARCH).tar.gz; \
 		wget https://storage.googleapis.com/kubernetes-helm/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
-		mv $(UNAME)-amd64/helm $(MYGOBIN)/helmV2; \
+		mv $(GOOS)-$(GOARCH)/helm $(MYGOBIN)/helmV2; \
 		rm -rf $$d \
 	)
 
@@ -318,10 +319,10 @@ $(MYGOBIN)/helmV3:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=helm-v3.5.3-$(UNAME)-amd64.tar.gz; \
+		tgzFile=helm-v3.5.3-$(GOOS)-$(GOARCH).tar.gz; \
 		wget https://get.helm.sh/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
-		mv $(UNAME)-amd64/helm $(MYGOBIN)/helmV3; \
+		mv $(GOOS)-$(GOARCH)/helm $(MYGOBIN)/helmV3; \
 		rm -rf $$d \
 	)
 
@@ -329,7 +330,7 @@ $(MYGOBIN)/kind:
 	( \
         set -e; \
         d=$(shell mktemp -d); cd $$d; \
-        wget -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(UNAME)-amd64; \
+        wget -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(GOOS)-$(GOARCH); \
         chmod +x ./kind; \
         mv ./kind $(MYGOBIN); \
         rm -rf $$d; \
@@ -340,10 +341,10 @@ $(MYGOBIN)/gh:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=gh_1.0.0_linux_amd64.tar.gz; \
+		tgzFile=gh_1.0.0_$(GOOS)_$(GOARCH).tar.gz; \
 		wget https://github.com/cli/cli/releases/download/v1.0.0/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
-		mv gh_1.0.0_linux_amd64/bin/gh  $(MYGOBIN)/gh; \
+		mv gh_1.0.0_$(GOOS)_$(GOARCH)/bin/gh  $(MYGOBIN)/gh; \
 		rm -rf $$d \
 	)
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # Makefile for kustomize CLI and API.
 
 SHELL := /usr/bin/env bash
+UNAME := $(shell uname | tr [:upper:] [:lower:])
 MYGOBIN = $(shell go env GOBIN)
 ifeq ($(MYGOBIN),)
 MYGOBIN = $(shell go env GOPATH)/bin
@@ -289,8 +290,8 @@ $(MYGOBIN)/kubeval:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz; \
-		tar xf kubeval-linux-amd64.tar.gz; \
+		wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-$(UNAME)-amd64.tar.gz; \
+		tar xf kubeval-$(UNAME)-amd64.tar.gz; \
 		mv kubeval $(MYGOBIN); \
 		rm -rf $$d; \
 	)
@@ -304,10 +305,10 @@ $(MYGOBIN)/helmV2:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=helm-v2.13.1-linux-amd64.tar.gz; \
+		tgzFile=helm-v2.13.1-$(UNAME)-amd64.tar.gz; \
 		wget https://storage.googleapis.com/kubernetes-helm/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
-		mv linux-amd64/helm $(MYGOBIN)/helmV2; \
+		mv $(UNAME)-amd64/helm $(MYGOBIN)/helmV2; \
 		rm -rf $$d \
 	)
 
@@ -317,10 +318,10 @@ $(MYGOBIN)/helmV3:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=helm-v3.5.3-linux-amd64.tar.gz; \
+		tgzFile=helm-v3.5.3-$(UNAME)-amd64.tar.gz; \
 		wget https://get.helm.sh/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
-		mv linux-amd64/helm $(MYGOBIN)/helmV3; \
+		mv $(UNAME)-amd64/helm $(MYGOBIN)/helmV3; \
 		rm -rf $$d \
 	)
 
@@ -328,7 +329,7 @@ $(MYGOBIN)/kind:
 	( \
         set -e; \
         d=$(shell mktemp -d); cd $$d; \
-        wget -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(shell uname)-amd64; \
+        wget -O ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-$(UNAME)-amd64; \
         chmod +x ./kind; \
         mv ./kind $(MYGOBIN); \
         rm -rf $$d; \


### PR DESCRIPTION
## Problem
When I tried to issue `make all` on my mac I got errors:
```
--- FAIL: TestHelmChartInflationGeneratorOld (0.01s)
    harness.go:98: : unable to run: 'helmV3 version -c --short' with env=[HELM_CONFIG_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-287857073/helm HELM_CACHE_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-287857073/helm/.cache HELM_DATA_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-287857073/helm/.data] (is 'helmV3' installed?)
--- FAIL: TestHelmChartInflationGenerator (0.01s)
    harness.go:98: : unable to run: 'helmV3 version -c --short' with env=[HELM_CONFIG_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-507316491/helm HELM_CACHE_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-507316491/helm/.cache HELM_DATA_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-507316491/helm/.data] (is 'helmV3' installed?)
--- FAIL: TestHelmChartProdVsDev (0.01s)
    harness.go:98: : unable to run: 'helmV3 version -c --short' with env=[HELM_CONFIG_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-608376181/helm HELM_CACHE_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-608376181/helm/.cache HELM_DATA_HOME=/var/folders/vc/54chww3n1fb9c81mq8mz973h00rl2k/T/kustomize-helm-608376181/helm/.data] (is 'helmV3' installed?)
```

Why is this happening?  The downloads for dependent tools in the Makefile are hardcoded for linux.

## Change
This change points the download to a particular OS (darwin or linux).  I don't think WIndows has a uname command.

## Testing

Issued directed commands for select tools that are downloaded:
 ~/src/kustomize » make /Users/mikebz/go/bin/helmV3
 ~/src/kustomize » make /Users/mikebz/go/bin/kind  

Question:
- Seems like helmV2 results in a 403.  Do we even need that any more?  Maybe it's time to remove the helmV2 support.
- Not sure why we need to install the dependencies locally when the tests already rely on Docker.  We are getting around that problem by appending V2 and V3 for helm, but not for kind.  What if I want a different version of kind?  Not good.
