### PR TITLE
deprecate enable-managedby-label flag in favor of a field

### DIFF
--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/builtins"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/internal/target"
+	"sigs.k8s.io/kustomize/api/internal/utils"
 	"sigs.k8s.io/kustomize/api/konfig"
 	fLdr "sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/provenance"
@@ -95,7 +96,7 @@ func (b *Kustomizer) Run(
 			return nil, err
 		}
 	}
-	if b.options.AddManagedbyLabel {
+	if b.options.AddManagedbyLabel || utils.StringSliceContains(kt.Kustomization().BuildMetadata, types.ManagedByLabelOption) {
 		t := builtins.LabelTransformerPlugin{
 			Labels: map[string]string{
 				konfig.ManagedbyLabelKey: fmt.Sprintf("kustomize-%s", provenance.GetProvenance().Semver()),

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -17,7 +17,9 @@ const (
 	ComponentVersion      = "kustomize.config.k8s.io/v1alpha1"
 	ComponentKind         = "Component"
 	MetadataNamespacePath = "metadata/namespace"
-	OriginAnnotations     = "originAnnotations"
+
+	OriginAnnotations    = "originAnnotations"
+	ManagedByLabelOption = "managedByLabel"
 )
 
 // Kustomization holds the information needed to generate customized k8s api resources.

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -104,6 +104,8 @@ func NewCmdBuild(
 	AddFlagEnablePlugins(cmd.Flags())
 	AddFlagReorderOutput(cmd.Flags())
 	AddFlagEnableManagedbyLabel(cmd.Flags())
+	cmd.Flags().MarkDeprecated(managedByFlag,
+		"The flag `enable-managedby-label` has been deprecated. Use the `managedByLabel` option in the `buildMetadata` field instead.")
 	AddFlagEnableHelm(cmd.Flags())
 	return cmd
 }

--- a/kustomize/commands/build/flagaddmanagedby.go
+++ b/kustomize/commands/build/flagaddmanagedby.go
@@ -10,10 +10,12 @@ import (
 	"sigs.k8s.io/kustomize/api/konfig"
 )
 
+const managedByFlag = "enable-managedby-label"
+
 func AddFlagEnableManagedbyLabel(set *pflag.FlagSet) {
 	set.BoolVar(
 		&theFlags.enable.managedByLabel,
-		"enable-managedby-label",
+		managedByFlag,
 		false,
 		`enable adding `+konfig.ManagedbyLabelKey)
 }


### PR DESCRIPTION
This deprecates the flag `enable-managedby-label` and replaces it with an option `managedByLabel` in the `buildMetadata` field. As discussed previously, we would like to move flags like this to fields as we prepare for kustomize v5 and kustomization v1. 

Fixes https://github.com/kubernetes-sigs/kustomize/issues/4047

/cc @yuwenma 
/cc @KnVerey 