### PR TITLE
add kustomize edit add generator command

### DIFF
--- a/kustomize/commands/edit/add/addgenerator.go
+++ b/kustomize/commands/edit/add/addgenerator.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package add
+
+import (
+	"errors"
+	"log"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type addGeneratorOptions struct {
+	generatorFilePaths []string
+}
+
+// newCmdAddGenerator adds the name of a file containing a generator
+// configuration to the kustomization file.
+func newCmdAddGenerator(fSys filesys.FileSystem) *cobra.Command {
+	var o addGeneratorOptions
+	cmd := &cobra.Command{
+		Use:   "generator",
+		Short: "Add the name of a file containing a generator configuration to the kustomization file.",
+		Example: `
+		add generator {filepath}`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate(fSys, args)
+			if err != nil {
+				return err
+			}
+			return o.RunAddGenerator(fSys)
+		},
+	}
+	return cmd
+}
+
+// Validate validates add generator command.
+func (o *addGeneratorOptions) Validate(fSys filesys.FileSystem, args []string) error {
+	// TODO: Add validation for the format of the generator.
+	if len(args) == 0 {
+		return errors.New("must specify a yaml file which contains a generator plugin resource")
+	}
+	var err error
+	o.generatorFilePaths, err = util.GlobPatterns(fSys, args)
+	return err
+}
+
+// RunAddGenerator runs add generator command (do real work).
+func (o *addGeneratorOptions) RunAddGenerator(fSys filesys.FileSystem) error {
+	if len(o.generatorFilePaths) == 0 {
+		return nil
+	}
+	mf, err := kustfile.NewKustomizationFile(fSys)
+	if err != nil {
+		return err
+	}
+	m, err := mf.Read()
+	if err != nil {
+		return err
+	}
+	for _, t := range o.generatorFilePaths {
+		if kustfile.StringInSlice(t, m.Generators) {
+			log.Printf("generator %s already in kustomization file", t)
+			continue
+		}
+		m.Generators = append(m.Generators, t)
+	}
+	return mf.Write(m)
+}

--- a/kustomize/commands/edit/add/addgenerator_test.go
+++ b/kustomize/commands/edit/add/addgenerator_test.go
@@ -14,41 +14,41 @@ import (
 )
 
 const (
-	transformerFileName    = "myWonderfulTransformer.yaml"
-	transformerFileContent = `
+	generatorFileName    = "myWonderfulGenerator.yaml"
+	generatorFileContent = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 `
 )
 
