### PR TITLE
Relax "create: true" constraints

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -142,9 +142,6 @@ func applyToOneNode(options *types.FieldOptions, t *yaml.RNode, value *yaml.RNod
 	}
 
 	for _, scalarNode := range t.YNode().Content {
-		if options != nil && options.Create {
-			return fmt.Errorf("cannot use create option in a multi-value target")
-		}
 		rn := yaml.NewRNode(scalarNode)
 		if err := setTargetValue(options, rn, value); err != nil {
 			return err

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -2317,6 +2317,45 @@ spec:
     - containerPort: 80
 `,
 		},
+		"create Job spec": {
+			input: `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hello
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox
+        name: myapp-container
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+    - image: busybox
+      name: myapp-container
+  restartPolicy: OnFailure
+`,
+			replacements: `replacements:
+  - source:
+      kind: Pod
+      name: my-pod
+      fieldPath: spec
+    targets:
+      - select:
+          name: hello
+          kind: Job
+        fieldPaths:
+          - spec.template.spec
+        options:
+          create: true
+`,
+			expectedErr: `cannot use create option in a multi-value target`,
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -2354,7 +2354,28 @@ spec:
         options:
           create: true
 `,
-			expectedErr: `cannot use create option in a multi-value target`,
+			expected: `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hello
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox
+        name: myapp-container
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+  - image: busybox
+    name: myapp-container
+  restartPolicy: OnFailure`,
 		},
 	}
 


### PR DESCRIPTION
The restriction introduced in https://github.com/kubernetes-sigs/kustomize/pull/4424 was intended to disallow the "create: true" options in `replacements` if the target targets multiple values, but

1) I've discovered that it's buggy (as demonstrated by this PR) and 

2) After thinking about it more, I don't think we need this restriction. If the target matches multiple fieldpaths, it should be allowed to create them all when the option is set. 

This PR removes that restriction and fixes the bug demonstrated by the first commit. 

/cc @KnVerey 