### PR TITLE
Implementation of k8s backend to run krm functions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,8 +46,8 @@ jobs:
         working-directory: ./kyaml
 
       - name: Test api
-        run: go test -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=v444.333.222"
-        working-directory: ./api
+        run: make install-tools test-unit-kustomize-api #go test -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=v444.333.222"
+        working-directory: ./
 
       - name: Test cmd/config
         run: go test -cover ./...

--- a/api/types/pluginrestrictions.go
+++ b/api/types/pluginrestrictions.go
@@ -59,4 +59,16 @@ type FnPluginLoadingOptions struct {
 	AsCurrentUser bool
 	// Run in this working directory
 	WorkingDir string
+	// Use Kubectl as backend for containers instead of Docker to run krm-function
+	UseKubectl bool
+	// List of global arguments for kubectl, e.g. -n for namespace & etc
+	KubectlGlobalArgs string
+	// Name of PodTemplate (must exist in the same namespace where pod will start) to use
+	// for creation of Pod to run krm function. That allows to set Mounted Volumes,
+	// Network Policies and etc.
+	// Can be empty - default template will be used
+	PodTemplateName string
+	// Maximum time to wait until the pod start. Can be nil in that case default (60s)
+	// will be used
+	PodStartTimeout string
 }

--- a/kustomize/commands/build/flagsforfunctions.go
+++ b/kustomize/commands/build/flagsforfunctions.go
@@ -33,4 +33,23 @@ func AddFunctionAlphaEnablementFlags(set *pflag.FlagSet) {
 	set.BoolVar(
 		&theFlags.fnOptions.EnableStar, "enable-star", false,
 		"enable support for starlark functions. (Alpha)")
+
+	set.BoolVar(
+		&theFlags.fnOptions.UseKubectl, "enable-in-a-pod", false,
+		"enable support for krm-functions running in pod instead of docker; "+
+			"requires kubectl. (Alpha)")
+	set.StringVar(
+		&theFlags.fnOptions.KubectlGlobalArgs, "pod-kubectl-args", "",
+		"list of global arguments to be used to run krm-functions in pod, "+
+			"e.g. -n namespace. (Alpha)")
+
+	set.StringVar(
+		&theFlags.fnOptions.PodTemplateName, "pod-template-name", "",
+		"тame of PodTemplate that will be used for creation of the pod to"+
+			"run krm-function. Must exist in the same namespace where"+
+			"krm-function is going to be ran (Alpha)")
+
+	set.StringVar(
+		&theFlags.fnOptions.PodStartTimeout, "pod-start-timeout", "",
+		"Maximum amount of time to wait until the pod start. (Alpha)")
 }

