### PR TITLE
Preserve scalar types when using the replacement filter

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -174,7 +174,12 @@ func setTargetValue(options *types.FieldOptions, t *yaml.RNode, value *yaml.RNod
 		value.YNode().Value = strings.Join(tv, options.Delimiter)
 	}
 
-	t.SetYNode(value.YNode())
+	if t.YNode().Kind == yaml.ScalarNode {
+		// For scalar, only copy the value (leave any type intact to auto-convert int->string or string->int)
+		t.YNode().Value = value.YNode().Value
+	} else {
+		t.SetYNode(value.YNode())
+	}
 
 	return nil
 }


### PR DESCRIPTION
Erasing the scalar type tag leads to unfortunate circumstances, in that
the resulting yaml code is valid yaml, but will not meet the object
spec.

For example, using the replacement transformer to take a port number as
a string from a ConfigMap and set a Pod port would previously end up
with:
 - port: "8080"
when the spec requires that this is not a string:
 - port: 8080

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>