### PR TITLE
Fixes 4123; Length check on originalFields of kustomizationFile to prevent panic

### DIFF
--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -212,7 +212,7 @@ func (mf *kustomizationFile) parseCommentedFields(content []byte) error {
 			if matched {
 				mf.originalFields = append(mf.originalFields, &commentedField{field: field, comment: squash(comments)})
 				comments = [][]byte{}
-			} else if len(comments) > 0 {
+			} else if len(comments) > 0 && len(mf.originalFields) > 0 {
 				mf.originalFields[len(mf.originalFields)-1].appendComment(squash(comments))
 				comments = [][]byte{}
 			}

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -356,6 +356,53 @@ kind: Kustomization
 	}
 }
 
+func TestCommentsWithDocumentSeperatorAtBeginning(t *testing.T) {
+	kustomizationContentWithComments := []byte(`
+
+    
+# Some comments
+# This is some comment we should preserve
+# don't delete it
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mynamespace
+`)
+
+	expected := []byte(`
+
+    
+# Some comments
+# This is some comment we should preserve
+# don't delete it
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mynamespace
+`)
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(
+		fSys, kustomizationContentWithComments)
+	mf, err := NewKustomizationFile(fSys)
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+
+	kustomization, err := mf.Read()
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	if err = mf.Write(kustomization); err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	bytes, _ := fSys.ReadFile(mf.path)
+
+	if diff := cmp.Diff(expected, bytes); diff != "" {
+		t.Errorf("Mismatch (-expected, +actual):\n%s", diff)
+	}
+}
+
 func TestUnknownFieldInKustomization(t *testing.T) {
 	kContent := []byte(`
 foo:


### PR DESCRIPTION
Fixes #4123 
`kustomize edit` was panicking when kustomization file began with a comment(or a blank line) which was immediately followed by a document separator because of `len(mf.originalFields)` was returning 0 [here](https://github.com/kubernetes-sigs/kustomize/blob/402f6ca72bd0d804d202376c39b5d8aeffbef8c6/kustomize/commands/internal/kustfile/kustomizationfile.go#L216). More explanation in this [comment](https://github.com/kubernetes-sigs/kustomize/issues/4123#issuecomment-917614762).

cc: @KnVerey 