### PR TITLE
feat: Add SetEntryCallback to annotations filter

### DIFF
--- a/api/filters/annotations/annotations.go
+++ b/api/filters/annotations/annotations.go
@@ -19,9 +19,24 @@ type Filter struct {
 
 	// FsSlice contains the FieldSpecs to locate the namespace field
 	FsSlice types.FsSlice
+
+	// SetEntryCallback is invoked each time an annotation is applied
+	// Example use cases:
+	//   - Tracking all paths where annotations have been applied
+	SetEntryCallback func(key, value, tag string, node *yaml.RNode)
 }
 
 var _ kio.Filter = Filter{}
+
+func (f Filter) setEntry(key, value, tag string) filtersutil.SetFn {
+	baseSetEntryFunc := filtersutil.SetEntry(key, value, tag)
+	return func(node *yaml.RNode) error {
+		if f.SetEntryCallback != nil {
+			f.SetEntryCallback(key, value, tag, node)
+		}
+		return baseSetEntryFunc(node)
+	}
+}
 
 func (f Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	keys := yaml.SortedMapKeys(f.Annotations)
@@ -30,7 +45,7 @@ func (f Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 			for _, k := range keys {
 				if err := node.PipeE(fsslice.Filter{
 					FsSlice: f.FsSlice,
-					SetValue: filtersutil.SetEntry(
+					SetValue: f.setEntry(
 						k, f.Annotations[k], yaml.NodeTagString),
 					CreateKind: yaml.MappingNode, // Annotations are MappingNodes.
 					CreateTag:  yaml.NodeTagMap,


### PR DESCRIPTION
Add a configurable callback that is invoked each time an
annotation is applied by the annotations filter. This is useful
for scenarios such as tracking annotations as they are applied.

Issues: GoogleContainerTools/kpt#2448