### PR TITLE
Helm: added environment values parsing for values

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kustomize/api
 go 1.16
 
 require (
+	github.com/a8m/envsubst v1.3.0
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/go-errors/errors v1.0.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/api/go.sum
+++ b/api/go.sum
@@ -44,6 +44,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/a8m/envsubst/parse"
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -220,6 +221,25 @@ func (p *HelmChartInflationGeneratorPlugin) cleanup() {
 	}
 }
 
+func (p *HelmChartInflationGeneratorPlugin) evaluateEnvs() (string, error) {
+	b, err := p.h.Loader().Load(p.ValuesFile)
+	if err != nil {
+		return "", fmt.Errorf("Failed to read file: %w", err)
+	}
+
+	// Parse input string
+	parserMode := parse.AllErrors
+	restrictions := &parse.Restrictions{
+		NoUnset: true,
+		NoEmpty: true,
+	}
+	result, err := (&parse.Parser{Name: "string", Env: os.Environ(), Restrict: restrictions, Mode: parserMode}).Parse(string(b))
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse input: %w", err)
+	}
+	return p.writeValuesBytes([]byte(result))
+}
+
 // Generate implements generator
 func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err error) {
 	defer p.cleanup()
@@ -243,6 +263,11 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err er
 	if err != nil {
 		return nil, err
 	}
+	p.ValuesFile, err = p.evaluateEnvs()
+	if err != nil {
+		return nil, err
+	}
+
 	var stdout []byte
 	stdout, err = p.runHelmCommand(p.templateCommand())
 	if err != nil {

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kustomize/kustomize/v4
 go 1.16
 
 require (
+	github.com/a8m/envsubst v1.3.0 // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -44,6 +44,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/plugin/builtin/helmchartinflationgenerator/go.mod
+++ b/plugin/builtin/helmchartinflationgenerator/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kustomize/plugin/builtin/helmchartinflationgenerator
 go 1.16
 
 require (
+	github.com/a8m/envsubst v1.3.0
 	github.com/imdario/mergo v0.3.5
 	github.com/pkg/errors v0.9.1
 	sigs.k8s.io/kustomize/api v0.8.9

--- a/plugin/builtin/helmchartinflationgenerator/go.sum
+++ b/plugin/builtin/helmchartinflationgenerator/go.sum
@@ -44,6 +44,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
This PR allows the user to use environment varuables as values for helm charts (either per values.yaml or valusInline).
Why is this useful? This way it is easily possible to deploy some helm charts with overwritten values settings that comes from env variables. Something like this this isn't currently possible.
The example below needs installs fleet via kustomize and helm. I want to define specific values before deploying and modifying afterwards. 

Example:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: fleet

helmCharts:
  - name: fleet
    version: 100.0.3+up0.3.9
    repo: https://charts.rancher.io
    releaseName: fleet
    valuesInline:
      apiServerURL: ${FLEET_API_SERVER_URL}
      apiServerCA: ${FLEET_API_SERVER_CA}
```

Signed-off-by: Armin Schlegel <armin.schlegel@gmx.de>