### PR TITLE
cache git clone directories between builds

### DIFF
--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -4,21 +4,62 @@
 package git
 
 import (
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // Cloner is a function that can clone a git repo.
 type Cloner func(repoSpec *RepoSpec) error
 
+// gitCacheRootDir returns a directory for caching git clones. The directory
+// "$XDG_CACHE_HOME/kustomize" is preferred if the environment variable is set,
+// otherwise "$HOME/.cache/kustomize" is used. If the user's home dir cannot be
+// determined, then "<system temp dir>/kustomize" is used as a fallback.
+func gitCacheRootDir() string {
+	// Try "$XDG_CACHE_HOME/kustomize".
+	if dir := os.Getenv(konfig.XdgCacheHomeEnv); dir != "" {
+		return filepath.Join(dir, konfig.ProgramName)
+	}
+
+	// Try "$HOME/.cache/kustomize".
+	if usr, err := user.Current(); err == nil && usr.HomeDir != "" {
+		return filepath.Join(usr.HomeDir, konfig.XdgCacheHomeEnvDefault, konfig.ProgramName)
+	}
+
+	// Fallback to "<system temp dir>/kustomize".
+	return filepath.Join(os.TempDir(), konfig.ProgramName)
+}
+
 // ClonerUsingGitExec uses a local git install, as opposed
 // to say, some remote API, to obtain a local clone of
 // a remote repo.
 func ClonerUsingGitExec(repoSpec *RepoSpec) error {
-	r, err := newCmdRunner(repoSpec.Timeout)
+	var dir filesys.ConfirmedDir
+	var err error
+	if repoSpec.Cached {
+		// Create a cache directory.
+		dir, err = filesys.NewCachedConfirmedDir(gitCacheRootDir(), repoSpec.Host, repoSpec.OrgRepo, repoSpec.Ref)
+	} else {
+		// Create a temporary directory.
+		dir, err = filesys.NewTmpConfirmedDir()
+	}
+
+	repoSpec.Dir = dir
+	if err == filesys.ErrCachedDirExists {
+		// Cached directory already exists, nothing more to do here!
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	r, err := newCmdRunner(dir, repoSpec.Timeout)
 	if err != nil {
 		return err
 	}
-	repoSpec.Dir = r.dir
 	if err = r.run("init"); err != nil {
 		return err
 	}

--- a/api/internal/git/gitrunner.go
+++ b/api/internal/git/gitrunner.go
@@ -21,14 +21,10 @@ type gitRunner struct {
 
 // newCmdRunner returns a gitRunner if it can find the binary.
 // It also creats a temp directory for cloning repos.
-func newCmdRunner(timeout time.Duration) (*gitRunner, error) {
+func newCmdRunner(dir filesys.ConfirmedDir, timeout time.Duration) (*gitRunner, error) {
 	gitProgram, err := exec.LookPath("git")
 	if err != nil {
 		return nil, errors.Wrap(err, "no 'git' program on path")
-	}
-	dir, err := filesys.NewTmpConfirmedDir()
-	if err != nil {
-		return nil, err
 	}
 	return &gitRunner{
 		gitProgram: gitProgram,

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -236,6 +236,7 @@ func TestPeelQuery(t *testing.T) {
 		path       string
 		ref        string
 		submodules bool
+		cached     bool
 		timeout    time.Duration
 	}{
 		"t1": {
@@ -350,14 +351,24 @@ func TestPeelQuery(t *testing.T) {
 			submodules: false,
 			timeout:    61 * time.Second,
 		},
+		"t16": {
+			input:      "somerepos?version=master&cache=true",
+			path:       "somerepos",
+			ref:        "master",
+			submodules: defaultSubmodules,
+			timeout:    defaultTimeout,
+			cached:     true,
+		},
 	}
+
 	for tn, tc := range testcases {
 		t.Run(tn, func(t *testing.T) {
-			path, ref, timeout, submodules := peelQuery(tc.input)
+			path, ref, timeout, submodules, cached := peelQuery(tc.input)
 			assert.Equal(t, tc.path, path, "path mismatch")
 			assert.Equal(t, tc.ref, ref, "ref mismatch")
 			assert.Equal(t, tc.timeout, timeout, "timeout mismatch")
 			assert.Equal(t, tc.submodules, submodules, "submodules mismatch")
+			assert.Equal(t, tc.cached, cached, "cache mismatch")
 		})
 	}
 }

--- a/api/konfig/general.go
+++ b/api/konfig/general.go
@@ -28,6 +28,14 @@ const (
 	// Use this when XdgConfigHomeEnv not defined.
 	XdgConfigHomeEnvDefault = ".config"
 
+	// An environment variable to consult for kustomization
+	// cached data.  See:
+	// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+	XdgCacheHomeEnv = "XDG_CACHE_HOME"
+
+	// Use this when XdgCacheHomeEnv not defined.
+	XdgCacheHomeEnvDefault = ".cache"
+
 	// A program name, for use in help, finding the XDG_CONFIG_DIR, etc.
 	ProgramName = "kustomize"
 

--- a/kyaml/filesys/confirmeddir.go
+++ b/kyaml/filesys/confirmeddir.go
@@ -4,7 +4,11 @@
 package filesys
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -29,6 +33,83 @@ func NewTmpConfirmedDir() (ConfirmedDir, error) {
 	// resolve the real absolute path.
 	deLinked, err := filepath.EvalSymlinks(n)
 	return ConfirmedDir(deLinked), err
+}
+
+// simplifyAndHash transforms the given string in such a way to avoid filepath
+// collisions. A single level of a filepaths cannot contain slashes, so those
+// must be removed. Some filesystems do differentiate between lower and
+// uppercase letters, so those must be normalized as well. The resulting
+// strings could easily collide, such as "example/git-repo"
+// ("example-git-repo") and "Example-Git/repo" (also "example-git-repo"). This
+// function also appends a hash of the given string to eliminate this ambiguity
+// and prevent filepath collisions.
+func simplifyAndHash(s string) string {
+	var result string
+	// Convert the original string to lowercase, and keep any alphanumeric
+	// characters. Replace anything else with a dash character.
+	for _, char := range strings.ToLower(s) {
+		switch {
+		case '0' <= char && char <= '9':
+			result += string(char)
+		case 'a' <= char && char <= 'z':
+			result += string(char)
+		default:
+			result += "-"
+		}
+	}
+
+	// Trim any dash characters from the start or end.
+	result = strings.Trim(result, "-")
+
+	// Compute a hash of the original string, and append it as a suffix.
+	// Why sha1? The algorithm choice doesn't matter as we are only attempting
+	// to avoid filepath collisions. This is not considered a cryptographic
+	// operation, so we do not need to prevent hash reversals.
+	hash := sha1.Sum([]byte(s))
+	result += "-" + hex.EncodeToString(hash[:])
+
+	return result
+}
+
+// ErrCachedDirExists is a sentinel error indicating that a cached directory
+// currently exists, and does not need to be repopulated by (for example)
+// running a git clone.
+var ErrCachedDirExists = errors.New("cached directory exists")
+
+// NewCachedConfirmedDir returns a cache directory. This directory is rooted
+// under the given cacheDir and named after the other given git values. The
+// sentinel error ErrCachedDirExists is returned in the event that the cache
+// directory already exists.
+func NewCachedConfirmedDir(cacheDir, gitHost, gitRepo, gitRef string) (ConfirmedDir, error) {
+	dir := filepath.Join(
+		cacheDir,
+		simplifyAndHash(gitHost),
+		simplifyAndHash(gitRepo),
+		gitRef,
+	)
+
+	// Check if the final cache dir exists and was cloned into. If it does, we
+	// know that it was populated by a previous clone operation, which
+	// subsequently can now be ignored. Return the ErrCachedDirExists sentinel
+	// error to signal to the caller that the cache directory already exists.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "index")); err == nil {
+		return ConfirmedDir(dir), ErrCachedDirExists
+	}
+
+	// There is a chance that the final cache directory was partially
+	// initialized, for example if a user hit ^C, or took too long to unlock
+	// their SSH key. Attempt to remove the directory, and if it doesn't exist
+	// then it's just a nop.
+	if err := os.RemoveAll(dir); err != nil {
+		return "", err
+	}
+
+	// Create the final cache directory.
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+
+	return ConfirmedDir(dir), nil
 }
 
 // HasPrefix returns true if the directory argument


### PR DESCRIPTION
A resource url can now include a `?cache=true` parameter which will cause
kustomize build to cache the directory used for git cloning between runs. This
enables kustomize to clone a unique resource reference only once.

This PR introduces a git clone caching concept that is opt-in, configurable per-resource, and **does not change existing behavior**.

Repositories will be cloned into a directory under `$XDG_CACHE_HOME/kustomize`, `$HOME/.cache/kustomize`, or `<system temp dir>/kustomize`. The existence of this directory will then be checked at `kustomize build` time, and the git cloner will nop if the underlying resource was already fetched.

---

You can now write a `kustomization.yaml` like this:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  # Latest commit from master.
  - git@github.com:kubernetes-sigs/kustomize/examples/helloWorld?ref=ed763991def7d7521df298d9d8d87761e02c6228&cache=true
```

If you try to `kustomize build` the above example, the first build will take a few seconds, but subsequent builds will be instant:

```
$ time kustomize build . &>/dev/null
kustomize build . &> /dev/null  1.01s user 1.55s system 24% cpu 10.340 total

$ time kustomize build . &>/dev/null
kustomize build . &> /dev/null  0.02s user 0.01s system 97% cpu 0.031 total

$ time kustomize build . &>/dev/null
kustomize build . &> /dev/null  0.02s user 0.01s system 96% cpu 0.033 total
```

The contents of this git clone cache can be viewed like so:

```
$ tree $XDG_CACHE_HOME/kustomize | head
~/.cache/kustomize
└── git-github-com-71bc7fe94461f8cc6e95ccb85c1d2fbb25e85379
    └── kubernetes-sigs-kustomize-4b8dfb53b2b9de44451843d1c56c4dbc8f45d089
        └── ed763991def7d7521df298d9d8d87761e02c6228
            ├── CONTRIBUTING.md
            ├── LICENSE
            ├── Makefile
            ...
```

Inspired by #3655

Fixes #2460


ALLOW_MODULE_SPAN