### PR TITLE
Order TargetGroupBinding before Deployment

### DIFF
--- a/kyaml/resid/gvk.go
+++ b/kyaml/resid/gvk.go
@@ -152,6 +152,7 @@ var orderFirst = []string{
 	"PriorityClass",
 	"PersistentVolume",
 	"PersistentVolumeClaim",
+	"TargetGroupBinding",
 	"Deployment",
 	"StatefulSet",
 	"CronJob",


### PR DESCRIPTION
TargetGroupBinding should be created before pods, otherwise pod readiness gate doesn't kick in by the AWS controller.

Although TargetGroupBinding is a custom resource, this comes from a popular cloud provider and might be useful for many users. 

Feel free to close the PR if you consider it out of scope.

Context:

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/deploy/pod_readiness_gate/

- There exists a **service** matching the pod labels in the same namespace
- There exists at least **one target group binding** that refers to the matching service