### PR TITLE
replacements: fix issue with `create: true` option when there is an existing field

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -4,10 +4,10 @@
 package replacement
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/go-errors/errors"
 	"sigs.k8s.io/kustomize/api/internal/utils"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
@@ -196,9 +196,12 @@ func copyValueToTarget(target *yaml.RNode, value *yaml.RNode, selector *types.Ta
 			// may return multiple fields, always wrapped in a sequence node
 			foundFieldSequence, lookupErr := target.Pipe(&yaml.PathMatcher{Path: fieldPath})
 			if lookupErr != nil {
-				return errors.WrapPrefix(lookupErr, "error finding field in replacement target", 0)
+				return fmt.Errorf("error finding field in replacement target: %w", lookupErr)
 			}
 			targetFields, err = foundFieldSequence.Elements()
+			if err != nil {
+				return fmt.Errorf("error fetching elements in replacement target: %w", err)
+			}
 		}
 
 		for _, t := range targetFields {

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -2367,7 +2367,7 @@ spec:
       containers:
       - image: busybox
         name: myapp-container
-      restartPolicy: OnFailure
+      restartPolicy: old
 ---
 apiVersion: v1
 kind: Pod
@@ -2377,7 +2377,7 @@ spec:
   containers:
     - image: busybox
       name: myapp-container
-  restartPolicy: OnFailure
+  restartPolicy: new
 `,
 			replacements: `replacements:
 - source:
@@ -2400,12 +2400,10 @@ metadata:
 spec:
   template:
     spec:
-      "":
-        containers:
-        - image: busybox
-          name: myapp-container
-        restartPolicy: OnFailure
-      "": ""
+      containers:
+      - image: busybox
+        name: myapp-container
+      restartPolicy: new
 ---
 apiVersion: v1
 kind: Pod
@@ -2415,7 +2413,7 @@ spec:
   containers:
   - image: busybox
     name: myapp-container
-  restartPolicy: OnFailure
+  restartPolicy: new
 `,
 		},
 	}

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -2356,6 +2356,68 @@ spec:
     - containerPort: 80
 `,
 		},
+		"replace an existing mapping value": {
+			input: `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hello
+spec:
+  template:
+    spec:
+      containers:
+      - image: busybox
+        name: myapp-container
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+    - image: busybox
+      name: myapp-container
+  restartPolicy: OnFailure
+`,
+			replacements: `replacements:
+- source:
+    kind: Pod
+    name: my-pod
+    fieldPath: spec
+  targets:
+  - select:
+      name: hello
+      kind: Job
+    fieldPaths:
+     - spec.template.spec
+    options:
+      create: true
+`,
+			expected: `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hello
+spec:
+  template:
+    spec:
+      "":
+        containers:
+        - image: busybox
+          name: myapp-container
+        restartPolicy: OnFailure
+      "": ""
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+spec:
+  containers:
+  - image: busybox
+    name: myapp-container
+  restartPolicy: OnFailure
+`,
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -580,6 +580,31 @@ a: {}
 	assert.Equal(t, "h\n", assertNoErrorString(t)(rn.String()))
 }
 
+// Don't keep this test--it is probably redundant, but clearly shows the problem is not being caused by LookupCreate
+func TestLookupCreate_5(t *testing.T) {
+	doc := `
+spec:
+  template:
+    spec:
+      containers:
+      - name: a
+      - name: b
+      restartPolicy: Always
+`
+	node, err := Parse(doc)
+	assert.NoError(t, err)
+	rn, err := node.Pipe(
+		LookupCreate(yaml.MappingNode, "spec", "template", "spec"))
+
+	assert.NoError(t, err)
+	expected := `containers:
+- name: a
+- name: b
+restartPolicy: Always
+`
+	assert.Equal(t, expected, assertNoErrorString(t)(rn.String()))
+}
+
 func TestLookup_Fn_create_with_wildcard_error(t *testing.T) {
 	node, err := Parse(s)
 	assert.NoError(t, err)

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -580,31 +580,6 @@ a: {}
 	assert.Equal(t, "h\n", assertNoErrorString(t)(rn.String()))
 }
 
-// Don't keep this test--it is probably redundant, but clearly shows the problem is not being caused by LookupCreate
-func TestLookupCreate_5(t *testing.T) {
-	doc := `
-spec:
-  template:
-    spec:
-      containers:
-      - name: a
-      - name: b
-      restartPolicy: Always
-`
-	node, err := Parse(doc)
-	assert.NoError(t, err)
-	rn, err := node.Pipe(
-		LookupCreate(yaml.MappingNode, "spec", "template", "spec"))
-
-	assert.NoError(t, err)
-	expected := `containers:
-- name: a
-- name: b
-restartPolicy: Always
-`
-	assert.Equal(t, expected, assertNoErrorString(t)(rn.String()))
-}
-
 func TestLookup_Fn_create_with_wildcard_error(t *testing.T) {
 	node, err := Parse(s)
 	assert.NoError(t, err)


### PR DESCRIPTION
First commit demonstrates the bug, second one fixes it. Likely caused by https://github.com/kubernetes-sigs/kustomize/pull/4424. Follow up to this review comment https://github.com/kubernetes-sigs/kustomize/pull/4577#discussion_r847718929.
`LookupCreate` seems to do weird things if the field already exists. So the logic here is just: if the field already exists, don't use `LookupCreate`. 

/cc @KnVerey @yuwenma 