### PR TITLE
add: "edit add labels" command adds an option for labels without selector

### DIFF
--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -34,10 +34,11 @@ func (k kindOfAdd) String() string {
 }
 
 type addMetadataOptions struct {
-	force        bool
-	metadata     map[string]string
-	mapValidator func(map[string]string) error
-	kind         kindOfAdd
+	force                 bool
+	metadata              map[string]string
+	mapValidator          func(map[string]string) error
+	kind                  kindOfAdd
+	labelsWithoutSelector bool
 }
 
 // newCmdAddAnnotation adds one or more commonAnnotations to the kustomization file.
@@ -78,6 +79,9 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	}
 	cmd.Flags().BoolVarP(&o.force, "force", "f", false,
 		"overwrite commonLabel if it already exists",
+	)
+	cmd.Flags().BoolVar(&o.labelsWithoutSelector, "without-selector", false,
+		"using add labels without selector option",
 	)
 	return cmd
 }
@@ -127,6 +131,10 @@ func (o *addMetadataOptions) addAnnotations(m *types.Kustomization) error {
 }
 
 func (o *addMetadataOptions) addLabels(m *types.Kustomization) error {
+	if o.labelsWithoutSelector {
+		m.Labels = append(m.Labels, types.Label{Pairs: make(map[string]string), IncludeSelectors: false})
+		return o.writeToMap(m.Labels[len(m.Labels)-1].Pairs, label)
+	}
 	if m.CommonLabels == nil {
 		m.CommonLabels = make(map[string]string)
 	}

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -273,3 +273,27 @@ func TestAddLabelForce(t *testing.T) {
 	assert.NoError(t, cmd.RunE(cmd, args))
 	v.VerifyCall()
 }
+
+func TestAddLabelWithoutSelector(t *testing.T) {
+	var o addMetadataOptions
+	o.labelsWithoutSelector = true
+	m := makeKustomization(t)
+	o.metadata = map[string]string{"new": "label"}
+	assert.NoError(t, o.addLabels(m))
+	assert.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"new": "label"}})
+}
+
+func TestAddLabelWithoutSelectorAddLabel(t *testing.T) {
+	var o addMetadataOptions
+	o.metadata = map[string]string{"owls": "cute", "otters": "adorable"}
+	o.labelsWithoutSelector = true
+
+	m := makeKustomization(t)
+	assert.NoError(t, o.addLabels(m))
+	// adding new labels should work
+	o.metadata = map[string]string{"new": "label"}
+	assert.NoError(t, o.addLabels(m))
+
+	assert.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"owls": "cute", "otters": "adorable"}})
+	assert.Equal(t, m.Labels[1], types.Label{Pairs: map[string]string{"new": "label"}})
+}


### PR DESCRIPTION
`kustomize edit add labels` command only support adding [commonLabels](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/commonlabels/) now. 
But, commonLabels inject labels in selector fields (like `spec.selector.matchLabels` ).

I want to add labels without injecting corresponding selectors with a command (using a [labels](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/) field).\
Therefore I add an option for labels without selector for `kustomize edit add labels` command.