### PR TITLE
Handle parsing of bare sequence yaml nodes

### DIFF
--- a/kyaml/kio/byteio_writer.go
+++ b/kyaml/kio/byteio_writer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"path/filepath"
+
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -113,7 +114,7 @@ func (w ByteWriter) Write(inputNodes []*yaml.RNode) error {
 			} else {
 				encoder.CompactSeqIndent()
 			}
-			if err := encoder.Encode(nodes[i].Document()); err != nil {
+			if err := encoder.Encode(upWrapBareSequenceNode(nodes[i].Document())); err != nil {
 				return errors.Wrap(err)
 			}
 		}
@@ -180,4 +181,14 @@ func (w ByteWriter) shouldJSONEncodeSingleBareNode(nodes []*yaml.RNode) bool {
 		}
 	}
 	return false
+}
+
+// upWrapBareSequenceNode unwraps the bare sequence nodes wrapped by yaml.BareSeqNodeWrappingKey
+func upWrapBareSequenceNode(node *yaml.Node) *yaml.Node {
+	rNode := yaml.NewRNode(node)
+	seqNode, err := rNode.Pipe(yaml.Lookup(yaml.BareSeqNodeWrappingKey))
+	if err == nil && !seqNode.IsNilOrEmpty() {
+		return seqNode.YNode()
+	}
+	return node
 }

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -82,6 +82,13 @@ type LocalPackageReadWriter struct {
 
 	// FileSystem can be used to mock the disk file system.
 	FileSystem filesys.FileSystemOrOnDisk
+
+	// WrapBareSeqNode wraps the bare sequence node document with map node,
+	// kyaml uses reader annotations to track resources, it is not possible to
+	// add them to bare sequence nodes, this option enables wrapping such bare
+	// sequence nodes into map node with key yaml.BareSeqNodeWrappingKey
+	// note that this wrapping is different and not related to ResourceList wrapping
+	WrapBareSeqNode bool
 }
 
 func (r *LocalPackageReadWriter) Read() ([]*yaml.RNode, error) {
@@ -95,6 +102,7 @@ func (r *LocalPackageReadWriter) Read() ([]*yaml.RNode, error) {
 		FileSkipFunc:        r.FileSkipFunc,
 		PreserveSeqIndent:   r.PreserveSeqIndent,
 		FileSystem:          r.FileSystem,
+		WrapBareSeqNode:     r.WrapBareSeqNode,
 	}.Read()
 	if err != nil {
 		return nil, errors.Wrap(err)
@@ -193,6 +201,13 @@ type LocalPackageReader struct {
 
 	// FileSystem can be used to mock the disk file system.
 	FileSystem filesys.FileSystemOrOnDisk
+
+	// WrapBareSeqNode wraps the bare sequence node document with map node,
+	// kyaml uses reader annotations to track resources, it is not possible to
+	// add them to bare sequence nodes, this option enables wrapping such bare
+	// sequence nodes into map node with key yaml.BareSeqNodeWrappingKey
+	// note that this wrapping is different and not related to ResourceList wrapping
+	WrapBareSeqNode bool
 }
 
 var _ Reader = LocalPackageReader{}
@@ -287,6 +302,7 @@ func (r *LocalPackageReader) readFile(path string, _ os.FileInfo) ([]*yaml.RNode
 		OmitReaderAnnotations: r.OmitReaderAnnotations,
 		SetAnnotations:        r.SetAnnotations,
 		PreserveSeqIndent:     r.PreserveSeqIndent,
+		WrapBareSeqNode:       r.WrapBareSeqNode,
 	}
 	return rr.Read()
 }

--- a/kyaml/yaml/alias.go
+++ b/kyaml/yaml/alias.go
@@ -14,6 +14,10 @@ const (
 	WideSequenceStyle    SequenceIndentStyle = "wide"
 	CompactSequenceStyle SequenceIndentStyle = "compact"
 	DefaultIndent                            = 2
+	// BareSeqNodeWrappingKey kyaml uses reader annotations to track resources, it is not possible to
+	// add them to bare sequence nodes, this key is used to wrap such bare
+	// sequence nodes into map node, byteio_writer unwraps it while writing back
+	BareSeqNodeWrappingKey = "bareSeqNodeWrappingKey"
 )
 
 // SeqIndentType holds the indentation style for sequence nodes


### PR DESCRIPTION
kyaml uses reader annotations to track resources for reading and writing back, it is not possible to add reader annotations to bare sequence nodes, this PR introduces a way to wrap/unwrap such nodes for smooth yaml processing.