### PR TITLE
From #4256 #3816 this introduces support for kube-version parameter

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -286,6 +286,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.KubeVersion != "" {
 		args = append(args, "--kube-version", p.KubeVersion)
 	}
+	if p.ApiVersions != "" {
+		args = append(args, "--api-versions", p.ApiVersions)
+	}
 	return args
 }
 

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -283,6 +283,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.IncludeCRDs {
 		args = append(args, "--include-crds")
 	}
+	if p.KubeVersion != "" {
+		args = append(args, "--kube-version", p.KubeVersion)
+	}
 	return args
 }
 

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -37,8 +37,11 @@ type HelmChart struct {
 	// Version is the version of the chart, e.g. '3.1.3'
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 
-	// Kubernetes api-version, same as --kube-version from helm template
+	// Kubernetes api-version, same as --kube-version from helm template, e.g. '1.22'
 	KubeVersion string `json:"kubeVersion,omitempty" yaml:"kubeVersion,omitempty"`
+
+	// allow helm to set the --api-versions flag when running helm template, e.g. 'monitoring.coreos.com/v1'
+	ApiVersions string `json:"apiVersions,omitempty" yaml:"apiVersions,omitempty"`
 
 	// Repo is a URL locating the chart on the internet.
 	// This is the argument to helm's  `--repo` flag, e.g.

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -37,6 +37,9 @@ type HelmChart struct {
 	// Version is the version of the chart, e.g. '3.1.3'
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 
+	// Kubernetes api-version, same as --kube-version from helm template
+	KubeVersion string `json:"kubeVersion,omitempty" yaml:"kubeVersion,omitempty"`
+
 	// Repo is a URL locating the chart on the internet.
 	// This is the argument to helm's  `--repo` flag, e.g.
 	// `https://itzg.github.io/minecraft-server-charts`.

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -291,6 +291,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.KubeVersion != "" {
 		args = append(args, "--kube-version", p.KubeVersion)
 	}
+	if p.ApiVersions != "" {
+		args = append(args, "--api-versions", p.ApiVersions)
+	}
 	return args
 }
 

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -288,6 +288,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.IncludeCRDs {
 		args = append(args, "--include-crds")
 	}
+	if p.KubeVersion != "" {
+		args = append(args, "--kube-version", p.KubeVersion)
+	}
 	return args
 }
 


### PR DESCRIPTION
To be able to consume helm templates that rely on `Capabilities` the `--kube-version` flag has to be supported.
This pr is introducing that configuration flag on `kustommization.yml` level under `helmCharts`, eg:
```yaml
- name: reloader
  version: '0.0.113'
  repo: https://stakater.github.io/stakater-charts
  releaseName: reloader
  namespace: reloader
  kubeVersion: '1.21'
  valuesInline:
    # https://github.com/stakater/Reloader/blob/master/deployments/kubernetes/chart/reloader/values.yaml
    fullnameOverride: reloader
    reloader:
      deployment:
        replicas: 1
        resources:
          limits:
            cpu: "100m"
            memory: "512Mi"
          requests:
            cpu: "10m"
            memory: "128Mi"
      containerSecurityContext:
        capabilities:
          drop:
            - ALL
        allowPrivilegeEscalation: false
        readOnlyRootFilesystem: true
      service:
        port: 9090
      serviceMonitor:
        enabled: true
        namespace: reloader
```

relates to #4256 and #3816 

I've executed `make verify-kustomize-repo` successfully and `make test-unit-kustomize-plugins`:
```
Testing ./plugin/builtin/helmchartinflationgenerator
=== RUN   TestHelmChartInflationGenerator
2022/06/07 17:05:44 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:20: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGenerator (2.36s)
=== RUN   TestHelmChartInflationGeneratorWithValuesInlineOverride
2022/06/07 17:05:47 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:367: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithValuesInlineOverride (2.24s)
=== RUN   TestHelmChartInflationGeneratorWithLocalValuesFile
2022/06/07 17:05:49 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:398: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithLocalValuesFile (2.27s)
=== RUN   TestHelmChartInflationGeneratorWithInLineReplace
2022/06/07 17:05:51 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:435: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithInLineReplace (2.22s)
=== RUN   TestHelmChartInflationGeneratorWithIncludeCRDs
2022/06/07 17:05:53 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:471: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithIncludeCRDs (2.24s)
=== RUN   TestHelmChartInflationGeneratorWithExcludeCRDs
2022/06/07 17:05:56 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:505: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithExcludeCRDs (2.24s)
=== RUN   TestHelmChartInflationGeneratorWithIncludeCRDsNotSpecified
2022/06/07 17:05:58 compiler created: /Users/dconstenla/gitClones/kustomize/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.so
    HelmChartInflationGenerator_test.go:534: skipping: exec: "helmV3": executable file not found in $PATH
--- SKIP: TestHelmChartInflationGeneratorWithIncludeCRDsNotSpecified (2.27s)
PASS
ok      command-line-arguments  16.457s
```