### PR TITLE
Emit a warning when env loading bug is being relied on

### DIFF
--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -133,7 +133,6 @@ func (kvl *loader) keyValuesFromLines(content []byte) ([]types.Pair, error) {
 }
 
 // KeyValuesFromLine returns a kv with blank key if the line is empty or a comment.
-// The value will be retrieved from the environment if necessary.
 func (kvl *loader) keyValuesFromLine(line []byte, currentLine int) (types.Pair, error) {
 	kv := types.Pair{}
 
@@ -164,7 +163,12 @@ func (kvl *loader) keyValuesFromLine(line []byte, currentLine int) (types.Pair, 
 		kv.Value = data[1]
 	} else {
 		// No value (no `=` in the line) is a signal to obtain the value
-		// from the environment.
+		// from the environment. This behaviour was accidentally imported from kubectl code, and
+		// will be removed in the next major release of Kustomize.
+		_, _ = fmt.Fprintln(os.Stderr, "WARNING: "+
+			"This Kustomization is relying on a bug that loads values from the environment "+
+			"when they are omitted from an env file. "+
+			"This behaviour will be removed in the next major release of Kustomize.")
 		kv.Value = os.Getenv(key)
 	}
 	kv.Key = key


### PR DESCRIPTION
## Problem

It recently came to our attention that the `configMapGenerator` has a bug where it will load values from the environment when a line in an env file has a key but no value. This bug dates back to the origins of Kustomize, when some of the original code was [copied out](https://github.com/kubernetes/kubectl/pull/198/files#diff-3b07013480d8cba7d964080b404d5714115f7225e9d299c86d681ce90727fd5dR67) of kubectl, and this undesirable behaviour (for kustomize, not kubectl) went unnoticed in the adaptation.

This behaviour is a clear violation of one of Kustomize's core principles, as documented in our [Eschewed Features list](https://kubectl.docs.kubernetes.io/faq/kustomize/eschewedfeatures/#build-time-side-effects-from-cli-args-or-env-variables):

![image](https://user-images.githubusercontent.com/4789493/181624436-bb3b0666-c75b-428e-a69c-f9f0e5425f33.png)

Very unfortunately, someone not only discovered this bug, but made a PR to document it as a feature [on kubernetes.io](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#configmapgenerator):  https://github.com/kubernetes/website/pull/30348. Unfortunately no Kustomize maintainers were tagged on the PR, and it has been live since January 2022. 😞 

As stated in Kustomize documentation screenshot above, any need for environment reading should be handled as part of a pre-build workflow. We can consider adding a `kustomize edit` subcommand for this specifically if there is demand from those currently relying on the bug. For example, it could look like `kustomize edit add configmap my-configmap --from-env-file=env/path.env --from-env=ONE,TWO`.

## Proposal

- Immediately revert the docs PR incorrectly describing this bug as a feature: https://github.com/kubernetes/website/pull/35522
- Start emitting a warning to those relying on this bug (because it has existed for so long, and was in the docs for 7 months) -- That's this PR
- Patch the bug in the next *major* version of Kustomize, i.e. v5: https://github.com/kubernetes-sigs/kustomize/issues/4731

I don't think there's a nice way to unit test the printing to sdterr like this, barring making invasive changes to the kv loader method signatures (lmk if you have an idea for something nice). Here are some manual tests:

![image](https://user-images.githubusercontent.com/4789493/181627444-18a376ea-ad37-4dfd-b7c1-81be6d4d1b99.png)

/cc @natasha41575 @annasong20 