### PR TITLE
Enable patching for secrets and configmaps listed in env and envFrom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 
 .idea
+.vscode
 *.iml
 
 # Test binary, build with `go test -c`

--- a/api/konfig/builtinpluginconsts/namereference.go
+++ b/api/konfig/builtinpluginconsts/namereference.go
@@ -140,6 +140,22 @@ nameReference:
     kind: ClusterRole
   - path: metadata/annotations/nginx.ingress.kubernetes.io\/fastcgi-params-configmap
     kind: Ingress
+  - path: spec/template/spec/containers/env/valueFrom/configMapKeyRef/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/containers/envFrom/configMapRef/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/volumes/configMap/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/volumes/projected/configMap/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
 
 - kind: Secret
   version: v1
@@ -288,6 +304,18 @@ nameReference:
   - path: rules/resourceNames
     kind: ClusterRole
   - path: spec/template/spec/containers/env/valueFrom/secretKeyRef/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/containers/envFrom/secretRef/name
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/volumes/secret/secretName
+    kind: Service
+    group: serving.knative.dev
+    version: v1
+  - path: spec/template/spec/volumes/projected/secret/name
     kind: Service
     group: serving.knative.dev
     version: v1


### PR DESCRIPTION
This PR allows rewriting the name of secrets and configmaps generated from `kustomize` when they are referred by `services.serving.knative.dev`.

So far, only `env/valueFrom` is accepting generated secrets and properly rewritten. It is not the case for, say, configmaps and secrets listed in `envFrom`. This PR will hopefully address this issue.