-func TestAddTransformerHappyPath(t *testing.T) {
+func TestAddGeneratorHappyPath(t *testing.T) {
 	fSys := filesys.MakeEmptyDirInMemory()
-	err := fSys.WriteFile(transformerFileName, []byte(transformerFileContent))
+	err := fSys.WriteFile(generatorFileName, []byte(generatorFileContent))
 	require.NoError(t, err)
-	err = fSys.WriteFile(transformerFileName+"another", []byte(transformerFileContent))
+	err = fSys.WriteFile(generatorFileName+"another", []byte(generatorFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
 
-	cmd := newCmdAddTransformer(fSys)
-	args := []string{transformerFileName + "*"}
+	cmd := newCmdAddGenerator(fSys)
+	args := []string{generatorFileName + "*"}
 	assert.NoError(t, cmd.RunE(cmd, args))
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	assert.NoError(t, err)
-	assert.Contains(t, string(content), transformerFileName)
-	assert.Contains(t, string(content), transformerFileName+"another")
+	assert.Contains(t, string(content), generatorFileName)
+	assert.Contains(t, string(content), generatorFileName+"another")
 }
 
-func TestAddTransformerAlreadyThere(t *testing.T) {
+func TestAddGeneratorAlreadyThere(t *testing.T) {
 	fSys := filesys.MakeEmptyDirInMemory()
-	err := fSys.WriteFile(transformerFileName, []byte(transformerFileName))
+	err := fSys.WriteFile(generatorFileName, []byte(generatorFileName))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
 
-	cmd := newCmdAddTransformer(fSys)
-	args := []string{transformerFileName}
+	cmd := newCmdAddGenerator(fSys)
+	args := []string{generatorFileName}
 	assert.NoError(t, cmd.RunE(cmd, args))
 
-	// adding an existing transformer shouldn't return an error
+	// adding an existing generator shouldn't return an error
 	assert.NoError(t, cmd.RunE(cmd, args))
 
 	// There can be only one. May it be the...
@@ -56,27 +56,27 @@ func TestAddTransformerAlreadyThere(t *testing.T) {
 	assert.NoError(t, err)
 	m, err := mf.Read()
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(m.Transformers))
-	assert.Equal(t, transformerFileName, m.Transformers[0])
+	assert.Equal(t, 1, len(m.Generators))
+	assert.Equal(t, generatorFileName, m.Generators[0])
 }
 
-func TestAddTransformerNoArgs(t *testing.T) {
+func TestAddGeneratorNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 
-	cmd := newCmdAddTransformer(fSys)
+	cmd := newCmdAddGenerator(fSys)
 	err := cmd.Execute()
-	assert.EqualError(t, err, "must specify a yaml file which contains a transformer plugin resource")
+	assert.EqualError(t, err, "must specify a yaml file which contains a generator plugin resource")
 }
 
-func TestAddTransformerMissingKustomizationYAML(t *testing.T) {
+func TestAddGeneratorMissingKustomizationYAML(t *testing.T) {
 	fSys := filesys.MakeEmptyDirInMemory()
-	err := fSys.WriteFile(transformerFileName, []byte(transformerFileContent))
+	err := fSys.WriteFile(generatorFileName, []byte(generatorFileContent))
 	require.NoError(t, err)
-	err = fSys.WriteFile(transformerFileName+"another", []byte(transformerFileContent))
+	err = fSys.WriteFile(generatorFileName+"another", []byte(generatorFileContent))
 	require.NoError(t, err)
 
-	cmd := newCmdAddTransformer(fSys)
-	args := []string{transformerFileName + "*"}
+	cmd := newCmdAddGenerator(fSys)
+	args := []string{generatorFileName + "*"}
 	err = cmd.RunE(cmd, args)
 	assert.EqualError(t, err, "Missing kustomization file 'kustomization.yaml'.\n")
 }

--- a/kustomize/commands/edit/add/addtransformer.go
+++ b/kustomize/commands/edit/add/addtransformer.go
@@ -21,14 +21,13 @@ type addTransformerOptions struct {
 // configuration to the kustomization file.
 func newCmdAddTransformer(fSys filesys.FileSystem) *cobra.Command {
 	var o addTransformerOptions
-
 	cmd := &cobra.Command{
 		Use:   "transformer",
 		Short: "Add the name of a file containing a transformer configuration to the kustomization file.",
 		Example: `
 		add transformer {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.Validate(args)
+			err := o.Validate(fSys, args)
 			if err != nil {
 				return err
 			}
@@ -39,41 +38,35 @@ func newCmdAddTransformer(fSys filesys.FileSystem) *cobra.Command {
 }
 
 // Validate validates add transformer command.
-func (o *addTransformerOptions) Validate(args []string) error {
+func (o *addTransformerOptions) Validate(fSys filesys.FileSystem, args []string) error {
+	// TODO: Add validation for the format of the transformer.
 	if len(args) == 0 {
-		return errors.New("must specify a transformer file")
+		return errors.New("must specify a yaml file which contains a transformer plugin resource")
 	}
-	o.transformerFilePaths = args
-	return nil
+	var err error
+	o.transformerFilePaths, err = util.GlobPatterns(fSys, args)
+	return err
 }
 
 // RunAddTransformer runs add transformer command (do real work).
 func (o *addTransformerOptions) RunAddTransformer(fSys filesys.FileSystem) error {
-	transformers, err := util.GlobPatterns(fSys, o.transformerFilePaths)
-	if err != nil {
-		return err
-	}
-	if len(transformers) == 0 {
+	if len(o.transformerFilePaths) == 0 {
 		return nil
 	}
-
 	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
 	}
-
 	m, err := mf.Read()
 	if err != nil {
 		return err
 	}
-
-	for _, t := range transformers {
+	for _, t := range o.transformerFilePaths {
 		if kustfile.StringInSlice(t, m.Transformers) {
 			log.Printf("transformer %s already in kustomization file", t)
 			continue
 		}
 		m.Transformers = append(m.Transformers, t)
 	}
-
 	return mf.Write(m)
 }

--- a/kustomize/commands/edit/add/all.go
+++ b/kustomize/commands/edit/add/all.go
@@ -60,6 +60,7 @@ func NewCmdAdd(
 		newCmdAddLabel(fSys, ldr.Validator().MakeLabelValidator()),
 		newCmdAddAnnotation(fSys, ldr.Validator().MakeAnnotationValidator()),
 		newCmdAddTransformer(fSys),
+		newCmdAddGenerator(fSys),
 	)
 	return c
 }


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kustomize/issues/4343

Per request, create a command `kustomize edit add generator`. Just like the existing `kustomize edit add transformer`, but for generators. This code is almost identical to the code in `addtransformer.go` and `addtransormer_test.go`.

/cc @KnVerey 
/cc @yuwenma 