### PR TITLE
Add support for exec plugins on Windows

### DIFF
--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -4,6 +4,12 @@
 package loader_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	. "sigs.k8s.io/kustomize/api/internal/plugins/loader"
@@ -76,5 +82,70 @@ func TestLoader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func TestAbsolutePath(t *testing.T) {
+	const group = "someteam.example.com"
+	const version = "v1"
+	const kind = "SedTransformer"
+
+	// Set KUSTOMIZE_PLUGIN_HOME to a temporary directory and create a dummy
+	// SedTransformer/SedTransformer.exe file in the expected directory.
+	tempDir := t.TempDir()
+	oldEnv := os.Getenv("KUSTOMIZE_PLUGIN_HOME")
+	defer func() { _ = os.Setenv("KUSTOMIZE_PLUGIN_HOME", oldEnv) }()
+	err := os.Setenv("KUSTOMIZE_PLUGIN_HOME", tempDir)
+	if err != nil {
+		t.Fatalf("Failed to set KUSTOMIZE_PLUGIN_HOME=%s: %v", tempDir, err)
+	}
+
+	execPluginDir := filepath.Join(tempDir, group, version, strings.ToLower(kind))
+	err = os.MkdirAll(execPluginDir, 0775)
+	if err != nil {
+		t.Fatalf("failed to create the directories %s: %v", execPluginDir, err)
+	}
+
+	execPluginBinary := filepath.Join(execPluginDir, kind)
+	if runtime.GOOS == "windows" {
+		execPluginBinary += ".exe"
+	}
+	err = ioutil.WriteFile(execPluginBinary, []byte{}, 0660)
+	if err != nil {
+		t.Fatalf(
+			"failed to write an empty file at %s: %v", execPluginBinary, err,
+		)
+	}
+
+	// Create the loader for the SedTransformer exec plugin
+	fSys := filesys.MakeFsOnDisk()
+	pvd := provider.NewDefaultDepProvider()
+	rf := resmap.NewFactory(pvd.GetResourceFactory())
+	pluginConfig := rf.RF().FromMap(
+		map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/%s", group, version),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name": "some-random-name",
+			},
+		},
+	)
+	pc := types.MakePluginConfig(
+		types.PluginRestrictionsNone, types.BploUseStaticallyLinked,
+	)
+	loader := NewLoader(pc, rf, fSys)
+
+	// Verify the absolute path is correct
+	pluginPath, err := loader.AbsolutePluginPath(pluginConfig.OrgId())
+	if err != nil {
+		t.Fatalf("An error occurred when calling AbsolutePluginPath: %v", err)
+	}
+
+	if pluginPath != execPluginBinary {
+		t.Fatalf(
+			`Expected the plugin path of "%s", got "%s"`,
+			execPluginBinary,
+			pluginPath,
+		)
 	}
 }


### PR DESCRIPTION
On Windows, the exec plugin script/binary must have an executable file
extension (e.g. .exe). This is so that Windows knows how to run it.
When the Start method of the Cmd type in the os/exec package strategy
is given a path without an extension, it attempts to discover it. This
commit adds this behavior to the AbsolutePluginPath method.

Resolves:
https://github.com/kubernetes-sigs/kustomize/issues/4213