### PR TITLE
Update owners file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,18 +3,14 @@
 aliases:
   kustomize-owners:
     - knverey
-    - monopole
-    - pwittrock
-  kustomize-approvers:
-    - justinsb
-    - knverey
-    - monopole
     - natasha41575
-    - pwittrock
+  kustomize-approvers:
+    - knverey
+    - natasha41575
   kustomize-reviewers:
     - knverey
-    - monopole
     - natasha41575
+    - yuwenma
 
   kyaml-approvers:
     - mengqiy
@@ -28,3 +24,6 @@ aliases:
   emeritus-approvers:
     - liujingfang1
     - Shell32-Natsu
+    - justinsb
+    - monopole
+    - pwittrock


### PR DESCRIPTION
This PR gives @natasha41575 a very well-deserved promotion to subproject owner status. In addition to keeping the lights on for this project over the past year, Natasha has increasingly been driving major designs and most recently co-authored the Kustomize roadmap for 2022. Congratulations, Natasha! 🎉 

This PR also recognizes @yuwenma as a reviewer. Yuwen has been getting increasingly involved in the project, and we're excited to have her join us officially. Welcome, Yuwen! 🎉 

This PR also moves @monopole and @pwittrock to Emeritus status at their request. It is impossible to overstate how important Jeff and Phil have been to Kustomize. Thank you for everything that you've done, and enjoy the reduction in automated pings. ❤️ 😉 

cc @soltysh @eddiezane @seans3 

