### PR TITLE
[fix] configMapGenerator: extra space in end of line gives "\n" instead of line breaks

### DIFF
--- a/api/internal/generators/utils.go
+++ b/api/internal/generators/utils.go
@@ -5,6 +5,7 @@ package generators
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-errors/errors"
 	"sigs.k8s.io/kustomize/api/ifc"
@@ -50,7 +51,11 @@ func makeValidatedDataMap(
 			return nil, errors.Errorf(
 				"configmap %s illegally repeats the key `%s`", name, p.Key)
 		}
-		knownKeys[p.Key] = p.Value
+		lines := strings.Split(p.Value, "\n")
+		for i := range lines {
+			lines[i] = strings.TrimSuffix(lines[i], " ")
+		}
+		knownKeys[p.Key] = strings.Join(lines, "\n")
 	}
 	return knownKeys, nil
 }

--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -292,8 +292,10 @@ metadata:
 ---
 apiVersion: v1
 data:
-  nonsense: "Lorem ipsum dolor sit amet, consectetur\nadipiscing elit, sed do eiusmod
-    tempor\nincididunt ut labore et dolore magna aliqua. \n"
+  nonsense: |
+    Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit, sed do eiusmod tempor
+    incididunt ut labore et dolore magna aliqua.
 kind: ConfigMap
 metadata:
   annotations:
@@ -302,6 +304,6 @@ metadata:
     app: mungebot
     org: kubernetes
     repo: test-infra
-  name: test-infra-app-config-49d6f5h7b5
+  name: test-infra-app-config-4thktg822m
 `)
 }

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -572,3 +572,71 @@ metadata:
   name: test-k9cc55dfm5
 `)
 }
+
+// regression test for https://github.com/kubernetes-sigs/kustomize/issues/4287
+func TestMultilineDataEndsWithSpace(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: config_bla
+    files:
+      - cfg.text=cfg.text
+`)
+	th.WriteF("cfg.text", `bla
+bla
+bla 
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `apiVersion: v1
+data:
+  cfg.text: "bla\nbla\nbla \n"
+kind: ConfigMap
+metadata:
+  name: config_bla-d6m295b8c5
+`)
+}
+
+// regression test to record the behavior prior to the fix for https://github.com/kubernetes-sigs/kustomize/issues/4287
+// so that the fix does not affect leading and trailing newlines in ConfigMap data
+func TestMultilineDataEndsLeadingAndTrailingNewlines(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: config_bla
+    files:
+      - cfg.text=cfg.text
+`)
+	th.WriteF("cfg.text", `
+
+bla
+bla
+bla
+
+
+
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `apiVersion: v1
+data:
+  cfg.text: |2+
+
+
+    bla
+    bla
+    bla
+
+
+
+kind: ConfigMap
+metadata:
+  name: config_bla-8dm6c68g22
+`)
+}

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -593,15 +593,18 @@ bla
 	th.AssertActualEqualsExpected(
 		m, `apiVersion: v1
 data:
-  cfg.text: "bla\nbla\nbla \n"
+  cfg.text: |
+    bla
+    bla
+    bla
 kind: ConfigMap
 metadata:
-  name: config_bla-d6m295b8c5
+  name: config_bla-4k548khbf5
 `)
 }
 
 // regression test to record the behavior prior to the fix for https://github.com/kubernetes-sigs/kustomize/issues/4287
-// so that the fix does not affect leading and trailing newlines in ConfigMap data
+// to ensure that the fix does not affect leading and trailing newlines in ConfigMap data
 func TestMultilineDataEndsLeadingAndTrailingNewlines(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK(".", `


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kustomize/issues/4287 by removing trailing spaces from ConfigMap data

/cc @KnVerey @yuwenma 