### PR TITLE
collect origin data only when the option is set

### DIFF
--- a/api/resource/origin.go
+++ b/api/resource/origin.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/internal/git"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // Origin retains information about where resources in the output
@@ -15,19 +16,22 @@ import (
 type Origin struct {
 	// Path is the path to the resource, rooted from the directory upon
 	// which `kustomize build` was invoked
-	Path string
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	// Repo is the remote repository that the resource originated from if it is
 	// not from a local file
-	Repo string
+	Repo string `json:"repo,omitempty" yaml:"repo,omitempty"`
 
 	// Ref is the ref of the remote repository that the resource originated from
 	// if it is not from a local file
-	Ref string
+	Ref string `json:"ref,omitempty" yaml:"ref,omitempty"`
 }
 
 // Copy returns a copy of origin
 func (origin *Origin) Copy() Origin {
+	if origin == nil {
+		return Origin{}
+	}
 	return *origin
 }
 
@@ -47,14 +51,7 @@ func (origin *Origin) Append(path string) *Origin {
 }
 
 // String returns a string version of origin
-func (origin *Origin) String() string {
-	var anno string
-	anno = anno + "path: " + origin.Path + "\n"
-	if origin.Repo != "" {
-		anno = anno + "repo: " + origin.Repo + "\n"
-	}
-	if origin.Ref != "" {
-		anno = anno + "ref: " + origin.Ref + "\n"
-	}
-	return anno
+func (origin *Origin) String() (string, error) {
+	anno, err := kyaml.Marshal(origin)
+	return string(anno), err
 }

--- a/api/resource/origin_test.go
+++ b/api/resource/origin_test.go
@@ -6,6 +6,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	. "sigs.k8s.io/kustomize/api/resource"
 )
 
@@ -34,10 +35,9 @@ repo: https://github.com/kubernetes-sigs/kustomize
 		},
 	}
 	for _, test := range tests {
-		actual := test.in.Append(test.path).String()
-		if actual != test.expected {
-			t.Fatalf("Expected %v, but got %v\n", test.expected, actual)
-		}
+		actual, err := test.in.Append(test.path).String()
+		assert.NoError(t, err)
+		assert.Equal(t, actual, test.expected)
 	}
 }
 
@@ -76,8 +76,8 @@ repo: github.com/kubernetes-sigs/kustomize/examples/multibases/dev/
 	}
 
 	for _, test := range tests {
-		if test.in.String() != test.expected {
-			t.Fatalf("Expected %v, but got %v\n", test.expected, test.in.String())
-		}
+		actual, err := test.in.String()
+		assert.NoError(t, err)
+		assert.Equal(t, actual, test.expected)
 	}
 }

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -17,6 +17,7 @@ const (
 	ComponentVersion      = "kustomize.config.k8s.io/v1alpha1"
 	ComponentKind         = "Component"
 	MetadataNamespacePath = "metadata/namespace"
+	OriginAnnotations     = "originAnnotations"
 )
 
 // Kustomization holds the information needed to generate customized k8s api resources.


### PR DESCRIPTION
This PR is inspired by but does not implement [the transformer annotations proposal](https://github.com/kubernetes-sigs/kustomize/pull/4267).

In the previous implementation, the origin data is collected regardless of the input and added as an annotation if the option is set. This PR makes it so that we only collect the origin data if the option is set, among other small improvements. 

/cc @yuwenma @KnVerey 