### PR TITLE
Testing code leaked to production

### DIFF
--- a/kyaml/kio/testing.go
+++ b/kyaml/kio/testing.go
@@ -18,7 +18,7 @@ type Setup struct {
 	Root string
 }
 
-// setupDirectories creates directories for reading test configuration from
+// SetupDirectories creates directories for reading test configuration from
 func SetupDirectories(t *testing.T, dirs ...string) Setup {
 	t.Helper()
 	d, err := ioutil.TempDir("", "kyaml-test")
@@ -32,7 +32,7 @@ func SetupDirectories(t *testing.T, dirs ...string) Setup {
 	return Setup{Root: d}
 }
 
-// writeFile writes a file under the test directory
+// WriteFile writes a file under the test directory
 func (s Setup) WriteFile(t *testing.T, path string, value []byte) {
 	t.Helper()
 	err := os.MkdirAll(filepath.Dir(filepath.Join(s.Root, path)), 0700)
@@ -41,7 +41,7 @@ func (s Setup) WriteFile(t *testing.T, path string, value []byte) {
 	require.NoError(t, err)
 }
 
-// clean deletes the test config
+// Clean deletes the test config
 func (s Setup) Clean() {
 	os.RemoveAll(s.Root)
 }

--- a/kyaml/kio/testing_test.go
+++ b/kyaml/kio/testing_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package kio
+package kio_test
 
 import (
 	"io/ioutil"

--- a/kyaml/kio/testing_test.go
+++ b/kyaml/kio/testing_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package kio_test
+package kio
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
Testing struct "Setup" is  leaked to production code.
Before change:
![image](https://user-images.githubusercontent.com/29161093/168103787-792e56b7-8954-4082-a411-c611d098c8d2.png)
After change:
![image](https://user-images.githubusercontent.com/29161093/168105220-577a5a63-c35b-458c-ac7f-054abe5d14bb.png)
