### PR TITLE
new command `kustomize edit add buildmetadata`

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -325,11 +325,7 @@ func (kt *KustTarget) runTransformers(ra *accumulator.ResAccumulator) error {
 		return err
 	}
 	r = append(r, lts...)
-	err = ra.Transform(newMultiTransformer(r))
-	if err != nil {
-		return err
-	}
-	return nil
+	return ra.Transform(newMultiTransformer(r))
 }
 
 func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]*resmap.TransformerWithProperties, error) {

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -23,6 +23,8 @@ const (
 	ManagedByLabelOption   = "managedByLabel"
 )
 
+var BuildMetadataOptions = []string{OriginAnnotations, TransformerAnnotations, ManagedByLabelOption}
+
 // Kustomization holds the information needed to generate customized k8s api resources.
 type Kustomization struct {
 	TypeMeta `json:",inline" yaml:",inline"`

--- a/kustomize/commands/edit/add/addbuildmetadata.go
+++ b/kustomize/commands/edit/add/addbuildmetadata.go
@@ -1,0 +1,86 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package add
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type addBuildMetadataOptions struct {
+	buildMetadataOptions []string
+}
+
+// newCmdAddBuildMetadata adds options to the kustomization's buildMetada field.
+func newCmdAddBuildMetadata(fSys filesys.FileSystem) *cobra.Command {
+	var o addBuildMetadataOptions
+
+	cmd := &cobra.Command{
+		Use:   "buildmetadata",
+		Short: "Adds one or more buildMetadata options to the kustomization.yaml in the current directory",
+		Long:  `Adds one or more buildMetadata options to the kustomization.yaml in the current directory.
+The following options are valid:
+  - originAnnotations
+  - transformerAnnotations
+  - managedByLabel
+originAnnotations will add the annotation config.kubernetes.io/origin to each resource, describing where 
+each resource originated from.
+transformerAnnotations will add the annotation alpha.config.kubernetes.io/transformations to each resource,
+describing the transformers that have acted upon the resource.
+managedByLabel will add the label app.kubernetes.io/managed-by to each resource, describing which version
+of kustomize managed the resource.`,
+		Example: `
+		add buildmetadata {option1},{option2}`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate(args)
+			if err != nil {
+				return err
+			}
+			return o.RunAddBuildMetadata(fSys)
+		},
+	}
+	return cmd
+}
+
+// Validate validates addBuildMetadata command.
+func (o *addBuildMetadataOptions) Validate(args []string) error {
+	if len(args) == 0 {
+		return errors.New("must specify a buildMetadata option")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: %s; to provide multiple buildMetadata options, please separate options by comma", args)
+	}
+	o.buildMetadataOptions = strings.Split(args[0], ",")
+	for _, opt := range o.buildMetadataOptions {
+		if !kustfile.StringInSlice(opt, types.BuildMetadataOptions) {
+			return fmt.Errorf("invalid buildMetadata option: %s", opt)
+		}
+	}
+	return nil
+}
+
+// RunAddBuildMetadata runs addBuildMetadata command (do real work).
+func (o *addBuildMetadataOptions) RunAddBuildMetadata(fSys filesys.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
+	if err != nil {
+		return err
+	}
+	m, err := mf.Read()
+	if err != nil {
+		return err
+	}
+	for _, opt := range o.buildMetadataOptions {
+		if kustfile.StringInSlice(opt, m.BuildMetadata) {
+			return fmt.Errorf("buildMetadata option %s already in kustomization file", opt)
+		}
+		m.BuildMetadata = append(m.BuildMetadata, opt)
+	}
+	return mf.Write(m)
+}

--- a/kustomize/commands/edit/add/addbuildmetadata_test.go
+++ b/kustomize/commands/edit/add/addbuildmetadata_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package add
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/types"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestAddBuildMetadataHappyPath(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	cmd := newCmdAddBuildMetadata(fSys)
+	args := []string{strings.Join(types.BuildMetadataOptions, ",")}
+	assert.NoError(t, cmd.RunE(cmd, args))
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	assert.NoError(t, err)
+	for _, opt := range types.BuildMetadataOptions {
+		assert.Contains(t, string(content), opt)
+	}
+}
+
+func TestAddBuildMetadataAlreadyThere(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	cmd := newCmdAddBuildMetadata(fSys)
+	args := []string{strings.Join(types.BuildMetadataOptions, ",")}
+	assert.NoError(t, cmd.RunE(cmd, args))
+	err := cmd.RunE(cmd, args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already in kustomization file")
+}
+
+func TestAddBuildMetadataInvalidArg(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	cmd := newCmdAddBuildMetadata(fSys)
+	args := []string{"invalid_option"}
+	err := cmd.RunE(cmd, args)
+	assert.Error(t, err)
+	assert.Equal(t, "invalid buildMetadata option: invalid_option", err.Error())
+}
+
+func TestAddBuildMetadataTooManyArgs(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomization(fSys)
+	cmd := newCmdAddBuildMetadata(fSys)
+	args := []string{"option1", "option2"}
+	err := cmd.RunE(cmd, args)
+	assert.Error(t, err)
+	assert.Equal(t, "too many arguments: [option1 option2]; to provide multiple buildMetadata options, please separate options by comma", err.Error())
+}

--- a/kustomize/commands/edit/add/all.go
+++ b/kustomize/commands/edit/add/all.go
@@ -57,6 +57,7 @@ func NewCmdAdd(
 		newCmdAddSecret(fSys, ldr, rf),
 		newCmdAddConfigMap(fSys, ldr, rf),
 		newCmdAddBase(fSys),
+		newCmdAddBuildMetadata(fSys),
 		newCmdAddLabel(fSys, ldr.Validator().MakeLabelValidator()),
 		newCmdAddAnnotation(fSys, ldr.Validator().MakeAnnotationValidator()),
 		newCmdAddTransformer(fSys),

--- a/kustomize/commands/edit/remove/all.go
+++ b/kustomize/commands/edit/remove/all.go
@@ -42,6 +42,7 @@ func NewCmdRemove(
 		newCmdRemoveAnnotation(fSys, v.MakeAnnotationNameValidator()),
 		newCmdRemovePatch(fSys),
 		newCmdRemoveTransformer(fSys),
+		newCmdRemoveBuildMetadata(fSys),
 	)
 	return c
 }

--- a/kustomize/commands/edit/remove/removebuildmetadata.go
+++ b/kustomize/commands/edit/remove/removebuildmetadata.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package remove
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type removeBuildMetadataOptions struct {
+	*util.BuildMetadataValidator
+	buildMetadataOptions []string
+}
+
+// newCmdRemoveBuildMetadata removes options to the kustomization's buildMetada field.
+func newCmdRemoveBuildMetadata(fSys filesys.FileSystem) *cobra.Command {
+	var o removeBuildMetadataOptions
+
+	cmd := &cobra.Command{
+		Use:   "buildmetadata",
+		Short: "Removes one or more buildMetadata options to the kustomization.yaml in the current directory",
+		Long: `Removes one or more buildMetadata options to the kustomization.yaml in the current directory.
+The following options are valid:
+  - originAnnotations
+  - transformerAnnotations
+  - managedByLabel
+originAnnotations will remove the annotation config.kubernetes.io/origin to each resource, describing where 
+each resource originated from.
+transformerAnnotations will remove the annotation alpha.config.kubernetes.io/transformations to each resource,
+describing the transformers that have acted upon the resource.
+managedByLabel will remove the label app.kubernetes.io/managed-by to each resource, describing which version
+of kustomize managed the resource.`,
+		Example: `
+		remove buildmetadata {option1},{option2}`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			o.buildMetadataOptions, err = o.BuildMetadataValidator.Validate(args)
+			if err != nil {
+				return err
+			}
+			return o.RunRemoveBuildMetadata(fSys)
+		},
+	}
+	return cmd
+}
+
+// RunRemoveBuildMetadata runs removeBuildMetadata command (do real work).
+func (o *removeBuildMetadataOptions) RunRemoveBuildMetadata(fSys filesys.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
+	if err != nil {
+		return err
+	}
+	m, err := mf.Read()
+	if err != nil {
+		return err
+	}
+	var newOptions []string
+	for _, opt := range m.BuildMetadata {
+		if !kustfile.StringInSlice(opt, o.buildMetadataOptions) {
+			newOptions = append(newOptions, opt)
+		}
+	}
+	m.BuildMetadata = newOptions
+	if len(m.BuildMetadata) == 0 {
+		m.BuildMetadata = nil
+	}
+	return mf.Write(m)
+}

