### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/api/loader/fileloader_test.go
+++ b/api/loader/fileloader_test.go
@@ -213,11 +213,9 @@ const (
 //   │   └── symLinkToExteriorData -> ../exteriorData
 //   └── exteriorData
 //
-func commonSetupForLoaderRestrictionTest() (string, filesys.FileSystem, error) {
-	dir, err := ioutil.TempDir("", "kustomize-test-")
-	if err != nil {
-		return "", nil, err
-	}
+func commonSetupForLoaderRestrictionTest(t *testing.T) (string, filesys.FileSystem) {
+	t.Helper()
+	dir := t.TempDir()
 	fSys := filesys.MakeFsOnDisk()
 	fSys.Mkdir(filepath.Join(dir, "base"))
 
@@ -233,7 +231,7 @@ func commonSetupForLoaderRestrictionTest() (string, filesys.FileSystem, error) {
 	os.Symlink(
 		filepath.Join(dir, "exteriorData"),
 		filepath.Join(dir, "base", "symLinkToExteriorData"))
-	return dir, fSys, nil
+	return dir, fSys
 }
 
 // Make sure everything works when loading files
@@ -283,11 +281,7 @@ func doSanityChecksAndDropIntoBase(
 }
 
 func TestRestrictionRootOnlyInRealLoader(t *testing.T) {
-	dir, fSys, err := commonSetupForLoaderRestrictionTest()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir, fSys := commonSetupForLoaderRestrictionTest(t)
 
 	var l ifc.Loader
 
@@ -296,7 +290,7 @@ func TestRestrictionRootOnlyInRealLoader(t *testing.T) {
 	l = doSanityChecksAndDropIntoBase(t, l)
 
 	// Reading symlink to exteriorData fails.
-	_, err = l.Load("symLinkToExteriorData")
+	_, err := l.Load("symLinkToExteriorData")
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -316,11 +310,7 @@ func TestRestrictionRootOnlyInRealLoader(t *testing.T) {
 }
 
 func TestRestrictionNoneInRealLoader(t *testing.T) {
-	dir, fSys, err := commonSetupForLoaderRestrictionTest()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir, fSys := commonSetupForLoaderRestrictionTest(t)
 
 	var l ifc.Loader
 
@@ -329,7 +319,7 @@ func TestRestrictionNoneInRealLoader(t *testing.T) {
 	l = doSanityChecksAndDropIntoBase(t, l)
 
 	// Reading symlink to exteriorData works.
-	_, err = l.Load("symLinkToExteriorData")
+	_, err := l.Load("symLinkToExteriorData")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/config/internal/commands/cat_test.go
+++ b/cmd/config/internal/commands/cat_test.go
@@ -20,13 +20,9 @@ import (
 // TODO(pwittrock): write tests for reading / writing ResourceLists
 
 func TestCmd_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -121,13 +117,9 @@ spec:
 }
 
 func TestCmd_filesWithReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -231,13 +223,9 @@ spec:
 }
 
 func TestCmd_filesWithoutNonReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -313,13 +301,9 @@ spec:
 }
 
 func TestCmd_outputTruncateFile(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -427,13 +411,9 @@ spec:
 }
 
 func TestCmd_outputCreateFile(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -483,11 +463,7 @@ spec:
 		return
 	}
 
-	d2, err := ioutil.TempDir("", "kustomize-cat-test-dest")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d2)
+	d2 := t.TempDir()
 	f := filepath.Join(d2, "output.yaml")
 
 	// fmt the files
@@ -638,17 +614,13 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.GetCatRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -699,14 +699,10 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			f := filepath.Join(baseDir, "Krmfile")
-			err = ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -847,17 +843,13 @@ setter with name "namespace" already exists, if you want to modify it, please de
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.NewCreateSetterRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -712,7 +712,10 @@ spec:
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
-				defer os.Remove(sch.Name())
+				t.Cleanup(func() {
+					sch.Close()
+					os.Remove(sch.Name())
+				})
 
 				err = ioutil.WriteFile(sch.Name(), []byte(test.schema), 0600)
 				if !assert.NoError(t, err) {
@@ -726,7 +729,7 @@ spec:
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
+			t.Cleanup(func() { r.Close() })
 			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -366,7 +365,7 @@ spec:
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
+			t.Cleanup(func() { r.Close() })
 			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -355,13 +355,9 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err = ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -484,17 +480,13 @@ created substitution "image-tag"`,
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.NewCreateSubstitutionRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmddeletesetter_test.go
+++ b/cmd/config/internal/commands/cmddeletesetter_test.go
@@ -301,13 +301,9 @@ kind: Deployment
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err = ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -422,17 +418,13 @@ deleted setter "namespace"
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			// defer os.RemoveAll(baseDir)
 			runner := commands.NewDeleteSetterRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmddeletesetter_test.go
+++ b/cmd/config/internal/commands/cmddeletesetter_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -312,7 +311,7 @@ kind: Deployment
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
+			t.Cleanup(func() { r.Close() })
 			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/cmd/config/internal/commands/cmddeletesubstitution_test.go
+++ b/cmd/config/internal/commands/cmddeletesubstitution_test.go
@@ -428,13 +428,9 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err = ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -539,17 +535,13 @@ deleted substitution "image-tag"
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			// defer os.RemoveAll(baseDir)
 			runner := commands.NewDeleteSubstitutionRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmddeletesubstitution_test.go
+++ b/cmd/config/internal/commands/cmddeletesubstitution_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -439,7 +438,7 @@ spec:
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
+			t.Cleanup(func() { r.Close() })
 			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -408,14 +407,9 @@ openAPI:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			dir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			dir := t.TempDir()
 
-			defer os.RemoveAll(dir)
-
-			err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.openapi), 0600)
+			err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.openapi), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1010,7 +1009,7 @@ spec:
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			defer os.Remove(r.Name())
+			t.Cleanup(func() { r.Close() })
 			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -998,14 +998,10 @@ spec:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			f := filepath.Join(baseDir, "Krmfile")
-			err = ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -1113,17 +1109,13 @@ set 1 field(s) of setter "namespace" to value "otherspace"
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.NewSetRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/count_test.go
+++ b/cmd/config/internal/commands/count_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,13 +17,9 @@ import (
 )
 
 func TestCountCommand_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-count-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -121,17 +116,13 @@ Deployment: 1
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.GetCountRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/fmt_test.go
+++ b/cmd/config/internal/commands/fmt_test.go
@@ -216,17 +216,13 @@ formatted resource files in the package
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.GetFmtRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append([]string{filepath.Join(baseDir, test.packagePath)}, test.args...))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/grep_test.go
+++ b/cmd/config/internal/commands/grep_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,13 +17,9 @@ import (
 
 // TestGrepCommand_files verifies grep reads the files and filters them
 func TestGrepCommand_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-kyaml-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -400,17 +395,13 @@ spec:
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			sourceDir := filepath.Join("test", "testdata", test.dataset)
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			baseDir := t.TempDir()
 			copyutil.CopyDir(sourceDir, baseDir)
-			defer os.RemoveAll(baseDir)
 			runner := commands.GetGrepRunner("")
 			actual := &bytes.Buffer{}
 			runner.Command.SetOut(actual)
 			runner.Command.SetArgs(append(test.args, filepath.Join(baseDir, test.packagePath)))
-			err = runner.Command.Execute()
+			err := runner.Command.Execute()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/init_test.go
+++ b/cmd/config/internal/commands/init_test.go
@@ -16,11 +16,7 @@ import (
 )
 
 func TestInit_args(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-cat-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// fmt the files
 	b := &bytes.Buffer{}
@@ -51,11 +47,7 @@ See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.
 }
 
 func TestInit_noargs(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-test-")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	if !assert.NoError(t, os.Chdir(d)) {
 		t.FailNow()

--- a/cmd/config/internal/commands/init_test.go
+++ b/cmd/config/internal/commands/init_test.go
@@ -49,9 +49,20 @@ See discussion in https://github.com/kubernetes-sigs/kustomize/issues/3953.
 func TestInit_noargs(t *testing.T) {
 	d := t.TempDir()
 
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	if !assert.NoError(t, os.Chdir(d)) {
 		t.FailNow()
 	}
+
+	t.Cleanup(func() {
+		if !assert.NoError(t, os.Chdir(cwd)) {
+			t.FailNow()
+		}
+	})
 
 	b := &bytes.Buffer{}
 	r := commands.GetInitRunner("")

--- a/cmd/config/internal/commands/merge3_test.go
+++ b/cmd/config/internal/commands/merge3_test.go
@@ -5,7 +5,6 @@ package commands_test
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,13 +15,9 @@ import (
 
 // TestMerge3Command verifies the merge3 correctly applies the diff between 2 sets of resources into another
 func TestMerge3Command(t *testing.T) {
-	datadir, err := ioutil.TempDir("", "test-data")
-	defer os.RemoveAll(datadir)
-	if !assert.NoError(t, err) {
-		return
-	}
+	datadir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(datadir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
+	err := ioutil.WriteFile(filepath.Join(datadir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -61,11 +56,7 @@ spec:
 		return
 	}
 
-	expectedDir, err := ioutil.TempDir("", "test-data-expected")
-	defer os.RemoveAll(expectedDir)
-	if !assert.NoError(t, err) {
-		return
-	}
+	expectedDir := t.TempDir()
 
 	err = ioutil.WriteFile(filepath.Join(expectedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
@@ -111,11 +102,7 @@ spec:
 		return
 	}
 
-	updatedDir, err := ioutil.TempDir("", "test-data-updated")
-	defer os.RemoveAll(updatedDir)
-	if !assert.NoError(t, err) {
-		return
-	}
+	updatedDir := t.TempDir()
 
 	err = ioutil.WriteFile(filepath.Join(updatedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
@@ -158,11 +145,7 @@ spec:
 		return
 	}
 
-	destDir, err := ioutil.TempDir("", "test-data-dest")
-	defer os.RemoveAll(destDir)
-	if !assert.NoError(t, err) {
-		return
-	}
+	destDir := t.TempDir()
 
 	err = ioutil.WriteFile(filepath.Join(destDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment

--- a/cmd/config/internal/commands/sink_test.go
+++ b/cmd/config/internal/commands/sink_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,11 +14,7 @@ import (
 )
 
 func TestSinkCommand(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	r := commands.GetSinkRunner("")
 	r.Command.SetIn(bytes.NewBufferString(`apiVersion: config.kubernetes.io/v1
@@ -137,11 +132,7 @@ spec:
 }
 
 func TestSinkCommandJSON(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	r := commands.GetSinkRunner("")
 	r.Command.SetIn(bytes.NewBufferString(`apiVersion: config.kubernetes.io/v1
@@ -182,12 +173,6 @@ items:
 }
 
 func TestSinkCommand_Stdout(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(d)
-
 	// fmt the files
 	out := &bytes.Buffer{}
 	r := commands.GetSinkRunner("")
@@ -296,12 +281,6 @@ spec:
 }
 
 func TestSinkCommandJSON_Stdout(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(d)
-
 	// fmt the files
 	out := &bytes.Buffer{}
 	r := commands.GetSinkRunner("")

--- a/cmd/config/internal/commands/source_test.go
+++ b/cmd/config/internal/commands/source_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,13 +14,9 @@ import (
 )
 
 func TestSourceCommand(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -144,13 +139,9 @@ items:
 }
 
 func TestSourceCommandJSON(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.json"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.json"), []byte(`
 {
   "kind": "Deployment",
   "metadata": {
@@ -224,12 +215,6 @@ items:
 }
 
 func TestSourceCommand_Stdin(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
-
 	in := bytes.NewBufferString(`
 kind: Deployment
 metadata:
@@ -290,12 +275,6 @@ items:
 }
 
 func TestSourceCommandJSON_Stdin(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-source-test")
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer os.RemoveAll(d)
-
 	in := bytes.NewBufferString(`
 {
   "kind": "Deployment",

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -17,10 +17,20 @@ import (
 
 func TestTreeCommandDefaultCurDir_files(t *testing.T) {
 	d := t.TempDir()
-	err := os.Chdir(d)
+	cwd, err := os.Getwd()
 	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	if !assert.NoError(t, os.Chdir(d)) {
 		return
 	}
+
+	t.Cleanup(func() {
+		if !assert.NoError(t, os.Chdir(cwd)) {
+			t.FailNow()
+		}
+	})
 
 	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 apiVersion: v1

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -16,12 +16,8 @@ import (
 )
 
 func TestTreeCommandDefaultCurDir_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
-	err = os.Chdir(d)
+	d := t.TempDir()
+	err := os.Chdir(d)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -95,13 +91,9 @@ spec:
 
 // TestCmd_files verifies fmt reads the files and filters them
 func TestTreeCommand_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -169,13 +161,9 @@ spec:
 }
 
 func TestTreeCommand_Kustomization(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err := ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx
@@ -215,13 +203,9 @@ resources:
 }
 
 func TestTreeCommand_subpkgs(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	d := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(d, "subpkg"), 0700)
+	err := os.MkdirAll(filepath.Join(d, "subpkg"), 0700)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -427,13 +411,9 @@ spec:
 }
 
 func TestTreeCommand_includeReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -499,13 +479,9 @@ spec:
 }
 
 func TestTreeCommand_excludeNonReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustmoize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
+	d := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:

--- a/cmd/config/runner/runner_test.go
+++ b/cmd/config/runner/runner_test.go
@@ -61,12 +61,8 @@ ${baseDir}/subpkg2/subpkg3/
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
-	err = createTestDirStructure(dir)
+	dir := t.TempDir()
+	err := createTestDirStructure(dir)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/cmd/pluginator/internal/krmfunction/converter_test.go
+++ b/cmd/pluginator/internal/krmfunction/converter_test.go
@@ -6,7 +6,6 @@ package krmfunction
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -14,13 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func makeTempDir(t *testing.T) string {
-	t.Helper()
-	s, err := ioutil.TempDir("", "pluginator-*")
-	assert.NoError(t, err)
-	return s
-}
 
 func getTransformerCode() []byte {
 	// a simple namespace transformer
@@ -122,8 +114,7 @@ func runKrmFunction(t *testing.T, input []byte, dir string) []byte {
 
 func TestTransformerConverter(t *testing.T) {
 	t.Skip("TODO: fix this test, which was not running in CI and does not pass")
-	dir := makeTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	err := ioutil.WriteFile(filepath.Join(dir, "Plugin.go"),
 		getTransformerCode(), 0644)
@@ -221,8 +212,7 @@ items: []
 
 func TestGeneratorConverter(t *testing.T) {
 	t.Skip("TODO: fix this test, which was not running in CI and does not pass")
-	dir := makeTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	err := ioutil.WriteFile(filepath.Join(dir, "Plugin.go"),
 		getGeneratorCode(), 0644)

--- a/kyaml/copyutil/copyutil_test.go
+++ b/kyaml/copyutil/copyutil_test.go
@@ -16,12 +16,10 @@ import (
 
 // TestDiff_identical verifies identical directories return an empty set
 func TestDiff_identical(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -41,12 +39,10 @@ func TestDiff_identical(t *testing.T) {
 // TestDiff_additionalSourceFiles verifies if there are additional files
 // in the source, the diff will contain them
 func TestDiff_additionalSourceFiles(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(s, "a2"), 0700)
@@ -63,12 +59,10 @@ func TestDiff_additionalSourceFiles(t *testing.T) {
 // TestDiff_additionalDestFiles verifies if there are additional files
 // in the dest, the diff will contain them
 func TestDiff_additionalDestFiles(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "a1"), 0700)
@@ -86,12 +80,10 @@ func TestDiff_additionalDestFiles(t *testing.T) {
 // differ between the source and destination, the diff
 // contains the differing files
 func TestDiff_srcDestContentsDiffer(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -113,12 +105,10 @@ func TestDiff_srcDestContentsDiffer(t *testing.T) {
 // TestDiff_srcDestContentsDifferInDirs verifies if identical files
 // exist in different directories, they are included in the diff
 func TestDiff_srcDestContentsDifferInDirs(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -143,12 +133,10 @@ func TestDiff_srcDestContentsDifferInDirs(t *testing.T) {
 // TestDiff_skipGitSrc verifies that .git directories in the source
 // are not looked at
 func TestDiff_skipGitSrc(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -184,12 +172,10 @@ func TestDiff_skipGitSrc(t *testing.T) {
 // TestDiff_skipGitDest verifies that .git directories in the destination
 // are not looked at
 func TestDiff_skipGitDest(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	d, err := ioutil.TempDir("", "copyutildest")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -215,13 +201,11 @@ func TestDiff_skipGitDest(t *testing.T) {
 
 // TestSyncFile tests if destination file is replaced by source file content
 func TestSyncFile(t *testing.T) {
-	d1, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	d2, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	d1 := t.TempDir()
+	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err = ioutil.WriteFile(f1Name, []byte("abc"), 0600)
+	err := ioutil.WriteFile(f1Name, []byte("abc"), 0600)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(f2Name, []byte("def"), 0644)
 	expectedFileInfo, _ := os.Stat(f2Name)
@@ -237,13 +221,11 @@ func TestSyncFile(t *testing.T) {
 
 // TestSyncFileNoDestFile tests if new file is created at destination with source file content
 func TestSyncFileNoDestFile(t *testing.T) {
-	d1, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	d2, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	d1 := t.TempDir()
+	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err = ioutil.WriteFile(f1Name, []byte("abc"), 0644)
+	err := ioutil.WriteFile(f1Name, []byte("abc"), 0644)
 	assert.NoError(t, err)
 	err = SyncFile(f1Name, f2Name)
 	assert.NoError(t, err)
@@ -257,13 +239,11 @@ func TestSyncFileNoDestFile(t *testing.T) {
 
 // TestSyncFileNoSrcFile tests if destination file is deleted if source file doesn't exist
 func TestSyncFileNoSrcFile(t *testing.T) {
-	d1, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	d2, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	d1 := t.TempDir()
+	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err = ioutil.WriteFile(f2Name, []byte("abc"), 0644)
+	err := ioutil.WriteFile(f2Name, []byte("abc"), 0644)
 	assert.NoError(t, err)
 	err = SyncFile(f1Name, f2Name)
 	assert.NoError(t, err)
@@ -294,12 +274,10 @@ metadata:
 }
 
 func TestCopyDir(t *testing.T) {
-	s, err := ioutil.TempDir("", "copyutilsrc")
-	assert.NoError(t, err)
-	v, err := ioutil.TempDir("", "copyutilvalidate")
-	assert.NoError(t, err)
+	s := t.TempDir()
+	v := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(s, "a1"), 0700)
+	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
@@ -327,8 +305,7 @@ func TestCopyDir(t *testing.T) {
 		filepath.Join(v, ".gitlab-ci.yml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
-	d, err := ioutil.TempDir("", "copyutildestination")
-	assert.NoError(t, err)
+	d := t.TempDir()
 
 	err = CopyDir(s, d)
 	assert.NoError(t, err)

--- a/kyaml/filesys/fsondisk_test.go
+++ b/kyaml/filesys/fsondisk_test.go
@@ -7,7 +7,6 @@
 package filesys
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -19,10 +18,7 @@ import (
 func makeTestDir(t *testing.T) (FileSystem, string) {
 	t.Helper()
 	fSys := MakeFsOnDisk()
-	td, err := ioutil.TempDir("", "kustomize_testing_dir")
-	if err != nil {
-		t.Fatalf("unexpected error %s", err)
-	}
+	td := t.TempDir()
 	testDir, err := filepath.EvalSymlinks(td)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -37,8 +33,7 @@ func makeTestDir(t *testing.T) (FileSystem, string) {
 }
 
 func TestCleanedAbs_1(t *testing.T) {
-	fSys, testDir := makeTestDir(t)
-	defer os.RemoveAll(testDir)
+	fSys, _ := makeTestDir(t)
 
 	d, f, err := fSys.CleanedAbs("")
 	if err != nil {
@@ -57,8 +52,7 @@ func TestCleanedAbs_1(t *testing.T) {
 }
 
 func TestCleanedAbs_2(t *testing.T) {
-	fSys, testDir := makeTestDir(t)
-	defer os.RemoveAll(testDir)
+	fSys, _ := makeTestDir(t)
 
 	d, f, err := fSys.CleanedAbs("/")
 	if err != nil {
@@ -74,7 +68,6 @@ func TestCleanedAbs_2(t *testing.T) {
 
 func TestCleanedAbs_3(t *testing.T) {
 	fSys, testDir := makeTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	err := fSys.WriteFile(
 		filepath.Join(testDir, "foo"), []byte(`foo`))
@@ -96,7 +89,6 @@ func TestCleanedAbs_3(t *testing.T) {
 
 func TestCleanedAbs_4(t *testing.T) {
 	fSys, testDir := makeTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	err := fSys.MkdirAll(filepath.Join(testDir, "d1", "d2"))
 	if err != nil {
@@ -136,7 +128,6 @@ func TestCleanedAbs_4(t *testing.T) {
 
 func TestReadFilesRealFS(t *testing.T) {
 	fSys, testDir := makeTestDir(t)
-	defer os.RemoveAll(testDir)
 
 	dir := path.Join(testDir, "dir")
 	nestedDir := path.Join(dir, "nestedDir")

--- a/kyaml/fix/fixsetters/fixsetters_test.go
+++ b/kyaml/fix/fixsetters/fixsetters_test.go
@@ -5,7 +5,6 @@ package fixsetters
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -407,14 +406,9 @@ spec:
 		t.Run(test.name, func(t *testing.T) {
 			openAPIFileName := "Krmfile"
 
-			dir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			dir := t.TempDir()
 
-			defer os.RemoveAll(dir)
-
-			err = ioutil.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(test.input), 0600)
+			err := ioutil.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/fn/framework/command/command_test.go
+++ b/kyaml/fn/framework/command/command_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,11 +23,7 @@ import (
 )
 
 func TestCommand_dockerfile(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// create a function
 	cmd := command.Build(&framework.SimpleProcessor{}, command.StandaloneEnabled, false)

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -872,11 +872,9 @@ func TestFormatFileOrDirectory_skipJsonExtFile(t *testing.T) {
 // TestFormatFileOrDirectory_directory verifies that yaml files will be formatted,
 // and other files will be ignored
 func TestFormatFileOrDirectory_directory(t *testing.T) {
-	d, err := ioutil.TempDir("", "yamlfmt")
-	assert.NoError(t, err)
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
-	err = os.Mkdir(filepath.Join(d, "config"), 0700)
+	err := os.Mkdir(filepath.Join(d, "config"), 0700)
 	assert.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(d, "c1.yaml"), testyaml.UnformattedYaml1, 0600)

--- a/kyaml/kio/filters/merge3_test.go
+++ b/kyaml/kio/filters/merge3_test.go
@@ -4,8 +4,6 @@
 package filters_test
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -28,11 +26,7 @@ func TestMerge3_Merge(t *testing.T) {
 	datadir = filepath.Join(filepath.Dir(datadir), "testdata")
 
 	// setup the local directory
-	dir, err := ioutil.TempDir("", "kyaml-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if !assert.NoError(t, copyutil.CopyDir(
 		filepath.Join(datadir, "dataset1-localupdates"),
@@ -40,7 +34,7 @@ func TestMerge3_Merge(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = filters.Merge3{
+	err := filters.Merge3{
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),
@@ -74,11 +68,7 @@ func TestMerge3_Merge_path(t *testing.T) {
 	datadir = filepath.Join(filepath.Dir(datadir), "testdata2")
 
 	// setup the local directory
-	dir, err := ioutil.TempDir("", "kyaml-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if !assert.NoError(t, copyutil.CopyDir(
 		filepath.Join(datadir, "dataset1-localupdates"),
@@ -86,7 +76,7 @@ func TestMerge3_Merge_path(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = filters.Merge3{
+	err := filters.Merge3{
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),
@@ -119,11 +109,7 @@ func TestMerge3_Merge_fail(t *testing.T) {
 	datadir = filepath.Join(filepath.Dir(datadir), "testdata2")
 
 	// setup the local directory
-	dir, err := ioutil.TempDir("", "kyaml-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if !assert.NoError(t, copyutil.CopyDir(
 		filepath.Join(datadir, "dataset1-localupdates"),
@@ -131,7 +117,7 @@ func TestMerge3_Merge_fail(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = filters.Merge3{
+	err := filters.Merge3{
 		OriginalPath: filepath.Join(datadir, "dataset1"),
 		UpdatedPath:  filepath.Join(datadir, "dataset1-remoteupdates"),
 		DestPath:     filepath.Join(dir, "dataset1"),

--- a/kyaml/kio/ignorefilesmatcher_test.go
+++ b/kyaml/kio/ignorefilesmatcher_test.go
@@ -42,8 +42,7 @@ func TestIgnoreFilesMatcher_readIgnoreFile(t *testing.T) {
 		// onDisk creates a temp directory and returns a nil FileSystem, testing
 		// the normal conditions under which ignoreFileMatcher is used.
 		"onDisk": func(writeIgnoreFile bool) (string, filesys.FileSystem) { //nolint:unparam
-			dir, err := ioutil.TempDir("", "kyaml-test")
-			require.NoError(t, err)
+			dir := t.TempDir()
 
 			if writeIgnoreFile {
 				ignoreFilePath := filepath.Join(dir, ignoreFileName)

--- a/kyaml/pathutil/pathutil_test.go
+++ b/kyaml/pathutil/pathutil_test.go
@@ -39,12 +39,8 @@ func TestSubDirsWithFile(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
-	err = createTestDirStructure(dir)
+	dir := t.TempDir()
+	err := createTestDirStructure(dir)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/runfn/runfn_test.go
+++ b/kyaml/runfn/runfn_test.go
@@ -648,7 +648,6 @@ metadata:
 		t.Run(tt.name, func(t *testing.T) {
 			// setup the test directory
 			d := setupTest(t)
-			defer os.RemoveAll(d)
 
 			// write the functions to files
 			var fnPaths []string
@@ -663,11 +662,7 @@ metadata:
 					// if out of package, write to a separate temp directory
 					if f.newFnPath || fnPath == "" {
 						// create a new fn directory
-						fnPath, err = ioutil.TempDir("", "kustomize-test")
-						if !assert.NoError(t, err) {
-							t.FailNow()
-						}
-						defer os.RemoveAll(fnPath)
+						fnPath = t.TempDir()
 						fnPaths = append(fnPaths, fnPath)
 					}
 					dir = fnPath
@@ -916,7 +911,6 @@ metadata:
 
 func TestCmd_Execute(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 
 	// write a test filter to the directory of configuration
 	if !assert.NoError(t, ioutil.WriteFile(
@@ -952,7 +946,6 @@ func (f *TestFilter) GetExit() error {
 
 func TestCmd_Execute_deferFailure(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 
 	// write a test filter to the directory of configuration
 	if !assert.NoError(t, ioutil.WriteFile(
@@ -1026,7 +1019,6 @@ replace: StatefulSet
 // TestCmd_Execute_setOutput tests the execution of a filter reading and writing to a dir
 func TestCmd_Execute_setFunctionPaths(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 
 	// write a test filter to a separate directory
 	tmpF, err := ioutil.TempFile("", "filter*.yaml")
@@ -1062,7 +1054,6 @@ func TestCmd_Execute_setFunctionPaths(t *testing.T) {
 // TestCmd_Execute_setOutput tests the execution of a filter using an io.Writer as output
 func TestCmd_Execute_setOutput(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 
 	// write a test filter
 	if !assert.NoError(t, ioutil.WriteFile(
@@ -1094,7 +1085,6 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 // TestCmd_Execute_setInput tests the execution of a filter using an io.Reader as input
 func TestCmd_Execute_setInput(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 	if !assert.NoError(t, ioutil.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
@@ -1109,11 +1099,7 @@ func TestCmd_Execute_setInput(t *testing.T) {
 		t.FailNow()
 	}
 
-	outDir, err := ioutil.TempDir("", "kustomize-test")
-	defer os.RemoveAll(outDir)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	outDir := t.TempDir()
 
 	if !assert.NoError(t, ioutil.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
@@ -1142,7 +1128,6 @@ func TestCmd_Execute_setInput(t *testing.T) {
 // TestCmd_Execute_enableLogSteps tests the execution of a filter with LogSteps enabled.
 func TestCmd_Execute_enableLogSteps(t *testing.T) {
 	dir := setupTest(t)
-	defer os.RemoveAll(dir)
 
 	// write a test filter to the directory of configuration
 	if !assert.NoError(t, ioutil.WriteFile(
@@ -1240,10 +1225,7 @@ metadata:
 // setupTest initializes a temp test directory containing test data
 func setupTest(t *testing.T) string {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "kustomize-kyaml-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	dir := t.TempDir()
 
 	_, filename, _, ok := runtime.Caller(0)
 	if !assert.True(t, ok) {
@@ -1256,9 +1238,23 @@ func setupTest(t *testing.T) string {
 	if !assert.NoError(t, copyutil.CopyDir(ds, dir)) {
 		t.FailNow()
 	}
+
+	cwd, err := os.Getwd()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
 	if !assert.NoError(t, os.Chdir(filepath.Dir(dir))) {
 		t.FailNow()
 	}
+
+	// Change back the current working directory when the test finishes
+	t.Cleanup(func() {
+		if !assert.NoError(t, os.Chdir(cwd)) {
+			t.FailNow()
+		}
+	})
+
 	return dir
 }
 

--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -5,7 +5,6 @@ package setters2
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1003,10 +1002,8 @@ spec:
 // initSchema initializes the openAPI with the definitions from s
 func SettersSchema(t *testing.T, s string) *spec.Schema {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-	err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(s), 0600)
+	dir := t.TempDir()
+	err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(s), 0600)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/setters2/settersutil/fieldsetter_test.go
+++ b/kyaml/setters2/settersutil/fieldsetter_test.go
@@ -5,7 +5,6 @@ package settersutil
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -83,20 +82,10 @@ spec:
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			srcDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			srcDir := t.TempDir()
+			destDir := t.TempDir()
 
-			destDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-
-			defer os.RemoveAll(srcDir)
-			defer os.RemoveAll(destDir)
-
-			err = ioutil.WriteFile(filepath.Join(srcDir, "Krmfile"), []byte(test.srcOpenAPIFile), 0600)
+			err := ioutil.WriteFile(filepath.Join(srcDir, "Krmfile"), []byte(test.srcOpenAPIFile), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/setters2/util_test.go
+++ b/kyaml/setters2/util_test.go
@@ -6,7 +6,6 @@ package setters2
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -141,10 +140,8 @@ openAPI:
 		t.Run(test.name, func(t *testing.T) {
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
-			dir, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
-			defer os.RemoveAll(dir)
-			err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.inputOpenAPIfile), 0600)
+			dir := t.TempDir()
+			err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.inputOpenAPIfile), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```