### PR TITLE
Migrate site content: overview and installation

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -95,6 +95,8 @@ weight = 1
 copyright_k8s = "The Kubernetes Authors"
 copyright_linux =  "Copyright © 2020 The Linux Foundation ®."
 
+kustomize_example_version = "v4.5.4"
+
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]
 

--- a/site/content/en/docs/Getting started/_index.md
+++ b/site/content/en/docs/Getting started/_index.md
@@ -2,6 +2,4 @@
 title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 2
-description: >
-  What does your user need to know to try your project?
 ---

--- a/site/content/en/docs/Getting started/installation.md
+++ b/site/content/en/docs/Getting started/installation.md
@@ -4,94 +4,94 @@ linkTitle: "Install Kustomize"
 date: 2022-02-27
 weight: 10
 description: >
-  Installing Kustomize
+  Kustomize can be installed in a variety of ways
 ---
 
-Kustomize can be installed in a variety of ways.
-
 ## Binaries
-Binaries are available for Linux, MacOS and Windows, across a variety of architectures.
 
-You can see the full list of releases here on the [Github releases page](https://github.com/kubernetes-sigs/kustomize/releases).
+Binaries at various versions for Linux, macOS and Windows are published on the [releases page].
 
-### Quick install
-Get the latest build of Kustomize for your platform.
+The following [script] detects your OS and downloads the appropriate kustomize binary to your
+current working directory.
+
 ```bash
 curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 ```
-You can also pass optional `version` and `target_dir` arguments to the script:
-```bash
-curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" 4.4.1 $HOME/bin  | bash
-```
 
-❗**This script doesn’t work for ARM architecture**. If you want to install ARM binaries, please refer to the [releases page](https://github.com/kubernetes-sigs/kustomize/releases).
+## Homebrew / MacPorts
 
-## Packages
-Kustomize is also available in some package repositories.
+For [Homebrew] users:
 
-### Debian/Ubuntu
-```bash
-sudo apt-get install kustomize
-```
-### Arch
-```bash
-pacman -S kustomize
-```
-
-### Mac
-[Homebrew](https://brew.sh/):
 ```bash
 brew install kustomize
 ```
 
-[MacPorts](https://www.macports.org/):
+For [MacPorts] users:
+
 ```bash
 sudo port install kustomize
 ```
 
-### Windows
-[Chocolatey](https://community.chocolatey.org/packages/kustomize)
+## Chocolatey
+
 ```bash
 choco install kustomize
 ```
 
-## Docker
-Docker images for kustomize are published on the [GCR Container Registry](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/US/kustomize/kustomize).
+For support on the chocolatey package
+and prior releases, see:
+
+- [Choco Package]
+- [Package Source]
+
+## Docker Images
+
+Starting with Kustomize v3.8.7, docker images are available to run Kustomize.
+The image artifacts are hosted on Google Container Registry (GCR).
+
+See [GCR page] for available images.
+
+The following commands are how to pull and run kustomize {{<example-semver-version>}} docker image.
+
 ```bash
-docker run k8s.gcr.io/kustomize/kustomize:v4.5.1 version
+docker pull k8s.gcr.io/kustomize/kustomize:{{< example-version >}}
+docker run k8s.gcr.io/kustomize/kustomize:{{< example-version >}} version
 ```
 
-## go get
-<!--
-TODO: is this still the way to do this? v3 seems old and my go module knowledge isn't great
--->
-Requires [Go](https://go.dev/) to be installed.
+## Go Source
+
+Requires [Go] to be installed.
+
+### Install the kustomize CLI from source without cloning the repo
+
 ```bash
-GOBIN=$(pwd)/ GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3
+go install sigs.k8s.io/kustomize/kustomize/{{< example-major-version >}}
 ```
 
-## Source
-<!--
-TODO: once again here, are these instructions up-to-date? We probably should bump to a later version of kustomize but I'm also not sure if these go env variables are modern practice
--->
-Clone the kustomize Github repo and build using go.
-```bash
-# Need go 1.13 or higher
-unset GOPATH
-# see https://golang.org/doc/go1.13#modules
-unset GO111MODULES
+### Install the kustomize CLI from local source
 
-# clone the repo
+```bash
+# Clone the repo
 git clone git@github.com:kubernetes-sigs/kustomize.git
-# get into the repo root
+# Get into the repo root
 cd kustomize
 
-# Optionally checkout a particular tag if you don't
-# want to build at head
-git checkout kustomize/v3.2.3
+# Optionally checkout a particular tag if you don't want to build at head
+git checkout kustomize/{{< example-version >}}
 
-# build the binary
+# Build the binary
 (cd kustomize; go install .)
 
-# run it
-~/go/bin/kustomize version
+# Run it - this assumes your Go bin (generally GOBIN or GOPATH/bin) is on your PATH
+# See the Go documentation for more details: https://go.dev/doc/code
+kustomize version
+```
+
+[Go]: https://golang.org
+[releases page]: https://github.com/kubernetes-sigs/kustomize/releases
+[script]: https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh
+[GCR page]: https://us.gcr.io/k8s-artifacts-prod/kustomize/kustomize
+[Homebrew]: https://brew.sh
+[MacPorts]: https://www.macports.org
+[Choco Package]: https://chocolatey.org/packages/kustomize
+[Package Source]: https://github.com/kenmaglio/choco-kustomize

--- a/site/content/en/docs/Overview/_index.md
+++ b/site/content/en/docs/Overview/_index.md
@@ -2,15 +2,27 @@
 title: "Overview"
 linkTitle: "Overview"
 weight: 1
+type: docs
 description: >
-  Introduction to Kustomize.
+  Introduction to Kustomize
 ---
+
+{{< alert color="success" title="TL;DR" >}}
+- Kustomize helps customizing config files in a template free way.
+- Kustomize provides a number of handy methods like generators to make customization easier.
+- Kustomize uses patches to introduce environment specific changes on an already existing standard config file without disturbing it.
+{{< /alert >}}
 
 Kustomize provides a solution for customizing Kubernetes resource configuration free from templates and DSLs.
 
-Kustomize lets you customize raw, template-free YAML files for multiple purposes, leaving the original YAML untouched and usable as is.
+Kustomize lets you customize raw, template-free YAML
+files for multiple purposes, leaving the original YAML
+untouched and usable as is.
 
-Kustomize targets kubernetes; it understands and can patch kubernetes style API objects. It’s like make, in that what it does is declared in a file, and it’s like sed, in that it emits edited text.
+Kustomize targets kubernetes; it understands and can
+patch `kubernetes style` API objects.  It's like
+[make](https://www.gnu.org/software/make), in that what it does is declared in a file,
+and it's like [sed](https://www.gnu.org/software/sed), in that it emits edited text.
 
 ## Usage
 
@@ -103,11 +115,4 @@ The YAML can be directly `applied` to a cluster:
  ```sh
  kustomize build ~/someApp/overlays/production | kubectl apply -f -
  ```
-
-## Where should I go next?
-
-Give your users next steps from the Overview. For example:
-
-* [Getting Started](/docs/getting-started/): Get started with $project
-* [Examples](/docs/examples/): Check out some example code!
 

--- a/site/layouts/shortcodes/example-major-version.html
+++ b/site/layouts/shortcodes/example-major-version.html
@@ -1,0 +1,4 @@
+{{- $latestVersion := site.Params.kustomize_example_version -}}
+{{- $latestSemverParts := (split $latestVersion ".") -}}
+{{- $latestSemver := (index $latestSemverParts 0) -}}
+{{- $latestSemver -}}

--- a/site/layouts/shortcodes/example-semver-version.html
+++ b/site/layouts/shortcodes/example-semver-version.html
@@ -1,0 +1,3 @@
+{{- $latestVersion := site.Params.kustomize_example_version -}}
+{{- $latestSemver := (replace $latestVersion "v" "") -}}
+{{- $latestSemver -}}

--- a/site/layouts/shortcodes/example-version.html
+++ b/site/layouts/shortcodes/example-version.html
@@ -1,0 +1,1 @@
+{{- site.Params.kustomize_example_version -}}


### PR DESCRIPTION
This PR is part of the larger docs clean up issue: https://github.com/kubernetes-sigs/kustomize/issues/4338

- Moved the installation docs [from here](https://kubectl.docs.kubernetes.io/installation/kustomize/) into `site/content/en/docs/Getting started/installation.md`. I merged all the installation instructions onto a single page as I felt the 5 sections didn't have enough content to justify their own pages. Let me know if I should break them out into separate pages.
- Moved the kustomize introduction [from here](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/) into `site/content/en/docs/Overview/_index.md`. 