### PR TITLE
Fixes 4240; added null check on namespace when resource is a RoleBinding

### DIFF
--- a/api/internal/accumulator/namereferencetransformer.go
+++ b/api/internal/accumulator/namereferencetransformer.go
@@ -52,7 +52,10 @@ func (t *nameReferenceTransformer) Transform(m resmap.ResMap) error {
 	fMap := t.determineFilters(m.Resources())
 	debug(fMap)
 	for r, fList := range fMap {
-		c := m.SubsetThatCouldBeReferencedByResource(r)
+		c, err := m.SubsetThatCouldBeReferencedByResource(r)
+		if err != nil {
+			return err
+		}
 		for _, f := range fList {
 			f.Referrer = r
 			f.ReferralCandidates = c

--- a/api/krusty/blankvalues_test.go
+++ b/api/krusty/blankvalues_test.go
@@ -1,0 +1,49 @@
+package krusty_test
+
+import (
+	"strings"
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// test for https://github.com/kubernetes-sigs/kustomize/issues/4240
+func TestBlankNamespace4240(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- resource.yaml
+`)
+
+	th.WriteF("resource.yaml", `
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test
+subjects:
+- kind: ServiceAccount
+  name: test
+  namespace:
+roleRef:
+  kind: Role
+  name: test
+  apiGroup: rbac.authorization.k8s.io	
+`)
+
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
+	if !strings.Contains(err.Error(), "Invalid Input: namespace is blank for resource") {
+		t.Fatalf("unexpected error: %q", err)
+	}
+}

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -212,7 +212,7 @@ type ResMap interface {
 	// This is a filter; it excludes things that cannot be
 	// referenced by the resource, e.g. objects in other
 	// namespaces. Cluster wide objects are never excluded.
-	SubsetThatCouldBeReferencedByResource(*resource.Resource) ResMap
+	SubsetThatCouldBeReferencedByResource(*resource.Resource) (ResMap, error)
 
 	// DeAnchor replaces YAML aliases with structured data copied from anchors.
 	// This cannot be undone; if desired, call DeepCopy first.

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -436,7 +436,9 @@ func getNamespacesForRoleBinding(r *resource.Resource) map[string]bool {
 		if ns, ok1 := subject["namespace"]; ok1 {
 			if kind, ok2 := subject["kind"]; ok2 {
 				if kind.(string) == "ServiceAccount" {
-					result[ns.(string)] = true
+					if n, ok3 := ns.(string); ok3 {
+						result[n] = true
+					}
 				}
 			}
 		}

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -442,7 +442,7 @@ func getNamespacesForRoleBinding(r *resource.Resource) (map[string]bool, error) 
 					if n, ok3 := ns.(string); ok3 {
 						result[n] = true
 					} else {
-						return nil, errors.New("Invalid Input: namespace is blank")
+						return nil, errors.New(fmt.Sprintf("Invalid Input: namespace is blank for resource %q\n", r.CurId()))
 					}
 				}
 			}

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -566,7 +566,10 @@ func TestSubsetThatCouldBeReferencedByResource(t *testing.T) {
 	for name, test := range tests {
 		test := test
 		t.Run(name, func(t *testing.T) {
-			got := m.SubsetThatCouldBeReferencedByResource(test.filter)
+			got, err1 := m.SubsetThatCouldBeReferencedByResource(test.filter)
+			if err1 != nil {
+				t.Fatalf("Expected error %v: ", err1)
+			}
 			err := test.expected.ErrorIfNotEqualLists(got)
 			if err != nil {
 				test.expected.Debug("expected")


### PR DESCRIPTION
Fixes #4240 
`kustomize build` was panicking because namespace was null at https://github.com/kubernetes-sigs/kustomize/blob/25ee506af489623ee2994ecab9953ed85cb73da4/api/resmap/reswrangler.go#L436-L442

A simple `null` check seems to solve the issue with all tests passing. I haven't added a test for this because the input is invalid. Please let me know if anything else needs to be done in this.