### PR TITLE
[Fix 4124]  Skip local resource until all transformations have completed.

### DIFF
--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -168,3 +168,23 @@ func (ra *ResAccumulator) FixBackReferences() (err error) {
 	return ra.Transform(
 		newNameReferenceTransformer(ra.tConfig.NameReference))
 }
+
+// Intersection drops the resources which "other" does not have.
+func (ra *ResAccumulator) Intersection(other resmap.ResMap) error {
+	for _, curId := range ra.resMap.AllIds() {
+		toDelete := true
+		for _, otherId := range other.AllIds() {
+			if otherId == curId {
+				toDelete = false
+				break
+			}
+		}
+		if toDelete {
+			err := ra.resMap.Remove(curId)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/api/krusty/localconfig_test.go
+++ b/api/krusty/localconfig_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// This test checks that if a resource is annotated as "local-config", this resource won't be ignored until
+// all transformations have completed. This makes sure the local resource can be used as a transformation input.
+// See https://github.com/kubernetes-sigs/kustomize/issues/4124 for details.
+func TestSKipLocalConfigAfterTransform(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pod.yaml
+  - deployment.yaml
+transformers:
+  - replacement.yaml
+`)
+	th.WriteF("pod.yaml", `apiVersion: v1
+kind: Pod
+metadata:
+  name: buildup
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  containers:
+    - name: app
+      image: nginx
+`)
+	th.WriteF("deployment.yaml", `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildup
+`)
+	th.WriteF("replacement.yaml", `
+apiVersion: builtin
+kind: ReplacementTransformer
+metadata:
+  name: buildup
+replacements:
+- source:
+    kind: Pod
+    fieldPath: spec
+  targets:
+  - select:
+      kind: Deployment
+    fieldPaths:
+    - spec.template.spec
+    options:
+      create: true
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildup
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx
+        name: app
+`)
+}

--- a/api/resource/factory_test.go
+++ b/api/resource/factory_test.go
@@ -13,6 +13,7 @@ import (
 	. "sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 func TestRNodesFromBytes(t *testing.T) {
@@ -470,30 +471,6 @@ metadata:
 `},
 			},
 		},
-		"localConfigYaml": {
-			input: []byte(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: winnie-skip
-  annotations:
-    # this annotation causes the Resource to be ignored by kustomize
-    config.kubernetes.io/local-config: ""
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: winnie
-`),
-			exp: expected{
-				out: []string{`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: winnie
-`},
-			},
-		},
 		"garbageInOneOfTwoObjects": {
 			input: []byte(`
 apiVersion: v1
@@ -669,6 +646,96 @@ data:
 				assert.NoError(t, err)
 				assert.Equal(
 					t, strings.TrimSpace(tc.exp.out[i]), strings.TrimSpace(actual))
+			}
+		})
+	}
+}
+
+func TestDropLocalNodes(t *testing.T) {
+	testCases := map[string]struct {
+		input    []byte
+		expected []byte
+	}{
+		"localConfigUnset": {
+			input: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie
+`),
+			expected: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie
+`),
+		},
+		"localConfigSet": {
+			input: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie-skip
+  annotations:
+     # this annotation causes the Resource to be ignored by kustomize
+     config.kubernetes.io/local-config: ""
+`),
+			expected: nil,
+		},
+		"localConfigSetToTrue": {
+			input: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie-skip
+  annotations:
+	 config.kubernetes.io/local-config: "true"
+		`),
+			expected: nil,
+		},
+		"localConfigSetToFalse": {
+			input: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie
+  annotations:
+    config.kubernetes.io/local-config: "false"
+`),
+			expected: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    config.kubernetes.io/local-config: "false"
+  name: winnie
+`),
+		},
+		"localConfigMultiInput": {
+			input: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie-skip
+  annotations:
+    config.kubernetes.io/local-config: "true"
+`),
+			expected: []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: winnie
+`),
+		},
+	}
+	for n := range testCases {
+		tc := testCases[n]
+		t.Run(n, func(t *testing.T) {
+			nin, _ := kio.FromBytes(tc.input)
+			res, err := factory.DropLocalNodes(nin)
+			assert.NoError(t, err)
+			if tc.expected == nil {
+				assert.Equal(t, 0, len(res))
+			} else {
+				actual, _ := res[0].AsYAML()
+				assert.Equal(t, tc.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
### Fix: #4124 

### Description

Resources annotated as `local-config` are expected to be filtered out from stdout. This filtering (in func `accumulateResources` ) happens before any transformation operations. This causes the issue since 
the local resources are needed in transformations. See #4124
    
This PR removes the "drop local resource" logic from "accumulateResources", and filter out the local resource after running transforms. 
    
Open to discuss:

None of the existing ResMap functions can drop the resource slice easily: `Clear` will ruin the resource order, `AppendAll` only adds non-existing resource, `AbsorbAll` only add or modify but not delete.
Thus, we introduce a new func "Intersection" in `resourceAccumulator` to specifically removes the resource by ID and keep the original order.