### PR TITLE
[fix] failed docker build on post-kustomize-push-images CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .github
 docs
 examples
-functions
 hack
 site
 travis


### PR DESCRIPTION
The `post-kustomize-push-images` ci pipeline is failed continually.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kustomize-push-images/1547657434594545664

I think it caused from go compiler to try to check to `go.mod` in the ./function directory and the check failed because the ./function directory is docker ignored.

This PR is deleting `./functions` in `.dockerignore`


## appendix
If you don't want to delete `./functions` in `.dockerignore`, we can edit `go.work` temporarily in ci using the below command.

```sh
$ go work edit $(ls -pd ./functions/examples/* |grep "/$" | awk '{ print "-dropuse " $1 "image"; }')
```