### PR TITLE
empty fields in smp patch targets are treated as wildcards

### DIFF
--- a/api/krusty/multiplepatch_test.go
+++ b/api/krusty/multiplepatch_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
@@ -1734,7 +1733,6 @@ replacements:
     - metadata.annotations.test-annotation
     options:
       create: true
-
 patches:
 - patch: |-
     kind: ServiceAccount
@@ -1743,8 +1741,15 @@ patches:
       annotations: 
         test-annotation: true
 `)
-	err := th.RunWithErr(".", th.MakeDefaultOptions())
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), `no matches for Id ServiceAccount.[noVer].[noGrp]/ksa-google-cas-issuer.[noNs]; failed to find unique target for patch ServiceAccount.[noVer].[noGrp]/ksa-google-cas-issuer.[noNs]`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	b, err := m.AsYaml()
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    test-annotation: "true"
+  name: ksa-google-cas-issuer
+  namespace: cert-manager
+`)
 }
-

--- a/api/krusty/openapicustomschema_test.go
+++ b/api/krusty/openapicustomschema_test.go
@@ -45,7 +45,7 @@ spec:
 
 func writeOtherCustomResource(th kusttest_test.Harness, filepath string) {
 	th.WriteF(filepath, `
-apiVersion: v1alpha1
+apiVersion: crd.com/v1alpha1
 kind: MyCRD
 metadata:
   name: service
@@ -109,7 +109,7 @@ patchesStrategicMerge:
         - name: server
           image: nginx
 - |-
-  apiVersion: v1alpha1
+  apiVersion: crd.com/v1alpha1
   kind: MyCRD
   metadata:
     name: service
@@ -185,7 +185,7 @@ spec:
           name: grpc
           protocol: TCP
 ---
-apiVersion: v1alpha1
+apiVersion: crd.com/v1alpha1
 kind: MyCRD
 metadata:
   name: service

--- a/api/krusty/testdata/customschema.json
+++ b/api/krusty/testdata/customschema.json
@@ -36,7 +36,7 @@
           "version": "v1alpha1"
         },
         {
-          "group": "",
+          "group": "crd.com",
           "kind": "MyCRD",
           "version": "v1alpha1"
         }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -224,7 +224,7 @@ type resFinder func(IdMatcher) []*resource.Resource
 
 func demandOneMatch(
 	f resFinder, id resid.ResId, s string) (*resource.Resource, error) {
-	r := f(id.Equals)
+	r := f(id.Selects)
 	if len(r) == 1 {
 		return r[0], nil
 	}

--- a/kyaml/resid/resid.go
+++ b/kyaml/resid/resid.go
@@ -102,6 +102,11 @@ func (id ResId) IsSelectedBy(selector ResId) bool {
 		id.Gvk.IsSelected(&selector.Gvk)
 }
 
+// Selects return true if the argument is selected by self.
+func (id ResId) Selects(o ResId) bool {
+	return o.IsSelectedBy(id)
+}
+
 // Equals returns true if the other id matches
 // namespace/Group/Version/Kind/name.
 func (id ResId) Equals(o ResId) bool {

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer_test.go
@@ -1049,9 +1049,11 @@ func TestMultipleNamespaces(t *testing.T) {
 		{
 			name:          "withschema-ns1-nil",
 			base:          []string{addNamespace("ns1", baseResource(Deployment))},
-			patch:         []string{changeImagePatch(Deployment, "nginx:1.7.9")},
-			errorExpected: true,
-			errorMsg:      "failed to find unique target for patch",
+			patch:         []string{addLabelAndEnvPatch(Deployment)},
+			errorExpected: false,
+			expected: []string{
+				addNamespace("ns1", expectedResultSMP()),
+			},
 		},
 		{
 			name:          "noschema-ns1-ns2",
@@ -1070,9 +1072,11 @@ func TestMultipleNamespaces(t *testing.T) {
 		{
 			name:          "noschema-ns1-nil",
 			base:          []string{addNamespace("ns1", baseResource(MyCRD))},
-			patch:         []string{changeImagePatch(MyCRD, "nginx:1.7.9")},
-			errorExpected: true,
-			errorMsg:      "failed to find unique target for patch",
+			patch:         []string{addLabelAndEnvPatch(MyCRD)},
+			errorExpected: false,
+			expected: []string{
+				addNamespace("ns1", expectedResultJMP("")),
+			},
 		},
 	}
 


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kustomize/issues/4273

Currently, omitted fields in patch IDs result in them not matching their targets. For example, leaving out the `apiVersion` in a patch file results in an error that there are no matches for this patch's ID. IMO a missing field in a patch ID should be treated as a wildcard - though I'm open to hearing alternative suggestions and opinions if there are any. 

/cc @yuwenma 
/cc @KnVerey 

First commit shows old behavior and error message, second commit changes it. 

There are some unit tests in `TestMultipleNamespaces` that had to be changed to reflect the new behavior as well. 

