### PR TITLE
repospec: support ssh urls with ssh certificates

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -278,15 +278,14 @@ func normalizeGitHostSpec(host string) (string, error) {
 	s := strings.ToLower(host)
 	m := userRegex.FindStringSubmatch(host)
 	if strings.Contains(s, "github.com") {
-		switch {
-		case len(m) > 0:
+		if len(m) > 0 {
 			if strings.HasPrefix(s, "git::") && m[1] != "git@" {
 				return "", fmt.Errorf("git protocol on github.com only allows git@ user")
 			}
 			host = m[1] + "github.com:"
-		case strings.Contains(s, "ssh:"):
+		} else if strings.Contains(s, "ssh:") {
 			host = "git@github.com:"
-		default:
+		} else {
 			host = "https://github.com/"
 		}
 	}

--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -297,14 +297,15 @@ func normalizeGitHostSpec(host string) (string, error) {
 	s := strings.ToLower(host)
 	m := userRegex.FindStringSubmatch(host)
 	if strings.Contains(s, "github.com") {
-		if len(m) > 0 {
+		switch {
+		case len(m) > 0:
 			if strings.HasPrefix(s, "git::") && m[1] != "git@" {
 				return "", fmt.Errorf("git protocol on github.com only allows git@ user")
 			}
 			host = m[1] + "github.com:"
-		} else if strings.Contains(s, "ssh:") {
+		case strings.Contains(s, "ssh:"):
 			host = "git@github.com:"
-		} else {
+		default:
 			host = "https://github.com/"
 		}
 	}

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -35,6 +35,8 @@ func TestNewRepoSpecFromUrl_Permute(t *testing.T) {
 		{"git::https://git.example.com/", "https://git.example.com/"},
 		{"git@github.com:", "git@github.com:"},
 		{"git@github.com/", "git@github.com:"},
+		{"org-12345@github.com:", "org-12345@github.com:"},
+		{"org-12345@github.com/", "org-12345@github.com:"},
 	}
 	var orgRepos = []string{"someOrg/someRepo", "kubernetes/website"}
 	var pathNames = []string{"README.md", "foo/krusty.txt", ""}

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -416,10 +416,10 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 		{
 			name:      "t25",
 			input:     "https://org-12345@github.com/kubernetes-sigs/kustomize",
-			cloneSpec: "org-12345@github.com:kubernetes-sigs/kustomize.git",
+			cloneSpec: "https://github.com/kubernetes-sigs/kustomize.git",
 			absPath:   notCloned.String(),
 			repoSpec: RepoSpec{
-				Host:      "org-12345@github.com:",
+				Host:      "https://github.com/",
 				OrgRepo:   "kubernetes-sigs/kustomize",
 				GitSuffix: ".git",
 			},

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -448,11 +448,11 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 		},
 		{
 			name:      "t28",
-			input:     "git::ssh://git@github.com/someorg/somerepo/somepath",
-			cloneSpec: "ssh://git@github.com/someorg/somerepo.git",
+			input:     "git@github.com/someorg/somerepo/somepath",
+			cloneSpec: "git@github.com:someorg/somerepo.git",
 			absPath:   notCloned.Join("somepath"),
 			repoSpec: RepoSpec{
-				Host:      "ssh://git@github.com/",
+				Host:      "git@github.com:",
 				OrgRepo:   "someorg/somerepo",
 				Path:      "somepath",
 				GitSuffix: ".git",

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -446,6 +446,18 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 				GitSuffix: ".git",
 			},
 		},
+		{
+			name:      "t28",
+			input:     "git::ssh://git@github.com/someorg/somerepo/somepath",
+			cloneSpec: "ssh://git@github.com/someorg/somerepo.git",
+			absPath:   notCloned.Join("somepath"),
+			repoSpec: RepoSpec{
+				Host:      "ssh://git@github.com/",
+				OrgRepo:   "someorg/somerepo",
+				Path:      "somepath",
+				GitSuffix: ".git",
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Organizations that use a custom SSH Certificate Authority with GitHub
Enterprise Cloud will have a host that starts with `org-12345@` instead
of `git@`. This removes the hard-coded `git@` in the repo spec parsing
for a regexp match on a valid username instead.

E.g. now it will be able to parse specs like `org-12345@github.com:someOrg/someRepo/README.md?ref=someBranch`.

Docs [here](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities#about-ssh-urls-with-ssh-certificates)