### PR TITLE
Add `localize` test data with remote reference

### DIFF
--- a/api/krusty/testdata/localize/remote/hpa.yaml
+++ b/api/krusty/testdata/localize/remote/hpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-deployment
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: localize-test-deployment-simple
+  minReplicas: 1
+  maxReplicas: 10

--- a/api/krusty/testdata/localize/remote/kustomization.yaml
+++ b/api/krusty/testdata/localize/remote/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/kubernetes-sigs/kustomize//api/krusty/testdata/localize/simple?ref=kustomize/v4.5.5
+  - hpa.yaml
+
+commonLabels:
+  purpose: remoteReference


### PR DESCRIPTION
Once merged and included in kustomize release, can be used in `localize` proposal as **Story 2**. However, before use, must look into #4623.