### PR TITLE
Updated README to use 'resources' instead of 'bases' in overlays example.

### DIFF
--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -148,7 +148,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
-bases:
+resources:
 - ../../base
 patchesStrategicMerge:
 - map.yaml
@@ -189,7 +189,7 @@ commonLabels:
   org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
-bases:
+resources:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml


### PR DESCRIPTION
Kubernetes v1.21 upgrade kustomize-in-kubectl to v4.0.5. https://github.com/kubernetes/kubernetes/pull/98946
So I think this example could use resources instead of bases?

resources -> bases PR: https://github.com/kubernetes-sigs/kustomize/pull/2255