### PR TITLE
Move go plugins behind build tag

### DIFF
--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -5,11 +5,8 @@ package loader
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
-	"plugin"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -17,7 +14,6 @@ import (
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/internal/plugins/execplugin"
 	"sigs.k8s.io/kustomize/api/internal/plugins/fnplugin"
-	"sigs.k8s.io/kustomize/api/internal/plugins/utils"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -268,39 +264,3 @@ func (l *Loader) loadExecOrGoPlugin(resId resid.ResId) (resmap.Configurable, err
 // "this plugin already loaded" errors if the registry is maintained
 // as a Loader instance variable.  So make it a package variable.
 var registry = make(map[string]resmap.Configurable)
-
-func (l *Loader) loadGoPlugin(id resid.ResId, absPath string) (resmap.Configurable, error) {
-	regId := relativePluginPath(id)
-	if c, ok := registry[regId]; ok {
-		return copyPlugin(c), nil
-	}
-	if !utils.FileExists(absPath) {
-		return nil, fmt.Errorf(
-			"expected file with Go object code at: %s", absPath)
-	}
-	log.Printf("Attempting plugin load from '%s'", absPath)
-	p, err := plugin.Open(absPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "plugin %s fails to load", absPath)
-	}
-	symbol, err := p.Lookup(konfig.PluginSymbol)
-	if err != nil {
-		return nil, errors.Wrapf(
-			err, "plugin %s doesn't have symbol %s",
-			regId, konfig.PluginSymbol)
-	}
-	c, ok := symbol.(resmap.Configurable)
-	if !ok {
-		return nil, fmt.Errorf("plugin '%s' not configurable", regId)
-	}
-	registry[regId] = c
-	return copyPlugin(c), nil
-}
-
-func copyPlugin(c resmap.Configurable) resmap.Configurable {
-	indirect := reflect.Indirect(reflect.ValueOf(c))
-	newIndirect := reflect.New(indirect.Type())
-	newIndirect.Elem().Set(reflect.ValueOf(indirect.Interface()))
-	newNamed := newIndirect.Interface()
-	return newNamed.(resmap.Configurable)
-}

--- a/api/internal/plugins/loader/loader_go.go
+++ b/api/internal/plugins/loader/loader_go.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !no_go_plugins
+// +build !no_go_plugins
+
+package loader
+
+import (
+	"fmt"
+	"log"
+	"plugin"
+	"reflect"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/kustomize/api/internal/plugins/utils"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+)
+
+func (l *Loader) loadGoPlugin(id resid.ResId, absPath string) (resmap.Configurable, error) {
+	regId := relativePluginPath(id)
+	if c, ok := registry[regId]; ok {
+		return copyPlugin(c), nil
+	}
+	if !utils.FileExists(absPath) {
+		return nil, fmt.Errorf(
+			"expected file with Go object code at: %s", absPath)
+	}
+	log.Printf("Attempting plugin load from '%s'", absPath)
+	p, err := plugin.Open(absPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "plugin %s fails to load", absPath)
+	}
+	symbol, err := p.Lookup(konfig.PluginSymbol)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "plugin %s doesn't have symbol %s",
+			regId, konfig.PluginSymbol)
+	}
+	c, ok := symbol.(resmap.Configurable)
+	if !ok {
+		return nil, fmt.Errorf("plugin '%s' not configurable", regId)
+	}
+	registry[regId] = c
+	return copyPlugin(c), nil
+}
+
+func copyPlugin(c resmap.Configurable) resmap.Configurable {
+	indirect := reflect.Indirect(reflect.ValueOf(c))
+	newIndirect := reflect.New(indirect.Type())
+	newIndirect.Elem().Set(reflect.ValueOf(indirect.Interface()))
+	newNamed := newIndirect.Interface()
+	return newNamed.(resmap.Configurable)
+}

--- a/api/internal/plugins/loader/loader_no_go.go
+++ b/api/internal/plugins/loader/loader_no_go.go
@@ -1,0 +1,17 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build no_go_plugins
+// +build no_go_plugins
+
+package loader
+
+import (
+	"fmt"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+)
+
+func (l *Loader) loadGoPlugin(id resid.ResId, absPath string) (resmap.Configurable, error) {
+	return nil, fmt.Errorf("kustomize was built without go plugin support (-tags=no_go_plugins)")
+}


### PR DESCRIPTION
This PR moves the Go plugin functionality behind a build tag.

By default Kustomize will be built with Go plugin support maintaining backwards compatibility. If a build of kustomize is wanted without Go plugin support the build tag `no_go_plugins` can be used.

Example: `CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' -tags='netgo,osusergo,no_go_plugins' ./`

Fixes https://github.com/kubernetes-sigs/kustomize/issues/4397

I have no idea if this is the right way to do this.

/cc @howardjohn 