### PR TITLE
Implement trackable filters

### DIFF
--- a/api/filters/namespace/namespace.go
+++ b/api/filters/namespace/namespace.go
@@ -18,9 +18,17 @@ type Filter struct {
 
 	// FsSlice contains the FieldSpecs to locate the namespace field
 	FsSlice types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+
+	trackableSetter filtersutil.TrackableSetter
 }
 
 var _ kio.Filter = Filter{}
+var _ kio.TrackableFilter = &Filter{}
+
+// WithMutationTracker registers a callback which will be invoked each time a field is mutated
+func (ns *Filter) WithMutationTracker(callback func(key, value, tag string, node *yaml.RNode)) {
+	ns.trackableSetter.WithMutationTracker(callback)
+}
 
 func (ns Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	return kio.FilterAll(yaml.FilterFunc(ns.run)).Filter(nodes)
@@ -44,7 +52,7 @@ func (ns Filter) run(node *yaml.RNode) (*yaml.RNode, error) {
 	// transformations based on data -- :)
 	err := node.PipeE(fsslice.Filter{
 		FsSlice:    ns.FsSlice,
-		SetValue:   filtersutil.SetScalar(ns.Namespace),
+		SetValue:   ns.trackableSetter.SetScalar(ns.Namespace),
 		CreateKind: yaml.ScalarNode, // Namespace is a ScalarNode
 		CreateTag:  yaml.NodeTagString,
 	})
@@ -77,7 +85,7 @@ func (ns Filter) metaNamespaceHack(obj *yaml.RNode, gvk resid.Gvk) error {
 		FsSlice: []types.FieldSpec{
 			{Path: types.MetadataNamespacePath, CreateIfNotPresent: true},
 		},
-		SetValue:   filtersutil.SetScalar(ns.Namespace),
+		SetValue:   ns.trackableSetter.SetScalar(ns.Namespace),
 		CreateKind: yaml.ScalarNode, // Namespace is a ScalarNode
 	}
 	_, err := f.Filter(obj)
@@ -123,11 +131,15 @@ func (ns Filter) roleBindingHack(obj *yaml.RNode, gvk resid.Gvk) error {
 		}
 
 		// set the namespace for the default account
-		v := yaml.NewScalarRNode(ns.Namespace)
-		return o.PipeE(
+		node, err := o.Pipe(
 			yaml.LookupCreate(yaml.ScalarNode, "namespace"),
-			yaml.FieldSetter{Value: v},
 		)
+		if err != nil {
+			return err
+		}
+
+		return ns.trackableSetter.SetScalar(ns.Namespace)(node)
+
 	})
 
 	return err

--- a/api/filters/prefix/prefix_test.go
+++ b/api/filters/prefix/prefix_test.go
@@ -11,7 +11,10 @@ import (
 	"sigs.k8s.io/kustomize/api/filters/prefix"
 	filtertest_test "sigs.k8s.io/kustomize/api/testutils/filtertest"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+var mutationTrackerStub = filtertest_test.MutationTrackerStub{}
 
 var tests = map[string]TestCase{
 	"prefix": {
@@ -83,17 +86,61 @@ a:
 			FieldSpec: types.FieldSpec{Path: "a/b/c"},
 		},
 	},
+
+	"mutation tracker": {
+		input: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: instance
+---
+apiVersion: example.com/v1
+kind: Bar
+metadata:
+  name: instance
+`,
+		expected: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: foo-instance
+---
+apiVersion: example.com/v1
+kind: Bar
+metadata:
+  name: foo-instance
+`,
+		filter: prefix.Filter{
+			Prefix:    "foo-",
+			FieldSpec: types.FieldSpec{Path: "metadata/name"},
+		},
+		mutationTracker: mutationTrackerStub.MutationTracker,
+		expectedSetValueArgs: []filtertest_test.SetValueArg{
+			{
+				Value:    "foo-instance",
+				NodePath: []string{"metadata", "name"},
+			},
+			{
+				Value:    "foo-instance",
+				NodePath: []string{"metadata", "name"},
+			},
+		},
+	},
 }
 
 type TestCase struct {
-	input    string
-	expected string
-	filter   prefix.Filter
+	input                string
+	expected             string
+	filter               prefix.Filter
+	mutationTracker      func(key, value, tag string, node *yaml.RNode)
+	expectedSetValueArgs []filtertest_test.SetValueArg
 }
 
 func TestFilter(t *testing.T) {
 	for name := range tests {
+		mutationTrackerStub.Reset()
 		test := tests[name]
+		test.filter.WithMutationTracker(test.mutationTracker)
 		t.Run(name, func(t *testing.T) {
 			if !assert.Equal(t,
 				strings.TrimSpace(test.expected),
@@ -101,6 +148,7 @@ func TestFilter(t *testing.T) {
 					filtertest_test.RunFilter(t, test.input, test.filter))) {
 				t.FailNow()
 			}
+			assert.Equal(t, test.expectedSetValueArgs, mutationTrackerStub.SetValueArgs())
 		})
 	}
 }

--- a/api/filters/replicacount/replicacount.go
+++ b/api/filters/replicacount/replicacount.go
@@ -14,9 +14,17 @@ import (
 type Filter struct {
 	Replica   types.Replica   `json:"replica,omitempty" yaml:"replica,omitempty"`
 	FieldSpec types.FieldSpec `json:"fieldSpec,omitempty" yaml:"fieldSpec,omitempty"`
+
+	trackableSetter filtersutil.TrackableSetter
 }
 
 var _ kio.Filter = Filter{}
+var _ kio.TrackableFilter = &Filter{}
+
+// WithMutationTracker registers a callback which will be invoked each time a field is mutated
+func (rc *Filter) WithMutationTracker(callback func(key, value, tag string, node *yaml.RNode)) {
+	rc.trackableSetter.WithMutationTracker(callback)
+}
 
 func (rc Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	return kio.FilterAll(yaml.FilterFunc(rc.run)).Filter(nodes)
@@ -33,5 +41,5 @@ func (rc Filter) run(node *yaml.RNode) (*yaml.RNode, error) {
 }
 
 func (rc Filter) set(node *yaml.RNode) error {
-	return filtersutil.SetScalar(strconv.FormatInt(rc.Replica.Count, 10))(node)
+	return rc.trackableSetter.SetScalar(strconv.FormatInt(rc.Replica.Count, 10))(node)
 }

--- a/api/filters/replicacount/replicacount_test.go
+++ b/api/filters/replicacount/replicacount_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	filtertest_test "sigs.k8s.io/kustomize/api/testutils/filtertest"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func TestFilter(t *testing.T) {
-
+	mutationTrackerStub := filtertest_test.MutationTrackerStub{}
 	testCases := map[string]struct {
-		input    string
-		expected string
-		filter   Filter
+		input                string
+		expected             string
+		filter               Filter
+		mutationTracker      func(key, value, tag string, node *yaml.RNode)
+		expectedSetValueArgs []filtertest_test.SetValueArg
 	}{
 		"update field": {
 			input: `
@@ -161,9 +164,43 @@ spec:
 				FieldSpec: types.FieldSpec{Path: "spec/template/replicas"},
 			},
 		},
+		"mutation tracker": {
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  replicas: 5
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  replicas: 42
+`,
+			filter: Filter{
+				Replica: types.Replica{
+					Name:  "dep",
+					Count: 42,
+				},
+				FieldSpec: types.FieldSpec{Path: "spec/replicas"},
+			},
+			mutationTracker: mutationTrackerStub.MutationTracker,
+			expectedSetValueArgs: []filtertest_test.SetValueArg{
+				{
+					Value:    "42",
+					NodePath: []string{"spec", "replicas"},
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {
+		mutationTrackerStub.Reset()
+		tc.filter.WithMutationTracker(tc.mutationTracker)
 		t.Run(tn, func(t *testing.T) {
 			if !assert.Equal(t,
 				strings.TrimSpace(tc.expected),
@@ -171,6 +208,7 @@ spec:
 					filtertest_test.RunFilter(t, tc.input, tc.filter))) {
 				t.FailNow()
 			}
+			assert.Equal(t, tc.expectedSetValueArgs, mutationTrackerStub.SetValueArgs())
 		})
 	}
 }

--- a/api/filters/suffix/suffix.go
+++ b/api/filters/suffix/suffix.go
@@ -18,9 +18,17 @@ type Filter struct {
 	Suffix string `json:"suffix,omitempty" yaml:"suffix,omitempty"`
 
 	FieldSpec types.FieldSpec `json:"fieldSpec,omitempty" yaml:"fieldSpec,omitempty"`
+
+	trackableSetter filtersutil.TrackableSetter
 }
 
 var _ kio.Filter = Filter{}
+var _ kio.TrackableFilter = &Filter{}
+
+// WithMutationTracker registers a callback which will be invoked each time a field is mutated
+func (f *Filter) WithMutationTracker(callback func(key, value, tag string, node *yaml.RNode)) {
+	f.trackableSetter.WithMutationTracker(callback)
+}
 
 func (f Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	return kio.FilterAll(yaml.FilterFunc(f.run)).Filter(nodes)
@@ -37,6 +45,6 @@ func (f Filter) run(node *yaml.RNode) (*yaml.RNode, error) {
 }
 
 func (f Filter) evaluateField(node *yaml.RNode) error {
-	return filtersutil.SetScalar(fmt.Sprintf(
+	return f.trackableSetter.SetScalar(fmt.Sprintf(
 		"%s%s", node.YNode().Value, f.Suffix))(node)
 }

--- a/api/filters/suffix/suffix_test.go
+++ b/api/filters/suffix/suffix_test.go
@@ -11,7 +11,10 @@ import (
 	"sigs.k8s.io/kustomize/api/filters/suffix"
 	filtertest_test "sigs.k8s.io/kustomize/api/testutils/filtertest"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+var mutationTrackerStub = filtertest_test.MutationTrackerStub{}
 
 var tests = map[string]TestCase{
 	"suffix": {
@@ -83,17 +86,61 @@ a:
 			FieldSpec: types.FieldSpec{Path: "a/b/c"},
 		},
 	},
+
+	"mutation tracker": {
+		input: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: instance
+---
+apiVersion: example.com/v1
+kind: Bar
+metadata:
+  name: instance
+`,
+		expected: `
+apiVersion: example.com/v1
+kind: Foo
+metadata:
+  name: instance-foo
+---
+apiVersion: example.com/v1
+kind: Bar
+metadata:
+  name: instance-foo
+`,
+		filter: suffix.Filter{
+			Suffix:    "-foo",
+			FieldSpec: types.FieldSpec{Path: "metadata/name"},
+		},
+		mutationTracker: mutationTrackerStub.MutationTracker,
+		expectedSetValueArgs: []filtertest_test.SetValueArg{
+			{
+				Value:    "instance-foo",
+				NodePath: []string{"metadata", "name"},
+			},
+			{
+				Value:    "instance-foo",
+				NodePath: []string{"metadata", "name"},
+			},
+		},
+	},
 }
 
 type TestCase struct {
-	input    string
-	expected string
-	filter   suffix.Filter
+	input                string
+	expected             string
+	filter               suffix.Filter
+	mutationTracker      func(key, value, tag string, node *yaml.RNode)
+	expectedSetValueArgs []filtertest_test.SetValueArg
 }
 
 func TestFilter(t *testing.T) {
 	for name := range tests {
+		mutationTrackerStub.Reset()
 		test := tests[name]
+		test.filter.WithMutationTracker(test.mutationTracker)
 		t.Run(name, func(t *testing.T) {
 			if !assert.Equal(t,
 				strings.TrimSpace(test.expected),
@@ -101,6 +148,7 @@ func TestFilter(t *testing.T) {
 					filtertest_test.RunFilter(t, test.input, test.filter))) {
 				t.FailNow()
 			}
+			assert.Equal(t, test.expectedSetValueArgs, mutationTrackerStub.SetValueArgs())
 		})
 	}
 }

--- a/api/testutils/filtertest/runfilter.go
+++ b/api/testutils/filtertest/runfilter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func run(input string, f kio.Filter) (string, error) {
@@ -45,4 +46,33 @@ func RunFilterE(t *testing.T, input string, f kio.Filter) (string, error) {
 		return "", err
 	}
 	return output, nil
+}
+
+type SetValueArg struct {
+	Key      string
+	Value    string
+	Tag      string
+	NodePath []string
+}
+
+// MutationTrackerStub to help stub a mutation tracker for kio.TrackableFilter
+type MutationTrackerStub struct {
+	setValueArgs []SetValueArg
+}
+
+func (mts *MutationTrackerStub) MutationTracker(key, value, tag string, node *yaml.RNode) {
+	mts.setValueArgs = append(mts.setValueArgs, SetValueArg{
+		Key:      key,
+		Value:    value,
+		Tag:      tag,
+		NodePath: node.FieldPath(),
+	})
+}
+
+func (mts *MutationTrackerStub) SetValueArgs() []SetValueArg {
+	return mts.setValueArgs
+}
+
+func (mts *MutationTrackerStub) Reset() {
+	mts.setValueArgs = nil
 }


### PR DESCRIPTION
Add a common test util for a mutation tracker stub.
This is intended to reduce the duplicated boilerplate as additional
filters implement the TrackableFilter interface.

Implements the TrackableFilter interface for the following filters:
- `namespace`
- `prefix`
- `replicacount`
- `suffix`

Issues: https://github.com/kubernetes-sigs/kustomize/issues/4372