### PR TITLE
Added chart parameter for helm charts

### DIFF
--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -42,6 +42,11 @@ type HelmChart struct {
 	// `https://itzg.github.io/minecraft-server-charts`.
 	Repo string `json:"repo,omitempty" yaml:"repo,omitempty"`
 
+	// Chart is a URL locating a package of the chart on the internet.
+	// This is the argument to helm's  `chart URL` argument, e.g.
+	// `https://github.com/orga/project/releases/download/v1.0.0/project-1.0.0.tgz`.
+	Chart string `json:"chart,omitempty" yaml:"chart,omitempty"`
+
 	// ReleaseName replaces RELEASE-NAME in chart template output,
 	// making a particular inflation of a chart unique with respect to
 	// other inflations of the same chart in a cluster. It's the first

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -87,6 +87,13 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 		return fmt.Errorf("chart name cannot be empty")
 	}
 
+	if p.Chart != "" && p.Repo != "" {
+		return fmt.Errorf("repo and chart cannot be defined both")
+	}
+
+	if p.Chart != "" && p.Version != "" {
+		return fmt.Errorf("version cannot be set when chart is defined")
+	}
 	// ChartHome might be consulted by the plugin (to read
 	// values files below it), so it must be located under
 	// the loader root (unless root restrictions are
@@ -232,9 +239,9 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err er
 		return nil, err
 	}
 	if path, exists := p.chartExistsLocally(); !exists {
-		if p.Repo == "" {
+		if p.Repo == "" && p.Chart == "" {
 			return nil, fmt.Errorf(
-				"no repo specified for pull, no chart found at '%s'", path)
+				"neither repo nor chart specified for pull, no chart found at '%s'", path)
 		}
 		if _, err := p.runHelmCommand(p.pullCommand()); err != nil {
 			return nil, err
@@ -295,11 +302,14 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 	args := []string{
 		"pull",
 		"--untar",
-		"--untardir", p.absChartHome(),
-		"--repo", p.Repo,
-		p.Name}
-	if p.Version != "" {
-		args = append(args, "--version", p.Version)
+	}
+	if p.Repo != "" {
+		args = append(args, "--untardir", p.absChartHome(), "--repo", p.Repo, p.Name)
+		if p.Version != "" {
+			args = append(args, "--version", p.Version)
+		}
+	} else if p.Chart != "" {
+		args = append(args, "--untardir", p.absChartHome(), p.Chart)
 	}
 	return args
 }


### PR DESCRIPTION
Consider the scenario where a maintainer of a helm chart only provides a download link to a .tgz file. 
Using `helm pull` it is already possible to use these URIs with those .tgz files.
This PR adds a `chart` parameter that can be used for that purpose. It is either `repo` or `chart`. When `chart` is defined the `version` parameter is forbidden.