--- a/kyaml/fn/runtime/container/container.go
+++ b/kyaml/fn/runtime/container/container.go
@@ -4,198 +4,70 @@
 package container
 
 import (
-	"fmt"
-	"os"
+	"time"
 
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/docker"
 	runtimeexec "sigs.k8s.io/kustomize/kyaml/fn/runtime/exec"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/kubectl"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
-
+	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// Filter filters Resources using a container image.
-// The container must start a process that reads the list of
-// input Resources from stdin, reads the Configuration from the env
-// API_CONFIG, and writes the filtered Resources to stdout.
-// If there is a error or validation failure, the process must exit
-// non-zero.
-// The full set of environment variables from the parent process
-// are passed to the container.
-//
-// Function Scoping:
-// Filter applies the function only to Resources to which it is scoped.
-//
-// Resources are scoped to a function if any of the following are true:
-// - the Resource were read from the same directory as the function config
-// - the Resource were read from a subdirectory of the function config directory
-// - the function config is in a directory named "functions" and
-//   they were read from a subdirectory of "functions" parent
-// - the function config doesn't have a path annotation (considered globally scoped)
-// - the Filter has GlobalScope == true
-//
-// In Scope Examples:
-//
-// Example 1: deployment.yaml and service.yaml in function.yaml scope
-//            same directory as the function config directory
-//     .
-//     ├── function.yaml
-//     ├── deployment.yaml
-//     └── service.yaml
-//
-// Example 2: apps/deployment.yaml and apps/service.yaml in function.yaml scope
-//            subdirectory of the function config directory
-//     .
-//     ├── function.yaml
-//     └── apps
-//         ├── deployment.yaml
-//         └── service.yaml
-//
-// Example 3: apps/deployment.yaml and apps/service.yaml in functions/function.yaml scope
-//            function config is in a directory named "functions"
-//     .
-//     ├── functions
-//     │   └── function.yaml
-//     └── apps
-//         ├── deployment.yaml
-//         └── service.yaml
-//
-// Out of Scope Examples:
-//
-// Example 1: apps/deployment.yaml and apps/service.yaml NOT in stuff/function.yaml scope
-//     .
-//     ├── stuff
-//     │   └── function.yaml
-//     └── apps
-//         ├── deployment.yaml
-//         └── service.yaml
-//
-// Example 2: apps/deployment.yaml and apps/service.yaml NOT in stuff/functions/function.yaml scope
-//     .
-//     ├── stuff
-//     │   └── functions
-//     │       └── function.yaml
-//     └── apps
-//         ├── deployment.yaml
-//         └── service.yaml
-//
-// Default Paths:
-// Resources emitted by functions will have default path applied as annotations
-// if none is present.
-// The default path will be the function-dir/ (or parent directory in the case of "functions")
-// + function-file-name/ + namespace/ + kind_name.yaml
-//
-// Example 1: Given a function in fn.yaml that produces a Deployment name foo and a Service named bar
-//     dir
-//     └── fn.yaml
-//
-// Would default newly generated Resources to:
-//
-//     dir
-//     ├── fn.yaml
-//     └── fn
-//         ├── deployment_foo.yaml
-//         └── service_bar.yaml
-//
-// Example 2: Given a function in functions/fn.yaml that produces a Deployment name foo and a Service named bar
-//     dir
-//     └── fn.yaml
-//
-// Would default newly generated Resources to:
-//
-//     dir
-//     ├── functions
-//     │   └── fn.yaml
-//     └── fn
-//         ├── deployment_foo.yaml
-//         └── service_bar.yaml
-//
-// Example 3: Given a function in fn.yaml that produces a Deployment name foo, namespace baz and a Service named bar namespace baz
-//     dir
-//     └── fn.yaml
-//
-// Would default newly generated Resources to:
-//
-//     dir
-//     ├── fn.yaml
-//     └── fn
-//         └── baz
-//             ├── deployment_foo.yaml
-//             └── service_bar.yaml
 type Filter struct {
 	runtimeutil.ContainerSpec `json:",inline" yaml:",inline"`
 
-	Exec runtimeexec.Filter
-
 	UIDGID string
+
+	UseKubectl        bool
+	KubectlGlobalArgs []string
+	PodTemplateName   string
+	PodStartTimeout   *time.Duration
+
+	Exec runtimeexec.Filter
 }
 
-func (c Filter) String() string {
-	if c.Exec.DeferFailure {
-		return fmt.Sprintf("%s deferFailure: %v", c.Image, c.Exec.DeferFailure)
-	}
-	return c.Image
-}
-func (c Filter) GetExit() error {
-	return c.Exec.GetExit()
+func NewContainer(spec runtimeutil.ContainerSpec, uidgid string, useKubectl bool, podTemplateName string, kubectlGlobalArgs []string, podStartTimeout *time.Duration) Filter {
+	f := Filter{ContainerSpec: spec, UIDGID: uidgid, UseKubectl: useKubectl, KubectlGlobalArgs: kubectlGlobalArgs, PodTemplateName: podTemplateName, PodStartTimeout: podStartTimeout}
+
+	return f
 }
 
 func (c *Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-	if err := c.setupExec(); err != nil {
-		return nil, err
+
+	var ifc kio.Filter
+	if c.UseKubectl {
+		flt := kubectl.NewContainer(c.ContainerSpec, c.PodTemplateName, c.KubectlGlobalArgs, c.PodStartTimeout)
+		flt.Exec.FunctionConfig = c.Exec.FunctionConfig
+		flt.Exec.GlobalScope = c.Exec.GlobalScope
+		flt.Exec.ResultsFile = c.Exec.ResultsFile
+		flt.Exec.DeferFailure = c.Exec.DeferFailure
+		ifc = &flt
+	} else {
+		flt := docker.NewContainer(c.ContainerSpec, c.UIDGID)
+		flt.Exec.FunctionConfig = c.Exec.FunctionConfig
+		flt.Exec.GlobalScope = c.Exec.GlobalScope
+		flt.Exec.ResultsFile = c.Exec.ResultsFile
+		flt.Exec.DeferFailure = c.Exec.DeferFailure
+		ifc = &flt
 	}
-	return c.Exec.Filter(nodes)
+	return ifc.Filter(nodes)
 }
 
-func (c *Filter) setupExec() error {
-	// don't init 2x
-	if c.Exec.Path != "" {
-		return nil
+func (c *Filter) String() string {
+	if c.UseKubectl {
+		flt := kubectl.NewContainer(c.ContainerSpec, c.PodTemplateName, c.KubectlGlobalArgs, c.PodStartTimeout)
+		flt.Exec.FunctionConfig = c.Exec.FunctionConfig
+		flt.Exec.GlobalScope = c.Exec.GlobalScope
+		flt.Exec.ResultsFile = c.Exec.ResultsFile
+		flt.Exec.DeferFailure = c.Exec.DeferFailure
+		return flt.String()
+	} else {
+		flt := docker.NewContainer(c.ContainerSpec, c.UIDGID)
+		flt.Exec.FunctionConfig = c.Exec.FunctionConfig
+		flt.Exec.GlobalScope = c.Exec.GlobalScope
+		flt.Exec.ResultsFile = c.Exec.ResultsFile
+		flt.Exec.DeferFailure = c.Exec.DeferFailure
+		return flt.String()
 	}
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	c.Exec.WorkingDir = wd
-
-	path, args := c.getCommand()
-	c.Exec.Path = path
-	c.Exec.Args = args
-	return nil
-}
-
-// getArgs returns the command + args to run to spawn the container
-func (c *Filter) getCommand() (string, []string) {
-	network := runtimeutil.NetworkNameNone
-	if c.ContainerSpec.Network {
-		network = runtimeutil.NetworkNameHost
-	}
-	// run the container using docker.  this is simpler than using the docker
-	// libraries, and ensures things like auth work the same as if the container
-	// was run from the cli.
-	args := []string{"run",
-		"--rm",                                              // delete the container afterward
-		"-i", "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR", // attach stdin, stdout, stderr
-		"--network", string(network),
-
-		// added security options
-		"--user", c.UIDGID,
-		"--security-opt=no-new-privileges", // don't allow the user to escalate privileges
-		// note: don't make fs readonly because things like heredoc rely on writing tmp files
-	}
-
-	// TODO(joncwong): Allow StorageMount fields to have default values.
-	for _, storageMount := range c.StorageMounts {
-		args = append(args, "--mount", storageMount.String())
-	}
-
-	args = append(args, runtimeutil.NewContainerEnvFromStringSlice(c.Env).GetDockerFlags()...)
-	a := append(args, c.Image)
-	return "docker", a
-}
-
-// NewContainer returns a new container filter
-func NewContainer(spec runtimeutil.ContainerSpec, uidgid string) Filter {
-	f := Filter{ContainerSpec: spec, UIDGID: uidgid}
-
-	return f
 }

--- a/kyaml/fn/runtime/docker/docker.go
+++ b/kyaml/fn/runtime/docker/docker.go
@@ -1,0 +1,201 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"fmt"
+	"os"
+
+	runtimeexec "sigs.k8s.io/kustomize/kyaml/fn/runtime/exec"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// Filter filters Resources using a container image.
+// The container must start a process that reads the list of
+// input Resources from stdin, reads the Configuration from the env
+// API_CONFIG, and writes the filtered Resources to stdout.
+// If there is a error or validation failure, the process must exit
+// non-zero.
+// The full set of environment variables from the parent process
+// are passed to the container.
+//
+// Function Scoping:
+// Filter applies the function only to Resources to which it is scoped.
+//
+// Resources are scoped to a function if any of the following are true:
+// - the Resource were read from the same directory as the function config
+// - the Resource were read from a subdirectory of the function config directory
+// - the function config is in a directory named "functions" and
+//   they were read from a subdirectory of "functions" parent
+// - the function config doesn't have a path annotation (considered globally scoped)
+// - the Filter has GlobalScope == true
+//
+// In Scope Examples:
+//
+// Example 1: deployment.yaml and service.yaml in function.yaml scope
+//            same directory as the function config directory
+//     .
+//     ├── function.yaml
+//     ├── deployment.yaml
+//     └── service.yaml
+//
+// Example 2: apps/deployment.yaml and apps/service.yaml in function.yaml scope
+//            subdirectory of the function config directory
+//     .
+//     ├── function.yaml
+//     └── apps
+//         ├── deployment.yaml
+//         └── service.yaml
+//
+// Example 3: apps/deployment.yaml and apps/service.yaml in functions/function.yaml scope
+//            function config is in a directory named "functions"
+//     .
+//     ├── functions
+//     │   └── function.yaml
+//     └── apps
+//         ├── deployment.yaml
+//         └── service.yaml
+//
+// Out of Scope Examples:
+//
+// Example 1: apps/deployment.yaml and apps/service.yaml NOT in stuff/function.yaml scope
+//     .
+//     ├── stuff
+//     │   └── function.yaml
+//     └── apps
+//         ├── deployment.yaml
+//         └── service.yaml
+//
+// Example 2: apps/deployment.yaml and apps/service.yaml NOT in stuff/functions/function.yaml scope
+//     .
+//     ├── stuff
+//     │   └── functions
+//     │       └── function.yaml
+//     └── apps
+//         ├── deployment.yaml
+//         └── service.yaml
+//
+// Default Paths:
+// Resources emitted by functions will have default path applied as annotations
+// if none is present.
+// The default path will be the function-dir/ (or parent directory in the case of "functions")
+// + function-file-name/ + namespace/ + kind_name.yaml
+//
+// Example 1: Given a function in fn.yaml that produces a Deployment name foo and a Service named bar
+//     dir
+//     └── fn.yaml
+//
+// Would default newly generated Resources to:
+//
+//     dir
+//     ├── fn.yaml
+//     └── fn
+//         ├── deployment_foo.yaml
+//         └── service_bar.yaml
+//
+// Example 2: Given a function in functions/fn.yaml that produces a Deployment name foo and a Service named bar
+//     dir
+//     └── fn.yaml
+//
+// Would default newly generated Resources to:
+//
+//     dir
+//     ├── functions
+//     │   └── fn.yaml
+//     └── fn
+//         ├── deployment_foo.yaml
+//         └── service_bar.yaml
+//
+// Example 3: Given a function in fn.yaml that produces a Deployment name foo, namespace baz and a Service named bar namespace baz
+//     dir
+//     └── fn.yaml
+//
+// Would default newly generated Resources to:
+//
+//     dir
+//     ├── fn.yaml
+//     └── fn
+//         └── baz
+//             ├── deployment_foo.yaml
+//             └── service_bar.yaml
+type Filter struct {
+	runtimeutil.ContainerSpec `json:",inline" yaml:",inline"`
+
+	Exec runtimeexec.Filter
+
+	UIDGID string
+}
+
+func (c Filter) String() string {
+	if c.Exec.DeferFailure {
+		return fmt.Sprintf("%s deferFailure: %v", c.Image, c.Exec.DeferFailure)
+	}
+	return c.Image
+}
+func (c Filter) GetExit() error {
+	return c.Exec.GetExit()
+}
+
+func (c *Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	if err := c.setupExec(); err != nil {
+		return nil, err
+	}
+	return c.Exec.Filter(nodes)
+}
+
+func (c *Filter) setupExec() error {
+	// don't init 2x
+	if c.Exec.Path != "" {
+		return nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	c.Exec.WorkingDir = wd
+
+	path, args := c.getCommand()
+	c.Exec.Path = path
+	c.Exec.Args = args
+	return nil
+}
+
+// getArgs returns the command + args to run to spawn the container
+func (c *Filter) getCommand() (string, []string) {
+	network := runtimeutil.NetworkNameNone
+	if c.ContainerSpec.Network {
+		network = runtimeutil.NetworkNameHost
+	}
+	// run the container using docker.  this is simpler than using the docker
+	// libraries, and ensures things like auth work the same as if the container
+	// was run from the cli.
+	args := []string{"run",
+		"--rm",                                              // delete the container afterward
+		"-i", "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR", // attach stdin, stdout, stderr
+		"--network", string(network),
+
+		// added security options
+		"--user", c.UIDGID,
+		"--security-opt=no-new-privileges", // don't allow the user to escalate privileges
+		// note: don't make fs readonly because things like heredoc rely on writing tmp files
+	}
+
+	// TODO(joncwong): Allow StorageMount fields to have default values.
+	for _, storageMount := range c.StorageMounts {
+		args = append(args, "--mount", storageMount.String())
+	}
+
+	args = append(args, runtimeutil.NewContainerEnvFromStringSlice(c.Env).GetDockerFlags()...)
+	a := append(args, c.Image)
+	return "docker", a
+}
+
+// NewContainer returns a new container filter
+func NewContainer(spec runtimeutil.ContainerSpec, uidgid string) Filter {
+	f := Filter{ContainerSpec: spec, UIDGID: uidgid}
+
+	return f
+}

--- a/kyaml/fn/runtime/docker/docker_test.go
+++ b/kyaml/fn/runtime/docker/docker_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package container
+package docker
 
 import (
 	"bytes"

--- a/kyaml/fn/runtime/kubectl/kubectl.go
+++ b/kyaml/fn/runtime/kubectl/kubectl.go
@@ -1,0 +1,335 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubectl
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	osexec "os/exec"
+	"time"
+
+	runtimeexec "sigs.k8s.io/kustomize/kyaml/fn/runtime/exec"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// We're running krm via kubectl here:
+// 1. If PodTemplateName is set - taking it from kubectl (the same namespace), and using defaultPodTemplate overwise. See some mandatory fields values there, e.g. stdin.
+// 2. Creating pod using PodTemplate spec and applying imageUrl and set of envs
+// 3. Waiting maximum PodStartTimeout for the pod up and running
+// 4. using kubectl attach -q to send input and to get output
+// 5. deleting the created pod
+
+const (
+	defaultPodTemplate = `
+{
+    "apiVersion": "v1",
+    "kind": "PodTemplate",
+    "metadata": {
+        "name": "not-important",
+        "labels": {
+                "app": "krm-pod"
+        }
+    },
+    "template": {
+        "spec": {
+            "containers": [
+                {
+                    "name": "default",
+                    "stdin": true,
+                    "stdinOnce": true
+                }
+            ],
+            "restartPolicy": "Never"
+	}
+    }
+}
+`
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+)
+
+var (
+	podTemplateCache        = ""
+	podTemplateCacheForName = ""
+)
+
+type Filter struct {
+	runtimeutil.ContainerSpec `json:",inline" yaml:",inline"`
+
+	PodTemplateName   string
+	KubectlGlobalArgs []string
+
+	PodStartTimeout *time.Duration
+
+	Exec runtimeexec.Filter
+}
+
+var rng *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphanums[rng.Intn(len(alphanums))]
+	}
+	return string(b)
+}
+
+func mergeYamlStrings(y1, y2 string) (string, error) {
+	var data1 []map[string]interface{}
+	err := yaml.Unmarshal([]byte(y1), &data1)
+	if err != nil {
+		return "", fmt.Errorf("couldn't unmarshal %s: %w", y1, err)
+	}
+	var data2 []map[string]interface{}
+	err = yaml.Unmarshal([]byte(y2), &data2)
+	if err != nil {
+		return "", fmt.Errorf("couldn't unmarshal %s: %w", y1, err)
+	}
+
+	for i := range data2 {
+		for j := range data1 {
+			if data1[j]["name"] == data2[i]["name"] {
+				// TODO - maybe first will override second?
+				return "", fmt.Errorf("key %v exists in both yamls", data1[j]["name"])
+			}
+		}
+	}
+
+	data1 = append(data1, data2...)
+
+	r, err := yaml.Marshal(data1)
+	if err != nil {
+		return "", fmt.Errorf("couldn't marshal %v: %w", data1, err)
+	}
+	return string(r), nil
+}
+
+func (c Filter) String() string {
+	if c.Exec.DeferFailure {
+		return fmt.Sprintf("%s deferFailure: %v", c.Image, c.Exec.DeferFailure)
+	}
+	return c.Image
+}
+func (c Filter) GetExit() error {
+	return c.Exec.GetExit()
+}
+
+func (c Filter) getPodTemplate() (*yaml.RNode, error) {
+	if podTemplateCache == "" || podTemplateCacheForName != c.PodTemplateName {
+		if c.PodTemplateName != "" {
+			args := append(c.GetKubectlGlobalArgs(),
+				"get",
+				fmt.Sprintf("podTemplate/%s", c.PodTemplateName),
+				"-o",
+				"json")
+			out, err := osexec.Command("kubectl", args...).Output()
+			if err != nil {
+				return nil, fmt.Errorf("kubectl %v failed: %w", args, err)
+			}
+			podTemplateCache = string(out)
+		} else {
+			podTemplateCache = defaultPodTemplate
+		}
+		podTemplateCacheForName = c.PodTemplateName
+	}
+
+	return yaml.ConvertJSONToYamlNode(podTemplateCache)
+}
+
+func (c Filter) getPodConfig(podName string) (string, error) {
+	template, err := c.getPodTemplate()
+	if err != nil {
+		return "", fmt.Errorf("getPodTemplate failed: %w", err)
+	}
+
+	res, err := yaml.Parse(
+		fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+`,
+			podName,
+		),
+	)
+
+	spec, err := template.Pipe(yaml.PathGetter{Path: []string{"template", "spec"}})
+	if err != nil {
+		return "", fmt.Errorf("PathGetter for spec failed: %w", err)
+	}
+	if spec == nil {
+		return "", fmt.Errorf("specified template doesn't contain spec")
+	}
+	err = res.PipeE(yaml.FieldSetter{Name: "spec", Value: spec})
+	if err != nil {
+		return "", fmt.Errorf("FieldSetter for spec failed: %w", err)
+	}
+
+	// set remaining fields
+	// labels:
+	labels, err := template.Pipe(yaml.PathGetter{Path: []string{"metadata", "labels"}})
+	if err != nil {
+		return "", fmt.Errorf("PathGetter for spec failed: %w", err)
+	}
+	if labels != nil {
+		metadata, err := res.Pipe(yaml.PathGetter{Path: []string{"metadata"}})
+		if err != nil {
+			return "", fmt.Errorf("PathGetter for metadata failed: %w", err)
+		}
+		err = metadata.PipeE(yaml.FieldSetter{Name: "labels", Value: labels})
+		if err != nil {
+			return "", fmt.Errorf("FieldSetter for metadata failed: %w", err)
+		}
+	}
+
+	// image:
+	container, err := res.Pipe(yaml.PathGetter{Path: []string{"spec", "containers", "0"}})
+	if err != nil {
+		return "", fmt.Errorf("PathGetter for default container failed: %w", err)
+	}
+	err = container.PipeE(yaml.FieldSetter{Name: "image", StringValue: c.Image})
+	if err != nil {
+		return "", fmt.Errorf("FieldSetter for image failed: %w", err)
+	}
+	// env:
+	tmpltEnvData, err := res.Pipe(yaml.PathGetter{Path: []string{"spec", "containers", "0", "env"}})
+	if err != nil {
+		return "", fmt.Errorf("PathGetter for default container env failed: %w", err)
+	}
+	envDataStr := runtimeutil.NewContainerEnvFromStringSlice(c.Env).GetPodEnvConfig()
+	if tmpltEnvData != nil {
+		// update envDataStr with data from tmpltEnvData merged with envDataStr
+		tmpltEnvDataStr, err := tmpltEnvData.String()
+		if err != nil {
+			return "", fmt.Errorf("failed to convert tmpltEnvData to string: %w", err)
+		}
+		envDataStr, err = mergeYamlStrings(envDataStr, tmpltEnvDataStr)
+		if err != nil {
+			return "", fmt.Errorf("failed to merge %s and %s: %w", envDataStr, tmpltEnvDataStr, err)
+		}
+	}
+	envData, err := yaml.Parse(envDataStr)
+	if err != nil {
+		return "", fmt.Errorf("Wasn't able to parse env string: %w", err)
+	}
+	err = container.PipeE(yaml.FieldSetter{Name: "env", Value: envData})
+	if err != nil {
+		return "", fmt.Errorf("FieldSetter for env failed: %w", err)
+	}
+
+	str, err := res.String()
+	if err != nil {
+		return "", fmt.Errorf("couldn't convert to string: %w", err)
+	}
+	return str, nil
+}
+
+func (c *Filter) GetKubectlGlobalArgs() []string {
+	if c.KubectlGlobalArgs == nil {
+		return []string{}
+	}
+	return c.KubectlGlobalArgs
+}
+
+func (c *Filter) runKubctlPodCmd(podName, cmdLine string) error {
+	podConfig, err := c.getPodConfig(podName)
+	if err != nil {
+		return err
+	}
+
+	args := append(c.GetKubectlGlobalArgs(),
+		cmdLine,
+		"-f",
+		"-")
+
+	cmd := osexec.Command("kubectl", args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer stdin.Close()
+		io.WriteString(stdin, podConfig)
+	}()
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Filter) getPodStartTimeout() time.Duration {
+	if c.PodStartTimeout != nil {
+		return *c.PodStartTimeout
+	}
+
+	return 60 * time.Second
+}
+
+func (c *Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	podName := "krm-" + randString(5)
+
+	// prepare attach command
+	if err := c.setupExec(podName); err != nil {
+		return nil, fmt.Errorf("setup exec filter returned error: %w", err)
+	}
+	// start pod
+	if err := c.runKubctlPodCmd(podName, "create"); err != nil {
+		return nil, fmt.Errorf("apply returned error: %w", err)
+	}
+	// we we'll need to clean that up
+	defer c.runKubctlPodCmd(podName, "delete")
+
+	// wait till pod is up
+	args := append(c.GetKubectlGlobalArgs(),
+		"wait",
+		"--for=condition=Ready",
+		fmt.Sprintf("--timeout=%s", c.getPodStartTimeout().String()),
+		fmt.Sprintf("pod/%s", podName))
+
+	cmd := osexec.Command("kubectl", args...)
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl with args %v returned error: %w", args, err)
+	}
+
+	return c.Exec.Filter(nodes)
+}
+
+func (c *Filter) setupExec(podName string) error {
+	// don't init 2x
+	if c.Exec.Path != "" {
+		return nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	c.Exec.WorkingDir = wd
+
+	path, args := c.getCommand(podName)
+	c.Exec.Path = path
+	c.Exec.Args = args
+	return nil
+}
+
+// getArgs returns the command + args to run to spawn the container
+func (c *Filter) getCommand(podName string) (string, []string) {
+	args := append(c.GetKubectlGlobalArgs(),
+		"attach",
+		"-iq",
+		podName,
+	)
+	return "kubectl", args
+}
+
+// NewContainer returns a new container filter
+func NewContainer(spec runtimeutil.ContainerSpec, podTemplateName string, kubectlGlobalArgs []string, podStartTimeout *time.Duration) Filter {
+	f := Filter{ContainerSpec: spec, PodTemplateName: podTemplateName, KubectlGlobalArgs: kubectlGlobalArgs, PodStartTimeout: podStartTimeout}
+
+	return f
+}

--- a/kyaml/fn/runtime/kubectl/kubectl_test.go
+++ b/kyaml/fn/runtime/kubectl/kubectl_test.go
@@ -1,0 +1,130 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kubectl
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
+)
+
+func Test_getPodConfig(t *testing.T) {
+	var tests = []struct {
+		ContainerSpec     runtimeutil.ContainerSpec
+		PodTemplateName   string
+		KubectlGlobalArgs []string
+		PodStartTimeout   *time.Duration
+		ExpectedErr       bool
+		ExpectedPodConfig string
+	}{
+		{
+			ContainerSpec: runtimeutil.ContainerSpec{
+				Image: "example.com:version",
+			},
+			ExpectedPodConfig: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: krm-example
+  labels:
+    app: krm-pod
+spec:
+  containers:
+  - name: default
+    stdin: true
+    stdinOnce: true
+    image: example.com:version
+    env: [{"name": "LOG_TO_STDERR", "value": "true"}, {"name": "STRUCTURED_RESULTS", "value": "true"}]
+  restartPolicy: Never
+`,
+		},
+		{
+			ContainerSpec: runtimeutil.ContainerSpec{
+				Image: "example.com:version",
+				Env: []string{
+					"a=a",
+					"b",
+				},
+			},
+			ExpectedPodConfig: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: krm-example
+  labels:
+    app: krm-pod
+spec:
+  containers:
+  - name: default
+    stdin: true
+    stdinOnce: true
+    image: example.com:version
+    env: [{"name": "LOG_TO_STDERR", "value": "true"}, {"name": "STRUCTURED_RESULTS", "value": "true"}, {"name": "a", "value": "a"}, {"name": "b", "value": ""}]
+  restartPolicy: Never
+`,
+		},
+		{
+			PodTemplateName: "doesntExist",
+			ExpectedErr:     true,
+		},
+	}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(fmt.Sprintf("Test%d", i), func(t *testing.T) {
+			o := NewContainer(tt.ContainerSpec, tt.PodTemplateName, tt.KubectlGlobalArgs, tt.PodStartTimeout)
+
+			podConfig, err := o.getPodConfig("krm-example")
+			if tt.ExpectedErr {
+				if err == nil {
+					t.FailNow()
+				}
+			} else {
+				if err != nil {
+					t.FailNow()
+				}
+				if !assert.Equal(t, tt.ExpectedPodConfig[1:], podConfig) {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}
+
+func Test_mergeYamlStrings(t *testing.T) {
+	var tests = []struct {
+		Y1          string
+		Y2          string
+		Expected    string
+		ExpectedErr bool
+	}{
+		{
+			Y1: `[{"name": "LOG_TO_STDERR", "value": "true"}, {"name": "STRUCTURED_RESULTS", "value": "true"}, ]`,
+			Y2: `
+- name: x1
+  value: y1
+- name: x2
+  value: y2
+`,
+			Expected: `
+- name: LOG_TO_STDERR
+  value: "true"
+- name: STRUCTURED_RESULTS
+  value: "true"
+- name: x1
+  value: y1
+- name: x2
+  value: y2
+`,
+		},
+	}
+	for i := range tests {
+		r, _ := mergeYamlStrings(tests[i].Y1, tests[i].Y2)
+		if !assert.Equal(t, tests[i].Expected[1:], r) {
+			t.FailNow()
+		}
+	}
+}

--- a/kyaml/runfn/runfn_test.go
+++ b/kyaml/runfn/runfn_test.go
@@ -68,7 +68,7 @@ kind:
 		return
 	}
 	filter, _ := instance.functionFilterProvider(spec, api, currentUser)
-	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "nobody")
+	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "nobody", false, "", nil, nil)
 	cf := &c
 	cf.Exec.FunctionConfig = api
 	assert.Equal(t, cf, filter)
@@ -98,7 +98,7 @@ kind:
 		return
 	}
 	filter, _ := instance.functionFilterProvider(spec, api, currentUser)
-	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "1:2")
+	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "1:2", false, "", nil, nil)
 	cf := &c
 	cf.Exec.FunctionConfig = api
 	assert.Equal(t, cf, filter)
@@ -129,7 +129,7 @@ kind:
 		return
 	}
 	filter, _ := instance.functionFilterProvider(spec, api, currentUser)
-	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "nobody")
+	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "nobody", false, "", nil, nil)
 	cf := &c
 	cf.Exec.FunctionConfig = api
 	cf.Exec.GlobalScope = true


### PR DESCRIPTION
We currently have a prerequisite to have docker installed to be able to run krm-functions, but it can not be always available:
e.g. not all Windows machines have it. Docker requires some restrictions to run it.

On another hand if one uses kustomize to build resources and to apply them to some k8s cluster, most likely he already has ability to run some pods on that cluster and krm-function may be as an alternative to be executed there **as a pod**.

Another use-case is to run kustomize itself in a pod. Couple of possible options to make that work is to use docker-in-docker, or mount host docker socket into the pod with kustomize. But all that may lead to some security concerns. Moreover in case of mounted socket it's not possible to mount volumes correctly, because the path will be treated as a path on the host, not inside the pod. 
Please refer to https://github.com/GoogleContainerTools/kpt/issues/2158 for more description of use-cases that can be applied to kustomize as well.

This PR introduces one more potential way to solve the listed situations:
if the flag `--enable-in-a-pod` is set explicitly, kustomize will try to run krm-function using kubectl client. There are several additional flags that allow to flexibly adjust this feature:

- `--pod-kubectl-args`  to set kubectl global args (kubeconfig location, context, namespace and etc);
- `--pod-template-name` to set pod template name that will be used as a [podTemplate](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L3777) for the running krm-function. That allows to restrict that pod by setting different policies, or to mount some existing volumes, that e.g. can be shared between that pod and the pod there kustomize is running. Note: podTemplate must exist and be located the same namespace where krm-function will run;
- `--pod-start-timeout` to set the pod start timeout (60s default) - the time needed by k8s to download krm-funciton image and start the container.

E.g.

```sh
kustomize build --enable-alpha-plugins --enable-in-a-pod --pod-kubectl-args="-n special-namespace" --pod-start-timeout=120s basedir
```

There is one more interesting aspect of this PR:
since kustomize is integrated into kubectl, in cases kubectl is used to work with kustomizations it will use another instance of kubectl with different parameters to run krm-functions. That means that kubectl will be self sufficient to run-krm functions and won't need any additional binaries installed.

ALLOW_MODULE_SPAN