### PR TITLE
install_kustomize: support linux/aarch64, with fallback to old behavior

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -77,13 +77,13 @@ function find_release_url() {
   local opsys=$1
   local arch=$2
 
-  echo "$(echo "${releases}" |\
-    grep browser_download.*${opsys}_${arch} |\
+  echo "${releases}" |\
+    grep "browser_download.*${opsys}_${arch}" |\
     cut -d '"' -f 4 |\
-    sort -V | tail -n 1)"
+    sort -V | tail -n 1
 }
 
-where="$(readlink_f $where)/"
+where="$(readlink_f "$where")/"
 
 if [ -f "${where}kustomize" ]; then
   echo "${where}kustomize exists. Remove it first."
@@ -93,7 +93,7 @@ elif [ -d "${where}kustomize" ]; then
   exit 1
 fi
 
-tmpDir=`mktemp -d`
+tmpDir=$(mktemp -d)
 if [[ ! "$tmpDir" || ! -d "$tmpDir" ]]; then
   echo "Could not create temp dir."
   exit 1
@@ -133,7 +133,7 @@ s390x)
     ;;
 esac
 
-releases=$(curl -s $release_url)
+releases=$(curl -s "$release_url")
 
 if [[ $releases == *"API rate limit exceeded"* ]]; then
   echo "Github rate-limiter failed the request. Either authenticate or wait a couple of minutes."
@@ -152,12 +152,12 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
     fi
 fi
 
-if [ ! -n "$RELEASE_URL" ]; then
+if [ -z "$RELEASE_URL" ]; then
   echo "Version $version does not exist or is not available for ${opsys}/${arch}."
   exit 1
 fi
 
-curl -sLO $RELEASE_URL
+curl -sLO "$RELEASE_URL"
 
 tar xzf ./kustomize_v*_${opsys}_${arch}.tar.gz
 
@@ -165,6 +165,6 @@ cp ./kustomize "$where"
 
 popd >& /dev/null
 
-${where}kustomize version
+"${where}kustomize" version
 
 echo "kustomize installed to ${where}kustomize"

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -146,11 +146,9 @@ RELEASE_URL="$(find_release_url "$releases" "$opsys" "$arch")"
 if [[ "$arch" == "arm64" ]] && [[ -z "$RELEASE_URL" ]] ; then
     # fallback to the old behavior of downloading amd64 binaries on aarch64 systems.
     # People might have qemu-binfmt-misc installed, so it worked for them previously.
-    echo "Version $version does not exist for ${opsys}_arm64, trying ${opsys}_amd64 instead."
+    echo "Version $version does not exist for ${opsys}/arm64, trying ${opsys}/amd64 instead."
+    arch=amd64
     RELEASE_URL="$(find_release_url "$releases" "$opsys" "amd64")"
-    if [[ -n "$RELEASE_URL" ]]; then
-      arch=amd64
-    fi
 fi
 
 if [[ -z "$RELEASE_URL" ]]; then

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -143,7 +143,7 @@ fi
 
 RELEASE_URL="$(find_release_url "$releases" "$opsys" "$arch")"
 
-if [[ "$(uname -m)" == "aarch64" ]]; then
+if [[ "$arch" == "arm64" ]] && [[ -z "$RELEASE_URL" ]] ; then
     # fallback to the old behavior of downloading amd64 binaries on aarch64 systems.
     # People might have qemu-binfmt-misc installed, so it worked for them previously.
     echo "Version $version does not exist for ${opsys}_arm64, trying ${opsys}_amd64 instead."

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -74,8 +74,9 @@ function readlink_f {
 }
 
 function find_release_url() {
-  local opsys=$1
-  local arch=$2
+  local releases=$1
+  local opsys=$2
+  local arch=$3
 
   echo "${releases}" |\
     grep "browser_download.*${opsys}_${arch}" |\
@@ -140,19 +141,19 @@ if [[ $releases == *"API rate limit exceeded"* ]]; then
   exit 1
 fi
 
-RELEASE_URL="$(find_release_url "$opsys" "$arch")"
+RELEASE_URL="$(find_release_url "$releases" "$opsys" "$arch")"
 
 if [[ "$(uname -m)" == "aarch64" ]]; then
     # fallback to the old behavior of downloading amd64 binaries on aarch64 systems.
     # People might have qemu-binfmt-misc installed, so it worked for them previously.
     echo "Version $version does not exist for ${opsys}_arm64, trying ${opsys}_amd64 instead."
-    RELEASE_URL="$(find_release_url "$opsys" "amd64")"
+    RELEASE_URL="$(find_release_url "$releases" "$opsys" "amd64")"
     if [[ -n "$RELEASE_URL" ]]; then
       arch=amd64
     fi
 fi
 
-if [ -z "$RELEASE_URL" ]; then
+if [[ -z "$RELEASE_URL" ]]; then
   echo "Version $version does not exist or is not available for ${opsys}/${arch}."
   exit 1
 fi


### PR DESCRIPTION
In docker on an M1 Mac -- and probably also on any ARM linux machine, the value for `uname -m` is `aarch64`.
The install script only detects `arm64` (which is the ARM uname value for native darwin).

Since the default is amd64, this leads to the script **installing the wrong (amd64) version on ARM** docker, instead of the arm64 version.

---

Caveat:

I appreciate that some people might be using this script to install older versions (which might not have an arm64 build yet), and have qemu-binfmt-misc installed, so this approach worked for them (but sometimes crashes, at least on M1 machines, a different issue). That's why I added a fallback that goes back to the old behavior if the arm64 binary does not exist.

Also fixed some shellcheck issues.


Any comments and feedback appreciated :)