### PR TITLE
kyaml/fn/framework ensures the annotation output format matches the input

### DIFF
--- a/api/filters/fieldspec/fieldspec_test.go
+++ b/api/filters/fieldspec/fieldspec_test.go
@@ -63,6 +63,9 @@ xxx:
 apiVersion: foo/v1
 kind: Bar
 xxx:
+metadata:
+  annotations:
+    internal.config.k8s.io/annotations-migration-resource-id: '0'
 : cannot set or create an empty field name`,
 			filter: fieldspec.Filter{
 				SetValue: filtersutil.SetScalar("e"),
@@ -220,6 +223,9 @@ a:
 kind: Bar
 a:
   b: a
+metadata:
+  annotations:
+    internal.config.k8s.io/annotations-migration-resource-id: '0'
 : expected sequence or mapping node`,
 			filter: fieldspec.Filter{
 				SetValue: filtersutil.SetScalar("e"),

--- a/api/filters/refvar/refvar_test.go
+++ b/api/filters/refvar/refvar_test.go
@@ -251,6 +251,7 @@ metadata:
   annotations:
     config.kubernetes.io/index: '0'
     internal.config.kubernetes.io/index: '0'
+    internal.config.k8s.io/annotations-migration-resource-id: '0'
 data:
   slice:
   - false
@@ -278,6 +279,7 @@ metadata:
   annotations:
     config.kubernetes.io/index: '0'
     internal.config.kubernetes.io/index: '0'
+    internal.config.k8s.io/annotations-migration-resource-id: '0'
 data:
   1: str
 : invalid map key: value='1', tag='` + yaml.NodeTagInt + `'`,

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -42,9 +42,12 @@ var BuildAnnotations = []string{
 	kioutil.PathAnnotation,
 	kioutil.IndexAnnotation,
 	kioutil.SeqIndentAnnotation,
+	kioutil.IdAnnotation,
+	kioutil.InternalAnnotationsMigrationResourceIDAnnotation,
 
 	kioutil.LegacyPathAnnotation,
 	kioutil.LegacyIndexAnnotation,
+	kioutil.LegacyIdAnnotation,
 }
 
 func (r *Resource) ResetRNode(incoming *Resource) {

--- a/cmd/config/internal/commands/e2e/e2e_test.go
+++ b/cmd/config/internal/commands/e2e/e2e_test.go
@@ -293,6 +293,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: foo
+  annotations:
+    internal.config.k8s.io/annotations-migration-resource-id: '1'
 `,
 				}
 			},

