### PR TITLE
merge/replace fieldSpecs in transformer configs per strategy (#4404)

### DIFF
--- a/api/types/fieldspec.go
+++ b/api/types/fieldspec.go
@@ -44,6 +44,21 @@ func (fs FieldSpec) effectivelyEquals(other FieldSpec) bool {
 
 type FsSlice []FieldSpec
 
+type fieldSpecStrategy int
+
+const (
+	// Replace means the version of the resource in FsSlice should be the output.
+	Replace fieldSpecStrategy = iota
+	// Merge means the output to FsSlice should be the merge of defaults,
+	// and FsSlice.
+	Merge
+)
+
+var FieldSpecStrategy = map[fieldSpecStrategy]string{
+	Replace: "replace",
+	Merge:   "merge",
+}
+
 func (s FsSlice) Len() int      { return len(s) }
 func (s FsSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s FsSlice) Less(i, j int) bool {

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer_test.go
@@ -54,3 +54,182 @@ spec:
   - port: 7002
 `)
 }
+
+func TestAnnotationsTransformerFieldSpecStrategyReplace(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: notImportantHere
+annotations:
+  app: bar
+fieldSpecs:
+  - path: spec/template/metadata/annotations
+    create: true
+fieldSpecStrategy: replace
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+  annotations:
+    app: foo
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app: foo
+  name: myDeployment
+spec:
+  template:
+    metadata:
+      annotations:
+        app: bar
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+`)
+}
+
+func TestAnnotationsTransformerFieldSpecStrategyMergeDefaults(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: notImportantHere
+annotations:
+  app: bar
+fieldSpecStrategy: merge
+  `, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  ports:
+  - port: 7002
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app: bar
+  name: myDeployment
+spec:
+  template:
+    metadata:
+      annotations:
+        app: bar
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app: bar
+  name: myService
+spec:
+  ports:
+  - port: 7002
+`)
+}
+
+func TestAnnotationsTransformerFieldSpecStrategyMergeOverrides(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("AnnotationsTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: notImportantHere
+annotations:
+  app: bar
+fieldSpecs:
+- path: spec/invalid/schema
+  create: true
+fieldSpecStrategy: merge
+  `, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  ports:
+  - port: 7002
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app: bar
+  name: myDeployment
+spec:
+  invalid:
+    schema:
+      app: bar
+  template:
+    metadata:
+      annotations:
+        app: bar
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app: bar
+  name: myService
+spec:
+  invalid:
+    schema:
+      app: bar
+  ports:
+  - port: 7002
+`)
+}

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"sigs.k8s.io/kustomize/api/filters/imagetag"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
@@ -14,8 +15,9 @@ import (
 // Find matching image declarations and replace
 // the name, tag and/or digest.
 type plugin struct {
-	ImageTag   types.Image       `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
-	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	ImageTag          types.Image       `json:"imageTag,omitempty" yaml:"imageTag,omitempty"`
+	FieldSpecs        []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	FieldSpecStrategy string            `json:"fieldSpecStrategy,omitempty" yaml:"fieldSpecStrategy,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -23,9 +25,28 @@ var KustomizePlugin plugin
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {
-	p.ImageTag = types.Image{}
-	p.FieldSpecs = nil
-	return yaml.Unmarshal(c, p)
+	kp := p
+	kp.ImageTag = types.Image{}
+	kp.FieldSpecs = nil
+	if err = yaml.Unmarshal(c, kp); err != nil {
+		return err
+	}
+	p = kp
+	switch kp.FieldSpecStrategy {
+	case types.FieldSpecStrategy[types.Merge]:
+		fsSliceAsMap, err := builtinpluginconsts.GetFsSliceAsMap()
+		if err != nil {
+			return err
+		}
+		kp.FieldSpecs, err = types.FsSlice(kp.FieldSpecs).MergeAll(fsSliceAsMap["images"])
+		if err != nil {
+			return err
+		}
+		p.FieldSpecs = kp.FieldSpecs
+	case types.FieldSpecStrategy[types.Replace]:
+		p.FieldSpecs = kp.FieldSpecs
+	}
+	return nil
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"sigs.k8s.io/kustomize/api/filters/labels"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
@@ -13,8 +14,9 @@ import (
 
 // Add the given labels to the given field specifications.
 type plugin struct {
-	Labels     map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	FieldSpecs        []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	FieldSpecStrategy string            `json:"fieldSpecStrategy,omitempty" yaml:"fieldSpecStrategy,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -22,9 +24,28 @@ var KustomizePlugin plugin
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {
-	p.Labels = nil
-	p.FieldSpecs = nil
-	return yaml.Unmarshal(c, p)
+	kp := p
+	kp.Labels = nil
+	kp.FieldSpecs = nil
+	if err = yaml.Unmarshal(c, kp); err != nil {
+		return err
+	}
+	p = kp
+	switch kp.FieldSpecStrategy {
+	case types.FieldSpecStrategy[types.Merge]:
+		fsSliceAsMap, err := builtinpluginconsts.GetFsSliceAsMap()
+		if err != nil {
+			return err
+		}
+		kp.FieldSpecs, err = types.FsSlice(kp.FieldSpecs).MergeAll(fsSliceAsMap["commonlabels"])
+		if err != nil {
+			return err
+		}
+		p.FieldSpecs = kp.FieldSpecs
+	case types.FieldSpecStrategy[types.Replace]:
+		p.FieldSpecs = kp.FieldSpecs
+	}
+	return nil
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {

--- a/plugin/builtin/prefixtransformer/PrefixTransformer_test.go
+++ b/plugin/builtin/prefixtransformer/PrefixTransformer_test.go
@@ -164,3 +164,207 @@ metadata:
   name: cm
 `)
 }
+
+func TestPrefixTransformerFieldSpecStrategyReplace(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: notImportantHere
+prefix: test-
+fieldSpecs:
+  - kind: Deployment
+    path: metadata/name
+  - kind: Deployment
+    path: spec/template/spec/containers/name
+fieldSpecStrategy: replace
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: myapp
+        name: main
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    internal.config.kubernetes.io/prefixes: test-
+    internal.config.kubernetes.io/previousKinds: Deployment
+    internal.config.kubernetes.io/previousNames: deployment
+    internal.config.kubernetes.io/previousNamespaces: default
+  name: test-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: myapp
+        name: test-main
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+}
+
+func TestPrefixTransformerFieldSpecStrategyMergeDefaults(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: notImportantHere
+prefix: baked-
+fieldSpecStrategy: merge
+`, `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    internal.config.kubernetes.io/prefixes: baked-
+    internal.config.kubernetes.io/previousKinds: Service
+    internal.config.kubernetes.io/previousNames: apple
+    internal.config.kubernetes.io/previousNamespaces: default
+  name: baked-apple
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    internal.config.kubernetes.io/prefixes: baked-
+    internal.config.kubernetes.io/previousKinds: ConfigMap
+    internal.config.kubernetes.io/previousNames: cm
+    internal.config.kubernetes.io/previousNamespaces: default
+  name: baked-cm
+`)
+}
+
+func TestPrefixTransformerFieldSpecStrategyMergeOverrides(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PrefixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: notImportantHere
+prefix: baked-
+fieldSpecs:
+  - path: spec/ports[]/name
+fieldSpecStrategy: merge
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple
+spec:
+  ports:
+  - name: apple
+    port: 7002
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    internal.config.kubernetes.io/prefixes: baked-
+    internal.config.kubernetes.io/previousKinds: Service
+    internal.config.kubernetes.io/previousNames: apple
+    internal.config.kubernetes.io/previousNamespaces: default
+  name: baked-apple
+spec:
+  ports:
+  - name: baked-apple
+    port: 7002
+`)
+}

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer_test.go
@@ -20,7 +20,6 @@ apiVersion: builtin
 kind: ReplicaCountTransformer
 metadata:
   name: notImportantHere
-
 replica:
   name: myapp
   count: 23
@@ -114,6 +113,325 @@ kind: Deployment
 metadata:
   name: myapp
 spec:
+  replicas: 23
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+`)
+}
+
+func TestReplicaCountTransformerFieldSpecStrategyReplace(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ReplicaCountTransformer
+metadata:
+  name: notImportantHere
+replica:
+  name: myapp
+  count: 23
+fieldSpecs:
+- path: spec/replicas
+  create: true
+  kind: Deployment
+fieldSpecStrategy: replace
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+`)
+
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+`)
+}
+
+func TestReplicaCountTransformerFieldSpecStrategyMergeDefaults(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ReplicaCountTransformer
+metadata:
+  name: notImportantHere
+replica:
+  name: myapp
+  count: 23
+fieldSpecStrategy: merge
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+`)
+
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  replicas: 23
+  selector:
+    matchLabels:
+      app: app
+`)
+}
+
+func TestReplicaCountTransformerFieldSpecStrategyMergeOverrides(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ReplicaCountTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ReplicaCountTransformer
+metadata:
+  name: notImportantHere
+replica:
+  name: myapp
+  count: 23
+fieldSpecs:
+  - path: spec/invalid/schema
+    create: true
+    kind: Deployment
+fieldSpecStrategy: merge
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+---
+apiVersion: apps/v1
+kind: ReplicationController
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: app
+`)
+
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otherapp
+spec:
+  replicas: 5
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  invalid:
+    schema: 23
   replicas: 23
 ---
 apiVersion: apps/v1

