### PR TITLE
Handle HTTP error codes in file loader

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -366,6 +366,9 @@ func (kt *KustTarget) accumulateResources(
 	for _, path := range paths {
 		// try loading resource as file then as base (directory or git repository)
 		if errF := kt.accumulateFile(ra, path, origin); errF != nil {
+			if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+				return nil, errF
+			}
 			ldr, err := kt.ldr.New(path)
 			if err != nil {
 				return nil, errors.Wrapf(

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/internal/utils"
 	"sigs.k8s.io/kustomize/api/konfig"
+	load "sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
@@ -366,7 +367,8 @@ func (kt *KustTarget) accumulateResources(
 	for _, path := range paths {
 		// try loading resource as file then as base (directory or git repository)
 		if errF := kt.accumulateFile(ra, path, origin); errF != nil {
-			if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+			// not much we can do if the error is an HTTP error so we bail out
+			if errors.Is(errF, load.ErrorHTTP) {
 				return nil, errF
 			}
 			ldr, err := kt.ldr.New(path)

--- a/api/loader/errors.go
+++ b/api/loader/errors.go
@@ -1,0 +1,5 @@
+package loader
+
+import "fmt"
+
+var ErrorHTTP = fmt.Errorf("HTTP Error")

--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -314,7 +314,7 @@ func (fl *fileLoader) Load(path string) ([]byte, error) {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("URL returned error %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+			return nil, fmt.Errorf("%w: status code %d (%s)", ErrorHTTP, resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -313,6 +313,9 @@ func (fl *fileLoader) Load(path string) ([]byte, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return nil, fmt.Errorf("URL returned error %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
GitHub release files like https://github.com/fluxcd/helm-controller/releases/download/v0.14.0/helm-controller.crds.yaml
seems to be hosted on Azure and it seems that there are egress limits that can be reached, e.g.:

```xml
<?xml version="1.0" encoding="utf-8"?><Error><Code>ServerBusy</Code><Message>Egress is over the account limit.
RequestId:f4a46b38-001e-0046-2437-ec16e2000000
Time:2021-12-08T13:28:03.8542138Z</Message></Error>
```

This patch allows to have a clear Error message instead of just `missing Resource metadata`:

```
Error: accumulating resources: accumulation err='accumulating resources from 'https://github.com/fluxcd/source-controller/releases/download/v0.19.0/source-controller.crds.yaml': URL returned error 503 (Service Unavailable)': evalsymlink failure on '/private/var/folders/hq/ttl6jyh539q55fz6282w0jyc0000gn/T/kustomize-3508224975/releases/download/v0.19.0/source-controller.crds.yaml' : lstat /private/var/folders/hq/ttl6jyh539q55fz6282w0jyc0000gn/T/kustomize-3508224975/releases: no such file or directory
```

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>