### PR TITLE
feat: add SetEntryCallback to labels filter

### DIFF
--- a/api/filters/labels/labels.go
+++ b/api/filters/labels/labels.go
@@ -20,9 +20,24 @@ type Filter struct {
 
 	// FsSlice identifies the label fields.
 	FsSlice types.FsSlice
+
+	// SetEntryCallback is invoked each time a label is applied
+	// Example use cases:
+	//   - Tracking all paths where labels have been applied
+	SetEntryCallback func(key, value, tag string, node *yaml.RNode)
 }
 
 var _ kio.Filter = Filter{}
+
+func (f Filter) setEntry(key, value, tag string) filtersutil.SetFn {
+	baseSetEntryFunc := filtersutil.SetEntry(key, value, tag)
+	return func(node *yaml.RNode) error {
+		if f.SetEntryCallback != nil {
+			f.SetEntryCallback(key, value, tag, node)
+		}
+		return baseSetEntryFunc(node)
+	}
+}
 
 func (f Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	keys := yaml.SortedMapKeys(f.Labels)
@@ -31,7 +46,7 @@ func (f Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 			for _, k := range keys {
 				if err := node.PipeE(fsslice.Filter{
 					FsSlice: f.FsSlice,
-					SetValue: filtersutil.SetEntry(
+					SetValue: f.setEntry(
 						k, f.Labels[k], yaml.NodeTagString),
 					CreateKind: yaml.MappingNode, // Labels are MappingNodes.
 					CreateTag:  yaml.NodeTagMap,


### PR DESCRIPTION
Add a configurable callback that is invoked each time a label is applied
by the labels filter. This is useful for scenarios such as tracking
labels as they are applied.

Issues: GoogleContainerTools/kpt#2448

This follows a similar approach as the set-annotations filter, as implemented here: https://github.com/kubernetes-sigs/kustomize/pull/4307