### PR TITLE
[WIP] ADD: string slice to preserve input order

### DIFF
--- a/api/internal/generators/configmap.go
+++ b/api/internal/generators/configmap.go
@@ -33,7 +33,10 @@ func MakeConfigMap(
 	if err != nil {
 		return nil, err
 	}
-	m, err := makeValidatedDataMap(ldr, args.Name, args.KvPairSources)
+	m, s, err := makeValidatedDataMap(ldr, args.Name, args.KvPairSources)
+	if s != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/generators/secret.go
+++ b/api/internal/generators/secret.go
@@ -46,7 +46,10 @@ func MakeSecret(
 			Value: yaml.NewStringRNode(t)}); err != nil {
 		return nil, err
 	}
-	m, err := makeValidatedDataMap(ldr, args.Name, args.KvPairSources)
+	m, s, err := makeValidatedDataMap(ldr, args.Name, args.KvPairSources)
+	if s != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/generators/utils.go
+++ b/api/internal/generators/utils.go
@@ -35,24 +35,26 @@ kind: %s
 }
 
 func makeValidatedDataMap(
-	ldr ifc.KvLoader, name string, sources types.KvPairSources) (map[string]string, error) {
+	ldr ifc.KvLoader, name string, sources types.KvPairSources) (map[string]string, []string, error) {
 	pairs, err := ldr.Load(sources)
 	if err != nil {
-		return nil, errors.WrapPrefix(err, "loading KV pairs", 0)
+		return nil, nil, errors.WrapPrefix(err, "loading KV pairs", 0)
 	}
 	knownKeys := make(map[string]string)
+	sortetKeys := make([]string, 0)
 	for _, p := range pairs {
 		// legal key: alphanumeric characters, '-', '_' or '.'
 		if err := ldr.Validator().ErrIfInvalidKey(p.Key); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if _, ok := knownKeys[p.Key]; ok {
-			return nil, errors.Errorf(
+			return nil, nil, errors.Errorf(
 				"configmap %s illegally repeats the key `%s`", name, p.Key)
 		}
 		knownKeys[p.Key] = p.Value
+		sortetKeys = append(sortetKeys, p.Key)
 	}
-	return knownKeys, nil
+	return knownKeys, sortetKeys, nil
 }
 
 // copyLabelsAndAnnotations copies labels and annotations from


### PR DESCRIPTION
As mentioned here I return a list of strings that contain the keys in order: https://github.com/kubernetes-sigs/kustomize/issues/4292#issuecomment-990355363

@natasha41575  Do I understand correctly that in order to actually create the items in the preserved order I would need to sort the map according to my list in the function that creates the Resource?
