### PR TITLE
Adds tests exhibiting possible bug in NamespaceTransformer

### DIFF
--- a/api/krusty/namedspacedserviceaccounts_test.go
+++ b/api/krusty/namedspacedserviceaccounts_test.go
@@ -1,0 +1,212 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestNamedspacedServiceAccountsWithoutOverlap(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteF("a/a.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-a
+subjects:
+  - kind: ServiceAccount
+    name: sa-a
+`)
+
+	th.WriteK("a/", `
+namespace: a
+resources:
+- a.yaml
+`)
+
+	th.WriteF("b/b.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-b
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-b
+subjects:
+  - kind: ServiceAccount
+    name: sa-b
+`)
+
+	th.WriteK("b/", `
+namespace: b
+resources:
+- b.yaml
+`)
+
+	th.WriteK(".", `
+resources:
+- a
+- b
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-a
+  namespace: a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-a
+subjects:
+- kind: ServiceAccount
+  name: sa-a
+  namespace: a
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-b
+  namespace: b
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-b
+subjects:
+- kind: ServiceAccount
+  name: sa-b
+  namespace: b
+`)
+}
+
+func TestNamedspacedServiceAccountsWithOverlap(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteF("a/a.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-a
+subjects:
+  - kind: ServiceAccount
+    name: sa
+`)
+
+	th.WriteK("a/", `
+namespace: a
+resources:
+- a.yaml
+`)
+
+	th.WriteF("b/b.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-b
+subjects:
+  - kind: ServiceAccount
+    name: sa
+`)
+
+	th.WriteK("b/", `
+namespace: b
+resources:
+- b.yaml
+`)
+
+	th.WriteK(".", `
+resources:
+- a
+- b
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  namespace: a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-a
+subjects:
+- kind: ServiceAccount
+  name: sa
+  namespace: a
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  namespace: b
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crb-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-b
+subjects:
+- kind: ServiceAccount
+  name: sa
+  namespace: a
+`)
+}

--- a/api/krusty/namedspacedserviceaccounts_test.go
+++ b/api/krusty/namedspacedserviceaccounts_test.go
@@ -69,6 +69,9 @@ resources:
 `)
 
 	m := th.Run(".", th.MakeDefaultOptions())
+
+	// Everything is as expected: each CRB gets updated to reference the SA in the appropriate namespace
+	// Changing order in the root kustomization.yaml does not change the result, as expected
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount
@@ -170,6 +173,9 @@ resources:
 `)
 
 	m := th.Run(".", th.MakeDefaultOptions())
+
+	// Unexpected result: crb-b's subject obtains the wrong namespace, having "namespace: a"
+	// If the order is swapped in the kustomization.yaml then it's crb-a that gets "namespace: b"
 	th.AssertActualEqualsExpected(m, `
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This PR creates a pair of tests, one with expected results and one with unexpected results (both tests pass), to exhibit a possible bug.

The tests create the following structure:

```
 .
 ┣ 📜kustomization.yaml
 ┣ 📂a
 ┃ ┗ 📜kustomization.yaml
 ┃ ┗ 📜a.yaml
 ┣ 📂b
 ┃ ┗ 📜kustomization.yaml
 ┃ ┗ 📜b.yaml
```

The root `kustomization.yaml` only has resources set to the two subdirectories (`a` and then `b`), and the `kustomization.yaml` on each of those subdirectories sets its namespace to `a` or `b` (same as its subdir), and includes either `a.yaml` or `b.yaml` as a resource.

The content of `a.yaml` and `b.yaml` is identical, only having different names (one uses `-a` suffix, the other `-b`), and is as follows:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa-a
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: crb-a
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cr-a
subjects:
  - kind: ServiceAccount
    name: sa-a
```

And in this case produces the following expected result:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa-a
  namespace: a
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: crb-a
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cr-a
subjects:
- kind: ServiceAccount
  name: sa-a
  namespace: a
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa-b
  namespace: b
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: crb-b
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cr-b
subjects:
- kind: ServiceAccount
  name: sa-b
  namespace: b
```

However, with a small change to each file, renaming `sa-a` and `sa-b` to `sa` (including in the ClusterRoleBinding), the output unexpectedly becomes:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa
  namespace: a
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: crb-a
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cr-a
subjects:
- kind: ServiceAccount
  name: sa
  namespace: a
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: sa
  namespace: b
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: crb-b
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cr-b
subjects:
- kind: ServiceAccount
  name: sa
  namespace: a # <-------
```

With the unexpected result being that `crb-b`'s subject's namespace became `a`, while I would've expected it to remain `b` as that would match the namespace of the ServiceAccount defined within its structure.

If the order is changed in the root `kustomization.yaml` so that the resource `b` comes before the resource `a`, then the opposite will happen, and `crb-a` will have the `b` namespace in its subject, which to me seems even more unexpected.

If this is indeed unexpected, then I'm guessing it comes from how the NamespaceTransformer applies its changes to a ClusterRoleBinding considering that a CRB has no namespace, possibly in: https://github.com/kubernetes-sigs/kustomize/blob/7e0fd02783ba65319b94076efb6b2414923feb86/api/filters/namespace/namespace.go#L109-L145