### PR TITLE
fix: set FieldPath for SequenceNode elements

### DIFF
--- a/api/filters/fieldspec/fieldspec.go
+++ b/api/filters/fieldspec/fieldspec.go
@@ -137,6 +137,8 @@ func (fltr Filter) handleMap(obj *yaml.RNode) error {
 // seq calls filter on all sequence elements
 func (fltr Filter) handleSequence(obj *yaml.RNode) error {
 	if err := obj.VisitElements(func(node *yaml.RNode) error {
+		// set an accurate FieldPath for nested elements
+		node.AppendToFieldPath(obj.FieldPath()...)
 		// recurse on each element -- re-allocating a Filter is
 		// not strictly required, but is more consistent with field
 		// and less likely to have side effects


### PR DESCRIPTION
The FieldPath was not being set for nodes underneath a SequenceNode
during fieldspec's traversal. This is in part because handleSequence
uses VisitElements in contrast to a PathGetter as is done by handleMap.

The accuracy of FieldPath is more relevant now with the recently added
support of mutation trackers in filtersutil. This change fixes the
case where a mutation tracker callback is called on a SequenceNode
element and the node does not have an accurate FieldPath value.


For example:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: app
spec:
  containers:
  - name: store
    image: redis:6.2.6
```
For the above input, the following `FieldPath` would be seen for the `image` node from the perspective of a [mutationTracker](https://github.com/kubernetes-sigs/kustomize/blob/master/api/filters/filtersutil/setters.go#L41):
Before this change: `image`
After this change: `spec.containers.image`