### PR TITLE
update release tools for go workspace mode

### DIFF
--- a/cmd/gorepomod/internal/edit/editor.go
+++ b/cmd/gorepomod/internal/edit/editor.go
@@ -57,8 +57,6 @@ func (e *Editor) Tidy() error {
 func (e *Editor) Pin(target misc.LaModule, oldV, newV semver.SemVer) error {
 	err := e.run(
 		"edit",
-		"-dropreplace="+target.ImportPath(),
-		"-dropreplace="+target.ImportPath()+"@"+oldV.String(),
 		"-require="+target.ImportPath()+"@"+newV.String(),
 	)
 	if err != nil {

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -349,43 +349,6 @@ Undraft the release on the [kustomize repo release page]:
 
 * Visit the [release page] and edit the release notes as desired.
 
-
-## Unpin everything
-
-
-Go back into development mode, where all modules depend on in-repo code:
-
-```
-gorepomod unpin api         --doIt &&
-gorepomod unpin cmd/config  --doIt &&
-gorepomod unpin kyaml       --doIt
-```
-
-Create the PR:
-```
-createBranch unpinEverything "Back to development mode; unpin the modules" &&
-createPr
-```
-
-Run local tests while GH runs tests in the cloud:
-```
-testKustomizeRepo
-```
-
-Wait for tests to pass, then merge the PR:
-```
-gh pr status  # rinse, repeat
-```
-```
-gh pr merge -m
-```
-
-Get back on master and do paranoia test:
-```
-refreshMaster &&
-testKustomizeRepo
-```
-
 ## Update example test target
 
 [Makefile]: https://github.com/kubernetes-sigs/kustomize/blob/master/Makefile

--- a/releasing/run-goreleaser.sh
+++ b/releasing/run-goreleaser.sh
@@ -121,6 +121,7 @@ checksum:
 env:
 - CGO_ENABLED=0
 - GO111MODULE=on
+- GOWORK=off
 
 release:
   github:


### PR DESCRIPTION
IIUC, the addition of [go workspace mode](https://github.com/kubernetes-sigs/kustomize/pull/4692) means that we no longer have `replace` statements. We still need to pin modules to the new releases, i.e. when we release `kyaml v0.13.8`, we need to pin all our other modules to it before we release those other modules. But we no longer need to unpin everything at the end.

I also set `GOWORK=off` to the goreleaser file to turn off workspace mode during release. [Doc link](https://go.dev/ref/mod#workspaces)