### PR TITLE
Install arch appropriate build if the 'arch' command is present

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -95,11 +95,15 @@ trap cleanup EXIT ERR
 pushd "$tmpDir" >& /dev/null
 
 opsys=windows
-arch=amd64
 if [[ "$OSTYPE" == linux* ]]; then
   opsys=linux
 elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
+fi
+
+arch=amd64
+if command -v arch &> /dev/null; then
+  arch=$(arch)
 fi
 
 releases=$(curl -s $release_url)

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -101,10 +101,24 @@ elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
 fi
 
-arch=amd64
-if command -v arch &> /dev/null; then
-  arch=$(arch)
-fi
+# Supported values of 'arch': amd64, arm64, ppc64le, s390x
+case $(uname -m) in
+x86_64)
+    arch=amd64
+    ;;
+arm64)
+    arch=arm64
+    ;;
+ppc64le)
+    arch=ppc64le
+    ;;
+s390x)
+    arch=s390x
+    ;;
+*)
+    arch=amd64
+    ;;
+esac
 
 releases=$(curl -s $release_url)
 


### PR DESCRIPTION
Fixes #4433 

Intent is to use the 'arch' command if present to find the suitable architecture, otherwise stay with the default of 'amd64'.

Tested on Mac with arm64 and Linux with amd64