### PR TITLE
WIP: Call DeAnchor in kustomization

### DIFF
--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -36,6 +36,11 @@ func (ra *ResAccumulator) ResMap() resmap.ResMap {
 	return ra.resMap.ShallowCopy()
 }
 
+// DeAnchor expands YAML anchor aliases with what they reference.
+func (ra *ResAccumulator) DeAnchor() error {
+	return ra.resMap.DeAnchor()
+}
+
 // Vars returns a copy of underlying vars.
 func (ra *ResAccumulator) Vars() []types.Var {
 	return ra.varSet.AsSlice()

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -205,6 +205,9 @@ func (kt *KustTarget) accumulateTarget(ra *accumulator.ResAccumulator, origin *r
 	if err != nil {
 		return nil, err
 	}
+	if err = ra.DeAnchor(); err != nil {
+		return nil, err
+	}
 	err = kt.runTransformers(ra)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pondering this.  Seems appropriate to run after generators (in case they have anchors) but before transformers.