### PR TITLE
OCI support in Helm builtin

### DIFF
--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -97,7 +97,11 @@ $(MYGOBIN)/helmV3:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
+<<<<<<< HEAD
 		tgzFile=helm-v3.10.2-$(GOOS)-$(GOARCH).tar.gz; \
+=======
+		tgzFile=helm-v3.8.2-$(GOOS)-$(GOARCH).tar.gz; \
+>>>>>>> bffa1db93 (updated to helm v3.8+)
 		wget https://get.helm.sh/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
 		mv $(GOOS)-$(GOARCH)/helm $(MYGOBIN)/helmV3; \

--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -97,11 +97,7 @@ $(MYGOBIN)/helmV3:
 	( \
 		set -e; \
 		d=$(shell mktemp -d); cd $$d; \
-<<<<<<< HEAD
 		tgzFile=helm-v3.10.2-$(GOOS)-$(GOARCH).tar.gz; \
-=======
-		tgzFile=helm-v3.8.2-$(GOOS)-$(GOARCH).tar.gz; \
->>>>>>> bffa1db93 (updated to helm v3.8+)
 		wget https://get.helm.sh/$$tgzFile; \
 		tar -xvzf $$tgzFile; \
 		mv $(GOOS)-$(GOARCH)/helm $(MYGOBIN)/helmV3; \

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -291,8 +291,8 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 
 	// OCI pull combine the repo and the chart name into one URL
 	if strings.HasPrefix(p.Repo, "oci://") {
-		chartUrl := p.Repo + "/" + p.Name
-		args = append(args, chartUrl)
+		chartURL := p.Repo + "/" + p.Name
+		args = append(args, chartURL)
 	} else {
 		args = append(args, "--repo", p.Repo, p.Name)
 	}

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -292,8 +292,8 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 
 	// OCI pull combine the repo and the chart name into one URL
 	if strings.HasPrefix(p.Repo, "oci://") {
-		chartURL := p.Repo + "/" + p.Name
-		args = append(args, chartURL)
+		chartLocation := p.Repo + "/" + p.Name
+		args = append(args, chartLocation)
 	} else {
 		args = append(args, "--repo", p.Repo, p.Name)
 	}

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -292,8 +292,8 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 
 	// OCI pull combine the repo and the chart name into one URL
 	if strings.HasPrefix(p.Repo, "oci://") {
-		chartUrl := p.Repo + "/" + p.Name
-		args = append(args, chartUrl)
+		chartURL := p.Repo + "/" + p.Name
+		args = append(args, chartURL)
 	} else {
 		args = append(args, "--repo", p.Repo, p.Name)
 	}

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -292,8 +292,8 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 
 	// OCI pull combine the repo and the chart name into one URL
 	if strings.HasPrefix(p.Repo, "oci://") {
-		chartURL := p.Repo + "/" + p.Name
-		args = append(args, chartURL)
+		chartUrl := p.Repo + "/" + p.Name
+		args = append(args, chartUrl)
 	} else {
 		args = append(args, "--repo", p.Repo, p.Name)
 	}

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -297,9 +297,15 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 	args := []string{
 		"pull",
 		"--untar",
-		"--untardir", p.absChartHome(),
-		"--repo", p.Repo,
-		p.Name}
+		"--untardir", p.absChartHome()}
+
+	// OCI pull combine the repo and the chart name into one URL
+	if strings.HasPrefix(p.Repo, "oci://") {
+		chartUrl := p.Repo + "/" + p.Name
+		args = append(args, chartUrl)
+	} else {
+		args = append(args, "--repo", p.Repo, p.Name)
+	}
 	if p.Version != "" {
 		args = append(args, "--version", p.Version)
 	}

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -579,3 +579,25 @@ valuesInline:
 `)
 	th.AssertActualEqualsExpected(rm, "")
 }
+
+func TestHelmChartInflationGeneratorOciRegistry(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	rm := th.LoadAndRunGenerator(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: ocichart
+name: chart1
+version: 0.1.0
+repo: oci://us-central1-docker.pkg.dev/mikebz-ex1/charts
+valuesInline:
+  nameOverride: foobar
+`)
+	th.AssertActualEqualsExpected(rm, "")
+}


### PR DESCRIPTION
This is currently WIP.  

fixes: #4381 

Questions for owner: @natasha41575 @yuwenma @KnVerey 
It seems like @monopole has added environment variables to put the data and cache for HELM into a temp directory.  Do we know why that is?  The reason why this is undesirable with OCI is that most of the OCI repos are protected with auth.  Auth is possible if one does authentication with Helm ahead of time.  Example:

> helm registry login -u _json_key --password-stdin https://us-central1-docker.pkg.dev

After that is run I am able to do things like:
```
helmCharts:
- name: chart1
  version: 0.1.0
  repo: oci://us-central1-docker.pkg.dev/mikebz-ex1/charts
  valuesInline:
    nameOverride: foobar
```
and if the configuration is not in the temp location I can easily get the chart.

One of the ideas is to include some sort of an authentication in kustomization.yaml, but I think that would be undesirable.

Things that are left to figure out:

- [ ] create a publicly available registry or something that can be used to ensure that the unit test works.
- [ ] figure out if unsetting the HELM* variables will have a security or other undesirable impact.
- [ ] is there an issue updating the default Helm download to 3.8+?  OCI is enabled by default in those builds