### PR TITLE
update the dockerfile gen command

### DIFF
--- a/kyaml/fn/framework/command/command.go
+++ b/kyaml/fn/framework/command/command.go
@@ -122,15 +122,17 @@ func AddGenerateDockerfile(cmd *cobra.Command) {
 		Use:  "gen [DIR]",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return ioutil.WriteFile(filepath.Join(args[0], "Dockerfile"), []byte(`FROM golang:1.15-alpine as builder
+			return ioutil.WriteFile(filepath.Join(args[0], "Dockerfile"), []byte(`FROM golang:1.16-alpine as builder
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go build -tags netgo -ldflags '-w' -v -o /usr/local/bin/function ./
+RUN go build -ldflags '-w -s' -v -o /usr/local/bin/function ./
 
 FROM alpine:latest
 COPY --from=builder /usr/local/bin/function /usr/local/bin/function
-CMD ["function"]
+ENTRYPOINT ["function"]
 `), 0600)
 		},
 	}

--- a/kyaml/fn/framework/command/command_test.go
+++ b/kyaml/fn/framework/command/command_test.go
@@ -45,15 +45,17 @@ func TestCommand_dockerfile(t *testing.T) {
 		t.FailNow()
 	}
 
-	expected := `FROM golang:1.15-alpine as builder
+	expected := `FROM golang:1.16-alpine as builder
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go build -tags netgo -ldflags '-w' -v -o /usr/local/bin/function ./
+RUN go build -ldflags '-w -s' -v -o /usr/local/bin/function ./
 
 FROM alpine:latest
 COPY --from=builder /usr/local/bin/function /usr/local/bin/function
-CMD ["function"]
+ENTRYPOINT ["function"]
 `
 	if !assert.Equal(t, expected, string(b)) {
 		t.FailNow()


### PR DESCRIPTION
- Split `go mod download` as a separate step to avoid download the go modules every single time when the users make non-dependency changes to the source code.
- Using `ENTRYPOINT` instead of `CMD`, so the users doesn't need to know what command they need to run (e.g. If the command is not called `function`, the user can still run `docker run my-image-name --help`)
- Dropped `-tags netgo`, since it's not necessary when we already set `CGO_ENABLED=0`.
- Added `-s` in `-ldflags` to disable symbol table and it further reduces the image size.
