### PR TITLE
move check for working dir for exec functions

### DIFF
--- a/kyaml/fn/runtime/exec/exec.go
+++ b/kyaml/fn/runtime/exec/exec.go
@@ -38,16 +38,17 @@ func (c *Filter) Run(reader io.Reader, writer io.Writer) error {
 	cmd.Stdin = reader
 	cmd.Stdout = writer
 	cmd.Stderr = os.Stderr
-	if c.WorkingDir != "" {
-		if !filepath.IsAbs(c.WorkingDir) {
-			return errors.Errorf(
-				"relative working directory %s not allowed", c.WorkingDir)
-		}
-		if c.WorkingDir == "/" {
-			return errors.Errorf(
-				"root working directory '/' not allowed")
-		}
-		cmd.Dir = c.WorkingDir
+	if c.WorkingDir == "" {
+		return errors.Errorf("no working directory set for exec function")
 	}
+	if !filepath.IsAbs(c.WorkingDir) {
+		return errors.Errorf(
+			"relative working directory %s not allowed", c.WorkingDir)
+	}
+	if c.WorkingDir == "/" {
+		return errors.Errorf(
+			"root working directory '/' not allowed")
+	}
+	cmd.Dir = c.WorkingDir
 	return cmd.Run()
 }

--- a/kyaml/fn/runtime/exec/exec_test.go
+++ b/kyaml/fn/runtime/exec/exec_test.go
@@ -4,15 +4,19 @@
 package exec_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/exec"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func TestFunctionFilter_Filter(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
 	var tests = []struct {
 		name           string
 		input          []string
@@ -51,8 +55,9 @@ metadata:
 			},
 			expectedError: "",
 			instance: exec.Filter{
-				Path: "sed",
-				Args: []string{"s/Deployment/StatefulSet/g"},
+				Path:       "sed",
+				Args:       []string{"s/Deployment/StatefulSet/g"},
+				WorkingDir: wd,
 			},
 		},
 	}

--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -510,10 +510,6 @@ func (r *RunFns) ffp(spec runtimeutil.FunctionSpec, api *yaml.RNode, currentUser
 	}
 
 	if r.EnableExec && spec.Exec.Path != "" {
-		if r.WorkingDir == "" {
-			return nil, fmt.Errorf("no working directory set for exec function")
-		}
-
 		ef := &exec.Filter{
 			Path:       spec.Exec.Path,
 			WorkingDir: r.WorkingDir,


### PR DESCRIPTION
This PR is a followup addressing https://github.com/kubernetes-sigs/kustomize/pull/4125#discussion_r693027562

It moves the working directory check to the exec filter rather than `runfn.go`.

A caveat however is that another entry point to the exec filter is the container runtime code, which uses the exec filter to run `docker run` - so to move this check, the container runtime now also has to set the working directory for its exec filter. 