### PR TITLE
fix: use k8syml.YAMLToJSON when marshalling resources

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -312,6 +312,31 @@ metadata:
 `)
 }
 
+func TestIssue3446(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- cm.yaml
+`)
+	th.WriteF("cm.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+  123: abc
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  "123": abc
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+}
+
 func TestGeneratorSimpleOverlay(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK("base", `

--- a/api/krusty/duplicatekeys_test.go
+++ b/api/krusty/duplicatekeys_test.go
@@ -41,6 +41,7 @@ spec:
 `)
 	m := th.Run(".", th.MakeDefaultOptions())
 	_, err := m.AsYaml()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "mapping key \"env\" already defined")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "key \"env\" already set in map")
+	}
 }

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	k8syaml "sigs.k8s.io/yaml"
+
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/go-yaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/sliceutil"
@@ -879,19 +881,11 @@ func (rn *RNode) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	if rn.YNode().Kind == SequenceNode {
-		var a []interface{}
-		if err := Unmarshal([]byte(s), &a); err != nil {
-			return nil, err
-		}
-		return json.Marshal(a)
+	b, err := k8syaml.YAMLToJSONStrict([]byte(s))
+	if err != nil {
+		return nil, errors.Wrap(err)
 	}
-
-	m := map[string]interface{}{}
-	if err := Unmarshal([]byte(s), &m); err != nil {
-		return nil, err
-	}
-	return json.Marshal(m)
+	return b, nil
 }
 
 // UnmarshalJSON overwrites this RNode with data from []byte.


### PR DESCRIPTION
Better handles cases where the YAML is not valid JSON, such as
maps with integer keys (#3446).