### PR TITLE
Add vulnerability scanning to cloudbuild_kustomize_image

### DIFF
--- a/releasing/cloudbuild_kustomize_image.yaml
+++ b/releasing/cloudbuild_kustomize_image.yaml
@@ -9,7 +9,8 @@ steps:
       - "PROJECT_ID=$PROJECT_ID"
       - "_GIT_TAG=$_GIT_TAG"
       - "_PULL_BASE_REF=$_PULL_BASE_REF"
-# We need to use bash to configure the build date and version properly.
+      - "_SEVERITY=$_SEVERITY"
+  # We need to use bash to configure the build date and version properly.
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: /bin/bash
     args:
@@ -30,6 +31,23 @@ steps:
         --build-arg
         DATE=$(date -u +%FT%TZ)
         .
+  - id: scan
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: /bin/bash
+    args:
+    - -c
+    - |
+      gcloud artifacts docker images scan gcr.io/$PROJECT_ID/kustomize:${_GIT_TAG} \
+      --format='value(response.scan)' > /workspace/scan_id.txt
+  - id: severity check
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: /bin/bash
+    args:
+    - -c
+    - |
+      gcloud artifacts docker images list-vulnerabilities $(cat /workspace/scan_id.txt) \
+      --format='value(vulnerability.effectiveSeverity)' | if grep -Fxq ${_SEVERITY}; \
+      then echo 'Failed vulnerability check' && exit 1; else exit 0; fi
 
 images:
   - "gcr.io/$PROJECT_ID/kustomize:${_GIT_TAG}"
@@ -42,6 +60,7 @@ substitutions:
   # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: "master"
+  _SEVERITY: "high"
   # Other substitutions will not be evaluated
 
 options:


### PR DESCRIPTION
Fix Issue #4238  @KnVerey @monopole @natasha41575 

