### PR TITLE
Option to customize NamespaceTransformer overwrite behaviour

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
     - gocyclo
 #    - godot
 #    - godox
-    - goerr113
+#    - goerr113
     - gofmt
 #    - gofumpt
     - goheader

--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -28,7 +28,7 @@ uninstall-out-of-tree-tools:
 	rm -f $(MYGOBIN)/stringer
 
 $(MYGOBIN)/golangci-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
 
 $(MYGOBIN)/mdrip:
 	go install github.com/monopole/mdrip@v1.0.2

--- a/api/filters/filtersutil/setters.go
+++ b/api/filters/filtersutil/setters.go
@@ -94,8 +94,7 @@ func hasExistingValue(node *yaml.RNode, key string) bool {
 	if node.IsNilOrEmpty() {
 		return false
 	}
-	if key == "" {
-		// scalar node
+	if err := yaml.ErrorIfInvalid(node, yaml.ScalarNode); err == nil {
 		return yaml.GetValue(node) != ""
 	}
 	entry := node.Field(key)

--- a/api/filters/filtersutil/setters.go
+++ b/api/filters/filtersutil/setters.go
@@ -12,13 +12,13 @@ type SetFn func(*yaml.RNode) error
 
 // SetScalar returns a SetFn to set a scalar value
 func SetScalar(value string) SetFn {
-	return func(node *yaml.RNode) error {
-		return node.PipeE(yaml.FieldSetter{StringValue: value})
-	}
+	return SetEntry("", value, yaml.NodeTagEmpty)
 }
 
-// SetEntry returns a SetFn to set an entry in a map
-func SetEntry(key, value, tag string) SetFn {
+// SetEntry returns a SetFn to set a field or a map entry to a value.
+// It can be used with an empty name to set both a value and a tag on a scalar node.
+// When setting only a value on a scalar node, use SetScalar instead.
+func SetEntry(name, value, tag string) SetFn {
 	n := &yaml.Node{
 		Kind:  yaml.ScalarNode,
 		Value: value,
@@ -26,7 +26,7 @@ func SetEntry(key, value, tag string) SetFn {
 	}
 	return func(node *yaml.RNode) error {
 		return node.PipeE(yaml.FieldSetter{
-			Name:  key,
+			Name:  name,
 			Value: yaml.NewRNode(n),
 		})
 	}
@@ -34,36 +34,73 @@ func SetEntry(key, value, tag string) SetFn {
 
 type TrackableSetter struct {
 	// SetValueCallback will be invoked each time a field is set
-	setValueCallback func(key, value, tag string, node *yaml.RNode)
+	setValueCallback func(name, value, tag string, node *yaml.RNode)
 }
 
 // WithMutationTracker registers a callback which will be invoked each time a field is mutated
-func (s *TrackableSetter) WithMutationTracker(callback func(key, value, tag string, node *yaml.RNode)) {
+func (s *TrackableSetter) WithMutationTracker(callback func(key, value, tag string, node *yaml.RNode)) *TrackableSetter {
 	s.setValueCallback = callback
+	return s
 }
 
-// SetScalar returns a SetFn to set a scalar value
+// SetScalar returns a SetFn to set a scalar value.
 // if a mutation tracker has been registered, the tracker will be invoked each
 // time a scalar is set
 func (s TrackableSetter) SetScalar(value string) SetFn {
-	origSetScalar := SetScalar(value)
+	return s.SetEntry("", value, yaml.NodeTagEmpty)
+}
+
+// SetScalarIfEmpty returns a SetFn to set a scalar value only if it isn't already set.
+// If a mutation tracker has been registered, the tracker will be invoked each
+// time a scalar is actually set.
+func (s TrackableSetter) SetScalarIfEmpty(value string) SetFn {
+	return s.SetEntryIfEmpty("", value, yaml.NodeTagEmpty)
+}
+
+// SetEntry returns a SetFn to set a field or a map entry to a value.
+// It can be used with an empty name to set both a value and a tag on a scalar node.
+// When setting only a value on a scalar node, use SetScalar instead.
+// If a mutation tracker has been registered, the tracker will be invoked each
+// time an entry is set.
+func (s TrackableSetter) SetEntry(name, value, tag string) SetFn {
+	origSetEntry := SetEntry(name, value, tag)
 	return func(node *yaml.RNode) error {
 		if s.setValueCallback != nil {
-			s.setValueCallback("", value, "", node)
+			s.setValueCallback(name, value, tag, node)
 		}
-		return origSetScalar(node)
+		return origSetEntry(node)
 	}
 }
 
-// SetEntry returns a SetFn to set an entry in a map
-// if a mutation tracker has been registered, the tracker will be invoked each
-// time an entry is set
-func (s TrackableSetter) SetEntry(key, value, tag string) SetFn {
+// SetEntryIfEmpty returns a SetFn to set a field or a map entry to a value only if it isn't already set.
+// It can be used with an empty name to set both a value and a tag on a scalar node.
+// When setting only a value on a scalar node, use SetScalar instead.
+// If a mutation tracker has been registered, the tracker will be invoked each
+// time an entry is actually set.
+func (s TrackableSetter) SetEntryIfEmpty(key, value, tag string) SetFn {
 	origSetEntry := SetEntry(key, value, tag)
 	return func(node *yaml.RNode) error {
+		if hasExistingValue(node, key) {
+			return nil
+		}
 		if s.setValueCallback != nil {
 			s.setValueCallback(key, value, tag, node)
 		}
 		return origSetEntry(node)
 	}
+}
+
+func hasExistingValue(node *yaml.RNode, key string) bool {
+	if node.IsNilOrEmpty() {
+		return false
+	}
+	if key == "" {
+		// scalar node
+		return yaml.GetValue(node) != ""
+	}
+	entry := node.Field(key)
+	if entry.IsNilOrEmpty() {
+		return false
+	}
+	return yaml.GetValue(entry.Value) != ""
 }

--- a/api/filters/filtersutil/setters_test.go
+++ b/api/filters/filtersutil/setters_test.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filtersutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/filters/filtersutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestTrackableSetter_SetScalarIfEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *yaml.RNode
+		value string
+		want  string
+	}{
+		{
+			name:  "sets null values",
+			input: yaml.MakeNullNode(),
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name:  "sets empty values",
+			input: yaml.NewScalarRNode(""),
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name:  "does not overwrite values",
+			input: yaml.NewStringRNode("a"),
+			value: "foo",
+			want:  "a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wasSet := false
+			s := (&filtersutil.TrackableSetter{}).WithMutationTracker(func(_, _, _ string, _ *yaml.RNode) {
+				wasSet = true
+			})
+			wantSet := tt.value == tt.want
+			fn := s.SetScalarIfEmpty(tt.value)
+			require.NoError(t, fn(tt.input))
+			assert.Equal(t, tt.want, yaml.GetValue(tt.input))
+			assert.Equal(t, wantSet, wasSet, "tracker invoked even though value was not changed")
+		})
+	}
+}
+
+func TestTrackableSetter_SetEntryIfEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *yaml.RNode
+		key   string
+		value string
+		want  string
+	}{
+		{
+			name:  "sets empty values",
+			input: yaml.NewMapRNode(&map[string]string{"setMe": ""}),
+			key:   "setMe",
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name:  "sets missing keys",
+			input: yaml.NewMapRNode(&map[string]string{}),
+			key:   "setMe",
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name:  "does not overwrite values",
+			input: yaml.NewMapRNode(&map[string]string{"existing": "original"}),
+			key:   "existing",
+			value: "foo",
+			want:  "original",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wasSet := false
+			s := (&filtersutil.TrackableSetter{}).WithMutationTracker(func(_, _, _ string, _ *yaml.RNode) {
+				wasSet = true
+			})
+			wantSet := tt.value == tt.want
+			fn := s.SetEntryIfEmpty(tt.key, tt.value, "")
+			require.NoError(t, fn(tt.input))
+			assert.Equal(t, tt.want, yaml.GetValue(tt.input.Field(tt.key).Value))
+			assert.Equal(t, wantSet, wasSet, "tracker invoked even though value was not changed")
+		})
+	}
+}
+
+func TestTrackableSetter_SetEntryIfEmpty_BadInputNodeKind(t *testing.T) {
+	fn := filtersutil.TrackableSetter{}.SetEntryIfEmpty("foo", "false", yaml.NodeTagBool)
+	rn := yaml.NewListRNode("nope")
+	rn.AppendToFieldPath("dummy", "path")
+	assert.EqualError(t, fn(rn), "wrong Node Kind for dummy.path expected: MappingNode was SequenceNode: value: {- nope}")
+}

--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -337,19 +337,16 @@ func (f Filter) selectReferral(
 		return candidates[0], nil
 	}
 	ids := getIds(candidates)
-	f.failureDetails(candidates)
-	return nil, fmt.Errorf(" found multiple possible referrals: %s", ids)
+	return nil, fmt.Errorf(" found multiple possible referrals: %s\n%s", ids, f.failureDetails(candidates))
 }
 
-func (f Filter) failureDetails(resources []*resource.Resource) {
-	fmt.Printf(
-		"\n**** Too many possible referral targets to referrer:\n%s\n",
-		f.Referrer.MustYaml())
+func (f Filter) failureDetails(resources []*resource.Resource) string {
+	msg := strings.Builder{}
+	msg.WriteString(fmt.Sprintf("\n**** Too many possible referral targets to referrer:\n%s\n", f.Referrer.MustYaml()))
 	for i, r := range resources {
-		fmt.Printf(
-			"--- possible referral %d:\n%s", i, r.MustYaml())
-		fmt.Println("------")
+		msg.WriteString(fmt.Sprintf("--- possible referral %d:\n%s\n", i, r.MustYaml()))
 	}
+	return msg.String()
 }
 
 func allNamesAreTheSame(resources []*resource.Resource) bool {

--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -337,7 +337,7 @@ func (f Filter) selectReferral(
 		return candidates[0], nil
 	}
 	ids := getIds(candidates)
-	return nil, fmt.Errorf(" found multiple possible referrals: %s\n%s", ids, f.failureDetails(candidates))
+	return nil, fmt.Errorf("found multiple possible referrals: %s\n%s", ids, f.failureDetails(candidates))
 }
 
 func (f Filter) failureDetails(resources []*resource.Resource) string {

--- a/api/filters/namespace/namespace.go
+++ b/api/filters/namespace/namespace.go
@@ -19,8 +19,8 @@ type Filter struct {
 	// FsSlice contains the FieldSpecs to locate the namespace field
 	FsSlice types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 
-	// SkipExisting means only blank namespace fields will be set
-	SkipExisting bool `json:"skipExisting" yaml:"skipExisting"`
+	// UnsetOnly means only blank namespace fields will be set
+	UnsetOnly bool `json:"unsetOnly" yaml:"unsetOnly"`
 
 	trackableSetter filtersutil.TrackableSetter
 }
@@ -134,12 +134,7 @@ func (ns Filter) roleBindingHack(obj *yaml.RNode, gvk resid.Gvk) error {
 }
 
 func isRoleBinding(kind string) bool {
-	switch kind {
-	case roleBindingKind, clusterRoleBindingKind:
-		return true
-	default:
-		return false
-	}
+	return kind == roleBindingKind || kind == clusterRoleBindingKind
 }
 
 // removeRoleBindingFieldSpecs removes from the list fieldspecs that
@@ -167,7 +162,7 @@ func (ns Filter) removeMetaNamespaceFieldSpecs(fs types.FsSlice) types.FsSlice {
 }
 
 func (ns *Filter) fieldSetter() filtersutil.SetFn {
-	if ns.SkipExisting {
+	if ns.UnsetOnly {
 		return ns.trackableSetter.SetEntryIfEmpty("", ns.Namespace, yaml.NodeTagString)
 	}
 	return ns.trackableSetter.SetEntry("", ns.Namespace, yaml.NodeTagString)

--- a/api/internal/builtins/NamespaceTransformer.go
+++ b/api/internal/builtins/NamespaceTransformer.go
@@ -16,7 +16,7 @@ import (
 type NamespaceTransformerPlugin struct {
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	FieldSpecs       []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
-	SkipExisting     bool              `json:"skipExisting" yaml:"skipExisting"`
+	UnsetOnly        bool              `json:"unsetOnly" yaml:"unsetOnly"`
 }
 
 func (p *NamespaceTransformerPlugin) Config(
@@ -37,9 +37,9 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
-			Namespace:    p.Namespace,
-			FsSlice:      p.FieldSpecs,
-			SkipExisting: p.SkipExisting,
+			Namespace: p.Namespace,
+			FsSlice:   p.FieldSpecs,
+			UnsetOnly: p.UnsetOnly,
 		}); err != nil {
 			return err
 		}

--- a/api/internal/builtins/NamespaceTransformer.go
+++ b/api/internal/builtins/NamespaceTransformer.go
@@ -16,6 +16,7 @@ import (
 type NamespaceTransformerPlugin struct {
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	FieldSpecs       []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	SkipExisting     bool              `json:"skipExisting" yaml:"skipExisting"`
 }
 
 func (p *NamespaceTransformerPlugin) Config(
@@ -36,8 +37,9 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
-			Namespace: p.Namespace,
-			FsSlice:   p.FieldSpecs,
+			Namespace:    p.Namespace,
+			FsSlice:      p.FieldSpecs,
+			SkipExisting: p.SkipExisting,
 		}); err != nil {
 			return err
 		}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -17,6 +17,7 @@ import (
 type plugin struct {
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	FieldSpecs       []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	SkipExisting     bool              `json:"skipExisting" yaml:"skipExisting"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -40,8 +41,9 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
-			Namespace: p.Namespace,
-			FsSlice:   p.FieldSpecs,
+			Namespace:    p.Namespace,
+			FsSlice:      p.FieldSpecs,
+			SkipExisting: p.SkipExisting,
 		}); err != nil {
 			return err
 		}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -17,7 +17,7 @@ import (
 type plugin struct {
 	types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	FieldSpecs       []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
-	SkipExisting     bool              `json:"skipExisting" yaml:"skipExisting"`
+	UnsetOnly        bool              `json:"unsetOnly" yaml:"unsetOnly"`
 }
 
 //noinspection GoUnusedGlobalVariable
@@ -41,9 +41,9 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
-			Namespace:    p.Namespace,
-			FsSlice:      p.FieldSpecs,
-			SkipExisting: p.SkipExisting,
+			Namespace: p.Namespace,
+			FsSlice:   p.FieldSpecs,
+			UnsetOnly: p.UnsetOnly,
 		}); err != nil {
 			return err
 		}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -272,7 +272,7 @@ metadata:
 		})
 }
 
-func TestNamespaceTransformer_SkipExistingTrue(t *testing.T) {
+func TestNamespaceTransformer_UnsetOnlyTrue(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
 		PrepBuiltin("NamespaceTransformer")
 	defer th.Reset()
@@ -282,7 +282,7 @@ kind: NamespaceTransformer
 metadata:
   name: notImportantHere
   namespace: test
-skipExisting: true
+unsetOnly: true
 fieldSpecs:
 - path: metadata/namespace
   create: true

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -10,6 +10,18 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
+const defaultFieldSpecs = `
+fieldSpecs:
+- path: metadata/namespace
+  create: true
+- path: subjects
+  kind: RoleBinding
+  group: rbac.authorization.k8s.io
+- path: subjects
+  kind: ClusterRoleBinding
+  group: rbac.authorization.k8s.io
+`
+
 func TestNamespaceTransformer1(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
 		PrepBuiltin("NamespaceTransformer")
@@ -20,16 +32,7 @@ kind: NamespaceTransformer
 metadata:
   name: notImportantHere
   namespace: test
-fieldSpecs:
-- path: metadata/namespace
-  create: true
-- path: subjects
-  kind: RoleBinding
-  group: rbac.authorization.k8s.io
-- path: subjects
-  kind: ClusterRoleBinding
-  group: rbac.authorization.k8s.io
-`, `
+`+defaultFieldSpecs, `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -267,4 +270,152 @@ metadata:
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
 		})
+}
+
+func TestNamespaceTransformer_SkipExistingTrue(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: notImportantHere
+  namespace: test
+skipExisting: true
+fieldSpecs:
+- path: metadata/namespace
+  create: true
+- path: subjects/namespace
+  kind: RoleBinding
+  group: rbac.authorization.k8s.io
+- path: subjects/namespace
+  kind: ClusterRoleBinding
+  group: rbac.authorization.k8s.io
+- path: spec/template/namespace
+  kind: MyWeirdObject
+- path: spec/template/altNamespace
+  kind: MyWeirdObject
+  create: true
+`, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+  namespace: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc2
+  namespace: ""
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: other
+- kind: ServiceAccount
+  name: default
+  namespace: ""
+- kind: ServiceAccount
+  name: default
+- kind: ServiceAccount
+  name: another
+  namespace: random
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: v1
+kind: MyWeirdObject
+metadata:
+  name: custom
+spec:
+  template:
+    namespace: original
+`,
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: test
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+  namespace: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc1
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc2
+  namespace: test
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: other
+- kind: ServiceAccount
+  name: default
+  namespace: test
+- kind: ServiceAccount
+  name: default
+  namespace: test
+- kind: ServiceAccount
+  name: another
+  namespace: random
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crd
+---
+apiVersion: v1
+kind: MyWeirdObject
+metadata:
+  name: custom
+  namespace: test
+spec:
+  template:
+    altNamespace: test
+    namespace: original
+`)
 }

--- a/plugin/builtin/namespacetransformer/go.mod
+++ b/plugin/builtin/namespacetransformer/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	sigs.k8s.io/kustomize/api v0.11.5
+	sigs.k8s.io/kustomize/kyaml v0.13.7
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -32,5 +33,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/kube-openapi v0.0.0-20220401212409-b28bf2818661 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.7 // indirect
 )


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/kustomize/issues/880 (the no. 2 issue by upvotes as of today)
Split out of https://github.com/kubernetes-sigs/kustomize/pull/4704, which will be rebased on top of this


We can't change the default, since that would be enormously disruptive to our users. Instead, this PR proposes a new option for the transformer to enable it to behave in the desired manner. This option are exposed explicitly via the transformer's configuration resource, which can be used in the `transformers` field. While using resource-specific annotations to configure transformers is an interesting idea that may be appropriate in some cases, my opinion is that transformer-level is better granularity for these particular options. I also considered a selection-base solution as suggested [here](https://github.com/kubernetes-sigs/kustomize/issues/880#issuecomment-742706290), but at that point I think folks should reach for replacements instead, now that they exist.


```yaml
apiVersion: builtin
kind: NamespaceTransformer
metadata:
  name: notImportantHere
  namespace: test
unsetOnly: true # new
fieldSpecs:
- path: metadata/name
  kind: Namespace
  create: true
```