### PR TITLE
Order HorizontalPodAutoscaler before Deployment

### DIFF
--- a/kyaml/resid/gvk.go
+++ b/kyaml/resid/gvk.go
@@ -148,6 +148,7 @@ var orderFirst = []string{
 	"Secret",
 	"Endpoints",
 	"Service",
+	"HorizontalPodAutoscaler",
 	"LimitRange",
 	"PriorityClass",
 	"PersistentVolume",


### PR DESCRIPTION
`HorizontalPodAutoscaler` should be deployed before `Deployment` because it controls the number of pods of deployments.