### PR TITLE
fix: krm exec function working dir

### DIFF
--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -47,8 +47,18 @@ func (l *Loader) Config() *types.PluginConfig {
 	return l.pc
 }
 
-// SetWorkDir sets the working directory for this loader's plugins
-func (l *Loader) SetWorkDir(wd string) {
+// DeepCopyPluginConfig makes a full copy the actual values of PluginConfig.
+func (l *Loader) DeepCopyPluginConfig() {
+	l.pc = &types.PluginConfig{
+		PluginRestrictions: l.pc.PluginRestrictions,
+		BpLoadingOptions:   l.pc.BpLoadingOptions,
+		FnpLoadingOptions:  l.pc.FnpLoadingOptions,
+		HelmConfig:         l.pc.HelmConfig,
+	}
+}
+
+// SetPluginConfigWorkingDir sets the working directory for the loader's plugins.
+func (l *Loader) SetPluginConfigWorkingDir(wd string) {
 	l.pc.FnpLoadingOptions.WorkingDir = wd
 }
 

--- a/api/internal/plugins/loader/loader.go
+++ b/api/internal/plugins/loader/loader.go
@@ -42,24 +42,22 @@ func NewLoader(
 	return &Loader{pc: pc, rf: rf, fs: fs}
 }
 
-// Config provides the global (not plugin specific) PluginConfig data.
-func (l *Loader) Config() *types.PluginConfig {
-	return l.pc
-}
-
-// DeepCopyPluginConfig makes a full copy the actual values of PluginConfig.
-func (l *Loader) DeepCopyPluginConfig() {
-	l.pc = &types.PluginConfig{
+// LoaderWithWorkingDir returns loader after setting its working directory.
+// NOTE: This is not really a new loader since some of the Loader struct fields are pointers.
+func (l *Loader) LoaderWithWorkingDir(wd string) *Loader {
+	lpc := &types.PluginConfig{
 		PluginRestrictions: l.pc.PluginRestrictions,
 		BpLoadingOptions:   l.pc.BpLoadingOptions,
 		FnpLoadingOptions:  l.pc.FnpLoadingOptions,
 		HelmConfig:         l.pc.HelmConfig,
 	}
+	lpc.FnpLoadingOptions.WorkingDir = wd
+	return &Loader{pc: lpc, rf: l.rf, fs: l.fs}
 }
 
-// SetPluginConfigWorkingDir sets the working directory for the loader's plugins.
-func (l *Loader) SetPluginConfigWorkingDir(wd string) {
-	l.pc.FnpLoadingOptions.WorkingDir = wd
+// Config provides the global (not plugin specific) PluginConfig data.
+func (l *Loader) Config() *types.PluginConfig {
+	return l.pc
 }
 
 func (l *Loader) LoadGenerators(

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -88,7 +88,11 @@ func TestLoaderWithWorkingDir(t *testing.T) {
 	pLdr := NewLoader(c, rmF, fsys)
 	npLdr := pLdr.LoaderWithWorkingDir("/tmp/dummy")
 	require.Equal(t,
+		"",
+		pLdr.Config().FnpLoadingOptions.WorkingDir,
+		"the plugin working dir should not change")
+	require.Equal(t,
 		"/tmp/dummy",
 		npLdr.Config().FnpLoadingOptions.WorkingDir,
-		"plugin working dir is not set correctly")
+		"the plugin working dir is not updated")
 }

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -6,6 +6,7 @@ package loader_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	. "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/provider"
@@ -79,16 +80,15 @@ func TestLoader(t *testing.T) {
 	}
 }
 
-func TestLoaderSetPluginConfigWorkingDir(t *testing.T) {
+func TestLoaderWithWorkingDir(t *testing.T) {
 	p := provider.NewDefaultDepProvider()
 	rmF := resmap.NewFactory(p.GetResourceFactory())
 	fsys := filesys.MakeFsInMemory()
 	c := types.EnabledPluginConfig(types.BploLoadFromFileSys)
 	pLdr := NewLoader(c, rmF, fsys)
-	pLdrCopy := *pLdr
-	pLdrCopy.DeepCopyPluginConfig()
-	pLdrCopy.SetPluginConfigWorkingDir("/tmp/dummy")
-	if pLdrCopy.Config().FnpLoadingOptions.WorkingDir != "/tmp/dummy" {
-		t.Fatal("plugin working dir is not set correctly")
-	}
+	npLdr := pLdr.LoaderWithWorkingDir("/tmp/dummy")
+	require.Equal(t,
+		"/tmp/dummy",
+		npLdr.Config().FnpLoadingOptions.WorkingDir,
+		"plugin working dir is not set correctly")
 }

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -78,3 +78,17 @@ func TestLoader(t *testing.T) {
 		}
 	}
 }
+
+func TestLoaderSetPluginConfigWorkingDir(t *testing.T) {
+	p := provider.NewDefaultDepProvider()
+	rmF := resmap.NewFactory(p.GetResourceFactory())
+	fsys := filesys.MakeFsInMemory()
+	c := types.EnabledPluginConfig(types.BploLoadFromFileSys)
+	pLdr := NewLoader(c, rmF, fsys)
+	pLdrCopy := *pLdr
+	pLdrCopy.DeepCopyPluginConfig()
+	pLdrCopy.SetPluginConfigWorkingDir("/tmp/dummy")
+	if pLdrCopy.Config().FnpLoadingOptions.WorkingDir != "/tmp/dummy" {
+		t.Fatal("plugin working dir is not set correctly")
+	}
+}

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -45,7 +45,9 @@ func NewKustTarget(
 	rFactory *resmap.Factory,
 	pLdr *loader.Loader) *KustTarget {
 	pLdrCopy := *pLdr
-	pLdrCopy.SetWorkDir(ldr.Root())
+	pLdrCopy.DeepCopyPluginConfig()
+	pLdrCopy.SetPluginConfigWorkingDir(ldr.Root())
+
 	return &KustTarget{
 		ldr:       ldr,
 		validator: validator,

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -44,15 +44,11 @@ func NewKustTarget(
 	validator ifc.Validator,
 	rFactory *resmap.Factory,
 	pLdr *loader.Loader) *KustTarget {
-	pLdrCopy := *pLdr
-	pLdrCopy.DeepCopyPluginConfig()
-	pLdrCopy.SetPluginConfigWorkingDir(ldr.Root())
-
 	return &KustTarget{
 		ldr:       ldr,
 		validator: validator,
 		rFactory:  rFactory,
-		pLdr:      &pLdrCopy,
+		pLdr:      pLdr.LoaderWithWorkingDir(ldr.Root()),
 	}
 }
 


### PR DESCRIPTION
Based on @seh [tip](https://github.com/kubernetes-sigs/kustomize/issues/4347#issuecomment-1140290946) in #4347

This change makes a deep copy from the loader config instead of passing a reference to the config.

How to test: Follow the steps in #4347.

I've added 2 tests:
- **TestFnExecTransformer:** This test will pass in all cases because before the fix the base path is used and there is only the base and no overlay.
- **TestFnExecTransformerWithOverlay:**
  - **Before the fix:** [The test failed](https://github.com/aabouzaid/kustomize/runs/7313566978?check_suite_focus=true#step:4:5295) with exact error as in 4347 because the working dir is set to the base path.
  - **After the fix:** [The test passed](https://github.com/aabouzaid/kustomize/runs/7313727469?check_suite_focus=true#step:4:5295) where the working dir is updated with the overlay path.