### PR TITLE
Add test directory for command localize

### DIFF
--- a/api/krusty/testdata/localize/simple/deployment.yaml
+++ b/api/krusty/testdata/localize/simple/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-simple
+  labels:
+    app: deployment-simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.16
+        ports:
+        - containerPort: 8080

--- a/api/krusty/testdata/localize/simple/kustomization.yaml
+++ b/api/krusty/testdata/localize/simple/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./deployment.yaml
+- ./service.yaml
+
+namePrefix: localize-

--- a/api/krusty/testdata/localize/simple/service.yaml
+++ b/api/krusty/testdata/localize/simple/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service-simple
+spec:
+  selector:
+    app: deployment-simple
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080 


### PR DESCRIPTION
Create simple kustomization directory that `kustomize localize` can download as remote reference in test.