### PR TITLE
Raise error for external generators or transformers

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -304,9 +304,8 @@ func (kt *KustTarget) configureExternalGenerators() (
 				rm.Replace(r)
 			}
 		}
-		err = ra.AppendAll(rm)
-		if err != nil {
-			return nil, errors.Wrapf(err, "configuring external generator '%v'", rm.Resources())
+		if err = ra.AppendAll(rm); err != nil {
+			return nil, errors.Wrapf(err, "configuring external generator")
 		}
 	}
 	ra, err := kt.accumulateResources(ra, generatorPaths)
@@ -351,10 +350,11 @@ func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]*r
 				rm.Replace(r)
 			}
 		}
-		err = ra.AppendAll(rm)
-		if err != nil {
-			return nil, errors.Wrapf(err, "configuring external transformer '%v'", rm.Resources())
+
+		if err = ra.AppendAll(rm); err != nil {
+			return nil, errors.Wrapf(err, "configuring external transformer")
 		}
+
 	}
 	ra, err := kt.accumulateResources(ra, transformerPaths)
 	if err != nil {

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -354,7 +354,6 @@ func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]*r
 		if err = ra.AppendAll(rm); err != nil {
 			return nil, errors.Wrapf(err, "configuring external transformer")
 		}
-
 	}
 	ra, err := kt.accumulateResources(ra, transformerPaths)
 	if err != nil {

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -304,7 +304,10 @@ func (kt *KustTarget) configureExternalGenerators() (
 				rm.Replace(r)
 			}
 		}
-		ra.AppendAll(rm)
+		err = ra.AppendAll(rm)
+		if err != nil {
+			return nil, errors.Wrapf(err, "configuring external generator '%v'", rm.Resources())
+		}
 	}
 	ra, err := kt.accumulateResources(ra, generatorPaths)
 	if err != nil {
@@ -348,7 +351,10 @@ func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]*r
 				rm.Replace(r)
 			}
 		}
-		ra.AppendAll(rm)
+		err = ra.AppendAll(rm)
+		if err != nil {
+			return nil, errors.Wrapf(err, "configuring external transformer '%v'", rm.Resources())
+		}
 	}
 	ra, err := kt.accumulateResources(ra, transformerPaths)
 	if err != nil {


### PR DESCRIPTION
 If duplicate org ids for external transformers or external generators are configured, then throw error instead of swallowing it.

Solves #4562