### PR TITLE
fix: prevent read file from throwing away OpenAPI config

### DIFF
--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -65,6 +65,7 @@ func determineFieldOrder() []string {
 		"Transformers",
 		"Inventory",
 		"Components",
+		"OpenAPI",
 	}
 
 	// Add deprecated fields here.

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -47,6 +47,7 @@ func TestFieldOrder(t *testing.T) {
 		"Transformers",
 		"Inventory",
 		"Components",
+		"OpenAPI",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {


### PR DESCRIPTION
Given the file
```
patchesStrategicMerge:
- configmap.yaml
- rollout.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- ../../base
images:
- name: myImage
  newName: myImageName
  newTag: myImageTag

configurations:
- https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform.yaml

openapi:
  path: ../../../custom_resources/rollout_cr_schema.json
```

Running `kustomize edit set image "myImage=*:foo"` will result in:

```
patchesStrategicMerge:
- configmap.yaml
- rollout.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- ../../base
images:
- name: myImage
  newName: myImageName
  newTag: foo


configurations:
- https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform.yaml
```

Whereas you would expect:
```
patchesStrategicMerge:
- configmap.yaml
- rollout.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- ../../base
images:
- name: myImage
  newName: myImageName
  newTag: foo

configurations:
- https://argoproj.github.io/argo-rollouts/features/kustomize/rollout-transform.yaml

openapi:
  path: ../../../custom_resources/rollout_cr_schema.json
```

This pull request resolves the issue by adding it to the `ordered` list which is used by the `read` method.
I'm not too familiar with the codebase, so if this is the incorrect place to put this, I would be glad to update it.

Thanks!