To have this vulnerability scanning work, we also need to [enable the "On-Demand Scanning API" for GCP project "k8s-staging-kustomize"](https://pantheon.corp.google.com/apis/enableflow?apiid=ondemandscanning.googleapis.com,cloudbuild.googleapis.com,artifactregistry.googleapis.com&redirect=https:%2F%2Fcloud.google.com%2Fcontainer-analysis%2Fdocs%2Fods-cloudbuild&_ga=2.100475934.148227784.1635779123-64591122.1631817593&_gac=1.161098319.1633470445.CjwKCAjw7--KBhAMEiwAxfpkWBO63hfCchqmYtGQC3EV7mq2_RDrTp5mpsOKa0IVfwwV4srS_4qlDBoC5A0QAvD_BwE&project=k8s-staging-kustomize)  (I don't have the permission to the project though)

Test: This PR is tested locally via [cloud-build-local](https://cloud.google.com/build/docs/build-debug-locally)

Step 1: Add one more step to releasing/cloudbuild_kustomize_image.yaml so as we can check the vulnerability result.
```yaml
  - id: push
    name: gcr.io/cloud-builders/docker
    entrypoint: /bin/bash
    args:
    - -c
    - |
      docker push gcr.io/$PROJECT_ID/kustomize:${_GIT_TAG}
```
Step 2: run `loud-build-local --config=./releasing/cloudbuild_kustomize_image.yaml  --dryrun=false .`

Output:
```bash
cloud-build-local --config=./releasing/cloudbuild_kustomize_image.yaml  --dryrun=false .
2021/11/01 16:21:36 Warning: The server docker version installed (20.10.5) is different from the one used in GCB (19.03.8)
2021/11/01 16:21:36 Warning: The client docker version installed (20.10.5) is different from the one used in GCB (19.03.8)
Using default tag: latest
latest: Pulling from cloud-builders/metadata
Digest: sha256:a043ab882783fd68d8a7986f2bd8697758055a9ce6c999f91a464ebd036ab0f2
Status: Image is up to date for gcr.io/cloud-builders/metadata:latest
gcr.io/cloud-builders/metadata:latest
2021/11/01 16:21:52 Started spoofed metadata server
2021/11/01 16:21:52 Build id = localbuild_30ab1fbe-2cbc-4923-b4ab-e9194879ba29
2021/11/01 16:21:53 status changed to "BUILD"
BUILD
Starting Step #0
Step #0: Already have image (with digest): bash
Step #0: Cloud build substitution check:  BUILD_ID=localbuild_30ab1fbe-2cbc-4923-b4ab-e9194879ba29 PROJECT_ID=yuwenma-gke-playground _GIT_TAG=v4.0.0-yuwenDirty _PULL_BASE_REF=master _SEVERITY=high
Finished Step #0
2021/11/01 16:21:54 Step Step #0 finished
Starting Step #1
Step #1: Already have image (with digest): gcr.io/cloud-builders/docker
Step #1: #1 [internal] load build definition from kustomize.Dockerfile
Step #1: #1 transferring dockerfile: 642B 0.0s done
Step #1: #1 DONE 0.0s
Step #1: 
Step #1: #2 [internal] load .dockerignore
Step #1: #2 transferring context:
Step #1: #2 transferring context: 94B done
Step #1: #2 DONE 0.0s
Step #1: 
Step #1: #4 [internal] load metadata for docker.io/library/golang:alpine
Step #1: #4 DONE 0.9s
Step #1: 
Step #1: #3 [internal] load metadata for docker.io/library/alpine:latest
Step #1: #3 DONE 0.9s
Step #1: 
Step #1: #5 [stage-1 1/4] FROM docker.io/library/alpine@sha256:e1c082e3d3c45cccac829...
Step #1: #5 DONE 0.0s
Step #1: 
Step #1: #7 [builder 1/5] FROM docker.io/library/golang:alpine@sha256:5519c8752f6b53...
Step #1: #7 CACHED
Step #1: 
Step #1: #9 [internal] load build context
Step #1: #9 ...
Step #1: 
Step #1: #8 [builder 2/5] RUN mkdir /build
Step #1: #8 DONE 0.8s
Step #1: 
Step #1: #9 [internal] load build context
Step #1: #9 transferring context: 103.20MB 4.1s
Step #1: #9 transferring context: 106.77MB 4.3s done
Step #1: #9 DONE 4.3s
Step #1: 
Step #1: #10 [builder 3/5] ADD . /build/
Step #1: #10 DONE 0.7s
Step #1: 
Step #1: #11 [builder 4/5] WORKDIR /build/kustomize
Step #1: #11 DONE 0.0s
Step #1: 
Step #1: #12 [builder 5/5] RUN CGO_ENABLED=0 GO111MODULE=on go build     -ldflags="-s...
Step #1: #12 1.092 go: downloading github.com/spf13/cobra v1.0.0
Step #1: 
Step #1: #12 1.109 go: downloading github.com/spf13/pflag v1.0.5
Step #1: #12 1.114 go: downloading sigs.k8s.io/yaml v1.2.0
Step #1: #12 1.143 go: downloading github.com/pkg/errors v0.9.1
Step #1: #12 1.179 go: downloading github.com/go-errors/errors v1.0.1
Step #1: #12 1.187 go: downloading github.com/olekukonko/tablewriter v0.0.4
Step #1: #12 1.192 go: downloading k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
Step #1: #12 1.205 go: downloading gopkg.in/yaml.v2 v2.4.0
Step #1: #12 1.209 go: downloading github.com/davecgh/go-spew v1.1.1
Step #1: #12 1.213 go: downloading github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
Step #1: #12 1.280 go: downloading github.com/stretchr/testify v1.7.0
Step #1: #12 1.284 go: downloading github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
Step #1: #12 1.295 go: downloading gopkg.in/inf.v0 v0.9.1
Step #1: #12 1.339 go: downloading github.com/evanphx/json-patch v4.11.0+incompatible
Step #1: #12 1.353 go: downloading github.com/imdario/mergo v0.3.5
Step #1: #12 1.374 go: downloading github.com/mattn/go-runewidth v0.0.7
Step #1: #12 1.395 go: downloading go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
Step #1: #12 1.465 go: downloading github.com/pmezard/go-difflib v1.0.0
Step #1: #12 1.466 go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
Step #1: #12 1.475 go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
Step #1: #12 1.485 go: downloading github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
Step #1: #12 1.485 go: downloading github.com/mitchellh/mapstructure v1.1.2
Step #1: #12 1.487 go: downloading github.com/go-openapi/swag v0.19.5
Step #1: #12 1.509 go: downloading github.com/go-openapi/jsonreference v0.19.3
Step #1: #12 1.521 go: downloading github.com/mailru/easyjson v0.7.0
Step #1: #12 1.524 go: downloading github.com/go-openapi/jsonpointer v0.19.3
Step #1: #12 1.524 go: downloading github.com/PuerkitoBio/purell v1.1.1
Step #1: #12 1.543 go: downloading github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
Step #1: #12 1.544 go: downloading golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
Step #1: #12 1.549 go: downloading golang.org/x/text v0.3.4
Step #1: #12 DONE 19.2s
Step #1: 
Step #1: #6 [stage-1 2/4] RUN apk add --no-cache git openssh
Step #1: #6 CACHED
Step #1: 
Step #1: #13 [stage-1 3/4] COPY --from=builder /build/kustomize/kustomize /app/
Step #1: #13 DONE 0.1s
Step #1: 
Step #1: #14 [stage-1 4/4] WORKDIR /app
Step #1: #14 DONE 0.0s
Step #1: 
Step #1: #15 exporting to image
Step #1: #15 exporting layers 0.1s done
Step #1: #15 writing image sha256:60bb1376cafbd60b49ed76c6969ecd9ebed17ece4dddffbc20dd7ce6a909b168 done
Step #1: #15 naming to gcr.io/yuwenma-gke-playground/kustomize:v4.0.0-yuwenDirty done
Step #1: #15 naming to gcr.io/yuwenma-gke-playground/kustomize:latest done
Step #1: #15 DONE 0.1s
Finished Step #1
2021/11/01 16:22:21 Step Step #1 finished
Starting Step #2 - "scan"
Step #2 - "scan": Already have image (with digest): gcr.io/cloud-builders/gcloud
Step #2 - "scan": Scanning container image
Step #2 - "scan": Locally extracting packages and versions from local container image..........................done
Step #2 - "scan": Remotely initiating analysis of packages and versions.......done
Step #2 - "scan": Waiting for analysis operation to complete......done
Step #2 - "scan": Done.
Finished Step #2 - "scan"
2021/11/01 16:22:27 Step Step #2 - "scan" finished
Starting Step #3 - "severity check"
Step #3 - "severity check": Already have image (with digest): gcr.io/cloud-builders/gcloud
Finished Step #3 - "severity check"
2021/11/01 16:22:29 Step Step #3 - "severity check" finished
Starting Step #4 - "push"
Step #4 - "push": Already have image (with digest): gcr.io/cloud-builders/docker
Step #4 - "push": The push refers to repository [gcr.io/yuwenma-gke-playground/kustomize]
Step #4 - "push": 5f70bf18a086: Preparing
Step #4 - "push": e4161a088bed: Preparing
Step #4 - "push": f2432ab6e3a6: Preparing
Step #4 - "push": e2eb06d8af82: Preparing
Step #4 - "push": 5f70bf18a086: Layer already exists
Step #4 - "push": e2eb06d8af82: Layer already exists
Step #4 - "push": e4161a088bed: Pushed
Step #4 - "push": f2432ab6e3a6: Pushed
Step #4 - "push": v4.0.0-yuwenDirty: digest: sha256:1fad8235211aa5d7883e8e7552e979d2bb701adfe0340de6812332213e3edb51 size: 1156
Finished Step #4 - "push"
2021/11/01 16:22:40 Step Step #4 - "push" finished
2021/11/01 16:22:41 status changed to "DONE"
DONE
```
Here's the scanning result 
<img width="955" alt="Screen Shot 2021-11-01 at 4 23 26 PM" src="https://user-images.githubusercontent.com/5606098/139754973-5d2c92b8-ea14-40da-b698-3319e9825dc5.png">


