### PR TITLE
docs: Update Plugin Links

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)
+Moved to [https://kubectl.docs.kubernetes.io/guides/extending_kustomize/](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)

--- a/docs/plugins/builtins.md
+++ b/docs/plugins/builtins.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubernetes-sigs.github.io/kustomize/guides/plugins/builtins/)
+Moved to [https://kubectl.docs.kubernetes.io/guides/extending_kustomize/](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)

--- a/docs/plugins/execPluginGuidedExample.md
+++ b/docs/plugins/execPluginGuidedExample.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubernetes-sigs.github.io/kustomize/guides/plugins)
+Moved to [https://kubectl.docs.kubernetes.io/guides/extending_kustomize/](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)

--- a/docs/plugins/goPluginCaveats.md
+++ b/docs/plugins/goPluginCaveats.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubernetes-sigs.github.io/kustomize/guides/plugins)
+Moved to [https://kubectl.docs.kubernetes.io/guides/extending_kustomize/](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)

--- a/docs/plugins/goPluginGuidedExample.md
+++ b/docs/plugins/goPluginGuidedExample.md
@@ -1,2 +1,2 @@
 
-Moved to [https://kubernetes-sigs.github.io/kustomize](https://kubernetes-sigs.github.io/kustomize/guides/plugins)
+Moved to [https://kubectl.docs.kubernetes.io/guides/extending_kustomize/](https://kubectl.docs.kubernetes.io/guides/extending_kustomize/)


### PR DESCRIPTION
Links to https://kubectl.docs.kubernetes.io/guides/extending_kustomize

The current link is stale