### PR TITLE
Return a meaningful message if we hit the rate-limiter of GitHub

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -102,7 +102,14 @@ elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
 fi
 
-RELEASE_URL=$(curl -s $release_url |\
+releases=$(curl -s $release_url)
+
+if [[ $releases == *"API rate limit exceeded"* ]]; then
+  echo "Github rate-limiter failed the request. Either authenticate or wait a couple of minutes."
+  exit 1
+fi
+
+RELEASE_URL=$(echo "${releases}" |\
   grep browser_download.*${opsys}_${arch} |\
   cut -d '"' -f 4 |\
   sort -V | tail -n 1)


### PR DESCRIPTION
Sometimes we get a very weird error:
```
Version v4.2.0 does not exist
```

Following the code it seems like github doesn't return any bad status code, but rather include a message about rate-limiter taking action:
```
{"message":"API rate limit exceeded for 82.81.161.50. (But here'\''s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

Because the code is just grepping the output, it misses this failure.

This change will make it much more indicative:
```
$ bash  ./install_kustomize.sh 4.2.0
Github rate-limiter failed the request. Either authenticate or wait a couple of minutes.
```