### PR TITLE
fix function spec example

### DIFF
--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -245,8 +245,8 @@ items:
       labels:
         app: wordpress
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: "service.yaml"
+        internal.config.kubernetes.io/index: "0"
+        internal.config.kubernetes.io/path: "service.yaml"
     spec: # Example comment
       type: LoadBalancer
       selector:
@@ -271,8 +271,8 @@ items:
       labels:
         app: wordpress
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: "service.yaml"
+        internal.config.kubernetes.io/index: "0"
+        internal.config.kubernetes.io/path: "service.yaml"
     spec: # Example comment
       type: LoadBalancer
       selector:


### PR DESCRIPTION
Examples in the function spec are using `config.kubernetes.io/path` and `config.kubernetes.io/index` instead of `internal.config.kubernetes.io/path` and `internal.config.kubernetes.io/index`.

ALLOW_MODULE_SPAN