### PR TITLE
Handle "Result" errors as non-fatal errors in kyaml FilterFuncs

### DIFF
--- a/kyaml/fn/framework/framework.go
+++ b/kyaml/fn/framework/framework.go
@@ -142,7 +142,7 @@ func Execute(p ResourceListProcessor, rlSource *kio.ByteReadWriter) error {
 // Filter executes the given kio.Filter and replaces the ResourceList's items with the result.
 // This can be used to help implement ResourceListProcessors. See SimpleProcessor for example.
 //
-// Filters that return a Result as error will store the result in the ResourceList instead of
+// Filters that return a Result as error will store the result in the ResourceList
 // and continue processing instead of erroring out.
 func (rl *ResourceList) Filter(api kio.Filter) error {
 	var err error


### PR DESCRIPTION
**Context & Description**

kyaml currently has no way of updating `ResourceList.Result` unless a custom processor is created by the end user.
This PR updates `ResourceList.Filter` used by all current processors so whenever the `kio.Filter` returns an error type `*Result` it will be assigned to `ResourceList.Result` instead of erroring out as is the current behavior.

This behavior change in `ResourceList.Filter` is a breaking change in the API, I believe this should be OK because IIUC this use case is not adopted widely.

**Alternative Considered**

Instead of special error handling, we can introduce a new `Resulter{ Result(...) (*Result, error) }` interface that can be implemented by the KRM's `Filter()`, but when trying this out it feels very non-idiomatic because in most cases where we want a `Resulter` we would also have a  no-op filter like `func (myExample) Filter(in) { return in, nil }`.

This is also an extra things to be kept in mind from KRM function authors because the interface is not explicitly called out and the behaviors can be unexpected and non idiomatic.

However this does avoid the breaking change.

**Workaround**
Introduce a new value in `Result.Severity` called `Fatal`, the `ResourceList.Filter` function could verify this value when applicable and throw an actual error instead of keep going.
(Or.. we can make erroring out the default behavior but adding a new `Result.NoError` flag to trigger this new behavior.

**Additional Notes**
- This PR is built on top of PR #4235, the first 2 commits are not part of this change.
- I also have a `function/example` that goes with this change but is blocked by this PR being merged because of go-modules
- This change has been discussed briefly with Katrina Verey and Jeremy Rickard (in case this needs to be discussed in a Kustomize meeting)