### PR TITLE
Teach kustomize about literal-subject annotation

### DIFF
--- a/api/filters/namespace/namespace_test.go
+++ b/api/filters/namespace/namespace_test.go
@@ -242,7 +242,31 @@ subjects:
 `,
 		filter: namespace.Filter{Namespace: "bar"},
 	},
-
+	{
+		name: "update-rolebinding-literal-subject",
+		input: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    kustomize.config.k8s.io/literal-subject: "true"
+subjects:
+- name: default
+  namespace: foo
+`,
+		expected: `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    kustomize.config.k8s.io/literal-subject: "true"
+  namespace: bar
+subjects:
+- name: default
+  namespace: foo
+`,
+		filter: namespace.Filter{Namespace: "bar"},
+	},
 	{
 		name: "data-fieldspecs",
 		input: `


### PR DESCRIPTION
Setting the `kustomize.config.k8s.io/literal-subject` annotation to
`"true"` will prevent kustomize from modifying the namespace attribute
of subjects in a `RoleBinding` or `ClusterRoleBinding`, even when they
apply to the "default" `ServiceAccount`.

Fixes #4301