### PR TITLE
deprecate StringPrefixer and DatePrefixer

### DIFF
--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
@@ -1,9 +1,13 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+// Deprecated: DatePrefixer will be removed with kustomize/api v1.
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -60,5 +64,9 @@ func getDate() string {
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	_, err := fmt.Fprintln(os.Stderr, "Deprecated: DatePrefixer will be removed with kustomize/api v1.")
+	if err != nil {
+		return err
+	}
 	return p.t.Transform(m)
 }

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
@@ -1,9 +1,13 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+// Deprecated: StringPrefixer will be removed with kustomize/api v1.
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/builtins"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -55,5 +59,9 @@ func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	_, err := fmt.Fprintln(os.Stderr, "Deprecated: StringPrefixer will be removed with kustomize/api v1.")
+	if err != nil {
+		return err
+	}
 	return p.t.Transform(m)
 }


### PR DESCRIPTION
Per discussion in https://github.com/kubernetes-sigs/kustomize/issues/3942#issuecomment-976018860, deprecate StringPrefixer and DatePrefixer. We will remove them along with the type aliases in `api/builtins` when we release v1 of the api module. 

Based on no responses in the [thread in the kustomize slack](https://kubernetes.slack.com/archives/C9A5ALABG/p1637626203223400) it seems unlikely that many people were using these anyways. 

/cc @KnVerey @yuwenma 