### PR TITLE
provide utility helpers for preserving internal annotations

### DIFF
--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -26,6 +26,7 @@ type Resource struct {
 	refVarNames []string
 }
 
+// nolint
 var BuildAnnotations = []string{
 	utils.BuildAnnotationPreviousKinds,
 	utils.BuildAnnotationPreviousNames,

--- a/cmd/config/internal/commands/cat.go
+++ b/cmd/config/internal/commands/cat.go
@@ -166,6 +166,7 @@ func (r *CatRunner) catFilters() []kio.Filter {
 	return fltrs
 }
 
+// nolint
 func (r *CatRunner) out(w io.Writer) ([]kio.Writer, error) {
 	var outputs []kio.Writer
 	var functionConfig *yaml.RNode

--- a/cmd/config/internal/commands/sink.go
+++ b/cmd/config/internal/commands/sink.go
@@ -46,6 +46,7 @@ See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.`)
 	return err
 }
 
+// nolint
 func (r *SinkRunner) runE(c *cobra.Command, args []string) error {
 	var outputs []kio.Writer
 	if len(args) == 1 {


### PR DESCRIPTION
Task 4 in https://github.com/kubernetes-sigs/kustomize/issues/4024, implementing [function spec v1](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md#krm-functions-specification).

This adds some helper functions for function authors to kyaml for preserving annotations with the prefix `internal.config.kubernetes.io`. 

It should go in the same release as #4248 and #4249.

ALLOW_MODULE_SPAN