### PR TITLE
Support for multiple replacements in a single file when replacing using path

### DIFF
--- a/api/internal/builtins/ReplacementTransformer.go
+++ b/api/internal/builtins/ReplacementTransformer.go
@@ -5,6 +5,7 @@ package builtins
 
 import (
 	"fmt"
+	"reflect"
 
 	"sigs.k8s.io/kustomize/api/filters/replacement"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -35,11 +36,29 @@ func (p *ReplacementTransformerPlugin) Config(
 			if err != nil {
 				return err
 			}
-			repl := types.Replacement{}
-			if err := yaml.Unmarshal(content, &repl); err != nil {
+			// find if the path contains a a list of replacements or a single replacement
+			var replacement interface{}
+			err = yaml.Unmarshal(content, &replacement)
+			if err != nil {
 				return err
 			}
-			p.Replacements = append(p.Replacements, repl)
+			items := reflect.ValueOf(replacement)
+			switch items.Kind() {
+			case reflect.Slice:
+				repl := []types.Replacement{}
+				if err := yaml.Unmarshal(content, &repl); err != nil {
+					return err
+				}
+				p.Replacements = append(p.Replacements, repl...)
+			case reflect.Map:
+				repl := types.Replacement{}
+				if err := yaml.Unmarshal(content, &repl); err != nil {
+					return err
+				}
+				p.Replacements = append(p.Replacements, repl)
+			default:
+				return fmt.Errorf("unsupported replacement type encountered within replacement path: %v", items.Kind())
+			}
 		} else {
 			// replacement information is already loaded
 			p.Replacements = append(p.Replacements, r.Replacement)


### PR DESCRIPTION
Issue #4356 

Provides the ability to have a list of replacements in the replacement file in addition to the single replacement way that exists.