### PR TITLE
improve fn authoring

### DIFF
--- a/kyaml/fn/framework/example_filter_GVK_test.go
+++ b/kyaml/fn/framework/example_filter_GVK_test.go
@@ -1,0 +1,34 @@
+package framework_test
+
+import (
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+)
+
+// This example implements a function that reads the desired replicas from the
+// functionConfig and updates the replicas field for all deployments.
+
+func Example_filterGVK() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(updateReplicas)); err != nil {
+		os.Exit(1)
+	}
+}
+
+// updateReplicas sets a field in resources selecting by GVK.
+func updateReplicas(rl *framework.ResourceList) error {
+	if rl.FunctionConfig == nil {
+		return framework.ErrMissingFnConfig{}
+	}
+	replicas, found, err := rl.FunctionConfig.GetNestedInt("replicas")
+	if !found || err != nil {
+		return err
+	}
+	for i, obj := range rl.Items {
+		if obj.GetApiVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
+			rl.Items[i].SetOrDie(replicas, "spec", "replicas")
+		}
+	}
+	return nil
+}

--- a/kyaml/fn/framework/example_generator_test.go
+++ b/kyaml/fn/framework/example_generator_test.go
@@ -1,0 +1,87 @@
+package framework_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// This function generates Graphana configuration in the form of ConfigMap. It
+// accepts Revision and ID as input.
+
+func Example_generator() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(generate)); err != nil {
+		os.Exit(1)
+	}
+}
+
+// generate generates a ConfigMap.
+func generate(rl *framework.ResourceList) error {
+	if rl.FunctionConfig == nil {
+		return framework.ErrMissingFnConfig{}
+	}
+
+	revision, foundRevision, err := rl.FunctionConfig.GetNestedString("data", "revision")
+	if err != nil {
+		return fmt.Errorf("failed to find field revision: %w", err)
+	}
+	id, foundId, err := rl.FunctionConfig.GetNestedString("data", "id")
+	if err != nil {
+		return fmt.Errorf("failed to find field id: %w", err)
+	}
+	if !foundRevision || !foundId {
+		return nil
+	}
+	js, err := fetchDashboard(revision, id)
+	if err != nil {
+		return fmt.Errorf("fetch dashboard: %v", err)
+	}
+
+	// corev1.ConfigMap should be used here. But we can't use it here due to dependency restriction in the kustomize repo.
+	cm := ConfigMap{
+		ResourceMeta: yaml.ResourceMeta{
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: yaml.ObjectMeta{
+				NameMeta: yaml.NameMeta{
+					Name:      fmt.Sprintf("%v-gen", rl.FunctionConfig.GetName()),
+					Namespace: rl.FunctionConfig.GetNamespace(),
+				},
+				Labels: map[string]string{
+					"grafana_dashboard": "true",
+				},
+			},
+		},
+		Data: map[string]string{
+			fmt.Sprintf("%v.json", rl.FunctionConfig.GetName()): fmt.Sprintf("%q", js),
+		},
+	}
+	return rl.UpsertObjectToItems(cm, nil, false)
+}
+
+func fetchDashboard(revision, id string) (string, error) {
+	url := fmt.Sprintf("https://grafana.com/api/dashboards/%s/revisions/%s/download", id, revision)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ConfigMap is a copy of corev1.ConfigMap.
+type ConfigMap struct {
+	yaml.ResourceMeta `json:",inline" yaml:",inline"`
+	Data              map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+}

--- a/kyaml/fn/framework/example_logger_injector_test.go
+++ b/kyaml/fn/framework/example_logger_injector_test.go
@@ -1,0 +1,63 @@
+package framework_test
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// In this example, we implement a function that injects a logger as a sidecar
+// container in workload APIs.
+
+func Example_loggeInjector() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(injectLogger)); err != nil {
+		os.Exit(1)
+	}
+}
+
+// injectLogger injects a logger container into the workload API resources.
+// generate implements the goframework.KRMFunction interface.
+func injectLogger(rl *framework.ResourceList) error {
+	var li LoggerInjection
+	if err := rl.FunctionConfig.As(&li); err != nil {
+		return err
+	}
+	for i, obj := range rl.Items {
+		if obj.GetApiVersion() == "apps/v1" && (obj.GetKind() == "Deployment" || obj.GetKind() == "StatefulSet" || obj.GetKind() == "DaemonSet" || obj.GetKind() == "ReplicaSet") {
+			var container Container
+			found, err := obj.Get(&container, "spec", "template", "spec", "containers", fmt.Sprintf("[name=%v]", li.ContainerName))
+			if err != nil {
+				return err
+			}
+			if found {
+				container.Image = li.ImageName
+			} else {
+				container = Container{
+					Name:  li.ContainerName,
+					Image: li.ImageName,
+				}
+			}
+			if err = rl.Items[i].Set(container, "spec", "template", "spec", "containers", fmt.Sprintf("[name=%v]", li.ContainerName)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// LoggerInjection is type definition of the functionConfig.
+type LoggerInjection struct {
+	yaml.ResourceMeta `json:",inline" yaml:",inline"`
+
+	ContainerName string `json:"containerName" yaml:"containerName"`
+	ImageName     string `json:"imageName" yaml:"imageName"`
+}
+
+// Container is a copy of corev1.Container.
+type Container struct {
+	Name  string `json:"name" yaml:"name"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+}

--- a/kyaml/fn/framework/example_mutate_comments_test.go
+++ b/kyaml/fn/framework/example_mutate_comments_test.go
@@ -1,0 +1,38 @@
+package framework_test
+
+import (
+	"os"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+)
+
+// In this example, we mutate line comments for field metadata.name.
+// Some function may want to store some information in the comments (e.g.
+// apply-setters function: https://catalog.kpt.dev/apply-setters/v0.2/)
+
+func Example_dMutateComments() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(mutateComments)); err != nil {
+		os.Exit(1)
+	}
+}
+
+func mutateComments(rl *framework.ResourceList) error {
+	for i := range rl.Items {
+		lineComment, err := rl.Items[i].GetLineComment("metadata", "name")
+		if err != nil {
+			return err
+		}
+
+		if strings.TrimSpace(lineComment) == "" {
+			lineComment = "# bar-system"
+		} else {
+			lineComment = strings.Replace(lineComment, "foo", "bar", -1)
+		}
+		if err = rl.Items[i].SetLineComment(lineComment, "metadata", "name"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kyaml/fn/framework/example_read_field_test.go
+++ b/kyaml/fn/framework/example_read_field_test.go
@@ -1,0 +1,29 @@
+package framework_test
+
+import (
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+)
+
+// In this example, we read a field from the input object and print it to the log.
+
+func Example_aReadField() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(readField)); err != nil {
+		os.Exit(1)
+	}
+}
+
+func readField(rl *framework.ResourceList) error {
+	for _, obj := range rl.Items {
+		if obj.GetApiVersion() == "apps/v1" && obj.GetKind() == "Deployment" {
+			replicas, found, err := obj.GetNestedInt("spec", "replicas")
+			if !found || err != nil {
+				return err
+			}
+			framework.Logf("replicas is %v\n", replicas)
+		}
+	}
+	return nil
+}

--- a/kyaml/fn/framework/example_read_functionConfig_test.go
+++ b/kyaml/fn/framework/example_read_functionConfig_test.go
@@ -1,0 +1,33 @@
+package framework_test
+
+import (
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// In this example, we convert the functionConfig as strong typed object and then
+// read a field from the functionConfig object.
+
+func Example_bReadFunctionConfig() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(readFunctionConfig)); err != nil {
+		os.Exit(1)
+	}
+}
+
+func readFunctionConfig(rl *framework.ResourceList) error {
+	var sr SetReplicas
+	if err := rl.FunctionConfig.As(&sr); err != nil {
+		return err
+	}
+	framework.Logf("desired replicas is %v\n", sr.DesiredReplicas)
+	return nil
+}
+
+// SetReplicas is the type definition of the functionConfig
+type SetReplicas struct {
+	yaml.ResourceIdentifier `json:",inline" yaml:",inline"`
+	DesiredReplicas         int `json:"desiredReplicas,omitempty" yaml:"desiredReplicas,omitempty"`
+}

--- a/kyaml/fn/framework/example_set_field_test.go
+++ b/kyaml/fn/framework/example_set_field_test.go
@@ -1,0 +1,25 @@
+package framework_test
+
+import (
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+)
+
+// In this example, we read a field from the input object and print it to the log.
+
+func Example_cSetField() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(setField)); err != nil {
+		os.Exit(1)
+	}
+}
+
+func setField(rl *framework.ResourceList) error {
+	for _, obj := range rl.Items {
+		if obj.GetKind() == "Deployment" && obj.GetName() == "nginx" {
+			return obj.Set(10, "spec", "replicas")
+		}
+	}
+	return nil
+}

--- a/kyaml/fn/framework/example_validator_test.go
+++ b/kyaml/fn/framework/example_validator_test.go
@@ -1,0 +1,33 @@
+package framework_test
+
+import (
+	"os"
+
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework/command"
+)
+
+// This example implements a function that validate resources to ensure
+// spec.template.spec.securityContext.runAsNonRoot is set in workload APIs.
+
+func Example_validator() {
+	if err := command.AsMain(framework.ResourceListProcessorFunc(validator)); err != nil {
+		os.Exit(1)
+	}
+}
+
+func validator(rl *framework.ResourceList) error {
+	var results framework.Results
+	for _, obj := range rl.Items {
+		if obj.GetApiVersion() == "apps/v1" && (obj.GetKind() == "Deployment" || obj.GetKind() == "StatefulSet" || obj.GetKind() == "DaemonSet" || obj.GetKind() == "ReplicaSet") {
+			runAsNonRoot, _, err := obj.GetNestedBool("spec", "template", "spec", "securityContext", "runAsNonRoot")
+			if err != nil {
+				return framework.ErrorConfigObjectResult(err, obj)
+			}
+			if !runAsNonRoot {
+				results = append(results, framework.ConfigObjectResult("`spec.template.spec.securityContext.runAsNonRoot` must be set to true", obj, framework.Error))
+			}
+		}
+	}
+	return results
+}

--- a/kyaml/fn/framework/framework.go
+++ b/kyaml/fn/framework/framework.go
@@ -4,8 +4,15 @@
 package framework
 
 import (
+	"bytes"
 	goerrors "errors"
+	"fmt"
+	"io"
 	"os"
+	"reflect"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sort"
+	"strconv"
 
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -54,6 +61,150 @@ type ResourceList struct {
 	// Validating functions can optionally use this field to communicate structured
 	// validation error data to downstream functions.
 	Results Results `yaml:"results,omitempty" json:"results,omitempty"`
+}
+
+// ParseResourceList parses a ResourceList from the input byte array.
+func ParseResourceList(in []byte) (*ResourceList, error) {
+	rl := &ResourceList{
+		Items: []*yaml.RNode{},
+	}
+
+	var nodes []*yaml.Node
+	decoder := yaml.NewDecoder(bytes.NewReader(in))
+	for {
+		node := &yaml.Node{}
+		if err := decoder.Decode(node); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		nodes = append(nodes, node)
+	}
+
+	if len(nodes) != 1 {
+		return nil, fmt.Errorf("expected exactly one resouceList object, got %d", len(nodes))
+	}
+	rlRNode := yaml.NewRNode(nodes[0])
+
+	if rlRNode.GetKind() != kio.ResourceListKind {
+		return nil, fmt.Errorf("input was of unexpected kind %q; expected ResourceList", rlRNode.GetKind())
+	}
+	fc := &yaml.RNode{}
+	found, err := rlRNode.Get(fc, "functionConfig")
+	if err != nil {
+		return nil, fmt.Errorf("failed when tried to get functionConfig: %w", err)
+	}
+	if found {
+		rl.FunctionConfig = fc
+	}
+
+	itemsRN := &yaml.RNode{}
+	found, err = rlRNode.Get(itemsRN, "items")
+	if err != nil {
+		return nil, fmt.Errorf("failed when tried to get items: %w", err)
+	}
+	if !found {
+		return rl, nil
+	}
+	itemYNodes := itemsRN.Content()
+	var items []*yaml.RNode
+	for i := range itemYNodes {
+		items = append(items, yaml.NewRNode(itemYNodes[i]))
+	}
+	rl.Items = items
+	return rl, nil
+}
+
+// ToYAML convert the ResourceList to its yaml representation.
+func (rl *ResourceList) ToYAML() (string, error) {
+	rl.SortItems()
+	var yml string
+	if err := func() error {
+		ko, err := rl.toRNode()
+		if err != nil {
+			return err
+		}
+		yml, err = ko.String()
+		return err
+	}(); err != nil {
+		return "", fmt.Errorf("failed to convert the resourceList to yaml: %v", err)
+	}
+	return yml, nil
+}
+
+// toRNode converts the ResourceList to a RNode.
+func (rl *ResourceList) toRNode() (*yaml.RNode, error) {
+	obj, err := yaml.NewEmptyRNode()
+	if err != nil {
+		return nil, err
+	}
+	obj.SetApiVersion(kio.ResourceListAPIVersion)
+	obj.SetKind(kio.ResourceListKind)
+
+	if rl.Items != nil && len(rl.Items) > 0 {
+		if err := obj.Set(rl.Items, "items"); err != nil {
+			return nil, err
+		}
+	}
+
+	if rl.FunctionConfig != nil {
+		if err := obj.Set(rl.FunctionConfig, "functionConfig"); err != nil {
+			return nil, err
+		}
+	}
+
+	if rl.Results != nil && len(rl.Results) > 0 {
+		if err = obj.Set(rl.Results, "results"); err != nil {
+			return nil, err
+		}
+	}
+
+	return obj, nil
+}
+
+// UpsertObjectToItems adds an object to ResourceList.items. The input object can
+// be a RNode or any typed object (e.g. corev1.Pod).
+func (rl *ResourceList) UpsertObjectToItems(obj interface{}, checkExistence func(obj, another *yaml.RNode) bool, replaceIfAlreadyExist bool) error {
+	if checkExistence == nil {
+		checkExistence = func(obj, another *yaml.RNode) bool {
+			ri1 := obj.GetResourceIdentifier()
+			ri2 := another.GetResourceIdentifier()
+			return reflect.DeepEqual(ri1, ri2)
+		}
+	}
+
+	var ko *yaml.RNode
+	switch obj := obj.(type) {
+	case yaml.RNode:
+		ko = &obj
+	case *yaml.RNode:
+		ko = obj
+	case yaml.Node:
+		ko = yaml.NewRNode(&obj)
+	case *yaml.Node:
+		ko = yaml.NewRNode(obj)
+	default:
+		var err error
+		ko, err = yaml.NewRNodeFrom(obj)
+		if err != nil {
+			return err
+		}
+	}
+
+	idx := -1
+	for i, item := range rl.Items {
+		if checkExistence(ko, item) {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		rl.Items = append(rl.Items, ko)
+	} else if replaceIfAlreadyExist {
+		rl.Items[idx] = ko
+	}
+	return nil
 }
 
 // ResourceListProcessor is implemented by configuration functions built with this framework
@@ -169,4 +320,121 @@ func (rl *ResourceList) Filter(api kio.Filter) error {
 		return errors.Wrap(err)
 	}
 	return nil
+}
+
+// SortItems sorts the ResourceList.items by apiVersion, kind, namespace and name.
+func (rl *ResourceList) SortItems() {
+	sort.Sort(sortRNodeObjects(rl.Items))
+}
+
+type sortRNodeObjects []*yaml.RNode
+
+func (o sortRNodeObjects) Len() int      { return len(o) }
+func (o sortRNodeObjects) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o sortRNodeObjects) Less(i, j int) bool {
+	idi := o[i].GetResourceIdentifier()
+	idj := o[j].GetResourceIdentifier()
+	idStrI := fmt.Sprintf("%s %s %s %s", idi.GetAPIVersion(), idi.GetKind(), idi.GetNamespace(), idi.GetName())
+	idStrJ := fmt.Sprintf("%s %s %s %s", idj.GetAPIVersion(), idj.GetKind(), idj.GetNamespace(), idj.GetName())
+	return idStrI < idStrJ
+}
+
+// Run evaluates the function. input must be a resourceList in yaml format. An
+// updated resourceList will be returned.
+func Run(p ResourceListProcessor, input []byte) ([]byte, error) {
+	rl, err := ParseResourceList(input)
+	if err != nil {
+		return nil, err
+	}
+	err = p.Process(rl)
+	if err != nil {
+		// If the error is not a Results type, we wrap the error as a Result.
+		if results, ok := err.(Results); ok {
+			rl.Results = append(rl.Results, results...)
+		} else if result, ok := err.(Result); ok {
+			rl.Results = append(rl.Results, &result)
+		} else if result, ok := err.(*Result); ok {
+			rl.Results = append(rl.Results, result)
+		} else {
+			rl.Results = append(rl.Results, ErrorResult(err))
+		}
+	}
+	yml, er := rl.ToYAML()
+	if er != nil {
+		return []byte(yml), er
+	}
+	if len(rl.Results) > 0 {
+		return []byte(yml), rl.Results
+	}
+	return []byte(yml), nil
+}
+
+type ErrMissingFnConfig struct{}
+
+func (ErrMissingFnConfig) Error() string {
+	return "unable to find the functionConfig in the resourceList"
+}
+
+// Chain chains a list of ResourceListProcessor as a single ResourceListProcessor.
+func Chain(processors ...ResourceListProcessor) ResourceListProcessor {
+	return ResourceListProcessorFunc(func(rl *ResourceList) error {
+		for _, processor := range processors {
+			if err := processor.Process(rl); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// ChainFunctions chains a list of ResourceListProcessorFunc as a single ResourceListProcessorFunc.
+func ChainFunctions(fns ...ResourceListProcessorFunc) ResourceListProcessorFunc {
+	return func(rl *ResourceList) error {
+		for _, fn := range fns {
+			if err := fn.Process(rl); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// GetPathAnnotation checks the path annotation first and then the legacy path
+// annotation. See: https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md#internalconfigkubernetesiopath
+func GetPathAnnotation(rn *yaml.RNode) string {
+	anno := rn.GetAnnotation(kioutil.PathAnnotation)
+	if anno == "" {
+		anno = rn.GetAnnotation(kioutil.LegacyPathAnnotation)
+	}
+	return anno
+}
+
+// GetIndexAnnotation checks the index annotation first and then the legacy index
+// annotation. It returns -1 if not found. See: https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md#internalconfigkubernetesioindex
+func GetIndexAnnotation(rn *yaml.RNode) int {
+	anno := rn.GetAnnotation(kioutil.IndexAnnotation)
+	if anno == "" {
+		anno = rn.GetAnnotation(kioutil.LegacyIndexAnnotation)
+	}
+
+	if anno == "" {
+		return -1
+	}
+	i, _ := strconv.Atoi(anno)
+	return i
+}
+
+// GetIdAnnotation checks the id annotation first and then the legacy id annotation.
+// It returns -1 if not found.
+func GetIdAnnotation(rn *yaml.RNode) int {
+	anno := rn.GetAnnotation(kioutil.IdAnnotation)
+	if anno == "" {
+		anno = rn.GetAnnotation(kioutil.LegacyIdAnnotation)
+	}
+
+	if anno == "" {
+		return -1
+	}
+	i, _ := strconv.Atoi(anno)
+	return i
 }

--- a/kyaml/fn/framework/log.go
+++ b/kyaml/fn/framework/log.go
@@ -1,0 +1,16 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+)
+
+// Log prints to stderr.
+func Log(in ...interface{}) {
+	fmt.Fprintln(os.Stderr, in...)
+}
+
+// Logf prints formatted messages to stderr.
+func Logf(format string, in ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, in...)
+}

--- a/kyaml/yaml/example_test.go
+++ b/kyaml/yaml/example_test.go
@@ -893,3 +893,111 @@ func ExampleRNode_ElementValues() {
 	// Output:
 	// [foo bar baz] <nil>
 }
+
+var (
+	deployment RNode
+	configMap  RNode
+)
+
+func ExampleRNode_mutatePrimitiveField() {
+	replicas, found, err := deployment.GetNestedInt("spec", "replicas")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// mutate the replicas variable
+
+	err = deployment.Set(&replicas, "spec", "replicas")
+	if err != nil { /* do something */
+	}
+}
+
+func ExampleRNode_mutatePrimitiveSlice() {
+	var finalizers []string
+	found, err := deployment.Get(&finalizers, "metadata", "finalizers")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// mutate the finalizers slice
+
+	err = deployment.Set(finalizers, "metadata", "finalizers")
+	if err != nil { /* do something */
+	}
+}
+
+func ExampleRNode_mutatePrimitiveMap() {
+	var data map[string]string
+	found, err := configMap.Get(&data, "data")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// mutate the data map
+
+	err = configMap.Set(data, "data")
+	if err != nil { /* do something */
+	}
+}
+
+func ExampleRNode_mutateStrongTypedField() {
+	// corev1.PodSpec should be used here. But we can't use it here due to dependency restriction in the kustomize repo.
+	var podSpec PodSpec
+	found, err := deployment.Get(&podSpec, "spec", "template", "spec")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// mutate the podSpec object
+
+	err = deployment.Set(podSpec, "spec", "template")
+	if err != nil { /* do something */
+	}
+}
+
+// PodSpec is a copy of corev1.PodSpec
+type PodSpec struct {
+	// some fields here
+}
+
+func ExampleRNode_mutateStrongTypedSlice() {
+	// corev1.Container should be used here. But we can't use it here due to dependency restriction in the kustomize repo.
+	var containers []Container
+	found, err := deployment.Get(&containers, "spec", "template", "spec", "containers")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// mutate the podTemplate object
+
+	err = deployment.Set(containers, "spec", "template", "spec", "containers")
+	if err != nil { /* do something */
+	}
+}
+
+// Container is a copy of corev1.Container
+type Container struct {
+	// some other fields here
+}
+
+func ExampleRNode_mutateRNode() {
+	var rnode RNode
+	// Get a field as RNode. This may be useful if you want to deal with low-level
+	// yaml manipulation (e.g. dealing with comments).
+	found, err := deployment.Get(&rnode, "metadata", "namespace")
+	if err != nil { /* do something */
+	}
+	if !found { /* do something */
+	}
+
+	// Any modification done on the rnode will be reflected on the original object.
+	// No need to invoke Set method when using RNode
+	ynode := rnode.YNode()
+	ynode.HeadComment = ynode.LineComment
+	ynode.LineComment = ""
+}

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -4,11 +4,14 @@
 package yaml
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
+	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -106,11 +109,41 @@ func NewScalarRNode(value string) *RNode {
 
 // NewStringRNode returns a new Scalar *RNode containing the provided string.
 // If the string is non-utf8, it will be base64 encoded, and the tag
-// will indicate binary data.
-func NewStringRNode(value string) *RNode {
-	n := yaml.Node{Kind: yaml.ScalarNode}
-	n.SetString(value)
-	return NewRNode(&n)
+// will indicate binary data. Otherwise, the tag will be String.
+func NewStringRNode(s string) *RNode {
+	n := yaml.Node{}
+	n.SetString(s)
+	return &RNode{value: &n}
+}
+
+// NewIntRNode returns a new int Scalar *RNode containing the provided int.
+func NewIntRNode(i int) *RNode {
+	return &RNode{
+		value: &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   NodeTagInt,
+			Value: strconv.FormatInt(int64(i), 10),
+		}}
+}
+
+// NewFloatRNode returns a new float Scalar *RNode containing the provided float.
+func NewFloatRNode(f float64) *RNode {
+	return &RNode{
+		value: &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   NodeTagFloat,
+			Value: strconv.FormatFloat(f, 'f', -1, 64),
+		}}
+}
+
+// NewBoolRNode returns a new bool Scalar *RNode containing the provided bool.
+func NewBoolRNode(b bool) *RNode {
+	return &RNode{
+		value: &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   NodeTagBool,
+			Value: strconv.FormatBool(b),
+		}}
 }
 
 // NewListRNode returns a new List *RNode containing the provided scalar values.
@@ -145,6 +178,91 @@ func NewMapRNode(values *map[string]string) *RNode {
 	}
 
 	return m
+}
+
+func newRNodeFromTypedObject(v interface{}) (*RNode, error) {
+	kind := reflect.ValueOf(v).Kind()
+	if kind == reflect.Ptr {
+		kind = reflect.TypeOf(v).Elem().Kind()
+	}
+	var node *Node
+	var err error
+	switch kind {
+	case reflect.Struct, reflect.Map:
+		node, err = newMappingYNodeFromTypedObject(v)
+	case reflect.Slice:
+		node, err = newSequenceYNodeFromTypedObject(v)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return NewRNodeFrom(node)
+}
+
+func newMappingYNodeFromTypedObject(v interface{}) (*Node, error) {
+	// The built-in types only have json tags. We can't simply do ynode.Encode(v),
+	// since it use the lowercased field name by default if no yaml tag is specified.
+	// This affects both k8s built-in types (e.g. appsv1.Deployment) and any types
+	// that depends on built-in types (e.g. metav1.ObjectMeta, corev1.PodTemplate).
+	// To work around it, we rely on the json tags. We first convert v to
+	// map[string]interface{} through json and then convert it to ynode.
+	node, err := func() (*yaml.Node, error) {
+		j, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var m map[string]interface{}
+		if err = json.Unmarshal(j, &m); err != nil {
+			return nil, err
+		}
+
+		node := &yaml.Node{}
+		if err = node.Encode(m); err != nil {
+			return nil, err
+		}
+		// Encode set the Style to FlowStyle sometimes, we reset the Style to empty.
+		node.Style = 0
+		return node, sortFields(node)
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert strong typed object to yaml node: %w", err)
+	}
+
+	// cleanup creationTimestamp field when it's null.
+	o := NewRNode(node)
+	o.cleanupCreationTimestamp()
+	return o.YNode(), nil
+}
+
+func newSequenceYNodeFromTypedObject(v interface{}) (*Node, error) {
+	// The built-in types only have json tags. We can't simply do ynode.Encode(v),
+	// since it use the lowercased field name by default if no yaml tag is specified.
+	// This affects both k8s built-in types (e.g. appsv1.Deployment) and any types
+	// that depends on built-in types (e.g. metav1.ObjectMeta, corev1.PodTemplate).
+	// To work around it, we rely on the json tags. We first convert v to
+	// []interface{} through json and then convert it to ynode.
+	node, err := func() (*yaml.Node, error) {
+		j, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var s []interface{}
+		if err = json.Unmarshal(j, &s); err != nil {
+			return nil, err
+		}
+
+		node := &yaml.Node{}
+		if err = node.Encode(s); err != nil {
+			return nil, err
+		}
+		// Encode set the Style to FlowStyle sometimes, we reset the Style to empty.
+		node.Style = 0
+		return node, sortFields(node)
+	}()
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert strong typed object to yaml node: %w", err)
+	}
+	return node, nil
 }
 
 // SyncMapNodesOrder sorts the map node keys in 'to' node to match the order of
@@ -194,6 +312,28 @@ func SyncMapNodesOrder(from, to *RNode) {
 // NewRNode returns a new RNode pointer containing the provided Node.
 func NewRNode(value *yaml.Node) *RNode {
 	return &RNode{value: value}
+}
+
+// NewEmptyRNode creates an empty mapping RNode.
+func NewEmptyRNode() (*RNode, error) {
+	return NewRNodeFrom(map[string]interface{}{})
+}
+
+// NewRNodeFrom creates a RNode from the passed-in val. val can be a map, a
+// struct or a yaml.Node.
+func NewRNodeFrom(val interface{}) (*RNode, error) {
+	switch typedVal := val.(type) {
+	case yaml.Node:
+		return &RNode{value: &typedVal}, nil
+	case *yaml.Node:
+		return &RNode{value: typedVal}, nil
+	default:
+		rn, err := newRNodeFromTypedObject(typedVal)
+		if err != nil {
+			return nil, err
+		}
+		return rn, nil
+	}
 }
 
 // RNode provides functions for manipulating Kubernetes Resources
@@ -246,6 +386,511 @@ func (rn *RNode) IsNilOrEmpty() bool {
 		IsYNodeEmptyMap(rn.YNode()) ||
 		IsYNodeEmptySeq(rn.YNode()) ||
 		IsYNodeZero(rn.YNode())
+}
+
+// AsOrDie converts a RNode to the desired typed object. ptr must
+// be a pointer to a typed object. It will panic if it encounters an error.
+func (rn *RNode) AsOrDie(ptr interface{}) {
+	if err := rn.As(ptr); err != nil {
+		panic(err)
+	}
+}
+
+// As converts a RNode to the desired typed object. ptr must be
+// a pointer to a typed object.
+func (rn *RNode) As(ptr interface{}) error {
+	if rn == nil {
+		return fmt.Errorf("the object doesn't exist")
+	}
+	if ptr == nil || reflect.ValueOf(ptr).Kind() != reflect.Ptr {
+		return fmt.Errorf("ptr must be a pointer to an object")
+	}
+
+	// The built-in types only have json tags. We can't simply do mv.Node().Decode(ptr),
+	// since it use the lowercased field name by default if no yaml tag is specified.
+	// This affects both k8s built-in types (e.g. appsv1.Deployment) and any types
+	// that depends on built-in types (e.g. metav1.ObjectMeta, corev1.PodTemplate).
+	// To work around it, we rely on the json tags. We first convert mv to json
+	// and then unmarshal it to ptr.
+	j, err := rn.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(j, ptr)
+	return err
+}
+
+// Get gets the value for a nested field located by fields. A pointer must be
+// passed in, and the value will be stored in ptr. ptr can be any concrete type
+// (e.g. string, []corev1.Container, []string, corev1.Pod, map[string]string) or
+// a RNode. RNode should be used if you are dealing with comments that is more
+// than what LineComment, HeadComment, SetLineComment and SetHeadComment can
+// handle. It returns if the field is found and a potential error.
+func (rn *RNode) Get(ptr interface{}, fields ...string) (bool, error) {
+	found, err := func() (bool, error) {
+		if rn.IsNil() {
+			return false, fmt.Errorf("the object doesn't exist")
+		}
+
+		if ptr == nil || reflect.ValueOf(ptr).Kind() != reflect.Ptr {
+			return false, fmt.Errorf("ptr must be a pointer to an object")
+		}
+
+		if rnptr, ok := ptr.(*RNode); ok {
+			val, found, err := rn.nestedValue(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			rnptr.SetYNode(val.value)
+			return found, err
+		}
+
+		switch k := reflect.TypeOf(ptr).Elem().Kind(); k {
+		case reflect.Struct, reflect.Map:
+			val, found, err := rn.nestedValue(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			if val.value.Kind != yaml.MappingNode {
+				return found, fmt.Errorf("unable to get field %v, since the RNode was not a MappingNode", fields)
+			}
+			err = val.value.Decode(ptr)
+			return found, err
+		case reflect.Slice:
+			val, found, err := rn.nestedValue(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			if val.value.Kind != yaml.SequenceNode {
+				return found, fmt.Errorf("unable to get field %v, since the RNode was not a SequenceNode", fields)
+			}
+			err = val.value.Decode(ptr)
+			return found, err
+		case reflect.String:
+			s, found, err := rn.GetNestedString(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			*(ptr.(*string)) = s
+			return found, nil
+		case reflect.Int, reflect.Int64:
+			i, found, err := rn.GetNestedInt(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			if k == reflect.Int {
+				*(ptr.(*int)) = i
+			} else if k == reflect.Int64 {
+				*(ptr.(*int64)) = int64(i)
+			}
+			return found, nil
+		case reflect.Float64:
+			f, found, err := rn.GetNestedFloat(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			*(ptr.(*float64)) = f
+			return found, nil
+		case reflect.Bool:
+			b, found, err := rn.GetNestedBool(fields...)
+			if err != nil || !found {
+				return found, err
+			}
+			*(ptr.(*bool)) = b
+			return found, nil
+		default:
+			return false, fmt.Errorf("unhandled kind %s", k)
+		}
+	}()
+	if err != nil {
+		return found, fmt.Errorf("unable to get fields %v as %T with error: %w", fields, ptr, err)
+	}
+	return found, nil
+}
+
+func (rn *RNode) nestedValue(fields ...string) (*RNode, bool, error) {
+	if rn.IsNil() {
+		return nil, false, fmt.Errorf("the object doesn't exist")
+	}
+
+	pg := &PathGetter{
+		Path: fields,
+	}
+	val, err := pg.Filter(rn)
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to get field %v: %w", fields, err)
+	}
+	if val == nil {
+		return nil, false, nil
+	}
+	return val, true, nil
+}
+
+func (rn *RNode) nestedMap(fields ...string) (*RNode, bool, error) {
+	node, found, err := rn.nestedValue(fields...)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	if node.value.Kind != yaml.MappingNode {
+		return nil, found, fmt.Errorf("the YNode kind should be MappingNode instead of %v", node.value.Kind)
+	}
+	return node, found, nil
+}
+
+func (rn *RNode) nestedSlice(fields ...string) (*RNode, bool, error) {
+	node, found, err := rn.nestedValue(fields...)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	if node.value.Kind != yaml.SequenceNode {
+		return nil, found, fmt.Errorf("the YNode kind should be SequenceNode instead of %v", node.value.Kind)
+	}
+	return node, found, nil
+}
+
+func (rn *RNode) nestedScalar(fields ...string) (*RNode, bool, error) {
+	node, found, err := rn.nestedValue(fields...)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	if node.value.Kind != yaml.ScalarNode {
+		return nil, found, fmt.Errorf("the YNode kind should be ScalarNode instead of %v", node.value.Kind)
+	}
+	return node, found, nil
+}
+
+// GetNestedString returns a nested string.
+func (rn *RNode) GetNestedString(fields ...string) (string, bool, error) {
+	scalarNode, found, err := rn.nestedScalar(fields...)
+	if err != nil || !found {
+		return "", found, err
+	}
+
+	switch scalarNode.value.Tag {
+	case NodeTagString:
+		return scalarNode.value.Value, true, nil
+	default:
+		return "", true, fmt.Errorf("node was not a string, was %v", scalarNode.value.Tag)
+	}
+}
+
+// GetNestedInt returns a nested int.
+func (rn *RNode) GetNestedInt(fields ...string) (int, bool, error) {
+	scalarNode, found, err := rn.nestedScalar(fields...)
+	if err != nil || !found {
+		return 0, found, err
+	}
+
+	switch scalarNode.value.Tag {
+	case NodeTagInt:
+		i, err := strconv.Atoi(scalarNode.value.Value)
+		if err != nil {
+			return 0, true, fmt.Errorf("unable to parse %q as int: %w", scalarNode.value.Value, err)
+		}
+		return i, true, nil
+	default:
+		return 0, true, fmt.Errorf("node was not an int, was %v", scalarNode.value.Tag)
+	}
+}
+
+// GetNestedFloat returns a nested float.
+func (rn *RNode) GetNestedFloat(fields ...string) (float64, bool, error) {
+	scalarNode, found, err := rn.nestedScalar(fields...)
+	if err != nil || !found {
+		return 0, found, err
+	}
+
+	switch scalarNode.value.Tag {
+	case NodeTagFloat:
+		f, err := strconv.ParseFloat(scalarNode.value.Value, 64)
+		if err != nil {
+			return 0, true, fmt.Errorf("unable to parse %q as float: %w", scalarNode.value.Value, err)
+		}
+		return f, true, nil
+	default:
+		return 0, true, fmt.Errorf("node was not a float, was %v", scalarNode.value.Tag)
+	}
+}
+
+// GetNestedBool returns a nested boolean.
+func (rn *RNode) GetNestedBool(fields ...string) (bool, bool, error) {
+	scalarNode, found, err := rn.nestedScalar(fields...)
+	if err != nil || !found {
+		return false, found, err
+	}
+
+	switch scalarNode.value.Tag {
+	case NodeTagBool:
+		b, err := strconv.ParseBool(scalarNode.value.Value)
+		if err != nil {
+			return false, true, fmt.Errorf("unable to parse %q as bool: %w", scalarNode.value.Value, err)
+		}
+		return b, true, nil
+	default:
+		return false, true, fmt.Errorf("node was not a bool, was %v", scalarNode.value.Tag)
+	}
+}
+
+// GetLineComment return the line comment of the field.
+func (rn *RNode) GetLineComment(fields ...string) (string, error) {
+	node, found, err := rn.nestedValue(fields...)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("unable to get line comment for field %v, since it doesn't exist", fields)
+	}
+	return node.value.LineComment, nil
+}
+
+// GetHeadComment return the head comment of the field.
+func (rn *RNode) GetHeadComment(fields ...string) (string, error) {
+	node, found, err := rn.nestedValue(fields...)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("unable to get line comment for field %v, since it doesn't exist", fields)
+	}
+	return node.value.HeadComment, nil
+}
+
+// SetOrDie sets a nested field located by fields to the value provided as val.
+// It will panic if it encounters any error.
+func (rn *RNode) SetOrDie(val interface{}, fields ...string) {
+	if err := rn.Set(val, fields...); err != nil {
+		panic(err)
+	}
+}
+
+// Set sets a nested field located by fields to the value provided as val. val
+// can be any type. e.g. int, string, []string, map[string]string, struct like
+// corev1.PodTemplate, yaml.RNode or yaml.Node.
+func (rn *RNode) Set(val interface{}, fields ...string) error {
+	if rn.IsNil() {
+		return fmt.Errorf("the object doesn't exist")
+	}
+	err := func() error {
+		if val == nil {
+			return fmt.Errorf("the passed-in object must not be nil")
+		}
+
+		switch typedVal := val.(type) {
+		case *RNode:
+			return rn.setYNode(typedVal.YNode(), fields...)
+		case RNode:
+			return rn.setYNode(typedVal.YNode(), fields...)
+		case *Node:
+			return rn.setYNode(typedVal, fields...)
+		case Node:
+			return rn.setYNode(&typedVal, fields...)
+		case []*RNode:
+			if len(typedVal) == 0 {
+				return nil
+			}
+			ynode := rnodesToYNode(typedVal)
+			return rn.setYNode(ynode, fields...)
+		}
+
+		kind := reflect.ValueOf(val).Kind()
+		if kind == reflect.Ptr {
+			kind = reflect.TypeOf(val).Elem().Kind()
+		}
+
+		switch kind {
+		case reflect.Struct, reflect.Map:
+			node, err := newMappingYNodeFromTypedObject(val)
+			if err != nil {
+				return err
+			}
+			return rn.setYNode(node, fields...)
+		case reflect.Slice:
+			node, err := newSequenceYNodeFromTypedObject(val)
+			if err != nil {
+				return err
+			}
+			return rn.setYNode(node, fields...)
+		case reflect.String:
+			var s string
+			switch val := val.(type) {
+			case string:
+				s = val
+			case *string:
+				s = *val
+			}
+			return rn.setYNode(NewStringRNode(s).YNode(), fields...)
+		case reflect.Int, reflect.Int64:
+			var i int
+			switch val := val.(type) {
+			case int:
+				i = val
+			case *int:
+				i = *val
+			case int64:
+				i = int(val)
+			case *int64:
+				i = int(*val)
+			}
+			return rn.setYNode(NewIntRNode(i).YNode(), fields...)
+		case reflect.Float64:
+			var f float64
+			switch val := val.(type) {
+			case float64:
+				f = val
+			case *float64:
+				f = *val
+			}
+			return rn.setYNode(NewFloatRNode(f).YNode(), fields...)
+		case reflect.Bool:
+			var b bool
+			switch val := val.(type) {
+			case bool:
+				b = val
+			case *bool:
+				b = *val
+			}
+			return rn.setYNode(NewBoolRNode(b).YNode(), fields...)
+		default:
+			return fmt.Errorf("unhandled kind %s", kind)
+		}
+	}()
+	if err != nil {
+		return fmt.Errorf("unable to set value %#v at fields %v with error: %w", val, fields, err)
+	}
+	return nil
+}
+
+func (rn *RNode) setYNode(yn *Node, fields ...string) error {
+	switch len(fields) {
+	case 0:
+		return fmt.Errorf("the length of fields must be at least 1")
+	case 1:
+		_, err := SetField(fields[0], &RNode{value: yn}).Filter(rn)
+		return err
+	default:
+		target, err := PathGetter{
+			Path:   fields,
+			Create: yn.Kind,
+		}.Filter(rn)
+		if err != nil {
+			return err
+		}
+		target.SetYNode(yn)
+	}
+	return nil
+}
+
+// SetLineComment sets the line comment of the field.
+func (rn *RNode) SetLineComment(comment string, fields ...string) error {
+	node := &RNode{}
+	found, err := rn.Get(node, fields...)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("can't set line comment because the field doesn't exist")
+	}
+	node.YNode().LineComment = comment
+	return nil
+}
+
+// SetHeadComment sets the head comment of the field.
+func (rn *RNode) SetHeadComment(comment string, fields ...string) error {
+	node := &RNode{}
+	found, err := rn.Get(node, fields...)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("can't set head comment because the field doesn't exist")
+	}
+	node.YNode().HeadComment = comment
+	return nil
+}
+
+// RemoveOrDie removes the field located by fields if found. It will panic if it
+// encounters any error.
+func (rn *RNode) RemoveOrDie(fields ...string) {
+	if err := rn.Remove(fields...); err != nil {
+		panic(err)
+	}
+}
+
+// Remove removes the field located by fields if found. It returns if the field
+// is found and a potential error.
+func (rn *RNode) Remove(fields ...string) error {
+	if rn.IsNil() {
+		return fmt.Errorf("the object doesn't exist")
+	}
+	err := func() error {
+		parent := rn
+		var found bool
+		var err error
+		if len(fields) > 1 {
+			parent, found, err = rn.nestedValue(fields[:len(fields)-1]...)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return nil
+			}
+		}
+
+		_, err = FieldClearer{
+			Name: fields[len(fields)-1],
+		}.Filter(parent)
+		if err != nil {
+			return err
+		}
+		return nil
+	}()
+	if err != nil {
+		return fmt.Errorf("unable to remove fields %v with error: %w", fields, err)
+	}
+	return nil
+}
+
+// RNodesToYAML encodes a list of RNode as yaml. The objects are seperated by "---"
+func RNodesToYAML(objs []RNode) (string, error) {
+	out, er := func() (string, error) {
+		var buf bytes.Buffer
+		isFirst := true
+		for _, obj := range objs {
+			if !isFirst {
+				if _, err := buf.WriteString("---\n"); err != nil {
+					return "", err
+				}
+			}
+			isFirst = false
+			s, err := obj.String()
+			if err != nil {
+				return "", err
+			}
+			if _, err = buf.WriteString(s); err != nil {
+				return "", err
+			}
+		}
+		return buf.String(), nil
+	}()
+	if er != nil {
+		return "", fmt.Errorf("unable to convert RNodes to yaml: %w", er)
+	}
+	return out, nil
+}
+
+// cleanupCreationTimestamp tries to remove field metadata.creationTimestamp. If
+// it encounters any error, it aborts.
+func (rn *RNode) cleanupCreationTimestamp() {
+	if rn.YNode().Kind != yaml.MappingNode {
+		return
+	}
+	scalar, found, err := rn.nestedScalar("metadata", "creationTimestamp")
+	if err != nil || !found {
+		return
+	}
+	if scalar.YNode().Tag == NodeTagNull {
+		rn.Remove("metadata", "creationTimestamp")
+	}
 }
 
 // GetMeta returns the ResourceMeta for an RNode
@@ -489,6 +1134,31 @@ func (rn *RNode) SetNamespace(ns string) error {
 		NewScalarRNode(ns), MetadataField, NamespaceField)
 }
 
+// GetResourceIdentifier returns the resource identifier including apiVersion,
+// kind, namespace and name.
+func (rn *RNode) GetResourceIdentifier() *ResourceIdentifier {
+	apiVersion := rn.GetApiVersion()
+	kind := rn.GetKind()
+	name := rn.GetName()
+	ns := rn.GetNamespace()
+	return &ResourceIdentifier{
+		TypeMeta: TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		NameMeta: NameMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+}
+
+// GetAnnotation gets the annotation value by looking up the key. If the key
+// doesn't exist, it returns an empty string.
+func (rn *RNode) GetAnnotation(key string) string {
+	return rn.GetAnnotations()[key]
+}
+
 // GetAnnotations gets the metadata annotations field.
 // If the field is missing, returns an empty map.
 // Use another method to check for missing metadata.
@@ -500,9 +1170,22 @@ func (rn *RNode) GetAnnotations() map[string]string {
 	return rn.getMapFromMeta(meta, AnnotationsField)
 }
 
+// SetAnnotation tries to set an annotations using the provided key and value.
+func (rn *RNode) SetAnnotation(key, value string) error {
+	annotations := rn.GetAnnotations()
+	annotations[key] = value
+	return rn.SetAnnotations(annotations)
+}
+
 // SetAnnotations tries to set the metadata annotations field.
 func (rn *RNode) SetAnnotations(m map[string]string) error {
 	return rn.setMapInMetadata(m, AnnotationsField)
+}
+
+// GetLabel gets the label value by looking up the key. If the key doesn't exist,
+// it returns an empty string.
+func (rn *RNode) GetLabel(key string) string {
+	return rn.GetLabels()[key]
 }
 
 // GetLabels gets the metadata labels field.
@@ -526,6 +1209,13 @@ func (rn *RNode) getMapFromMeta(meta *RNode, fName string) map[string]string {
 		})
 	}
 	return result
+}
+
+// SetLabel sets a label using the provided key and value.
+func (rn *RNode) SetLabel(key, value string) error {
+	lbls := rn.GetLabels()
+	lbls[key] = value
+	return rn.SetLabels(lbls)
 }
 
 // SetLabels sets the metadata labels field.
@@ -1063,6 +1753,7 @@ func checkKey(key string, elems []*Node) bool {
 	return count == len(elems)
 }
 
+// Deprecated: Use Get instead.
 // GetSlice returns the contents of the slice field at the given path.
 func (rn *RNode) GetSlice(path string) ([]interface{}, error) {
 	value, err := rn.GetFieldValue(path)
@@ -1075,6 +1766,7 @@ func (rn *RNode) GetSlice(path string) ([]interface{}, error) {
 	return nil, fmt.Errorf("node %s is not a slice", path)
 }
 
+// Deprecated: Use GetNestedString instead.
 // GetString returns the contents of the string field at the given path.
 func (rn *RNode) GetString(path string) (string, error) {
 	value, err := rn.GetFieldValue(path)
@@ -1087,6 +1779,7 @@ func (rn *RNode) GetString(path string) (string, error) {
 	return "", fmt.Errorf("node %s is not a string: %v", path, value)
 }
 
+// Deprecated: Use Get instead.
 // GetFieldValue finds period delimited fields.
 // TODO: When doing kustomize var replacement, which is likely a
 // a primary use of this function and the reason it returns interface{}
@@ -1179,3 +1872,85 @@ type NoFieldError struct {
 func (e NoFieldError) Error() string {
 	return fmt.Sprintf("no field named '%s'", e.Field)
 }
+
+func rnodesToYNode(rnodes []*RNode) *Node {
+	var nodes []*Node
+	for i := range rnodes {
+		nodes = append(nodes, rnodes[i].YNode())
+	}
+	return &Node{Kind: SequenceNode, Content: nodes}
+}
+
+func sortFields(ynode *Node) error {
+	switch ynode.Kind {
+	case MappingNode:
+		pairs, err := ynodeToYamlKeyValuePairs(ynode)
+		if err != nil {
+			return fmt.Errorf("unable to sort fields in yaml: %w", err)
+		}
+		for _, pair := range pairs {
+			if err = sortFields(pair.value); err != nil {
+				return err
+			}
+		}
+		sort.Sort(pairs)
+		ynode.Content = yamlKeyValuePairsToYnode(pairs)
+	case SequenceNode:
+		for i := range ynode.Content {
+			if err := sortFields(ynode.Content[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ynodeToYamlKeyValuePairs(ynode *Node) (yamlKeyValuePairs, error) {
+	if len(ynode.Content)%2 != 0 {
+		return nil, fmt.Errorf("invalid number of nodes: %d", len(ynode.Content))
+	}
+
+	var pairs yamlKeyValuePairs
+	for i := 0; i < len(ynode.Content); i += 2 {
+		pairs = append(pairs, &yamlKeyValuePair{name: ynode.Content[i], value: ynode.Content[i+1]})
+	}
+	return pairs, nil
+}
+
+func yamlKeyValuePairsToYnode(pairs yamlKeyValuePairs) []*Node {
+	var nodes []*yaml.Node
+	for _, pair := range pairs {
+		nodes = append(nodes, pair.name, pair.value)
+	}
+	return nodes
+}
+
+type yamlKeyValuePair struct {
+	name  *Node
+	value *Node
+}
+
+type yamlKeyValuePairs []*yamlKeyValuePair
+
+func (nodes yamlKeyValuePairs) Len() int { return len(nodes) }
+
+func (nodes yamlKeyValuePairs) Less(i, j int) bool {
+	iIndex, iFound := FieldOrder[nodes[i].name.Value]
+	jIndex, jFound := FieldOrder[nodes[j].name.Value]
+	if iFound && jFound {
+		return iIndex < jIndex
+	}
+	if iFound {
+		return true
+	}
+	if jFound {
+		return false
+	}
+
+	if nodes[i].name != nodes[j].name {
+		return nodes[i].name.Value < nodes[j].name.Value
+	}
+	return false
+}
+
+func (nodes yamlKeyValuePairs) Swap(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] }


### PR DESCRIPTION
To try it out, add the following in your `go.mod`:
```
replace sigs.k8s.io/kustomize/kyaml => github.com/mengqiy/kustomize/kyaml v0.16.0
```

godoc can be found at:
- http://104.197.156.154/pkg/sigs.k8s.io/kustomize/kyaml/fn/framework/

The problems with the existing go SDK in `kyaml`:
- The surface in kyaml is way too big. It contains the things to build not only KRM functions but also KRM function orchestrators (e.g. kustomize and kpt).
  - "kyaml is pretty huge, so I'm finding it challenging to navigate" -- Brian Grant.
- It exposes too much of the low-level implementation details. e.g. To use a ResourseList type, a use has to learn how to use RNode . Learning how to deal with RNode and YNode is not trivial.
- No strong type support when dealing with k8s objects.
- If I want to embed a KRM function in a Go program (e.g. HTTP server), there is no easy way to do it. I have to use kio package directly to dealing with (de)serialization. Learning `kio` can be another burden for a function author.

The goals are:
- Make the common developer use cases much easier
- Easier to getting started
- Smaller surface that is focusing on KRM function developers
- Hide the complexity of low-level implementation details, but still provide ways to access it for advanced users.
- Provide strong type support when reading, generating or manipulating objects.

Things to highlight:

- Introduction of [`KubeObject`](http://104.197.156.154/pkg/sigs.k8s.io/kustomize/kyaml/fn/sdk/#KubeObject)
  - It provides  `Get`, `Set`, `Remove` and a bunch of other methods
  - `Get` and `Set` allow users to work with typed object (e.g. corev1.Pod)
- [`ResourceList`](http://104.197.156.154/pkg/sigs.k8s.io/kustomize/kyaml/fn/sdk/#ResourceList) uses `KubeObject`
- Added several helper functions for creating `Result`.
- Added several package level [examples](http://104.197.156.154/pkg/sigs.k8s.io/kustomize/kyaml/fn/sdk/#pkg-examples) to demonstrate how to use the new interface

Known limitation:

After a field round tripping through the typed object, we lose comments. Some tests are failing because we drop the license header comment. There are at least 2 ways to work around it:
- Rely on the KRM function orchestrator to preserve the comments. (kpt relies on the id annotation to copy over the comments).
- Make our fn framework preserve comments automatically. e.g. Record the comments before passing it to the `ResourceListProcessor`.
