### PR TITLE
fix deprecated help message to `kustomize fn run --help`

### DIFF
--- a/cmd/config/docs/commands/run-fns.md
+++ b/cmd/config/docs/commands/run-fns.md
@@ -1,6 +1,6 @@
 ## run
 
-[Alpha] Reoncile config functions to Resources.
+[Alpha] Reconcile config functions to Resources.
 
 ### Synopsis
 
@@ -46,7 +46,7 @@ order they appear in the file).
   would then write the container stdout back to example/, replacing the directory
   file contents.
 
-  See `kustomize help cfg docs-fn` for more details on writing functions.
+  See `kustomize docs-fn` for more details on writing functions.
 
 ### Examples
 


### PR DESCRIPTION
I think help message of `kustomize fn run --help` has mistake.

Output is
```
$ kustomize fn run --help

[Alpha] Reconcile config functions to Resources.
...
  In the preceding example, 'kustomize run example/' would identify the function by
  the metadata.annotations.[config.kubernetes.io/function] field.  It would then write all Resources in the directory to
  a container stdin (running the gcr.io/example/examplefunction:v1.0.1 image).  It
  would then write the container stdout back to example/, replacing the directory
  file contents.

  See `kustomize help cfg docs-fn` for more details on writing functions.

Usage:
  kustomize fn run [DIR] [flags]
...
```

But, `kustomize help cfg docs-fn` is wrong command to show docs.\
I think the right command is `kustomize docs-fn`.

```
$ kustomize help cfg docs-fn
Commands for reading and writing configuration.

Usage:
  kustomize cfg [command]

Available Commands:
  cat           [Alpha] Print Resource Config from a local directory.
  count         [Alpha] Count Resources Config from a local directory.
  grep          [Alpha] Search for matching Resources in a directory or from stdin
  tree          [Alpha] Display Resource structure from a directory or stdin.

Flags:
  -h, --help   help for cfg

Global Flags:
      --stack-trace   print a stack-trace on error

Use "kustomize cfg [command] --help" for more information about a command.

$ kustomize docs-fn
# Running Configuration Functions using kustomize CLI

Configuration functions can be implemented using any toolchain and invoked using any
container workflow orchestrator including Tekton, Cloud Build, or run directly using `docker run`.

Run `config help docs-fn-spec` to see the Configuration Functions Specification.
...
```

I want to fix this wrong message.

## extra
I think this line has typo. I want to fix it at the same time.
```
[Alpha] Reoncile config functions to Resources.
```