### PR TITLE
Imagetag trackable filter

### DIFF
--- a/api/filters/imagetag/imagetag.go
+++ b/api/filters/imagetag/imagetag.go
@@ -4,7 +4,6 @@
 package imagetag
 
 import (
-	"sigs.k8s.io/kustomize/api/filters/filtersutil"
 	"sigs.k8s.io/kustomize/api/filters/fsslice"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -41,7 +40,9 @@ func (f Filter) filter(node *yaml.RNode) (*yaml.RNode, error) {
 	}
 	if err := node.PipeE(fsslice.Filter{
 		FsSlice:  f.FsSlice,
-		SetValue: updateImageTagFn(f.ImageTag),
+		SetValue: imageTagUpdater{
+			ImageTag: f.ImageTag,
+		}.SetImageValue,
 	}); err != nil {
 		return nil, err
 	}
@@ -58,12 +59,4 @@ func (f Filter) isOnDenyList(node *yaml.RNode) bool {
 	// Ignore CRDs
 	// https://github.com/kubernetes-sigs/kustomize/issues/890
 	return meta.Kind == `CustomResourceDefinition`
-}
-
-func updateImageTagFn(imageTag types.Image) filtersutil.SetFn {
-	return func(node *yaml.RNode) error {
-		return node.PipeE(imageTagUpdater{
-			ImageTag: imageTag,
-		})
-	}
 }

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -14,8 +14,9 @@ import (
 // that will update the value of the yaml node based on the provided
 // ImageTag if the current value matches the format of an image reference.
 type imageTagUpdater struct {
-	Kind     string      `yaml:"kind,omitempty"`
-	ImageTag types.Image `yaml:"imageTag,omitempty"`
+	Kind            string      `yaml:"kind,omitempty"`
+	ImageTag        types.Image `yaml:"imageTag,omitempty"`
+	trackableSetter filtersutil.TrackableSetter
 }
 
 func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
@@ -40,7 +41,7 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		tag = "@" + u.ImageTag.Digest
 	}
 
-	return filtersutil.SetScalar(name + tag)(rn)
+	return u.trackableSetter.SetScalar(name + tag)(rn)
 }
 
 func (u imageTagUpdater) Filter(rn *yaml.RNode) (*yaml.RNode, error) {


### PR DESCRIPTION
This change updates the imagetag filter to implement the TrackableFilter
interface. This provides the functionality for the user to track which
fields were updated by the imagetag filter.

Issues: https://github.com/kubernetes-sigs/kustomize/issues/4372