### PR TITLE
Install goreleaser into go 1.18 image for build

### DIFF
--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -45,6 +45,9 @@ $(MYGOBIN)/addlicense:
 $(MYGOBIN)/statik:
 	go install github.com/rakyll/statik@latest
 
+$(MYGOBIN)/goreleaser:
+	go install github.com/goreleaser/goreleaser@v0.179.0 # https://github.com/kubernetes-sigs/kustomize/issues/4542
+
 $(MYGOBIN)/kind:
 	( \
         set -e; \

--- a/releasing/cloudbuild.sh
+++ b/releasing/cloudbuild.sh
@@ -9,27 +9,41 @@
 #
 # To test it locally, run it in a goreleaser container:
 #
-#   # Get goreleaser image from cloudbuild.yaml
-#   export GORELEASER_IMAGE=goreleaser/goreleaser:v0.179.0
+#   # Get build image from cloudbuild.yaml
+#   export GOLANG_IMAGE=golang:1.18
 #
 #   # Drop into a shell
-#   docker run -it --entrypoint=/bin/bash  -v $(pwd):/go/src/github.com/kubernetes-sigs/kustomize -w /go/src/github.com/kubernetes-sigs/kustomize $GORELEASER_IMAGE
+#   docker run -it --entrypoint=/bin/bash -v $(pwd):/go/src/github.com/kubernetes-sigs/kustomize -w /go/src/github.com/kubernetes-sigs/kustomize $GOLANG_IMAGE
 #
 #   # Run this script in the container, where $TAG is the tag to "release" (e.g. kyaml/v0.13.4)
 #   ./releasing/cloudbuild.sh $TAG --snapshot
 #
 
-set -e
-set -x
+set -o errexit
+set -o nounset
+set -o pipefail
 
+if [[ -z "${1-}" ]] ; then
+  echo "Usage: $0 <fullTag> [--snapshot]"
+  echo "Example: $0 kyaml/v0.13.4"
+  exit 1
+fi
+
+set -x
 fullTag=$1
 shift
 
 if ! command -v jq &> /dev/null
 then
-    # This assumes we are in an alpine container (which is the case for goreleaser images)
+    # This is expecting to be run from Cloud Build, in a Debian-based official golang container
     echo "Installing jq."
-    apk add jq --no-cache
+    apt-get update && apt-get install -y jq
+fi
+
+if ! command -v goreleaser &> /dev/null
+then
+    echo "Installing goreleaser."
+    make --file Makefile-tools.mk "$(go env GOPATH)/bin/goreleaser"
 fi
 
 ./releasing/run-goreleaser.sh "$fullTag" release "$@"

--- a/releasing/cloudbuild.yaml
+++ b/releasing/cloudbuild.yaml
@@ -39,9 +39,8 @@ steps:
 
 # Run goreleaser indirectly via a shell script
 # to configure it properly.
-- name: goreleaser/goreleaser:v0.179.0
-  timeout: 12m
-  entrypoint: /bin/sh
+- name: golang:1.18
+  entrypoint: /bin/bash
   dir: myClone
   secretEnv: ['GITHUB_TOKEN']
   args:

--- a/releasing/run-goreleaser.sh
+++ b/releasing/run-goreleaser.sh
@@ -54,16 +54,6 @@ echo "module=$module"
 semVer=${fullTag#$module/}
 echo "semVer=$semVer"
 
-# Because of https://github.com/kubernetes-sigs/kustomize/issues/4542
-# we need to manually install a newer version of Go into an older goreleaser image.
-# This points goreleaser to that version of Go, or the version discovered from PATH if unspecified.
-goBinary="go"
-if [[ -n "${GO_BINARY_PATH:-}" ]]; then
-    echo "GO_BINARY_PATH is set, using go version from $GO_BINARY_PATH"
-    goBinary="$GO_BINARY_PATH"
-fi
-sh -c "$goBinary version"
-
 # Generate the changelog for this release
 # using the last two tags for the module
 changeLogFile=$(mktemp)
@@ -113,8 +103,6 @@ builds:
     -X sigs.k8s.io/kustomize/api/provenance.version={{.Version}}
     -X sigs.k8s.io/kustomize/api/provenance.gitCommit={{.Commit}}
     -X sigs.k8s.io/kustomize/api/provenance.buildDate={{.Date}}
-
-  gobinary: ${goBinary}
 
   goos:
   - linux


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kustomize/issues/4523

We still need to stick with goreleaser v0.179.0 because of #4542, but that doesn't inherently stop us from building with a newer Go version. This PR takes the approach of manually installing the correct version into the official Go container (instead of the other way around as in my previous attempt).

Note: I did not use alpine because it doesn't have bash, and our scripts are written for bash. This didn't actually cause problems so far, but I think this choice is more maintainable and future-proof.

I tested this as described in `releasing/cloudbuild.sh`, which should be representative since only one container is involved in this solution. But it would still be great if you could test it with cloud-build-local (which still isn't available to me). 🙏 

/cc @natasha41575 