--- a/plugin/builtin/suffixtransformer/SuffixTransformer.go
+++ b/plugin/builtin/suffixtransformer/SuffixTransformer.go
@@ -5,9 +5,8 @@
 package main
 
 import (
-	"errors"
-
 	"sigs.k8s.io/kustomize/api/filters/suffix"
+	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
@@ -16,8 +15,9 @@ import (
 
 // Add the given suffix to the field
 type plugin struct {
-	Suffix     string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
-	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Suffix            string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
+	FieldSpecs        types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	FieldSpecStrategy string        `json:"fieldSpecStrategy,omitempty" yaml:"fieldSpecStrategy,omitempty"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -32,16 +32,28 @@ var suffixFieldSpecsToSkip = types.FsSlice{
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {
-	p.Suffix = ""
-	p.FieldSpecs = nil
-	err = yaml.Unmarshal(c, p)
-	if err != nil {
-		return
+	kp := p
+	kp.Suffix = ""
+	kp.FieldSpecs = nil
+	if err = yaml.Unmarshal(c, kp); err != nil {
+		return err
 	}
-	if p.FieldSpecs == nil {
-		return errors.New("fieldSpecs is not expected to be nil")
+	p = kp
+	switch kp.FieldSpecStrategy {
+	case types.FieldSpecStrategy[types.Merge]:
+		fsSliceAsMap, err := builtinpluginconsts.GetFsSliceAsMap()
+		if err != nil {
+			return err
+		}
+		kp.FieldSpecs, err = types.FsSlice(kp.FieldSpecs).MergeAll(fsSliceAsMap["namesuffix"])
+		if err != nil {
+			return err
+		}
+		p.FieldSpecs = kp.FieldSpecs
+	case types.FieldSpecStrategy[types.Replace]:
+		p.FieldSpecs = kp.FieldSpecs
 	}
-	return
+	return nil
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {

--- a/plugin/builtin/suffixtransformer/SuffixTransformer_test.go
+++ b/plugin/builtin/suffixtransformer/SuffixTransformer_test.go
@@ -164,3 +164,207 @@ metadata:
   name: cm
 `)
 }
+
+func TestSuffixTransformerFieldSpecStrategyReplace(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("SuffixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: SuffixTransformer
+metadata:
+  name: notImportantHere
+suffix: -test
+fieldSpecs:
+  - kind: Deployment
+    path: metadata/name
+  - kind: Deployment
+    path: spec/template/spec/containers/name
+fieldSpecStrategy: replace
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: myapp
+        name: main
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    internal.config.kubernetes.io/previousKinds: Deployment
+    internal.config.kubernetes.io/previousNames: deployment
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -test
+  name: deployment-test
+spec:
+  template:
+    spec:
+      containers:
+      - image: myapp
+        name: main-test
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+}
+
+func TestSuffixTransformerFieldSpecStrategyMergeDefaults(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("SuffixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: SuffixTransformer
+metadata:
+  name: notImportantHere
+suffix: -pie
+fieldSpecStrategy: merge
+`, `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: apple
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    internal.config.kubernetes.io/previousKinds: Service
+    internal.config.kubernetes.io/previousNames: apple
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -pie
+  name: apple-pie
+spec:
+  ports:
+  - port: 7002
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: apiservice
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    internal.config.kubernetes.io/previousKinds: ConfigMap
+    internal.config.kubernetes.io/previousNames: cm
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -pie
+  name: cm-pie
+`)
+}
+
+func TestSuffixTransformerFieldSpecStrategyMergeOverrides(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("SuffixTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: SuffixTransformer
+metadata:
+  name: notImportantHere
+suffix: -pie
+fieldSpecs:
+  - path: spec/ports[]/name
+fieldSpecStrategy: merge
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: apple
+spec:
+  ports:
+  - name: apple
+    port: 7002
+`)
+
+	th.AssertActualEqualsExpected(rm, `
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    internal.config.kubernetes.io/previousKinds: Service
+    internal.config.kubernetes.io/previousNames: apple
+    internal.config.kubernetes.io/previousNamespaces: default
+    internal.config.kubernetes.io/suffixes: -pie
+  name: apple-pie
+spec:
+  ports:
+  - name: apple-pie
+    port: 7002
+`)
+}


### PR DESCRIPTION
This PR includes a `DefaultFieldSpecs()` function for each of the filters utilizing `fsslice`, since `builtinconfig` is internal to `api` and thus not accessible from `plugin/builtin`. Likewise, for each of the builtin plugins using said filters, if the end-user omits a `fieldSpecs` attribute in the respective builtin transformer config function specification (i.e. - `p.FieldSpecs == nil`), the defaults will be applied by way of the aforementioned filter function related to that plugin.

Regarding backwards compatibility, as @KnVerey noted in #4404, if `fieldSpecs` are not specified then the builtin transformer config functions were of limited use, so the end-user was required to set the `fieldSpecs` attribute to achieve the desired results. Given that most of the builtin plugins did not croak on the absence of the `fieldSpecs` attribute, it is conceivable that there are builtin transformer config function specifications in the field that will suddenly start mutating resources with this change. Builtin transformer config functions with a `fieldSpecs` attribute set will continue functioning as previously.

On a forwards compatibility note, it would now be possible for two versions of kustomize to produce unequal results, which I think poses the question whether the `builtin` `apiVersion` ought not be versioned.