### PR TITLE
Remove dots from short descriptions

### DIFF
--- a/cmd/config/configcobra/cfg.go
+++ b/cmd/config/configcobra/cfg.go
@@ -11,7 +11,7 @@ import (
 func GetCfg(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cfg",
-		Short: "Commands for reading and writing configuration.",
+		Short: "Commands for reading and writing configuration",
 	}
 
 	cmd.AddCommand(commands.AnnotateCommand(name))

--- a/cmd/config/configcobra/fn.go
+++ b/cmd/config/configcobra/fn.go
@@ -11,7 +11,7 @@ import (
 func GetFn(name string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fn",
-		Short: "Commands for running functions against configuration.",
+		Short: "Commands for running functions against configuration",
 	}
 
 	cmd.AddCommand(commands.RunCommand(name))

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -42,7 +42,7 @@ func MakeHelp(pgmName, cmdName string) *Help {
 	fN := konfig.DefaultKustomizationFileName()
 	return &Help{
 		Use:   cmdName + " DIR",
-		Short: "Build a kustomization target from a directory or URL.",
+		Short: "Build a kustomization target from a directory or URL",
 		Long: fmt.Sprintf(`Build a set of KRM resources using a '%s' file.
 The DIR argument must be a path to a directory containing
 '%s', or a git repository URL with a path suffix

--- a/kustomize/commands/build/build_test.go
+++ b/kustomize/commands/build/build_test.go
@@ -204,7 +204,7 @@ func TestHelp(t *testing.T) {
 	if cmd.Use != "bar DIR" {
 		t.Fatalf("Unexpected usage: %s\n", cmd.Use)
 	}
-	if cmd.Short != "Build a kustomization target from a directory or URL." {
+	if cmd.Short != "Build a kustomization target from a directory or URL" {
 		t.Fatalf("Unexpected short help: %s\n", cmd.Short)
 	}
 	if !strings.Contains(cmd.Long, "If DIR is omitted, '.' is assumed.") {

--- a/kustomize/commands/edit/add/addcomponent.go
+++ b/kustomize/commands/edit/add/addcomponent.go
@@ -24,7 +24,7 @@ func newCmdAddComponent(fSys filesys.FileSystem) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "component",
-		Short: "Add the name of a file containing a component to the kustomization file.",
+		Short: "Add the name of a file containing a component to the kustomization file",
 		Example: `
 		add component {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/commands/edit/add/addgenerator.go
+++ b/kustomize/commands/edit/add/addgenerator.go
@@ -23,7 +23,7 @@ func newCmdAddGenerator(fSys filesys.FileSystem) *cobra.Command {
 	var o addGeneratorOptions
 	cmd := &cobra.Command{
 		Use:   "generator",
-		Short: "Add the name of a file containing a generator configuration to the kustomization file.",
+		Short: "Add the name of a file containing a generator configuration to the kustomization file",
 		Example: `
 		add generator {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/commands/edit/add/addpatch.go
+++ b/kustomize/commands/edit/add/addpatch.go
@@ -24,7 +24,7 @@ func newCmdAddPatch(fSys filesys.FileSystem) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "patch",
-		Short: "Add an item to patches field.",
+		Short: "Add an item to patches field",
 		Long: `This command will add an item to patches field in the kustomization file.
 Each item may:
 

--- a/kustomize/commands/edit/add/addresource.go
+++ b/kustomize/commands/edit/add/addresource.go
@@ -24,7 +24,7 @@ func newCmdAddResource(fSys filesys.FileSystem) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "resource",
-		Short: "Add the name of a file containing a resource to the kustomization file.",
+		Short: "Add the name of a file containing a resource to the kustomization file",
 		Example: `
 		add resource {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/commands/edit/add/addtransformer.go
+++ b/kustomize/commands/edit/add/addtransformer.go
@@ -23,7 +23,7 @@ func newCmdAddTransformer(fSys filesys.FileSystem) *cobra.Command {
 	var o addTransformerOptions
 	cmd := &cobra.Command{
 		Use:   "transformer",
-		Short: "Add the name of a file containing a transformer configuration to the kustomization file.",
+		Short: "Add the name of a file containing a transformer configuration to the kustomization file",
 		Example: `
 		add transformer {filepath}`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/kustomize/commands/edit/add/all.go
+++ b/kustomize/commands/edit/add/all.go
@@ -17,7 +17,7 @@ func NewCmdAdd(
 	rf *resource.Factory) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "add",
-		Short: "Adds an item to the kustomization file.",
+		Short: "Adds an item to the kustomization file",
 		Long:  "",
 		Example: `
 	# Adds a secret to the kustomization file

--- a/kustomize/commands/edit/add/configmap.go
+++ b/kustomize/commands/edit/add/configmap.go
@@ -20,7 +20,7 @@ func newCmdAddConfigMap(
 	var flags flagsAndArgs
 	cmd := &cobra.Command{
 		Use:   "configmap NAME [--behavior={create|merge|replace}] [--from-file=[key=]source] [--from-literal=key1=value1]",
-		Short: "Adds a configmap to the kustomization file.",
+		Short: "Adds a configmap to the kustomization file",
 		Long:  "",
 		Example: `
 	# Adds a configmap to the kustomization file (with a specified key)

--- a/kustomize/commands/edit/remove/all.go
+++ b/kustomize/commands/edit/remove/all.go
@@ -15,7 +15,7 @@ func NewCmdRemove(
 	v ifc.Validator) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "remove",
-		Short: "Removes items from the kustomization file.",
+		Short: "Removes items from the kustomization file",
 		Long:  "",
 		Example: `
 	# Removes resources from the kustomization file

--- a/kustomize/commands/edit/set/all.go
+++ b/kustomize/commands/edit/set/all.go
@@ -13,7 +13,7 @@ import (
 func NewCmdSet(fSys filesys.FileSystem, ldr ifc.KvLoader, v ifc.Validator) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set",
-		Short: "Sets the value of different fields in kustomization file.",
+		Short: "Sets the value of different fields in kustomization file",
 		Long:  "",
 		Example: `
 	# Sets the nameprefix field

--- a/kustomize/commands/edit/set/set_name_prefix.go
+++ b/kustomize/commands/edit/set/set_name_prefix.go
@@ -21,7 +21,7 @@ func newCmdSetNamePrefix(fSys filesys.FileSystem) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "nameprefix",
-		Short: "Sets the value of the namePrefix field in the kustomization file.",
+		Short: "Sets the value of the namePrefix field in the kustomization file",
 		Example: `
 The command
   set nameprefix acme-

--- a/kustomize/commands/edit/set/set_name_suffix.go
+++ b/kustomize/commands/edit/set/set_name_suffix.go
@@ -21,7 +21,7 @@ func newCmdSetNameSuffix(fSys filesys.FileSystem) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "namesuffix",
-		Short: "Sets the value of the nameSuffix field in the kustomization file.",
+		Short: "Sets the value of the nameSuffix field in the kustomization file",
 		Example: `
 The command
   set namesuffix -- -acme


### PR DESCRIPTION
When running `kustomize` some of the (short command) descriptions end with period while others don't. 

Here is the output from the current master branch build
```
Available Commands:
  build                     Build a kustomization target from a directory or URL.
  cfg                       Commands for reading and writing configuration.
  completion                Generate shell completion script
  create                    Create a new kustomization in the current directory
  edit                      Edits a kustomization file
  fn                        Commands for running functions against configuration.
  help                      Help about any command
  version                   Prints the kustomize version
```

As a reference `kubectl` mostly doesn't use periods. 

```
Basic Commands (Beginner):
  create          Create a resource from a file or from stdin
  expose          Take a replication controller, service, deployment or pod and expose it as a new Kubernetes service
  run             Run a particular image on the cluster
  set             Set specific features on objects
(...)
```
