### PR TITLE
Fix 3812; Error message changed and check for MalformedYamlError

### DIFF
--- a/api/internal/kusterr/yamlformaterror.go
+++ b/api/internal/kusterr/yamlformaterror.go
@@ -19,10 +19,26 @@ func (e YamlFormatError) Error() string {
 	return fmt.Sprintf("YAML file [%s] encounters a format error.\n%s\n", e.Path, e.ErrorMsg)
 }
 
+// MalformedYamlError represents an error that occurred while trying to decode a given YAML.
+type MalformedYamlError struct {
+	Path     string
+	ErrorMsg string
+}
+
+func (e MalformedYamlError) Error() string {
+	return fmt.Sprintf("%s in File: %s", e.ErrorMsg, e.Path)
+}
+
 // Handler handles YamlFormatError
 func Handler(e error, path string) error {
 	if isYAMLSyntaxError(e) {
 		return YamlFormatError{
+			Path:     path,
+			ErrorMsg: e.Error(),
+		}
+	}
+	if IsMalformedYAMLError(e) {
+		return MalformedYamlError{
 			Path:     path,
 			ErrorMsg: e.Error(),
 		}
@@ -32,4 +48,8 @@ func Handler(e error, path string) error {
 
 func isYAMLSyntaxError(e error) bool {
 	return strings.Contains(e.Error(), "error converting YAML to JSON") || strings.Contains(e.Error(), "error unmarshaling JSON")
+}
+
+func IsMalformedYAMLError(e error) bool {
+	return strings.Contains(e.Error(), "MalformedYAMLError")
 }

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -406,7 +406,7 @@ func (kt *KustTarget) accumulateResources(
 			if errors.Is(errF, load.ErrorHTTP) {
 				return nil, errF
 			}
-			if kusterr.IsMalformedYAMLError(errF) { // Some error occured while tyring to decode YAML file
+			if kusterr.IsMalformedYAMLError(errF) { // Some error occurred while tyring to decode YAML file
 				return nil, errF
 			}
 			ldr, err := kt.ldr.New(path)

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/accumulator"
 	"sigs.k8s.io/kustomize/api/internal/builtins"
+	"sigs.k8s.io/kustomize/api/internal/kusterr"
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
@@ -403,6 +404,9 @@ func (kt *KustTarget) accumulateResources(
 		if errF := kt.accumulateFile(ra, path); errF != nil {
 			// not much we can do if the error is an HTTP error so we bail out
 			if errors.Is(errF, load.ErrorHTTP) {
+				return nil, errF
+			}
+			if kusterr.IsMalformedYAMLError(errF) { // Some error occured while tyring to decode YAML file
 				return nil, errF
 			}
 			ldr, err := kt.ldr.New(path)

--- a/api/krusty/basic_io_test.go
+++ b/api/krusty/basic_io_test.go
@@ -6,6 +6,7 @@ package krusty_test
 import (
 	"testing"
 
+	"sigs.k8s.io/kustomize/api/internal/kusterr"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
@@ -79,4 +80,36 @@ metadata:
 spec:
   clusterIP: None
 `)
+}
+
+//test for https://github.com/kubernetes-sigs/kustomize/issues/3812#issuecomment-862339267
+func TestBasicIO3812(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml
+`)
+
+	th.WriteF("service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: kapacitor
+  labels:
+    app.kubernetes.io/name: tick-kapacitor
+spec:
+  selector:
+    app.kubernetes.io/name: tick-kapacitor
+    - name: http
+      port: 9092
+      protocol: TCP
+  type: ClusterIP
+`)
+
+	err := th.RunWithErr(".", th.MakeDefaultOptions())
+	if !kusterr.IsMalformedYAMLError(err) {
+		t.Fatalf("unexpected error: %q", err)
+	}
 }

--- a/api/krusty/component_test.go
+++ b/api/krusty/component_test.go
@@ -551,7 +551,7 @@ components:
 `),
 			},
 			runPath:       "filesincomponents",
-			expectedError: "'/filesincomponents/stub.yaml' must be a directory to be a root",
+			expectedError: "'/filesincomponents/stub.yaml' must be a directory so that it can used as a build root",
 		},
 		"invalid-component-api-version": {
 			input: []FileGen{writeTestBase, writeOverlayProd,

--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -159,8 +159,8 @@ func demandDirectoryRoot(
 	}
 	if f != "" {
 		return "", fmt.Errorf(
-			"got file '%s', but '%s' must be a directory to be a root",
-			f, path)
+			"'%s' must be a directory so that it can used as a build root",
+			path)
 	}
 	return d, nil
 }

--- a/cmd/config/internal/commands/fmt_test.go
+++ b/cmd/config/internal/commands/fmt_test.go
@@ -164,7 +164,7 @@ func TestCmd_failFileContents(t *testing.T) {
 	err := r.Command.Execute()
 
 	// expect an error
-	assert.EqualError(t, err, "yaml: line 1: did not find expected node content")
+	assert.EqualError(t, err, "MalformedYAMLError: yaml: line 1: did not find expected node content")
 }
 
 func TestFmtSubPackages(t *testing.T) {

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -294,7 +294,7 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 		return nil, io.EOF
 	}
 	if err != nil {
-		return nil, errors.Wrap(err)
+		return nil, errors.WrapPrefixf(err, "MalformedYAMLError")
 	}
 
 	if yaml.IsYNodeEmptyDoc(node) {

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -673,7 +673,7 @@ apiVersion: example.com/v1beta1
 `
 
 	_, err := FormatInput(strings.NewReader(y))
-	assert.EqualError(t, err, "yaml: line 15: found character that cannot start any token")
+	assert.EqualError(t, err, "MalformedYAMLError: yaml: line 15: found character that cannot start any token")
 }
 
 // TestFormatFileOrDirectory_yamlExtFile verifies that FormatFileOrDirectory will format a file


### PR DESCRIPTION
Fixes #3812 

I have created a new Error type MalformedYamlError and introduced a check for it at: https://github.com/kubernetes-sigs/kustomize/blob/c65ef489ca2782dafc2f50a62b21b2560dd54168/api/internal/target/kusttarget.go#L407-L412 If the check is successful, return so that Kustomize does not try to load the file as a directory.