### PR TITLE
throw error instead of panic when replacements source.fieldPath doesn't exist

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -131,10 +131,11 @@ func getReplacement(nodes []*yaml.RNode, r *types.Replacement) (*yaml.RNode, err
 	if err != nil {
 		return nil, err
 	}
-	if !rn.IsNilOrEmpty() {
-		return getRefinedValue(r.Source.Options, rn)
+	if rn.IsNilOrEmpty() {
+		return nil, fmt.Errorf("fieldPath `%s` is missing for replacement source %s", r.Source.FieldPath, r.Source)
 	}
-	return rn, nil
+
+	return getRefinedValue(r.Source.Options, rn)
 }
 
 func getRefinedValue(options *types.FieldOptions, rn *yaml.RNode) (*yaml.RNode, error) {

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -1573,7 +1573,6 @@ data:
   grpcPort: 8081
 `,
 			replacements: `replacements:
-# failing case
 - source:
     kind: ConfigMap
     name: ports-from
@@ -1587,8 +1586,7 @@ data:
     options:
       create: true
 `,
-			// this test currently panics instead of throwing an error
-			expectedErr: "fieldPath data.httpPort is missing for source ~G_~V_ConfigMap|~X|ports-from:data.httpPort",
+			expectedErr: "fieldPath `data.httpPort` is missing for replacement source ~G_~V_ConfigMap|~X|ports-from:data.httpPort",
 		},
 	}
 

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -1556,6 +1556,40 @@ spec:
         name: postgresdb
 `,
 		},
+
+		"replacement source.fieldPath does not exist": {
+			input: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ports-from
+data:
+  grpcPort: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ports-to
+data:
+  grpcPort: 8081
+`,
+			replacements: `replacements:
+# failing case
+- source:
+    kind: ConfigMap
+    name: ports-from
+    fieldPath: data.httpPort
+  targets:
+  - select:
+      kind: ConfigMap
+      name: ports-to
+    fieldPaths:
+    - data.grpcPort
+    options:
+      create: true
+`,
+			// this test currently panics instead of throwing an error
+			expectedErr: "fieldPath data.httpPort is missing for source ~G_~V_ConfigMap|~X|ports-from:data.httpPort",
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/4078

cc  @marshall007 