### PR TITLE
support labels field in edit add command

### DIFF
--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -173,6 +173,7 @@ func TestAddAnnotationForce(t *testing.T) {
 func TestRunAddLabel(t *testing.T) {
 	var o addMetadataOptions
 	o.metadata = map[string]string{"owls": "cute", "otters": "adorable"}
+	o.includeSelectors = true
 
 	m := makeKustomization(t)
 	assert.NoError(t, o.addLabels(m))
@@ -268,6 +269,37 @@ func TestAddLabelForce(t *testing.T) {
 	// but trying to add it with --force should
 	v = valtest_test.MakeHappyMapValidator(t)
 	cmd = newCmdAddLabel(fSys, v.Validator)
+	err = cmd.Flag("force").Value.Set("true")
+	require.NoError(t, err)
+	assert.NoError(t, cmd.RunE(cmd, args))
+	v.VerifyCall()
+}
+
+func TestAddLabelNoSelector(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	v := valtest_test.MakeHappyMapValidator(t)
+	cmd := newCmdAddLabel(fSys, v.Validator)
+	err := cmd.Flag("include-selectors").Value.Set("false")
+	require.NoError(t, err)
+	args := []string{"key:foo"}
+	assert.NoError(t, cmd.RunE(cmd, args))
+	v.VerifyCall()
+	// trying to add the same label again should not work
+	args = []string{"key:bar"}
+	v = valtest_test.MakeHappyMapValidator(t)
+	cmd = newCmdAddLabel(fSys, v.Validator)
+	err = cmd.Flag("include-selectors").Value.Set("false")
+	require.NoError(t, err)
+	err = cmd.RunE(cmd, args)
+	v.VerifyCall()
+	assert.Error(t, err)
+	assert.Equal(t, "label key already in kustomization file", err.Error())
+	// but trying to add it with --force should
+	v = valtest_test.MakeHappyMapValidator(t)
+	cmd = newCmdAddLabel(fSys, v.Validator)
+	err = cmd.Flag("include-selectors").Value.Set("false")
+	require.NoError(t, err)
 	err = cmd.Flag("force").Value.Set("true")
 	require.NoError(t, err)
 	assert.NoError(t, cmd.RunE(cmd, args))

--- a/kustomize/commands/edit/add/all.go
+++ b/kustomize/commands/edit/add/all.go
@@ -39,7 +39,7 @@ func NewCmdAdd(
 	kustomize edit add base <filepath>
 	kustomize edit add base <filepath1>,<filepath2>,<filepath3>
 
-	# Adds one or more commonLabels to the kustomization
+	# Adds one or more labels or commonLabels to the kustomization
 	kustomize edit add label {labelKey1:labelValue1},{labelKey2:labelValue2}
 
 	# Adds one or more commonAnnotations to the kustomization


### PR DESCRIPTION
Support [labels](https://github.com/kubernetes-sigs/kustomize/blob/master/api/types/kustomization.go#L51) field in `kustomize edit add` command to allow adding labels without also automatically injecting corresponding selectors