### PR TITLE
allow colon in filenames

### DIFF
--- a/kyaml/filesys/fsnode.go
+++ b/kyaml/filesys/fsnode.go
@@ -569,7 +569,7 @@ func (n *fsNode) DebugPrint() {
 	})
 }
 
-var legalFileNamePattern = regexp.MustCompile("^[a-zA-Z0-9-_.]+$")
+var legalFileNamePattern = regexp.MustCompile("^[a-zA-Z0-9-_.:]+$")
 
 // This rules enforced here should be simpler and tighter
 // than what's allowed on a real OS.

--- a/kyaml/filesys/fsnode_test.go
+++ b/kyaml/filesys/fsnode_test.go
@@ -35,6 +35,12 @@ var topCases = []pathCase{
 		errStr: "illegal name '..' in file creation",
 	},
 	{
+		what: "colon",
+		arg:  "a:b",
+		name: "a:b",
+		path: "a:b",
+	},
+	{
 		what:   "empty",
 		arg:    "",
 		name:   "",


### PR DESCRIPTION
Colons (`:`) are legal in filenames on Mac and Linux, so we should make them legal in our filesystem abstraction as well.

This is causing an issue for kpt where we are trying to use kyaml's FSInMemory to store files from a git repository in memory, and it is failing for filenames containing a colon. 

/cc @KnVerey 

cc @droot 