### PR TITLE
Clean code near `Loader`

### DIFF
--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -43,8 +43,8 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 }
 
 // DoNothingCloner returns a cloner that only sets
-// cloneDir field in the repoSpec.  It's assumed that
-// the cloneDir is associated with some fake filesystem
+// the Dir field in the repoSpec.  It's assumed that
+// the Dir is associated with some fake filesystem
 // used in a test.
 func DoNothingCloner(dir filesys.ConfirmedDir) Cloner {
 	return func(rs *RepoSpec) error {

--- a/kustomize/commands/create/create.go
+++ b/kustomize/commands/create/create.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/konfig"
-	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
@@ -99,7 +98,7 @@ func runCreate(opts createFlags, fSys filesys.FileSystem, rf *resource.Factory) 
 	var resources []string
 	var err error
 	if opts.resources != "" {
-		resources, err = util.GlobPatternsWithLoader(fSys, loader.NewFileLoaderAtCwd(fSys), strings.Split(opts.resources, ","))
+		resources, err = util.GlobPatternsWithRemotes(fSys, strings.Split(opts.resources, ","))
 		if err != nil {
 			return err
 		}

--- a/kustomize/commands/edit/add/addcomponent.go
+++ b/kustomize/commands/edit/add/addcomponent.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -49,7 +48,7 @@ func (o *addComponentOptions) Validate(args []string) error {
 
 // RunAddComponent runs addComponent command (do real work).
 func (o *addComponentOptions) RunAddComponent(fSys filesys.FileSystem) error {
-	components, err := util.GlobPatternsWithLoader(fSys, loader.NewFileLoaderAtCwd(fSys), o.componentFilePaths)
+	components, err := util.GlobPatternsWithRemotes(fSys, o.componentFilePaths)
 	if err != nil {
 		return err
 	}

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/konfig"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -21,6 +22,7 @@ sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 )
 
 func TestAddComponentHappyPath(t *testing.T) {
+	// cannot use MakeFsInMemory(), since it cannot Glob relative paths
 	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
 	require.NoError(t, err)
@@ -38,7 +40,7 @@ func TestAddComponentHappyPath(t *testing.T) {
 }
 
 func TestAddComponentAlreadyThere(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
+	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
@@ -52,18 +54,16 @@ func TestAddComponentAlreadyThere(t *testing.T) {
 }
 
 func TestAddKustomizationFileAsComponent(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
-	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
-	require.NoError(t, err)
+	fSys := filesys.MakeEmptyDirInMemory()
 	testutils_test.WriteTestKustomization(fSys)
 
 	cmd := newCmdAddComponent(fSys)
-	args := []string{componentFileName}
+	args := []string{konfig.DefaultKustomizationFileName()}
 	require.NoError(t, cmd.RunE(cmd, args))
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	require.NoError(t, err)
-	assert.NotContains(t, string(content), componentFileName)
+	assert.NotContains(t, string(content), konfig.DefaultKustomizationFileName())
 }
 
 func TestAddComponentNoArgs(t *testing.T) {

--- a/kustomize/commands/edit/add/addresource.go
+++ b/kustomize/commands/edit/add/addresource.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
 	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/util"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -49,7 +48,7 @@ func (o *addResourceOptions) Validate(args []string) error {
 
 // RunAddResource runs addResource command (do real work).
 func (o *addResourceOptions) RunAddResource(fSys filesys.FileSystem) error {
-	resources, err := util.GlobPatternsWithLoader(fSys, loader.NewFileLoaderAtCwd(fSys), o.resourceFilePaths)
+	resources, err := util.GlobPatternsWithRemotes(fSys, o.resourceFilePaths)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix
* util.GlobPatternsWithLoader doesn't load remote files
* `edit add` command TestAddKustomizationFileAs* adds normal config instead of kustomization file

Clean
* fileloader_test.go, which has 1 invalid check, multiple lengthy checks, and 1 test that's difficult to understand