### PR TITLE
fix: handle error of remove annotations

### DIFF
--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 )
@@ -114,13 +115,13 @@ func (b *Kustomizer) Run(
 	if !utils.StringSliceContains(kt.Kustomization().BuildMetadata, types.OriginAnnotations) {
 		err = m.RemoveOriginAnnotations()
 		if err != nil {
-			return nil, err
+			return nil, errors.WrapPrefixf(err, "failed to clean up origin tracking annotations")
 		}
 	}
 	if !utils.StringSliceContains(kt.Kustomization().BuildMetadata, types.TransformerAnnotations) {
 		err = m.RemoveTransformerAnnotations()
 		if err != nil {
-			return nil, err
+			return nil, errors.WrapPrefixf(err, "failed to clean up transformer annotations")
 		}
 	}
 	return m, nil

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -112,10 +112,16 @@ func (b *Kustomizer) Run(
 	}
 	m.RemoveBuildAnnotations()
 	if !utils.StringSliceContains(kt.Kustomization().BuildMetadata, types.OriginAnnotations) {
-		m.RemoveOriginAnnotations()
+		err = m.RemoveOriginAnnotations()
+		if err != nil {
+			return nil, err
+		}
 	}
 	if !utils.StringSliceContains(kt.Kustomization().BuildMetadata, types.TransformerAnnotations) {
-		m.RemoveTransformerAnnotations()
+		err = m.RemoveTransformerAnnotations()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return m, nil
 }


### PR DESCRIPTION
Errors of `RemoveOriginAnnotations` and `RemoveTransformerAnnotations` are not handled.
So, I fixed it to handle `err`.