### PR TITLE
Update error message for m1 mac users trying to fetch older versions

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -136,7 +136,7 @@ RELEASE_URL=$(echo "${releases}" |\
   sort -V | tail -n 1)
 
 if [ ! -n "$RELEASE_URL" ]; then
-  echo "Version $version does not exist."
+  echo "Version $version does not have a release for ${opsys}/${arch}."
   exit 1
 fi
 

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -136,7 +136,7 @@ RELEASE_URL=$(echo "${releases}" |\
   sort -V | tail -n 1)
 
 if [ ! -n "$RELEASE_URL" ]; then
-  echo "Version $version does not have a release for ${opsys}/${arch}."
+  echo "Version $version does not exist or is not available for ${opsys}/${arch}."
   exit 1
 fi
 


### PR DESCRIPTION
While trying to install this on an m1 mac, I ended up spending a bunch of time trying to figure out why my targeted version didn't exist before realizing that it was because the release didn't exist specifically for m1 architecture.  This error message should help people who encounter the same issue in the future.

Sample output after this change:
```
alexvulaj@avulaj-mac hack % ./install_kustomize.sh 3.8.7     
Version v3.8.7 does not have a release for darwin/arm64.
```