--- a/kyaml/fn/framework/framework.go
+++ b/kyaml/fn/framework/framework.go
@@ -117,7 +117,7 @@ func Execute(p ResourceListProcessor, rlSource *kio.ByteReadWriter) error {
 	rl.FunctionConfig = rlSource.FunctionConfig
 
 	// We store the original
-	nodeAnnos, err := kio.StoreInternalAnnotations(rl.Items)
+	nodeAnnos, err := kio.GetInternalAnnotationsFromResourceList(rl.Items)
 	if err != nil {
 		return err
 	}

--- a/kyaml/fn/framework/framework.go
+++ b/kyaml/fn/framework/framework.go
@@ -117,7 +117,7 @@ func Execute(p ResourceListProcessor, rlSource *kio.ByteReadWriter) error {
 	rl.FunctionConfig = rlSource.FunctionConfig
 
 	// We store the original
-	nodeAnnos, err := kio.GetInternalAnnotationsFromResourceList(rl.Items)
+	nodeAnnos, err := kio.PreprocessResourcesForInternalAnnotationMigration(rl.Items)
 	if err != nil {
 		return err
 	}

--- a/kyaml/fn/framework/framework.go
+++ b/kyaml/fn/framework/framework.go
@@ -116,7 +116,20 @@ func Execute(p ResourceListProcessor, rlSource *kio.ByteReadWriter) error {
 	}
 	rl.FunctionConfig = rlSource.FunctionConfig
 
+	// We store the original
+	nodeAnnos, err := kio.StoreInternalAnnotations(rl.Items)
+	if err != nil {
+		return err
+	}
+
 	retErr := p.Process(&rl)
+
+	// If either the internal annotations for path, index, and id OR the legacy
+	// annotations for path, index, and id are changed, we have to update the other.
+	err = kio.ReconcileInternalAnnotations(rl.Items, nodeAnnos)
+	if err != nil {
+		return err
+	}
 
 	// Write the results
 	// Set the ResourceList.results for validating functions

--- a/kyaml/fn/framework/result.go
+++ b/kyaml/fn/framework/result.go
@@ -64,7 +64,12 @@ func (i Result) String() string {
 		}
 	}
 	formatString := "[%s]"
-	list := []interface{}{i.Severity}
+	severity := i.Severity
+	// We default Severity to Info when converting a result to a message.
+	if i.Severity == "" {
+		severity = Info
+	}
+	list := []interface{}{severity}
 	if len(idStringList) > 0 {
 		formatString += " %s"
 		list = append(list, strings.Join(idStringList, "/"))

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -400,7 +400,6 @@ metadata:
   "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
   "metadata": {
     "annotations": {
-      "config.kubernetes.io/path": "test.json",
       "internal.config.kubernetes.io/path": "test.json"
     }
   }
@@ -429,7 +428,6 @@ metadata:
   "a": "a long string that would certainly see a newline introduced by the YAML marshaller abcd123",
   "metadata": {
     "annotations": {
-      "config.kubernetes.io/path": "test.json",
       "internal.config.kubernetes.io/path": "test.json"
     }
   }
@@ -449,7 +447,6 @@ metadata:
   "a": "b",
   "metadata": {
     "annotations": {
-      "config.kubernetes.io/path": "test.json",
       "internal.config.kubernetes.io/path": "test.json"
     }
   }

--- a/kyaml/kio/kioutil/kioutil.go
+++ b/kyaml/kio/kioutil/kioutil.go
@@ -44,7 +44,8 @@ const (
 )
 
 func GetFileAnnotations(rn *yaml.RNode) (string, string, error) {
-	annotations := rn.GetAnnotations()
+	rm, _ := rn.GetMeta()
+	annotations := rm.Annotations
 	path, found := annotations[PathAnnotation]
 	if !found {
 		path = annotations[LegacyPathAnnotation]
@@ -57,7 +58,8 @@ func GetFileAnnotations(rn *yaml.RNode) (string, string, error) {
 }
 
 func GetIdAnnotation(rn *yaml.RNode) string {
-	annotations := rn.GetAnnotations()
+	rm, _ := rn.GetMeta()
+	annotations := rm.Annotations
 	id, found := annotations[IdAnnotation]
 	if !found {
 		id = annotations[LegacyIdAnnotation]
@@ -391,7 +393,8 @@ func ConfirmInternalAnnotationUnchanged(r1 *yaml.RNode, r2 *yaml.RNode, exclusio
 // `internal.config.kubernetes.io` 2) is one of `config.kubernetes.io/path`,
 // `config.kubernetes.io/index` and `config.k8s.io/id`.
 func GetInternalAnnotations(rn *yaml.RNode) map[string]string {
-	annotations := rn.GetAnnotations()
+	meta, _ := rn.GetMeta()
+	annotations := meta.Annotations
 	result := make(map[string]string)
 	for k, v := range annotations {
 		if strings.HasPrefix(k, internalPrefix) || k == LegacyPathAnnotation || k == LegacyIndexAnnotation || k == LegacyIdAnnotation {

--- a/kyaml/kio/kioutil/kioutil.go
+++ b/kyaml/kio/kioutil/kioutil.go
@@ -41,6 +41,11 @@ const (
 
 	// Deprecated: use IdAnnotation instead.
 	LegacyIdAnnotation = "config.k8s.io/id"
+
+	// InternalAnnotationsMigrationResourceIDAnnotation is used to uniquely identify
+	// resources during round trip to and from a function execution. We will use it
+	// to track the internal annotations and reconcile them if needed.
+	InternalAnnotationsMigrationResourceIDAnnotation = "internal.config.k8s.io/annotations-migration-resource-id"
 )
 
 func GetFileAnnotations(rn *yaml.RNode) (string, string, error) {


### PR DESCRIPTION
If the input only contains legacy format anntations (path, index, id), the
output will be the same.

ALLOW_MODULE_SPAN