### PR TITLE
Modified code for patches and patchJson6902 which will throw error if target is not found

### DIFF
--- a/api/internal/builtins/PatchJson6902Transformer.go
+++ b/api/internal/builtins/PatchJson6902Transformer.go
@@ -24,6 +24,8 @@ type PatchJson6902TransformerPlugin struct {
 	JsonOp       string          `json:"jsonOp,omitempty" yaml:"jsonOp,omitempty"`
 }
 
+// noinspection GoUnusedGlobalVariable
+
 func (p *PatchJson6902TransformerPlugin) Config(
 	h *resmap.PluginHelpers, c []byte) (err error) {
 	p.ldr = h.Loader()
@@ -78,6 +80,11 @@ func (p *PatchJson6902TransformerPlugin) Transform(m resmap.ResMap) error {
 	if err != nil {
 		return err
 	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("patchesJson6902 target not found for %s", p.Target.ResId)
+	}
+
 	for _, res := range resources {
 		internalAnnotations := kioutil.GetInternalAnnotations(&res.RNode)
 

--- a/api/internal/builtins/PatchTransformer.go
+++ b/api/internal/builtins/PatchTransformer.go
@@ -25,6 +25,8 @@ type PatchTransformerPlugin struct {
 	Options      map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
+// noinspection GoUnusedGlobalVariable
+
 func (p *PatchTransformerPlugin) Config(
 	h *resmap.PluginHelpers, c []byte) error {
 	err := yaml.Unmarshal(c, p)
@@ -97,6 +99,11 @@ func (p *PatchTransformerPlugin) transformStrategicMerge(m resmap.ResMap, patch 
 	if err != nil {
 		return err
 	}
+
+	if len(selected) == 0 {
+		return fmt.Errorf("patches target not found for  %s", p.Target.ResId)
+	}
+
 	return m.ApplySmPatch(resource.MakeIdSet(selected), patch)
 }
 
@@ -110,6 +117,11 @@ func (p *PatchTransformerPlugin) transformJson6902(m resmap.ResMap, patch jsonpa
 	if err != nil {
 		return err
 	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	}
+
 	for _, res := range resources {
 		res.StorePreviousId()
 		internalAnnotations := kioutil.GetInternalAnnotations(&res.RNode)

--- a/api/internal/builtins/PatchTransformer.go
+++ b/api/internal/builtins/PatchTransformer.go
@@ -101,7 +101,7 @@ func (p *PatchTransformerPlugin) transformStrategicMerge(m resmap.ResMap, patch 
 	}
 
 	if len(selected) == 0 {
-		return fmt.Errorf("patches target not found for  %s", p.Target.ResId)
+		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
 	}
 
 	return m.ApplySmPatch(resource.MakeIdSet(selected), patch)

--- a/api/internal/builtins/PatchTransformer.go
+++ b/api/internal/builtins/PatchTransformer.go
@@ -5,6 +5,7 @@ package builtins
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -24,8 +25,6 @@ type PatchTransformerPlugin struct {
 	Target       *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
 	Options      map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
 }
-
-// noinspection GoUnusedGlobalVariable
 
 func (p *PatchTransformerPlugin) Config(
 	h *resmap.PluginHelpers, c []byte) error {
@@ -100,8 +99,8 @@ func (p *PatchTransformerPlugin) transformStrategicMerge(m resmap.ResMap, patch 
 		return err
 	}
 
-	if len(selected) == 0 {
-		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	if p.Options["allowNoTargetMatch"] {
+		log.Println("Warning: patches target not found for Target")
 	}
 
 	return m.ApplySmPatch(resource.MakeIdSet(selected), patch)
@@ -118,8 +117,8 @@ func (p *PatchTransformerPlugin) transformJson6902(m resmap.ResMap, patch jsonpa
 		return err
 	}
 
-	if len(resources) == 0 {
-		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	if p.Options["allowNoTargetMatch"] {
+		log.Println("Warning: patches target not found for Target")
 	}
 
 	for _, res := range resources {

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
@@ -81,6 +81,11 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	if err != nil {
 		return err
 	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("patchesJson6902 target not found for %s", p.Target.ResId)
+	}
+
 	for _, res := range resources {
 		internalAnnotations := kioutil.GetInternalAnnotations(&res.RNode)
 

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -101,8 +101,8 @@ func (p *plugin) transformStrategicMerge(m resmap.ResMap, patch *resource.Resour
 		return err
 	}
 
-	if len(selected) == 0 {
-		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	if p.Options["allowNoTargetMatch"] {
+		log.Println("Warning: patches target not found for Target")
 	}
 
 	return m.ApplySmPatch(resource.MakeIdSet(selected), patch)
@@ -119,8 +119,8 @@ func (p *plugin) transformJson6902(m resmap.ResMap, patch jsonpatch.Patch) error
 		return err
 	}
 
-	if len(resources) == 0 {
-		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	if p.Options["allowNoTargetMatch"] {
+		log.Println("Warning: patches target not found for Target")
 	}
 
 	for _, res := range resources {

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -100,6 +100,11 @@ func (p *plugin) transformStrategicMerge(m resmap.ResMap, patch *resource.Resour
 	if err != nil {
 		return err
 	}
+
+	if len(selected) == 0 {
+		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	}
+
 	return m.ApplySmPatch(resource.MakeIdSet(selected), patch)
 }
 
@@ -113,6 +118,11 @@ func (p *plugin) transformJson6902(m resmap.ResMap, patch jsonpatch.Patch) error
 	if err != nil {
 		return err
 	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("patches target not found for %s", p.Target.ResId)
+	}
+
 	for _, res := range resources {
 		res.StorePreviousId()
 		internalAnnotations := kioutil.GetInternalAnnotations(&res.RNode)


### PR DESCRIPTION
Fix for `patchesJson6902`, `patches` is completed. This fix verifies whether is `resources` filed has any data or not. If it is empty then there is definitely a missing target. 

`patchStrategicMerge` is already throwing an error if the `target` is missing.

This will fix #4379 