### PR TITLE
Using uname -m, get machine architecture,

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -25,6 +25,17 @@ unset CDPATH
 
 where=$PWD
 
+get_machine_arch () {
+  machine_arch=""
+  case $(uname -m) in
+    ppc64)   machine_arch="ppc64le" ;;
+    s390)    machine_arch="s390x" ;;
+    x86_64)  machine_arch="amd64" ;;
+    aarch64) machine_arch="arm64" ;;
+  esac
+  echo $machine_arch
+}
+
 release_url=https://api.github.com/repos/kubernetes-sigs/kustomize/releases
 if [ -n "$1" ]; then
   if [[ "$1" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
@@ -98,8 +109,10 @@ opsys=windows
 arch=amd64
 if [[ "$OSTYPE" == linux* ]]; then
   opsys=linux
+  arch=$(get_machine_arch)
 elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
+  arch=$(get_machine_arch)
 fi
 
 releases=$(curl -s $release_url)


### PR DESCRIPTION
Use bash function get_machine_arch for linux and darwin installs.

Then use machines_arch to update RELEASE_URL var to broaden
search for arm64, ppc64le, or s390x for linux and or darwin.

If RELEASE_URL not found, existing code will print:
Version does not exist.

Successfully tested on linux arm64, linux amd64, and darwin X86_64