### PR TITLE
Support edit set image with both tag and digest

### DIFF
--- a/kustomize/commands/edit/set/setimage.go
+++ b/kustomize/commands/edit/set/setimage.go
@@ -229,8 +229,16 @@ func parse(arg string) (types.Image, error) {
 // parseOverwrite parses the overwrite parameters
 // from the given arg into a struct
 func parseOverwrite(arg string, overwriteImage bool) (overwrite, error) {
-	// match <image>@<digest>
+	// match <image[:tag]>@<digest>
 	if d := strings.Split(arg, "@"); len(d) > 1 {
+		// match <image>:<tag>@<digest>
+		if t := strings.Split(d[0], ":"); len(t) > 1 {
+			return overwrite{
+				name:   t[0],
+				tag:    t[1],
+				digest: d[1],
+			}, nil
+		}
 		return overwrite{
 			name:   d[0],
 			digest: d[1],

--- a/kustomize/commands/edit/set/setimage_test.go
+++ b/kustomize/commands/edit/set/setimage_test.go
@@ -97,6 +97,19 @@ func TestSetImage(t *testing.T) {
 				}},
 		},
 		{
+			description: "image with tag and digest",
+			given: given{
+				args: []string{"org/image1:tag@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- digest: sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3",
+					"  name: org/image1",
+					"  newTag: tag",
+				}},
+		},
+		{
 			description: "<image>=<image>",
 			given: given{
 				args: []string{"ngnix=localhost:5000/my-project/ngnix"},


### PR DESCRIPTION
Resolves kubernetes-sigs/kustomize#4713 Support edit set image with both tag and digest.