### PR TITLE
fn framework: bugfix for schema providers + configurable template extensions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,19 @@ linters-settings:
   gomnd:
      ignored-functions:
      - ioutil.WriteFile
+  wrapcheck:
+    ignoreSigs:
+      # defaults
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+      - .WithMessagef(
+      - .WithStack(
+      # from kyaml's errors package
+      - .WrapPrefixf(
 
 issues:
   new-from-rev: c94b5d8f2 # enables us to enforce a larger set of linters for new code than pass on existing code

--- a/kyaml/fn/framework/parser/parser.go
+++ b/kyaml/fn/framework/parser/parser.go
@@ -13,9 +13,9 @@ import (
 )
 
 type parser struct {
-	fs        iofs.FS
-	paths     []string
-	extension string
+	fs         iofs.FS
+	paths      []string
+	extensions []string
 }
 
 type contentProcessor func(content []byte, name string) error
@@ -51,14 +51,23 @@ func (l parser) readPath(path string, processContent contentProcessor) error {
 	}
 
 	// Path is a file -- check extension and read it
-	if !strings.HasSuffix(path, l.extension) {
-		return errors.Errorf("file %s did not have required extension %s", path, l.extension)
+	if err := checkExtension(path, l.extensions); err != nil {
+		return err
 	}
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
 		return err
 	}
 	return processContent(b, path)
+}
+
+func checkExtension(path string, extensions []string) error {
+	for _, ext := range extensions {
+		if strings.HasSuffix(path, ext) {
+			return nil
+		}
+	}
+	return errors.Errorf("file %s does not have any of permitted extensions %s", path, extensions)
 }
 
 func (l parser) readDir(dir iofs.ReadDirFile, dirname string, processContent contentProcessor) error {
@@ -68,7 +77,7 @@ func (l parser) readDir(dir iofs.ReadDirFile, dirname string, processContent con
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), l.extension) {
+		if err := checkExtension(entry.Name(), l.extensions); err != nil || entry.IsDir() {
 			continue
 		}
 		// Note: using filepath.Join will break Windows, because io/fs.FS implementations require slashes on all OS.

--- a/kyaml/fn/framework/parser/schema.go
+++ b/kyaml/fn/framework/parser/schema.go
@@ -56,7 +56,7 @@ func SchemaStrings(data ...string) framework.SchemaParser {
 //		AdditionalSchemas: parser.SchemaFiles("path/to/crd-schemas", "path/to/special-schema.json),
 //	}
 func SchemaFiles(paths ...string) SchemaParser {
-	return SchemaParser{parser{paths: paths, extension: SchemaExtension}}
+	return SchemaParser{parser{paths: paths, extensions: []string{SchemaExtension}}}
 }
 
 // SchemaParser is a framework.SchemaParser that can parse files or directories containing openapi schemas.

--- a/kyaml/fn/framework/parser/schema_test.go
+++ b/kyaml/fn/framework/parser/schema_test.go
@@ -52,7 +52,7 @@ func TestSchemaFiles(t *testing.T) {
 		{
 			name:    "rejects non-.template.yaml files",
 			paths:   []string{"testdata/ignore.yaml"},
-			wantErr: "file testdata/ignore.yaml did not have required extension .json",
+			wantErr: "file testdata/ignore.yaml does not have any of permitted extensions [.json]",
 		},
 	}
 	for _, tt := range tests {

--- a/kyaml/fn/framework/parser/template.go
+++ b/kyaml/fn/framework/parser/template.go
@@ -61,7 +61,7 @@ func TemplateStrings(data ...string) framework.TemplateParser {
 //		}},
 //   }
 func TemplateFiles(paths ...string) TemplateParser {
-	return TemplateParser{parser{paths: paths, extension: TemplateExtension}}
+	return TemplateParser{parser{paths: paths, extensions: []string{TemplateExtension}}}
 }
 
 // TemplateParser is a framework.TemplateParser that can parse files or directories containing Go templated YAML.
@@ -93,5 +93,11 @@ func (l TemplateParser) Parse() ([]*template.Template, error) {
 // For example, you can use an embed.FS.
 func (l TemplateParser) FromFS(fs iofs.FS) TemplateParser {
 	l.parser.fs = fs
+	return l
+}
+
+// WithExtensions allows you to replace the extension the parser accept on the input files.
+func (l TemplateParser) WithExtensions(ext ...string) TemplateParser {
+	l.parser.extensions = ext
 	return l
 }

--- a/kyaml/fn/framework/parser/template_test.go
+++ b/kyaml/fn/framework/parser/template_test.go
@@ -81,7 +81,7 @@ func TestTemplateFiles(t *testing.T) {
 		{
 			name:    "rejects non-.template.yaml files",
 			paths:   []string{"testdata/ignore.yaml"},
-			wantErr: "file testdata/ignore.yaml did not have required extension .template.yaml",
+			wantErr: "file testdata/ignore.yaml does not have any of permitted extensions [.template.yaml]",
 		},
 	}
 	for _, tt := range tests {
@@ -112,6 +112,23 @@ func TestTemplateFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTemplateParser_WithExtensions(t *testing.T) {
+	p := parser.TemplateFiles("testdata").WithExtensions(".json")
+	templates, err := p.Parse()
+	require.NoError(t, err)
+	require.Len(t, templates, 2)
+
+	p = p.WithExtensions(".yaml")
+	templates, err = p.Parse()
+	require.NoError(t, err)
+	require.Len(t, templates, 3)
+
+	p = p.WithExtensions(".yaml", ".json")
+	templates, err = p.Parse()
+	require.NoError(t, err)
+	require.Len(t, templates, 5)
 }
 
 func TestTemplateStrings(t *testing.T) {

--- a/kyaml/fn/framework/processors.go
+++ b/kyaml/fn/framework/processors.go
@@ -173,7 +173,7 @@ func LoadFunctionConfig(src *yaml.RNode, api interface{}) error {
 	if v, ok := api.(Validator); ok {
 		return combineErrors(schemaValidationError, v.Validate())
 	}
-	return nil
+	return schemaValidationError
 }
 
 func combineErrors(schemaErr, customErr error) error {

--- a/kyaml/fn/framework/processors.go
+++ b/kyaml/fn/framework/processors.go
@@ -150,7 +150,7 @@ func LoadFunctionConfig(src *yaml.RNode, api interface{}) error {
 		if err != nil {
 			return errors.WrapPrefixf(err, "loading provided schema")
 		}
-		schemaValidationError = validate.AgainstSchema(schema, src, strfmt.Default)
+		schemaValidationError = errors.Wrap(validate.AgainstSchema(schema, src, strfmt.Default))
 		// don't return it yet--try to make it to custom validation stage to combine errors
 	}
 
@@ -166,7 +166,7 @@ func LoadFunctionConfig(src *yaml.RNode, api interface{}) error {
 
 	if d, ok := api.(Defaulter); ok {
 		if err := d.Default(); err != nil {
-			return err
+			return errors.Wrap(err)
 		}
 	}
 


### PR DESCRIPTION
A small enhancement and a bug fix for the functions framework, in separate commits:
- Configurable extensions for template parser: the default extension we expect is `.template.yaml`, which is non-standard. This allows one or more other extensions to be explicitly targeted.
- Regression test and fix for APIs that satisfy ValidationSchemaProvider but not Validator: Before this fix, if you implemented ValidationSchemaProvider but not Validator, your schema validation errors would be ignored, leading to the strange behaviour that implementing Validator and returning no errors would cause the incorrectly ignored schema errors to surface.