--- a/kustomize/commands/edit/set/all.go
+++ b/kustomize/commands/edit/set/all.go
@@ -30,6 +30,7 @@ func NewCmdSet(fSys filesys.FileSystem, ldr ifc.KvLoader, v ifc.Validator) *cobr
 		newCmdSetNameSuffix(fSys),
 		newCmdSetNamespace(fSys, v),
 		newCmdSetImage(fSys),
+		newCmdSetBuildMetadata(fSys),
 		newCmdSetReplicas(fSys),
 		newCmdSetLabel(fSys, ldr.Validator().MakeLabelValidator()),
 		newCmdSetAnnotation(fSys, ldr.Validator().MakeAnnotationValidator()),

--- a/kustomize/commands/edit/set/setbuildmetadata.go
+++ b/kustomize/commands/edit/set/setbuildmetadata.go
@@ -1,30 +1,29 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package add
+package set
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-type addBuildMetadataOptions struct {
+type setBuildMetadataOptions struct {
 	*util.BuildMetadataValidator
 	buildMetadataOptions []string
 }
 
-// newCmdAddBuildMetadata adds options to the kustomization's buildMetada field.
-func newCmdAddBuildMetadata(fSys filesys.FileSystem) *cobra.Command {
-	var o addBuildMetadataOptions
+// newCmdSetBuildMetadata sets options in the kustomization's buildMetada field.
+func newCmdSetBuildMetadata(fSys filesys.FileSystem) *cobra.Command {
+	var o setBuildMetadataOptions
 
 	cmd := &cobra.Command{
 		Use:   "buildmetadata",
-		Short: "Adds one or more buildMetadata options to the kustomization.yaml in the current directory",
-		Long: `Adds one or more buildMetadata options to the kustomization.yaml in the current directory.
+		Short: "Sets one or more buildMetadata options to the kustomization.yaml in the current directory",
+		Long: `Sets one or more buildMetadata options to the kustomization.yaml in the current directory.
+Existing options in the buildMetadata field will be replaced entirely by the new options set by this command.
 The following options are valid:
   - originAnnotations
   - transformerAnnotations
@@ -36,21 +35,21 @@ describing the transformers that have acted upon the resource.
 managedByLabel will add the label app.kubernetes.io/managed-by to each resource, describing which version
 of kustomize managed the resource.`,
 		Example: `
-		add buildmetadata {option1},{option2}`,
+		set buildmetadata {option1},{option2}`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			o.buildMetadataOptions, err = o.BuildMetadataValidator.Validate(args)
 			if err != nil {
 				return err
 			}
-			return o.RunAddBuildMetadata(fSys)
+			return o.RunSetBuildMetadata(fSys)
 		},
 	}
 	return cmd
 }
 
-// RunAddBuildMetadata runs addBuildMetadata command (do real work).
-func (o *addBuildMetadataOptions) RunAddBuildMetadata(fSys filesys.FileSystem) error {
+// RunSetBuildMetadata runs setBuildMetadata command (do real work).
+func (o *setBuildMetadataOptions) RunSetBuildMetadata(fSys filesys.FileSystem) error {
 	mf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		return err
@@ -59,11 +58,6 @@ func (o *addBuildMetadataOptions) RunAddBuildMetadata(fSys filesys.FileSystem) e
 	if err != nil {
 		return err
 	}
-	for _, opt := range o.buildMetadataOptions {
-		if kustfile.StringInSlice(opt, m.BuildMetadata) {
-			return fmt.Errorf("buildMetadata option %s already in kustomization file", opt)
-		}
-		m.BuildMetadata = append(m.BuildMetadata, opt)
-	}
+	m.BuildMetadata = o.buildMetadataOptions
 	return mf.Write(m)
 }

--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -67,6 +67,7 @@ func determineFieldOrder() []string {
 		"Inventory",
 		"Components",
 		"OpenAPI",
+		"BuildMetadata",
 	}
 
 	// Add deprecated fields here.

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -49,6 +49,7 @@ func TestFieldOrder(t *testing.T) {
 		"Inventory",
 		"Components",
 		"OpenAPI",
+		"BuildMetadata",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {

--- a/kustomize/commands/internal/util/util_test.go
+++ b/kustomize/commands/internal/util/util_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (

--- a/kustomize/commands/internal/util/validate.go
+++ b/kustomize/commands/internal/util/validate.go
@@ -1,0 +1,31 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+)
+
+type BuildMetadataValidator struct{}
+
+func (b *BuildMetadataValidator) Validate(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return nil, errors.New("must specify a buildMetadata option")
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("too many arguments: %s; to provide multiple buildMetadata options, please separate options by comma", args)
+	}
+	opts := strings.Split(args[0], ",")
+	for _, opt := range opts {
+		if !kustfile.StringInSlice(opt, types.BuildMetadataOptions) {
+			return nil, fmt.Errorf("invalid buildMetadata option: %s", opt)
+		}
+	}
+	return opts, nil
+}

--- a/plugin/builtin/prefixtransformer/PrefixTransformer.go
+++ b/plugin/builtin/prefixtransformer/PrefixTransformer.go
@@ -71,7 +71,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 				if p.Prefix != "" {
 					// TODO: There are multiple transformers that can change a resource's name, and each makes a call to
 					// StorePreviousID(). We should make it so that we only call StorePreviousID once per kustomization layer
-					// to avoid storing intermediate names between transformations, to prevent intermediate name conflicts. 
+					// to avoid storing intermediate names between transformations, to prevent intermediate name conflicts.
 					r.StorePreviousId()
 				}
 			}


### PR DESCRIPTION
This is the last PR needed to finish implementation of the proposal to add origin and transformer annotations [[link to KEP](https://github.com/kubernetes-sigs/kustomize/pull/4267)]. 

This adds a command `kustomize edit add buildmetadata` that allows users to edit the buildMetadata options in the kustomization file. It also adds `kustomize edit set buildmetadata` and `kustomize edit remove buildmetadata` commands. 

E.g. `kustomize edit add buildmetadata managedByLabel`, `kustomize edit add buildmetadata originAnnotations,transformerAnnotations`

/cc @yuwenma 
/cc @KnVerey 