### PR TITLE
api/krusty: fix typo fileystem -> filesystem

### DIFF
--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -26,7 +26,7 @@ import (
 // used instead of performing an exec to a kustomize CLI subprocess.
 // To use, load a filesystem with kustomization files (any
 // number of overlays and bases), then make a Kustomizer
-// injected with the given fileystem, then call Run.
+// injected with the given filesystem, then call Run.
 type Kustomizer struct {
 	options     *Options
 	depProvider *provider.DepProvider


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/pull/104747.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>