### PR TITLE
Add support for s390x

### DIFF
--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -96,6 +96,7 @@ builds:
   goarch:
   - amd64
   - arm64
+  - s390x
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Add s390x to goreleaser config, so that a kustomize binary is created for s390x

Resolves  #3823