### PR TITLE
Upgrade Helm v3 to v3.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ $(MYGOBIN)/helmV3:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-		tgzFile=helm-v3.5.3-$(GOOS)-$(GOARCH).tar.gz; \
+		tgzFile=helm-v3.6.3-$(GOOS)-$(GOARCH).tar.gz; \
 		wget https://get.helm.sh/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
 		mv $(GOOS)-$(GOARCH)/helm $(MYGOBIN)/helmV3; \


### PR DESCRIPTION
Helm has started to propose darwin/arm64 builds from v3.6.0.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>