### PR TITLE
Fix: replacements entries get source and targets with null value appended

### DIFF
--- a/api/types/replacement.go
+++ b/api/types/replacement.go
@@ -16,10 +16,10 @@ const DefaultReplacementFieldPath = "metadata.name"
 // where it is from and where it is to.
 type Replacement struct {
 	// The source of the value.
-	Source *SourceSelector `json:"source" yaml:"source"`
+	Source *SourceSelector `json:"source,omitempty" yaml:"source,omitempty"`
 
 	// The N fields to write the value to.
-	Targets []*TargetSelector `json:"targets" yaml:"targets"`
+	Targets []*TargetSelector `json:"targets,omitempty" yaml:"targets,omitempty"`
 }
 
 // SourceSelector is the source of the replacement transformer.

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -33,8 +33,29 @@ func TestAddResourceHappyPath(t *testing.T) {
 	assert.NoError(t, cmd.RunE(cmd, args))
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	assert.NoError(t, err)
-	assert.Contains(t, string(content), resourceFileName)
-	assert.Contains(t, string(content), resourceFileName+"another")
+	assert.Equal(t, string(content), `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: some-prefix
+nameSuffix: some-suffix
+# Labels to add to all objects and selectors.
+# These labels would also be used to form the selector for apply --prune
+# Named differently than “labels” to avoid confusion with metadata for this object
+commonLabels:
+  app: helloworld
+commonAnnotations:
+  note: This is an example annotation
+resources:
+- myWonderfulResource.yaml
+- myWonderfulResource.yamlanother
+#- service.yaml
+#- ../some-dir/
+# There could also be configmaps in Base, which would make these overlays
+# There could be secrets in Base, if just using a fork/rebase workflow
+replacements:
+- path: replacement.yaml
+  source: null
+  targets: null
+`)
 }
 
 func TestAddResourceAlreadyThere(t *testing.T) {

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -53,8 +53,6 @@ resources:
 # There could be secrets in Base, if just using a fork/rebase workflow
 replacements:
 - path: replacement.yaml
-  source: null
-  targets: null
 `)
 }
 

--- a/kustomize/commands/internal/testutils/testutils.go
+++ b/kustomize/commands/internal/testutils/testutils.go
@@ -28,6 +28,8 @@ resources: []
 configMapGenerator: []
 # There could be secrets in Base, if just using a fork/rebase workflow
 secretGenerator: []
+replacements:
+  - path: replacement.yaml
 `
 )
 


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kustomize/issues/4270

First commit demonstrates issue behavior, second commit fixes it. 

cc @yuwenma 

ALLOW_MODULE_SPAN