### PR TITLE
fix bug with migrating kyaml reader path, index, and id annotations

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -316,6 +316,10 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 		r.SetAnnotations = map[string]string{}
 	}
 	if !r.OmitReaderAnnotations {
+		err := kioutil.CopyLegacyAnnotations(n)
+		if err != nil {
+			return nil, err
+		}
 		r.SetAnnotations[kioutil.IndexAnnotation] = fmt.Sprintf("%d", index)
 		r.SetAnnotations[kioutil.LegacyIndexAnnotation] = fmt.Sprintf("%d", index)
 

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -299,7 +299,13 @@ g:
 `,
 			},
 
-			expectedOutput: `a: b #first
+			expectedOutput: `e: f
+g:
+  h:
+  - i # has a list
+  - j
+---
+a: b #first
 metadata:
   annotations:
     internal.config.kubernetes.io/path: "a/b/a_test.yaml"
@@ -310,12 +316,6 @@ metadata:
   annotations:
     internal.config.kubernetes.io/path: "a/b/a_test.yaml"
     config.kubernetes.io/path: 'a/b/a_test.yaml'
----
-e: f
-g:
-  h:
-  - i # has a list
-  - j
 `,
 		},
 


### PR DESCRIPTION
In writing an e2e test for kpt, I discovered a couple issues with the migration of the path/index/id annotation code I'd written earlier. The legacy annotations were being overwritten by the internal ones after being processed by functions. This PR fixes these bugs.

`copyAnnotations` should copy the annotations from one annotation (internal or legacy) to the other _only if_ the other is empty. That way, if a function changes one but not the other we still have both and `kio.reconcileInternalAnnotations` will detect that they are different and reconcile them. Additionally, I added a check to detect if either the legacy or internal index annotation is set, in which case it should be copied to the other and not overwritten by the reader. 

I've also added some unit tests to verify that it now behaves correctly. 