### PR TITLE
fix issue with quotations being dropped in configmap generation

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -550,6 +550,7 @@ metadata:
 `)
 }
 
+// regression test for https://github.com/kubernetes-sigs/kustomize/issues/4233
 func TestDataEndsWithQuotes(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK(".", `
@@ -562,14 +563,12 @@ configMapGenerator:
 `)
 
 	m := th.Run(".", th.MakeDefaultOptions())
-	// The annotations are sorted by key, hence the order change.
-	// Quotes are added intentionally.
 	th.AssertActualEqualsExpected(
 		m, `apiVersion: v1
 data:
-  TEST: this is a 'test
+  TEST: this is a 'test'
 kind: ConfigMap
 metadata:
-  name: test-k7hhfb697g
+  name: test-k9cc55dfm5
 `)
 }

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -209,5 +209,17 @@ func parseLiteralSource(source string) (keyName, value string, err error) {
 	if len(items) != 2 {
 		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
 	}
-	return items[0], strings.Trim(items[1], "\"'"), nil
+	return items[0], removeQuotes(items[1]), nil
+}
+
+// removeQuotes removes the surrounding quotes from the provided string only if it is surrounded on both sides
+// rather than blindly trimming all quotation marks on either side.
+func removeQuotes(str string) string {
+	if len(str) == 0 || str[0] != str[len(str)-1] {
+		return str
+	}
+	if str[0] == '"' || str[0] == '\'' {
+		return str[1 : len(str)-1]
+	}
+	return str
 }


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kustomize/issues/4233