### PR TITLE
docs: improve prefix/suffix transformer docs

### DIFF
--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -60,6 +60,9 @@ The prefix/suffix transformer adds a prefix/suffix to the `metadata/name` field 
 ```yaml
 namePrefix:
 - path: metadata/name
+
+nameSuffix:
+- path: metadata/name
 ```
 
 Example kustomization.yaml:


### PR DESCRIPTION
Previously `namePrefix:` covered both prefix and suffix,
but now it is separated into `namePrefix:` and `nameSuffix: ` by [refactoring](https://github.com/kubernetes-sigs/kustomize/pull/4318).