### PR TITLE
adds AddOriginAnnotations option to krusty kustomizer

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -553,3 +553,10 @@ func (kt *KustTarget) configureBuiltinPlugin(
 	}
 	return nil
 }
+
+// AddOriginAnnotations adds originAnnotations to buildMetadata
+func (kt *KustTarget) AddOriginAnnotations() {
+	if !utils.StringSliceContains(kt.kustomization.BuildMetadata, types.OriginAnnotations) {
+		kt.kustomization.BuildMetadata = append(kt.kustomization.BuildMetadata, types.OriginAnnotations)
+	}
+}

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -85,6 +85,9 @@ func (b *Kustomizer) Run(
 	if err != nil {
 		return nil, err
 	}
+	if b.options.AddOriginAnnotations {
+		kt.AddOriginAnnotations()
+	}
 	var m resmap.ResMap
 	m, err = kt.MakeCustomizedResMap()
 	if err != nil {

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -23,6 +23,9 @@ type Options struct {
 	// is added to all the resources in the build out.
 	AddManagedbyLabel bool
 
+	// When true, origin annotations will be added to resources
+	AddOriginAnnotations bool
+
 	// Restrictions on what can be loaded from the file system.
 	// See type definition.
 	LoadRestrictions types.LoadRestrictions


### PR DESCRIPTION
Currently there is no option to add origin annotation when using `krusty/kustomizer`
this PR adds `AddOriginAnnotations` option to achieve that