### PR TITLE
fn framework: Enable validation using openAPI schema for functionConfig

### DIFF
--- a/cmd/pluginator/go.sum
+++ b/cmd/pluginator/go.sum
@@ -48,6 +48,7 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
@@ -156,6 +157,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -218,6 +220,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/kyaml/fn/framework/example/main.go
+++ b/kyaml/fn/framework/example/main.go
@@ -33,7 +33,7 @@ func buildProcessor(value *string) framework.ResourceListProcessor {
 		}},
 		// This will be populated from the --value flag if provided,
 		// or the config file's `value` field if provided, with the latter taking precedence.
-		TemplateData: struct {
+		TemplateData: &struct {
 			Value *string `yaml:"value"`
 		}{Value: value}}
 }

--- a/kyaml/fn/framework/function_definition.go
+++ b/kyaml/fn/framework/function_definition.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const FunctionDefinitionKind = "KRMFunctionDefinition"
+const FunctionDefinitionGroupVersion = "config.kubernetes.io/v1alpha1"
+
+// KRMFunctionDefinition is metadata that defines a KRM function the same way a CRD defines a custom resource.
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2906-kustomize-function-catalog#function-metadata-schema
+type KRMFunctionDefinition struct {
+	// APIVersion and Kind of the object. Must be config.kubernetes.io/v1alpha1 and KRMFunctionDefinition respectively.
+	yaml.TypeMeta `yaml:",inline" json:",inline"`
+	// Standard KRM object metadata
+	yaml.ObjectMeta `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	// Spec contains the properties of the KRM function this object defines.
+	Spec KrmFunctionDefinitionSpec `yaml:"spec" json:"spec"`
+}
+
+type KrmFunctionDefinitionSpec struct {
+	//
+	// The following fields are shared with CustomResourceDefinition.
+	//
+	// Group is the API group of the defined KRM function.
+	Group string `yaml:"group" json:"group"`
+	// Names specify the resource and kind names for the KRM function.
+	Names KRMFunctionNames `yaml:"names" json:"names"`
+	// Versions is the list of all API versions of the defined KRM function.
+	Versions []KRMFunctionVersion `yaml:"versions" json:"versions"`
+
+	//
+	// The following fields are custom to KRMFunctionDefinition
+	//
+	// Description briefly describes the KRM function.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	// Publisher is the entity (e.g. organization) that produced and owns this KRM function.
+	Publisher string `yaml:"publisher,omitempty" json:"publisher,omitempty"`
+	// Home is a URI pointing the home page of the KRM function.
+	Home string `yaml:"home,omitempty" json:"home,omitempty"`
+	// Maintainers lists the individual maintainers of the KRM function.
+	Maintainers []string `yaml:"maintainers,omitempty" json:"maintainers,omitempty"`
+	// Tags are keywords describing the function. e.g. mutator, validator, generator, prefix, GCP.
+	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+}
+
+type KRMFunctionVersion struct {
+	//
+	// The following fields are shared with CustomResourceDefinition.
+	//
+	// Name is the version name, e.g. “v1”, “v2beta1”, etc.
+	Name string `yaml:"name" json:"name"`
+	// Schema describes the schema of this version of the KRM function.
+	// This can be used for validation, pruning, and/or defaulting.
+	Schema *KRMFunctionValidation `yaml:"schema,omitempty" json:"schema,omitempty"`
+
+	//
+	// The following fields are custom to KRMFunctionDefinition
+	//
+	// Idempotent indicates whether the function can be re-run multiple times without changing the result.
+	Idempotent bool `yaml:"idempotent,omitempty" json:"idempotent,omitempty"`
+	// Usage is URI pointing to a README.md that describe the details of how to use the KRM function.
+	// It should at least cover what the function does and should give a detailed explanation about each
+	// field used to configure it.
+	Usage string `yaml:"usage,omitempty" json:"usage,omitempty"`
+	// A list of URIs that point to README.md files. Each README.md should cover an example.
+	// It should at least cover how to get input resources, how to run it and what is the expected
+	// output.
+	Examples []string `yaml:"examples,omitempty" json:"examples,omitempty"`
+	// License is the name of the license covering the function.
+	License string `yaml:"license,omitempty" json:"license,omitempty"`
+	// The maintainers for this version of the function, if different from the primary maintainers.
+	Maintainers []string `yaml:"maintainers,omitempty" json:"maintainers,omitempty"`
+	// The runtime information describing how to execute this function.
+	Runtime runtimeutil.FunctionSpec `yaml:"runtime" json:"runtime"`
+}
+
+type KRMFunctionValidation struct {
+	// OpenAPIV3Schema is the OpenAPI v3 schema for an instance of the KRM function.
+	OpenAPIV3Schema *spec.Schema `yaml:"openAPIV3Schema,omitempty" json:"openAPIV3Schema,omitempty"`
+}
+
+type KRMFunctionNames struct {
+	// Kind is the kind of the defined KRM Function. It is normally CamelCase and singular.
+	Kind string `yaml:"kind" json:"kind"`
+}

--- a/kyaml/fn/framework/testdata/validation/error/errors.txt
+++ b/kyaml/fn/framework/testdata/validation/error/errors.txt
@@ -1,5 +1,5 @@
-JavaSpringBoot had 4 errors:
-\[\d\] replicas must be less than 10
-\[\d\] name is required
-\[\d\] image should not have latest tag
-\[\d\] domain must be a subdomain of example.com
+validation failure list:
+spec.domain in body should match 'example\\.com\$'
+spec.image should not have latest tag
+metadata.name in body should be at least 1 chars long
+spec.replicas in body should be less than or equal to 9

--- a/kyaml/fn/framework/validation.go
+++ b/kyaml/fn/framework/validation.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+	k8syaml "sigs.k8s.io/yaml"
+)
+
+// SchemaFromFunctionDefinition extracts the schema for a particular GVK from the provided KRMFunctionDefinition
+// Since the relevant fields of KRMFunctionDefinition exactly match the ones in CustomResourceDefinition,
+// this helper can also load CRDs (e.g. produced by KubeBuilder) transparently.
+func SchemaFromFunctionDefinition(gvk resid.Gvk, data string) (*spec.Schema, error) {
+	var def KRMFunctionDefinition
+	// need to use sigs yaml because spec.Schema type only has json tags
+	if err := k8syaml.Unmarshal([]byte(data), &def); err != nil {
+		return nil, errors.WrapPrefixf(err, "unmarshalling %s", FunctionDefinitionKind)
+	}
+	var foundGVKs []*resid.Gvk
+	var schema *spec.Schema
+	for i, version := range def.Spec.Versions {
+		versionGVK := resid.Gvk{Group: def.Spec.Group, Kind: def.Spec.Names.Kind, Version: version.Name}
+		if gvk.Equals(versionGVK) {
+			schema = def.Spec.Versions[i].Schema.OpenAPIV3Schema
+			break
+		}
+		foundGVKs = append(foundGVKs, &versionGVK)
+	}
+	if schema == nil {
+		return nil, errors.Errorf("%s does not define %s (defines: %s)", FunctionDefinitionKind, gvk, foundGVKs)
+	}
+	return schema, nil
+}

--- a/kyaml/fn/framework/validation_test.go
+++ b/kyaml/fn/framework/validation_test.go
@@ -1,0 +1,153 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+)
+
+var demoFunctionDefinition = `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: KRMFunctionDefinition
+metadata:
+  name: demos.example.io
+spec:
+  group: example.io
+  names:
+    kind: Demo
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          color:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+        required:
+        - color
+        type: object
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          flavor:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+        required:
+        - flavor
+        type: object
+`
+
+var demoCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: demos.example.io
+spec:
+  group: example.io
+  names:
+    kind: Demo
+    listKind: DemoList
+    plural: demos
+    singular: demo
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          color:
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        required:
+        - color
+        type: object
+    served: true
+    storage: true
+`
+
+func TestSchemaFromFunctionDefinition(t *testing.T) {
+	tests := []struct {
+		name      string
+		gvk       resid.Gvk
+		data      string
+		wantProps []string
+		wantErr   string
+	}{
+		{
+			name:      "demo KRMFunctionDefinition extract v1alpha1",
+			gvk:       resid.NewGvk("example.io", "v1alpha1", "Demo"),
+			data:      demoFunctionDefinition,
+			wantProps: []string{"apiVersion", "kind", "metadata", "color"},
+		}, {
+			name:      "demo KRMFunctionDefinition extract v1alpha2",
+			gvk:       resid.NewGvk("example.io", "v1alpha2", "Demo"),
+			data:      demoFunctionDefinition,
+			wantProps: []string{"apiVersion", "kind", "metadata", "flavor"},
+		}, {
+			name:      "works with CustomResourceDefinition",
+			gvk:       resid.NewGvk("example.io", "v1alpha1", "Demo"),
+			data:      demoCRD,
+			wantProps: []string{"apiVersion", "kind", "metadata", "color"},
+		}, {
+			name:    "group mismatch",
+			gvk:     resid.NewGvk("example.com", "v1alpha2", "Demo"),
+			data:    demoFunctionDefinition,
+			wantErr: "KRMFunctionDefinition does not define Demo.v1alpha2.example.com (defines: [Demo.v1alpha1.example.io Demo.v1alpha2.example.io])",
+		}, {
+			name:    "version mismatch",
+			gvk:     resid.NewGvk("example.io", "v1alpha3", "Demo"),
+			data:    demoFunctionDefinition,
+			wantErr: "KRMFunctionDefinition does not define Demo.v1alpha3.example.io (defines: [Demo.v1alpha1.example.io Demo.v1alpha2.example.io])",
+		}, {
+			name:    "kind mismatch",
+			gvk:     resid.NewGvk("example.io", "v1alpha2", "Demonstration"),
+			data:    demoFunctionDefinition,
+			wantErr: "KRMFunctionDefinition does not define Demonstration.v1alpha2.example.io (defines: [Demo.v1alpha1.example.io Demo.v1alpha2.example.io])",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SchemaFromFunctionDefinition(tt.gvk, tt.data)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				var gotProps []string
+				for prop, _ := range got.Properties {
+					gotProps = append(gotProps, prop)
+				}
+				sort.Strings(tt.wantProps)
+				sort.Strings(gotProps)
+				assert.Equal(t, gotProps, tt.wantProps)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This introduces a new interface, `ValidationSchemaProvider`, and a new helper, `SchemaFromFunctionDefinition(gvk resid.Gvk, data string) (*spec.Schema, error)`. Together, they enable a function author to use OpenAPI they have written to validate their inputs instead of manually writing the rules in the `Validate()` hook we already have (they can be used together, as the test show). 

```go
func (a v1alpha1JavaSpringBoot) Schema() (*spec.Schema, error) {
	schema, err := framework.SchemaFromFunctionDefinition(resid.NewGvk("example.com", "v1alpha1", "JavaSpringBoot"), javaSpringBootDefinition)
	return schema, errors.WrapPrefixf(err, "parsing JavaSpringBoot schema")
}
```

I used `k8s.io/kube-openapi/pkg/validation/spec` for this (instead of say, kubeval) for two reasons: we already depend on that package, and it is what the extensions API server [appears to be using](https://github.com/kubernetes/apiextensions-apiserver/blob/29400d7010f44f7d6ad2c6762604185143382598/pkg/apiserver/validation/validation.go#L46).

See also https://github.com/kubernetes/enhancements/pull/3220, which makes the one change required for this to work for both KRMFunctionDefinition and CustomResourceDefinition. The advantage, as illustrated in one of the tests, is that you can use a tool like Kubebuilder to generate a CRD from your type structs, and then consume it directly with these new tools to get validation. Ideally we'd provide a bespoke KRMFunctionDefinition generator some day, but this should work nicely in the meantime.

This PR also defines the `KRMFunctionDefinition` type proposed in the KEP, since I need it for this feature. Alternatively, I could define only the subset of fields I actually need for this PR and/or make the type private for now--LMK if you want that. 

/kind feature
/triage accepted
/cc @natasha41575 @mengqiy @jeremyrickard 