### PR TITLE
Stop using deprecated ioutil functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,9 @@ linters-settings:
       arguments:
       - [ "ID", "API", "JSON" ] # AllowList
       - [ ] # DenyList
+  gomnd:
+    ignored-functions:
+    - os.WriteFile
   gomoddirectives:
     replace-local: true
   gosec:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,9 +107,6 @@ linters-settings:
   gosec:
     config:
       G306: "0644"
-  gomnd:
-     ignored-functions:
-     - ioutil.WriteFile
   wrapcheck:
     ignoreSigs:
       # defaults

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -210,7 +210,7 @@ func (p *HelmChartInflationGeneratorPlugin) writeValuesBytes(
 		return "", fmt.Errorf("cannot create tmp dir to write helm values")
 	}
 	path := filepath.Join(p.tmpDir, p.Name+"-kustomize-values.yaml")
-	return path, os.WriteFile(path, b, 0644)
+	return path, errors.Wrap(os.WriteFile(path, b, 0644), "failed to write values file")
 }
 
 func (p *HelmChartInflationGeneratorPlugin) cleanup() {

--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -6,7 +6,6 @@ package builtins
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,7 +72,7 @@ func (p *HelmChartInflationGeneratorPlugin) establishTmpDir() (err error) {
 		// already done.
 		return nil
 	}
-	p.tmpDir, err = ioutil.TempDir("", "kustomize-helm-")
+	p.tmpDir, err = os.MkdirTemp("", "kustomize-helm-")
 	return err
 }
 
@@ -211,7 +210,7 @@ func (p *HelmChartInflationGeneratorPlugin) writeValuesBytes(
 		return "", fmt.Errorf("cannot create tmp dir to write helm values")
 	}
 	path := filepath.Join(p.tmpDir, p.Name+"-kustomize-values.yaml")
-	return path, ioutil.WriteFile(path, b, 0644)
+	return path, os.WriteFile(path, b, 0644)
 }
 
 func (p *HelmChartInflationGeneratorPlugin) cleanup() {

--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -6,7 +6,6 @@ package execplugin
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -150,7 +149,7 @@ func (p *ExecPlugin) Transform(rm resmap.ResMap) error {
 // passes the full temp file path as the first arg to a process
 // running the plugin binary.  Process output is returned.
 func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
-	f, err := ioutil.TempFile("", tmpConfigFilePrefix)
+	f, err := os.CreateTemp("", tmpConfigFilePrefix)
 	if err != nil {
 		return nil, errors.Wrap(
 			err, "creating tmp plugin config file")

--- a/api/krusty/openapitests/openapicustomschema_test.go
+++ b/api/krusty/openapitests/openapicustomschema_test.go
@@ -7,7 +7,6 @@ package openapitests //nolint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,12 +17,12 @@ import (
 )
 
 func writeTestSchema(th kusttest_test.Harness, filepath string) {
-	bytes, _ := ioutil.ReadFile("../testdata/customschema.json")
+	bytes, _ := os.ReadFile("../testdata/customschema.json")
 	th.WriteF(filepath+"mycrd_schema.json", string(bytes))
 }
 
 func writeTestSchemaYaml(th kusttest_test.Harness, filepath string) {
-	bytes, _ := ioutil.ReadFile("../testdata/customschema.yaml")
+	bytes, _ := os.ReadFile("../testdata/customschema.yaml")
 	th.WriteF(filepath+"mycrd_schema.yaml", string(bytes))
 }
 
@@ -486,7 +485,7 @@ spec:
 `)
 
 		// openapi schema referred to by the component
-		bytes, _ := ioutil.ReadFile("../testdata/openshiftschema.json")
+		bytes, _ := os.ReadFile("../testdata/openshiftschema.json")
 		th.WriteF("components/dc-openapi/openapi.json", string(bytes))
 
 		// patch referred to by the component

--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -5,7 +5,7 @@ package loader
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -302,7 +302,7 @@ func (fl *fileLoader) Load(path string) ([]byte, error) {
 			}
 			return nil, fmt.Errorf("%w: status code %d (%s)", ErrHTTP, resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/api/loader/fileloader_test.go
+++ b/api/loader/fileloader_test.go
@@ -5,7 +5,7 @@ package loader
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -518,7 +518,7 @@ func TestLoaderHTTP(t *testing.T) {
 			require.Equal(x.path, u)
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(x.expectedContent)),
+				Body:       io.NopCloser(bytes.NewBufferString(x.expectedContent)),
 				Header:     make(http.Header),
 			}
 		})

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -4,7 +4,6 @@
 package kusttest_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,7 +60,7 @@ func MakeEnhancedHarnessWithTmpRoot(t *testing.T) *HarnessEnhanced {
 	r := makeBaseEnhancedHarness(t)
 	fSys := filesys.MakeFsOnDisk()
 	r.Harness = MakeHarnessWithFs(t, fSys)
-	tmpDir, err := ioutil.TempDir("", "kust-testing-")
+	tmpDir, err := os.MkdirTemp("", "kust-testing-")
 	if err != nil {
 		panic("test harness cannot make tmp dir: " + err.Error())
 	}

--- a/cmd/config/internal/commands/annotate_test.go
+++ b/cmd/config/internal/commands/annotate_test.go
@@ -5,7 +5,7 @@ package commands
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -88,11 +88,11 @@ func TestAnnotateCommand(t *testing.T) {
 func initTestDir(t *testing.T) string {
 	t.Helper()
 	d := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(f1Input), 0600)
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(f1Input), 0600)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(f2Input), 0600)
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(f2Input), 0600)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/cmd/config/internal/commands/cat_test.go
+++ b/cmd/config/internal/commands/cat_test.go
@@ -5,7 +5,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ import (
 func TestCmd_files(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -45,7 +44,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -119,7 +118,7 @@ spec:
 func TestCmd_filesWithReconcilers(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -142,7 +141,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -225,7 +224,7 @@ spec:
 func TestCmd_filesWithoutNonReconcilers(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -248,7 +247,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -303,7 +302,7 @@ spec:
 func TestCmd_outputTruncateFile(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -326,7 +325,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -353,7 +352,7 @@ spec:
 		return
 	}
 
-	f, err := ioutil.TempFile("", "kustomize-cat-test-dest")
+	f, err := os.CreateTemp("", "kustomize-cat-test-dest")
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -372,7 +371,7 @@ spec:
 		return
 	}
 
-	actual, err := ioutil.ReadFile(f.Name())
+	actual, err := os.ReadFile(f.Name())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -413,7 +412,7 @@ spec:
 func TestCmd_outputCreateFile(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -436,7 +435,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -479,7 +478,7 @@ spec:
 		return
 	}
 
-	actual, err := ioutil.ReadFile(f)
+	actual, err := os.ReadFile(f)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/cmd/config/internal/commands/cmdcreatesetter.go
+++ b/cmd/config/internal/commands/cmdcreatesetter.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -213,7 +213,7 @@ func schemaFromFile(schemaPath string) (*spec.Schema, error) {
 	if schemaPath == "" {
 		return sc, nil
 	}
-	sch, err := ioutil.ReadFile(schemaPath)
+	sch, err := os.ReadFile(schemaPath)
 	if err != nil {
 		return sc, err
 	}

--- a/cmd/config/internal/commands/cmdcreatesetter_test.go
+++ b/cmd/config/internal/commands/cmdcreatesetter_test.go
@@ -5,7 +5,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -702,13 +701,13 @@ spec:
 			baseDir := t.TempDir()
 
 			f := filepath.Join(baseDir, "Krmfile")
-			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := os.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
 			if test.schema != "" {
-				sch, err := ioutil.TempFile("", "schema.json")
+				sch, err := os.CreateTemp("", "schema.json")
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -717,7 +716,7 @@ spec:
 					os.Remove(sch.Name())
 				})
 
-				err = ioutil.WriteFile(sch.Name(), []byte(test.schema), 0600)
+				err = os.WriteFile(sch.Name(), []byte(test.schema), 0600)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -725,12 +724,12 @@ spec:
 				test.args = append(test.args, "--schema-path", sch.Name())
 			}
 
-			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			t.Cleanup(func() { r.Close() })
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -763,7 +762,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := os.ReadFile(r.Name())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -773,7 +772,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f)
+			actualOpenAPI, err := os.ReadFile(f)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdcreatesubstitution_test.go
+++ b/cmd/config/internal/commands/cmdcreatesubstitution_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -356,17 +356,17 @@ spec:
 
 			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := os.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			t.Cleanup(func() { r.Close() })
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -399,7 +399,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := os.ReadFile(r.Name())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -409,7 +409,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f)
+			actualOpenAPI, err := os.ReadFile(f)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmddeletesetter_test.go
+++ b/cmd/config/internal/commands/cmddeletesetter_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -302,17 +302,17 @@ kind: Deployment
 
 			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := os.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			t.Cleanup(func() { r.Close() })
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -346,7 +346,7 @@ kind: Deployment
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := os.ReadFile(r.Name())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -356,7 +356,7 @@ kind: Deployment
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f)
+			actualOpenAPI, err := os.ReadFile(f)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmddeletesubstitution_test.go
+++ b/cmd/config/internal/commands/cmddeletesubstitution_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -429,17 +429,17 @@ spec:
 
 			baseDir := t.TempDir()
 			f := filepath.Join(baseDir, "Krmfile")
-			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := os.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			t.Cleanup(func() { r.Close() })
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -472,7 +472,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f)
+			actualOpenAPI, err := os.ReadFile(f)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -482,7 +482,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := os.ReadFile(r.Name())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdinit.go
+++ b/cmd/config/internal/commands/cmdinit.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +55,7 @@ func (r *InitRunner) runE(c *cobra.Command, args []string) error {
 		return errors.Errorf("directory already initialized with a Krmfile")
 	}
 
-	return ioutil.WriteFile(filename, []byte(strings.TrimSpace(`
+	return os.WriteFile(filename, []byte(strings.TrimSpace(`
 apiVersion: config.k8s.io/v1alpha1
 kind: Krmfile
 `)), 0600)

--- a/cmd/config/internal/commands/cmdinit.go
+++ b/cmd/config/internal/commands/cmdinit.go
@@ -55,8 +55,9 @@ func (r *InitRunner) runE(c *cobra.Command, args []string) error {
 		return errors.Errorf("directory already initialized with a Krmfile")
 	}
 
-	return os.WriteFile(filename, []byte(strings.TrimSpace(`
+	err := os.WriteFile(filename, []byte(strings.TrimSpace(`
 apiVersion: config.k8s.io/v1alpha1
 kind: Krmfile
 `)), 0600)
+	return errors.Wrap(err)
 }

--- a/cmd/config/internal/commands/cmdlistsetters_test.go
+++ b/cmd/config/internal/commands/cmdlistsetters_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -409,12 +409,12 @@ openAPI:
 
 			dir := t.TempDir()
 
-			err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.openapi), 0600)
+			err := os.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.openapi), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			err = ioutil.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(test.input), 0600)
+			err = os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -433,7 +433,7 @@ openAPI:
 			}
 
 			// make sure that the resources are not altered
-			actualResources, err := ioutil.ReadFile(filepath.Join(dir, "deployment.yaml"))
+			actualResources, err := os.ReadFile(filepath.Join(dir, "deployment.yaml"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -443,7 +443,7 @@ openAPI:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(filepath.Join(dir, "Krmfile"))
+			actualOpenAPI, err := os.ReadFile(filepath.Join(dir, "Krmfile"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/cmdset_test.go
+++ b/cmd/config/internal/commands/cmdset_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1000,17 +1000,17 @@ spec:
 			baseDir := t.TempDir()
 
 			f := filepath.Join(baseDir, "Krmfile")
-			err := ioutil.WriteFile(f, []byte(test.inputOpenAPI), 0600)
+			err := os.WriteFile(f, []byte(test.inputOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			t.Cleanup(func() { r.Close() })
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -1037,7 +1037,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualResources, err := ioutil.ReadFile(r.Name())
+			actualResources, err := os.ReadFile(r.Name())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -1047,7 +1047,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualOpenAPI, err := ioutil.ReadFile(f)
+			actualOpenAPI, err := os.ReadFile(f)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/cmd/config/internal/commands/count_test.go
+++ b/cmd/config/internal/commands/count_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,7 +19,7 @@ import (
 func TestCountCommand_files(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -42,7 +42,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx

--- a/cmd/config/internal/commands/e2e/e2e_test.go
+++ b/cmd/config/internal/commands/e2e/e2e_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -706,7 +705,7 @@ metadata:
 				t.Skip()
 			}
 
-			dir, err := ioutil.TempDir("", "kustomize-test-data-")
+			dir, err := os.MkdirTemp("", "kustomize-test-data-")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -715,7 +714,7 @@ metadata:
 
 			// write the input
 			for path, data := range tt.files(binDir) {
-				err := ioutil.WriteFile(path, []byte(data), 0600)
+				err := os.WriteFile(path, []byte(data), 0600)
 				testutil.AssertNoError(t, err)
 			}
 
@@ -737,7 +736,7 @@ metadata:
 			testutil.AssertNoError(t, err, stdErr.String())
 
 			for path, data := range tt.expectedFiles(binDir) {
-				b, err := ioutil.ReadFile(path)
+				b, err := os.ReadFile(path)
 				testutil.AssertNoError(t, err, stdErr.String())
 
 				if !assert.Equal(t, strings.TrimSpace(data), strings.TrimSpace(string(b)), stdErr.String()) {
@@ -757,7 +756,7 @@ func build() string {
 	// only build the binaries once
 	buildOnce.Do(func() {
 		var err error
-		binDir, err = ioutil.TempDir("", "kustomize-test-")
+		binDir, err = os.MkdirTemp("", "kustomize-test-")
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/config/internal/commands/e2e/test_util_test.go
+++ b/cmd/config/internal/commands/e2e/test_util_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,7 +42,7 @@ func runTests(t *testing.T, tests []test) {
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			dataDir, err := ioutil.TempDir("", "kustomize-test-data-")
+			dataDir, err := os.MkdirTemp("", "kustomize-test-data-")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -52,7 +51,7 @@ func runTests(t *testing.T, tests []test) {
 
 			// write the input
 			for path, data := range tt.files {
-				err := ioutil.WriteFile(path, []byte(data), 0600)
+				err := os.WriteFile(path, []byte(data), 0600)
 				testutil.AssertNoError(t, err)
 			}
 
@@ -79,7 +78,7 @@ func runTests(t *testing.T, tests []test) {
 			}
 
 			for path, data := range tt.expectedFiles {
-				b, err := ioutil.ReadFile(path)
+				b, err := os.ReadFile(path)
 				testutil.AssertNoError(t, err, stdErr.String())
 
 				if !assert.Equal(t, strings.TrimSpace(data), strings.TrimSpace(string(b)), stdErr.String()) {

--- a/cmd/config/internal/commands/fmt_test.go
+++ b/cmd/config/internal/commands/fmt_test.go
@@ -5,7 +5,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,22 +20,22 @@ import (
 
 // TestCmd_files verifies the fmt command formats the files
 func TestFmtCommand_files(t *testing.T) {
-	f1, err := ioutil.TempFile("", "cmdfmt*.yaml")
+	f1, err := os.CreateTemp("", "cmdfmt*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
 	defer os.RemoveAll(f1.Name())
-	err = ioutil.WriteFile(f1.Name(), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(f1.Name(), testyaml.UnformattedYaml1, 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	f2, err := ioutil.TempFile("", "cmdfmt*.yaml")
+	f2, err := os.CreateTemp("", "cmdfmt*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
 	defer os.RemoveAll(f2.Name())
-	err = ioutil.WriteFile(f2.Name(), testyaml.UnformattedYaml2, 0600)
+	err = os.WriteFile(f2.Name(), testyaml.UnformattedYaml2, 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -50,7 +49,7 @@ func TestFmtCommand_files(t *testing.T) {
 	}
 
 	// verify the contents
-	b, err := ioutil.ReadFile(f1.Name())
+	b, err := os.ReadFile(f1.Name())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -58,7 +57,7 @@ func TestFmtCommand_files(t *testing.T) {
 		return
 	}
 
-	b, err = ioutil.ReadFile(f2.Name())
+	b, err = os.ReadFile(f2.Name())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -84,20 +83,20 @@ func TestFmtCommand_stdin(t *testing.T) {
 // TestCmd_filesAndstdin verifies that if both files and stdin input are provided, only
 // the files are formatted and the input is ignored
 func TestFmtCmd_filesAndStdin(t *testing.T) {
-	f1, err := ioutil.TempFile("", "cmdfmt*.yaml")
+	f1, err := os.CreateTemp("", "cmdfmt*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(f1.Name(), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(f1.Name(), testyaml.UnformattedYaml1, 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	f2, err := ioutil.TempFile("", "cmdfmt*.yaml")
+	f2, err := os.CreateTemp("", "cmdfmt*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(f2.Name(), testyaml.UnformattedYaml2, 0600)
+	err = os.WriteFile(f2.Name(), testyaml.UnformattedYaml2, 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -117,7 +116,7 @@ func TestFmtCmd_filesAndStdin(t *testing.T) {
 	}
 
 	// verify the output
-	b, err := ioutil.ReadFile(f1.Name())
+	b, err := os.ReadFile(f1.Name())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -125,7 +124,7 @@ func TestFmtCmd_filesAndStdin(t *testing.T) {
 		return
 	}
 
-	b, err = ioutil.ReadFile(f2.Name())
+	b, err = os.ReadFile(f2.Name())
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/cmd/config/internal/commands/grep_test.go
+++ b/cmd/config/internal/commands/grep_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,7 +19,7 @@ import (
 func TestGrepCommand_files(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -42,7 +42,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx

--- a/cmd/config/internal/commands/init_test.go
+++ b/cmd/config/internal/commands/init_test.go
@@ -5,7 +5,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func TestInit_args(t *testing.T) {
 		t.FailNow()
 	}
 
-	actual, err := ioutil.ReadFile(filepath.Join(d, "Krmfile"))
+	actual, err := os.ReadFile(filepath.Join(d, "Krmfile"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -71,7 +70,7 @@ func TestInit_noargs(t *testing.T) {
 		t.FailNow()
 	}
 
-	actual, err := ioutil.ReadFile(filepath.Join(d, "Krmfile"))
+	actual, err := os.ReadFile(filepath.Join(d, "Krmfile"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/cmd/config/internal/commands/merge3_test.go
+++ b/cmd/config/internal/commands/merge3_test.go
@@ -4,7 +4,7 @@
 package commands_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 func TestMerge3Command(t *testing.T) {
 	datadir := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(datadir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
+	err := os.WriteFile(filepath.Join(datadir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -58,7 +58,7 @@ spec:
 
 	expectedDir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(expectedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
+	err = os.WriteFile(filepath.Join(expectedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -104,7 +104,7 @@ spec:
 
 	updatedDir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(updatedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
+	err = os.WriteFile(filepath.Join(updatedDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
@@ -147,7 +147,7 @@ spec:
 
 	destDir := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(destDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
+	err = os.WriteFile(filepath.Join(destDir, "java-deployment.resource.yaml"), []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app

--- a/cmd/config/internal/commands/sink_test.go
+++ b/cmd/config/internal/commands/sink_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -72,7 +72,7 @@ items:
 		t.FailNow()
 	}
 
-	actual, err := ioutil.ReadFile(filepath.Join(d, "f1.yaml"))
+	actual, err := os.ReadFile(filepath.Join(d, "f1.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -99,7 +99,7 @@ spec:
 		t.FailNow()
 	}
 
-	actual, err = ioutil.ReadFile(filepath.Join(d, "f2.yaml"))
+	actual, err = os.ReadFile(filepath.Join(d, "f2.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -147,7 +147,7 @@ items:
 		t.FailNow()
 	}
 
-	actual, err := ioutil.ReadFile(filepath.Join(d, "f1.json"))
+	actual, err := os.ReadFile(filepath.Join(d, "f1.json"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/cmd/config/internal/commands/source_test.go
+++ b/cmd/config/internal/commands/source_test.go
@@ -5,7 +5,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,7 +16,7 @@ import (
 func TestSourceCommand(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -39,7 +39,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -141,7 +141,7 @@ items:
 func TestSourceCommandJSON(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.json"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.json"), []byte(`
 {
   "kind": "Deployment",
   "metadata": {
@@ -161,7 +161,7 @@ func TestSourceCommandJSON(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.json"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.json"), []byte(`
 {
   "apiVersion": "v1",
   "kind": "Abstraction",

--- a/cmd/config/internal/commands/tree_test.go
+++ b/cmd/config/internal/commands/tree_test.go
@@ -6,7 +6,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func TestTreeCommandDefaultCurDir_files(t *testing.T) {
 		}
 	})
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -67,7 +66,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx
@@ -103,7 +102,7 @@ spec:
 func TestTreeCommand_files(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -138,7 +137,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx
@@ -173,7 +172,7 @@ spec:
 func TestTreeCommand_Kustomization(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
+	err := os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx
@@ -187,7 +186,7 @@ spec:
 		return
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d, "Kustomization"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+	err = os.WriteFile(filepath.Join(d, "Kustomization"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - f2.yaml
@@ -220,7 +219,7 @@ func TestTreeCommand_subpkgs(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:
@@ -255,7 +254,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "subpkg", "f2.yaml"), []byte(`kind: Deployment
+	err = os.WriteFile(filepath.Join(d, "subpkg", "f2.yaml"), []byte(`kind: Deployment
 metadata:
   labels:
     app: nginx
@@ -269,7 +268,7 @@ spec:
 		return
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d, "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
+	err = os.WriteFile(filepath.Join(d, "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
 kind: Krmfile
 metadata:
   name: mainpkg
@@ -279,7 +278,7 @@ openAPI:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "subpkg", "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
+	err = os.WriteFile(filepath.Join(d, "subpkg", "Krmfile"), []byte(`apiVersion: kpt.dev/v1alpha1
 kind: Krmfile
 metadata:
   name: subpkg
@@ -423,7 +422,7 @@ spec:
 func TestTreeCommand_includeReconcilers(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -446,7 +445,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: gcr.io/example/reconciler:v1
 kind: Abstraction
 metadata:
@@ -491,7 +490,7 @@ spec:
 func TestTreeCommand_excludeNonReconcilers(t *testing.T) {
 	d := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+	err := os.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
 kind: Deployment
 metadata:
   labels:
@@ -514,7 +513,7 @@ spec:
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
 apiVersion: v1
 kind: Abstraction
 metadata:

--- a/cmd/config/runner/runner_test.go
+++ b/cmd/config/runner/runner_test.go
@@ -6,7 +6,6 @@ package runner
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,27 +136,27 @@ func createTestDirStructure(dir string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg1", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg1", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg2", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg2", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg2/subpkg3", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg2/subpkg3", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg4", "error.txt"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg4", "error.txt"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg4", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg4", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
@@ -167,7 +166,7 @@ func createTestDirStructure(dir string) error {
 type TestRunner struct{}
 
 func (r *TestRunner) ExecuteCmd(w io.Writer, pkgPath string) error {
-	children, err := ioutil.ReadDir(pkgPath)
+	children, err := os.ReadDir(pkgPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/gorepomod/internal/repo/protomodule.go
+++ b/cmd/gorepomod/internal/repo/protomodule.go
@@ -5,7 +5,6 @@ package repo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -68,7 +67,7 @@ func loadProtoModules(
 
 func loadProtoModule(path string) (*protoModule, error) {
 	mPath := filepath.Join(path, goModFile)
-	content, err := ioutil.ReadFile(mPath)
+	content, err := os.ReadFile(mPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %q: %v\n", mPath, err)
 	}

--- a/cmd/k8scopy/internal/modulespec.go
+++ b/cmd/k8scopy/internal/modulespec.go
@@ -4,7 +4,7 @@
 package internal
 
 import (
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 )
@@ -25,7 +25,7 @@ type PackageSpec struct {
 }
 
 func ReadSpec(fileName string) *ModuleSpec {
-	bytes, err := ioutil.ReadFile(fileName)
+	bytes, err := os.ReadFile(fileName)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/k8scopy/internal/modulespec_test.go
+++ b/cmd/k8scopy/internal/modulespec_test.go
@@ -4,7 +4,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -51,7 +50,7 @@ func TestReadSpec(t *testing.T) {
 
 // Write content to temp file, returning file name.
 func writeFile(t *testing.T, content []byte) string {
-	f, err := ioutil.TempFile("", "testjunk")
+	f, err := os.CreateTemp("", "testjunk")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/mdtogo/main.go
+++ b/cmd/mdtogo/main.go
@@ -41,7 +41,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -68,7 +67,7 @@ func main() {
 	source := os.Args[1]
 	dest := os.Args[2]
 
-	files, err := ioutil.ReadDir(source)
+	files, err := os.ReadDir(source)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -79,7 +78,7 @@ func main() {
 		if filepath.Ext(f.Name()) != ".md" {
 			continue
 		}
-		b, err := ioutil.ReadFile(filepath.Join(source, f.Name()))
+		b, err := os.ReadFile(filepath.Join(source, f.Name()))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
@@ -96,7 +95,7 @@ func main() {
 	} else if licenseFile == "none" {
 		// no license -- maybe added by another tool
 	} else {
-		b, err := ioutil.ReadFile(licenseFile)
+		b, err := os.ReadFile(licenseFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
@@ -117,7 +116,7 @@ package ` + filepath.Base(dest) + "\n"}
 	}
 
 	o := strings.Join(out, "\n")
-	err = ioutil.WriteFile(filepath.Join(dest, "docs.go"), []byte(o), 0600)
+	err = os.WriteFile(filepath.Join(dest, "docs.go"), []byte(o), 0600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/cmd/pluginator/internal/krmfunction/converter.go
+++ b/cmd/pluginator/internal/krmfunction/converter.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,7 +130,7 @@ func (c *Converter) readEmbeddedFile(name string) (string, error) {
 		return "", err
 	}
 	defer r.Close()
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +139,7 @@ func (c *Converter) readEmbeddedFile(name string) (string, error) {
 }
 
 func (c *Converter) readDiskFile(path string) (string, error) {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -159,7 +159,7 @@ func (c *Converter) mkDstDir() error {
 func (c *Converter) write(m map[string]string) error {
 	for k, v := range m {
 		p := filepath.Join(c.outputDir, k)
-		err := ioutil.WriteFile(p, []byte(v), 0644)
+		err := os.WriteFile(p, []byte(v), 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/pluginator/internal/krmfunction/converter_test.go
+++ b/cmd/pluginator/internal/krmfunction/converter_test.go
@@ -5,7 +5,7 @@ package krmfunction
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -116,7 +116,7 @@ func TestTransformerConverter(t *testing.T) {
 	t.Skip("TODO: fix this test, which was not running in CI and does not pass")
 	dir := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(dir, "Plugin.go"),
+	err := os.WriteFile(filepath.Join(dir, "Plugin.go"),
 		getTransformerCode(), 0644)
 	require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func TestGeneratorConverter(t *testing.T) {
 	t.Skip("TODO: fix this test, which was not running in CI and does not pass")
 	dir := t.TempDir()
 
-	err := ioutil.WriteFile(filepath.Join(dir, "Plugin.go"),
+	err := os.WriteFile(filepath.Join(dir, "Plugin.go"),
 		getGeneratorCode(), 0644)
 	require.NoError(t, err)
 

--- a/functions/examples/application-cr/image/main_test.go
+++ b/functions/examples/application-cr/image/main_test.go
@@ -8,7 +8,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -219,7 +218,7 @@ func Test(t *testing.T) {
 		outC <- buf.String()
 	}()
 
-	tmpfile, err := ioutil.TempFile("", "test-input")
+	tmpfile, err := os.CreateTemp("", "test-input")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kyaml/copyutil/copyutil.go
+++ b/kyaml/copyutil/copyutil.go
@@ -7,7 +7,6 @@ package copyutil
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,11 +40,11 @@ func CopyDir(src string, dst string) error {
 		}
 
 		// copy file by reading and writing it
-		b, err := ioutil.ReadFile(filepath.Join(src, copyTo))
+		b, err := os.ReadFile(filepath.Join(src, copyTo))
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(filepath.Join(dst, copyTo), b, info.Mode())
+		err = os.WriteFile(filepath.Join(dst, copyTo), b, info.Mode())
 		if err != nil {
 			return err
 		}
@@ -112,11 +111,11 @@ func Diff(sourceDir, destDir string) (sets.String, error) {
 		}
 
 		// compare upstreamFiles
-		b1, err := ioutil.ReadFile(filepath.Join(destDir, f))
+		b1, err := os.ReadFile(filepath.Join(destDir, f))
 		if err != nil {
 			return diff, err
 		}
-		b2, err := ioutil.ReadFile(filepath.Join(sourceDir, f))
+		b2, err := os.ReadFile(filepath.Join(sourceDir, f))
 		if err != nil {
 			return diff, err
 		}
@@ -162,7 +161,7 @@ func SyncFile(src, dst string) error {
 		return nil
 	}
 
-	input, err := ioutil.ReadFile(src)
+	input, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
@@ -178,7 +177,7 @@ func SyncFile(src, dst string) error {
 		filePerm = dstFileInfo.Mode().Perm()
 	}
 
-	err = ioutil.WriteFile(dst, input, filePerm)
+	err = os.WriteFile(dst, input, filePerm)
 	if err != nil {
 		return err
 	}

--- a/kyaml/copyutil/copyutil_test.go
+++ b/kyaml/copyutil/copyutil_test.go
@@ -5,7 +5,6 @@ package copyutil_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,13 +20,13 @@ func TestDiff_identical(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
@@ -85,13 +84,13 @@ func TestDiff_srcDestContentsDiffer(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, "a1", "f.yaml"), []byte(`b`), 0600)
 	assert.NoError(t, err)
 
@@ -110,13 +109,13 @@ func TestDiff_srcDestContentsDifferInDirs(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "b1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, "b1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
@@ -138,29 +137,29 @@ func TestDiff_skipGitSrc(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	// files that just happen to start with .git should not be ignored.
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, ".gitlab-ci.yml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	// git should be ignored
 	err = os.Mkdir(filepath.Join(s, ".git"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, ".git", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, ".gitlab-ci.yml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
@@ -177,20 +176,20 @@ func TestDiff_skipGitDest(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(d, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	// git should be ignored
 	err = os.Mkdir(filepath.Join(d, ".git"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(d, ".git", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
@@ -205,14 +204,14 @@ func TestSyncFile(t *testing.T) {
 	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err := ioutil.WriteFile(f1Name, []byte("abc"), 0600)
+	err := os.WriteFile(f1Name, []byte("abc"), 0600)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(f2Name, []byte("def"), 0644)
+	err = os.WriteFile(f2Name, []byte("def"), 0644)
 	expectedFileInfo, _ := os.Stat(f2Name)
 	assert.NoError(t, err)
 	err = SyncFile(f1Name, f2Name)
 	assert.NoError(t, err)
-	actual, err := ioutil.ReadFile(f2Name)
+	actual, err := os.ReadFile(f2Name)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", string(actual))
 	dstFileInfo, _ := os.Stat(f2Name)
@@ -225,11 +224,11 @@ func TestSyncFileNoDestFile(t *testing.T) {
 	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err := ioutil.WriteFile(f1Name, []byte("abc"), 0644)
+	err := os.WriteFile(f1Name, []byte("abc"), 0644)
 	assert.NoError(t, err)
 	err = SyncFile(f1Name, f2Name)
 	assert.NoError(t, err)
-	actual, err := ioutil.ReadFile(f2Name)
+	actual, err := os.ReadFile(f2Name)
 	assert.NoError(t, err)
 	assert.Equal(t, "abc", string(actual))
 	dstFileInfo, _ := os.Stat(f2Name)
@@ -243,11 +242,11 @@ func TestSyncFileNoSrcFile(t *testing.T) {
 	d2 := t.TempDir()
 	f1Name := d1 + "/temp.txt"
 	f2Name := d2 + "/temp.txt"
-	err := ioutil.WriteFile(f2Name, []byte("abc"), 0644)
+	err := os.WriteFile(f2Name, []byte("abc"), 0644)
 	assert.NoError(t, err)
 	err = SyncFile(f1Name, f2Name)
 	assert.NoError(t, err)
-	_, err = ioutil.ReadFile(f2Name)
+	_, err = os.ReadFile(f2Name)
 	assert.Error(t, err)
 }
 
@@ -279,29 +278,29 @@ func TestCopyDir(t *testing.T) {
 
 	err := os.Mkdir(filepath.Join(s, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	// files that just happen to start with .git should not be ignored.
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, ".gitlab-ci.yml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	// git should be ignored
 	err = os.Mkdir(filepath.Join(s, ".git"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(s, ".git", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
 	err = os.Mkdir(filepath.Join(v, "a1"), 0700)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(v, "a1", "f.yaml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		filepath.Join(v, ".gitlab-ci.yml"), []byte(`a`), 0600)
 	assert.NoError(t, err)
 

--- a/kyaml/filesys/confirmeddir.go
+++ b/kyaml/filesys/confirmeddir.go
@@ -4,7 +4,7 @@
 package filesys
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -17,12 +17,12 @@ type ConfirmedDir string
 // The directory is cleaned, no symlinks, etc. so it's
 // returned as a ConfirmedDir.
 func NewTmpConfirmedDir() (ConfirmedDir, error) {
-	n, err := ioutil.TempDir("", "kustomize-")
+	n, err := os.MkdirTemp("", "kustomize-")
 	if err != nil {
 		return "", err
 	}
 
-	// In MacOs `ioutil.TempDir` creates a directory
+	// In MacOs `os.MkdirTemp` creates a directory
 	// with root in the `/var` folder, which is in turn
 	// a symlinked path to `/private/var`.
 	// Function `filepath.EvalSymlinks`is used to

--- a/kyaml/filesys/fsnode_test.go
+++ b/kyaml/filesys/fsnode_test.go
@@ -9,7 +9,6 @@ package filesys
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -141,7 +140,7 @@ func runBasicOperations(
 		if fi.Name() != c.name {
 			t.Fatalf("%s; expected name '%s', got '%s'", c.what, c.name, fi.Name())
 		}
-		buff, err := ioutil.ReadAll(f)
+		buff, err := io.ReadAll(f)
 		if err != nil {
 			t.Fatalf("%s; unexpected error: %v", c.what, err)
 		}

--- a/kyaml/filesys/fsondisk.go
+++ b/kyaml/filesys/fsondisk.go
@@ -125,7 +125,10 @@ func (fsOnDisk) ReadDir(name string) ([]string, error) {
 }
 
 // ReadFile delegates to os.ReadFile.
-func (fsOnDisk) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
+func (fsOnDisk) ReadFile(name string) ([]byte, error) {
+	//nolint:wrapcheck
+	return os.ReadFile(name)
+}
 
 // WriteFile delegates to os.WriteFile with read/write permissions.
 func (fsOnDisk) WriteFile(name string, c []byte) error {

--- a/kyaml/filesys/fsondisk.go
+++ b/kyaml/filesys/fsondisk.go
@@ -5,7 +5,6 @@ package filesys
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -125,12 +124,12 @@ func (fsOnDisk) ReadDir(name string) ([]string, error) {
 	return result, nil
 }
 
-// ReadFile delegates to ioutil.ReadFile.
-func (fsOnDisk) ReadFile(name string) ([]byte, error) { return ioutil.ReadFile(name) }
+// ReadFile delegates to os.ReadFile.
+func (fsOnDisk) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
 
-// WriteFile delegates to ioutil.WriteFile with read/write permissions.
+// WriteFile delegates to os.WriteFile with read/write permissions.
 func (fsOnDisk) WriteFile(name string, c []byte) error {
-	return errors.Wrap(ioutil.WriteFile(name, c, 0666)) //nolint:gosec
+	return errors.Wrap(os.WriteFile(name, c, 0666)) //nolint:gosec
 }
 
 // Walk delegates to filepath.Walk.

--- a/kyaml/fix/fixsetters/fixsetters_test.go
+++ b/kyaml/fix/fixsetters/fixsetters_test.go
@@ -4,7 +4,7 @@
 package fixsetters
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -408,13 +408,13 @@ spec:
 
 			dir := t.TempDir()
 
-			err := ioutil.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(test.input), 0600)
+			err := os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
 			if test.openAPIFile != "" {
-				err = ioutil.WriteFile(filepath.Join(dir, openAPIFileName), []byte(test.openAPIFile), 0600)
+				err = os.WriteFile(filepath.Join(dir, openAPIFileName), []byte(test.openAPIFile), 0600)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -437,14 +437,14 @@ spec:
 				return
 			}
 
-			actualOutput, err := ioutil.ReadFile(filepath.Join(dir, "deploy.yaml"))
+			actualOutput, err := os.ReadFile(filepath.Join(dir, "deploy.yaml"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			assert.Equal(t, test.expectedOutput, string(actualOutput))
 
 			if test.expectedOpenAPI != "" {
-				actualOpenAPI, err := ioutil.ReadFile(filepath.Join(dir, openAPIFileName))
+				actualOpenAPI, err := os.ReadFile(filepath.Join(dir, openAPIFileName))
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}

--- a/kyaml/fn/framework/command/command.go
+++ b/kyaml/fn/framework/command/command.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -122,7 +121,7 @@ func AddGenerateDockerfile(cmd *cobra.Command) {
 		Use:  "gen [DIR]",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := ioutil.WriteFile(filepath.Join(args[0], "Dockerfile"), []byte(`FROM golang:1.18-alpine as builder
+			if err := os.WriteFile(filepath.Join(args[0], "Dockerfile"), []byte(`FROM golang:1.18-alpine as builder
 ENV CGO_ENABLED=0
 WORKDIR /go/src/
 COPY go.mod go.sum ./
@@ -143,7 +142,7 @@ ENTRYPOINT ["function"]
 }
 
 func functionConfigFromFile(file string) (*yaml.RNode, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return nil, errors.WrapPrefixf(err, "unable to read configuration file %q", file)
 	}
@@ -161,7 +160,7 @@ type deferredFileReader struct {
 
 func (fr *deferredFileReader) Read(dest []byte) (int, error) {
 	if fr.srcReader == nil {
-		src, err := ioutil.ReadFile(fr.path)
+		src, err := os.ReadFile(fr.path)
 		if err != nil {
 			return 0, errors.WrapPrefixf(err, "unable to read input file %s", fr.path)
 		}

--- a/kyaml/fn/framework/command/command_test.go
+++ b/kyaml/fn/framework/command/command_test.go
@@ -6,7 +6,7 @@ package command_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,7 +36,7 @@ func TestCommand_dockerfile(t *testing.T) {
 		t.FailNow()
 	}
 
-	b, err := ioutil.ReadFile(filepath.Join(d, "Dockerfile"))
+	b, err := os.ReadFile(filepath.Join(d, "Dockerfile"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
+++ b/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
@@ -6,7 +6,6 @@ package frameworktestutil
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -216,7 +215,7 @@ func (rc *ProcessorResultsChecker) runInCurrentDir(t *testing.T) (string, string
 	require.NoError(t, err)
 
 	actualOutput := bytes.NewBuffer([]byte{})
-	rlBytes, err := ioutil.ReadFile(rc.InputFilename)
+	rlBytes, err := os.ReadFile(rc.InputFilename)
 	require.NoError(t, err)
 
 	rw := kio.ByteReadWriter{
@@ -338,10 +337,10 @@ func (rc *checkerCore) shouldUpdateFixtures() bool {
 func (rc *checkerCore) updateFixtures(t *testing.T, actualOutput string, actualError string) {
 	t.Helper()
 	if actualError != "" {
-		require.NoError(t, ioutil.WriteFile(rc.expectedErrorFilename, []byte(actualError), 0600))
+		require.NoError(t, os.WriteFile(rc.expectedErrorFilename, []byte(actualError), 0600))
 	}
 	if len(actualOutput) > 0 {
-		require.NoError(t, ioutil.WriteFile(rc.expectedOutputFilename, []byte(actualOutput), 0600))
+		require.NoError(t, os.WriteFile(rc.expectedOutputFilename, []byte(actualOutput), 0600))
 	}
 	t.Skip("Updated fixtures for test case")
 }
@@ -367,7 +366,7 @@ func (rc *checkerCore) readAssertionFiles(t *testing.T) (string, string) {
 		}
 		if err == nil {
 			// only read the file if it exists
-			b, err := ioutil.ReadFile(rc.expectedOutputFilename)
+			b, err := os.ReadFile(rc.expectedOutputFilename)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -381,7 +380,7 @@ func (rc *checkerCore) readAssertionFiles(t *testing.T) (string, string) {
 		}
 		if err == nil {
 			// only read the file if it exists
-			b, err := ioutil.ReadFile(rc.expectedErrorFilename)
+			b, err := os.ReadFile(rc.expectedErrorFilename)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/fn/framework/parser/parser.go
+++ b/kyaml/fn/framework/parser/parser.go
@@ -100,5 +100,6 @@ func (l parser) readFile(path string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return io.ReadAll(f)
+	content, err := io.ReadAll(f)
+	return content, errors.Wrap(err)
 }

--- a/kyaml/fn/framework/parser/parser.go
+++ b/kyaml/fn/framework/parser/parser.go
@@ -4,8 +4,8 @@
 package parser
 
 import (
+	"io"
 	iofs "io/fs"
-	"io/ioutil"
 	"path"
 	"strings"
 
@@ -54,7 +54,7 @@ func (l parser) readPath(path string, processContent contentProcessor) error {
 	if err := checkExtension(path, l.extensions); err != nil {
 		return err
 	}
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}
@@ -100,5 +100,5 @@ func (l parser) readFile(path string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }

--- a/kyaml/fn/runtime/runtimeutil/runtimeutil.go
+++ b/kyaml/fn/runtime/runtimeutil/runtimeutil.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -268,7 +268,7 @@ func (c *FunctionFilter) doResults(r *kio.ByteReader) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(c.ResultsFile, []byte(results), 0600)
+		err = os.WriteFile(c.ResultsFile, []byte(results), 0600)
 		if err != nil {
 			return err
 		}

--- a/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
+++ b/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
@@ -6,7 +6,6 @@ package runtimeutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +23,7 @@ type testRun struct {
 
 func (r testRun) run(reader io.Reader, writer io.Writer) error {
 	if r.expectedInput != "" {
-		input, err := ioutil.ReadAll(reader)
+		input, err := io.ReadAll(reader)
 		if !assert.NoError(r.t, err) {
 			r.t.FailNow()
 		}
@@ -1040,7 +1039,7 @@ metadata:
 			// results file setup
 			if len(tt.expectedResults) > 0 && !tt.noMakeResultsFile {
 				// expect result files to be written -- create a directory for them
-				f, err := ioutil.TempFile("", "test-kyaml-*.yaml")
+				f, err := os.CreateTemp("", "test-kyaml-*.yaml")
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -1123,7 +1122,7 @@ metadata:
 					t.FailNow()
 				}
 
-				b, err := ioutil.ReadFile(tt.instance.ResultsFile)
+				b, err := os.ReadFile(tt.instance.ResultsFile)
 				writtenResults := strings.TrimSpace(string(b))
 				if !assert.NoError(t, err) {
 					t.FailNow()

--- a/kyaml/fn/runtime/starlark/example_test.go
+++ b/kyaml/fn/runtime/starlark/example_test.go
@@ -6,7 +6,6 @@ package starlark_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -200,13 +199,13 @@ run(ctx.resource_list["items"], ctx.resource_list["functionConfig"]["spec"]["val
 // resource configuration read from a directory.
 func ExampleFilter_Filter_file() {
 	// setup the configuration
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Println(err)
 	}
 	defer os.RemoveAll(d)
 
-	err = ioutil.WriteFile(filepath.Join(d, "deploy1.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "deploy1.yaml"), []byte(`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -222,7 +221,7 @@ spec:
 		log.Println(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d, "deploy2.yaml"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "deploy2.yaml"), []byte(`
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -238,7 +237,7 @@ spec:
 		log.Println(err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d, "annotate.star"), []byte(`
+	err = os.WriteFile(filepath.Join(d, "annotate.star"), []byte(`
 def run(items):
   for item in items:
     item["metadata"]["annotations"]["foo"] = "bar"

--- a/kyaml/fn/runtime/starlark/starlark.go
+++ b/kyaml/fn/runtime/starlark/starlark.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"go.starlark.net/starlark"
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -57,7 +57,7 @@ func (sf *Filter) setup() error {
 
 	// read the program from a file
 	if sf.Path != "" {
-		b, err := ioutil.ReadFile(sf.Path)
+		b, err := os.ReadFile(sf.Path)
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func (sf *Filter) setup() error {
 				return err
 			}
 			defer resp.Body.Close()
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err
 			}

--- a/kyaml/kio/filters/fmtr_test.go
+++ b/kyaml/kio/filters/fmtr_test.go
@@ -6,7 +6,6 @@ package filters_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -680,12 +679,12 @@ apiVersion: example.com/v1beta1
 // with a .yaml extension.
 func TestFormatFileOrDirectory_yamlExtFile(t *testing.T) {
 	// write the unformatted file
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -697,7 +696,7 @@ func TestFormatFileOrDirectory_yamlExtFile(t *testing.T) {
 	}
 
 	// check the result is formatted
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -706,10 +705,10 @@ func TestFormatFileOrDirectory_yamlExtFile(t *testing.T) {
 
 func TestFormatFileOrDirectory_multipleYamlEntries(t *testing.T) {
 	// write the unformatted file
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(),
+	err = os.WriteFile(f.Name(),
 		[]byte(string(testyaml.UnformattedYaml1)+"---\n"+string(testyaml.UnformattedYaml2)), 0600)
 	assert.NoError(t, err)
 
@@ -718,7 +717,7 @@ func TestFormatFileOrDirectory_multipleYamlEntries(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check the result is formatted
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedYaml1)+"---\n"+string(testyaml.FormattedYaml2), string(b))
 }
@@ -727,10 +726,10 @@ func TestFormatFileOrDirectory_multipleYamlEntries(t *testing.T) {
 // with a .yml extension.
 func TestFormatFileOrDirectory_ymlExtFile(t *testing.T) {
 	// write the unformatted file
-	f, err := ioutil.TempFile("", "yamlfmt*.yml")
+	f, err := os.CreateTemp("", "yamlfmt*.yml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
 	assert.NoError(t, err)
 
 	// format the file
@@ -738,7 +737,7 @@ func TestFormatFileOrDirectory_ymlExtFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check the result is formatted
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
 }
@@ -747,10 +746,10 @@ func TestFormatFileOrDirectory_ymlExtFile(t *testing.T) {
 // YAML content is formatted as such.
 func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
 	// write the unformatted JSON file contents
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
+	err = os.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
 	assert.NoError(t, err)
 
 	// format the file
@@ -758,7 +757,7 @@ func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check the result is formatted as yaml
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedFlowYAML1), string(b))
 }
@@ -767,10 +766,10 @@ func TestFormatFileOrDirectory_YamlExtFileWithJson(t *testing.T) {
 // and JSON contents won't be modified.
 func TestFormatFileOrDirectory_JsonExtFileWithNotModified(t *testing.T) {
 	// write the unformatted JSON file contents
-	f, err := ioutil.TempFile("", "yamlfmt*.json")
+	f, err := os.CreateTemp("", "yamlfmt*.json")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
+	err = os.WriteFile(f.Name(), testyaml.UnformattedJSON1, 0600)
 	assert.NoError(t, err)
 
 	// format the file
@@ -778,7 +777,7 @@ func TestFormatFileOrDirectory_JsonExtFileWithNotModified(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check the result is formatted as yaml
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.UnformattedJSON1), string(b))
 }
@@ -787,10 +786,10 @@ func TestFormatFileOrDirectory_JsonExtFileWithNotModified(t *testing.T) {
 // Kubernetes and non-Kubernetes documents, it will only format the Kubernetes documents
 func TestFormatFileOrDirectory_partialKubernetesYamlFile(t *testing.T) {
 	// write the unformatted file
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), []byte(string(testyaml.UnformattedYaml1)+`---
+	err = os.WriteFile(f.Name(), []byte(string(testyaml.UnformattedYaml1)+`---
 status:
   conditions:
   - 3
@@ -806,7 +805,7 @@ spec: a
 	assert.NoError(t, err)
 
 	// check the result is  NOT formatted
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedYaml1)+`---
 status:
@@ -823,10 +822,10 @@ spec: a
 // kubernetes
 func TestFormatFileOrDirectory_skipNonKubernetesYamlFile(t *testing.T) {
 	// write the unformatted JSON file contents
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), []byte(`
+	err = os.WriteFile(f.Name(), []byte(`
 status:
   conditions:
   - 3
@@ -841,7 +840,7 @@ spec: a
 	assert.NoError(t, err)
 
 	// check the result is formatted as yaml
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, `status:
   conditions:
@@ -854,16 +853,16 @@ spec: a
 
 // TestFormatFileOrDirectory_jsonFile should not fmt the file even though it contains yaml.
 func TestFormatFileOrDirectory_skipJsonExtFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "yamlfmt*.json")
+	f, err := os.CreateTemp("", "yamlfmt*.json")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(f.Name(), testyaml.UnformattedYaml1, 0600)
 	assert.NoError(t, err)
 
 	err = FormatFileOrDirectory(f.Name())
 	assert.NoError(t, err)
 
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(testyaml.UnformattedYaml1), string(b))
@@ -877,27 +876,27 @@ func TestFormatFileOrDirectory_directory(t *testing.T) {
 	err := os.Mkdir(filepath.Join(d, "config"), 0700)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(d, "c1.yaml"), testyaml.UnformattedYaml1, 0600)
+	err = os.WriteFile(filepath.Join(d, "c1.yaml"), testyaml.UnformattedYaml1, 0600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(d, "config", "c2.yaml"), testyaml.UnformattedYaml2, 0600)
+	err = os.WriteFile(filepath.Join(d, "config", "c2.yaml"), testyaml.UnformattedYaml2, 0600)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(d, "README.md"), []byte(`# Markdown`), 0600)
+	err = os.WriteFile(filepath.Join(d, "README.md"), []byte(`# Markdown`), 0600)
 	assert.NoError(t, err)
 
 	err = FormatFileOrDirectory(d)
 	assert.NoError(t, err)
 
-	b, err := ioutil.ReadFile(filepath.Join(d, "c1.yaml"))
+	b, err := os.ReadFile(filepath.Join(d, "c1.yaml"))
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
 
-	b, err = ioutil.ReadFile(filepath.Join(d, "config", "c2.yaml"))
+	b, err = os.ReadFile(filepath.Join(d, "config", "c2.yaml"))
 	assert.NoError(t, err)
 	assert.Equal(t, string(testyaml.FormattedYaml2), string(b))
 
-	b, err = ioutil.ReadFile(filepath.Join(d, "README.md"))
+	b, err = os.ReadFile(filepath.Join(d, "README.md"))
 	assert.NoError(t, err)
 	assert.Equal(t, `# Markdown`, string(b))
 
@@ -917,16 +916,16 @@ func TestFormatFileOrDirectory_directory(t *testing.T) {
 // TestFormatFileOrDirectory_trimWhiteSpace verifies that trailling and leading whitespace is
 // trimmed
 func TestFormatFileOrDirectory_trimWhiteSpace(t *testing.T) {
-	f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+	f, err := os.CreateTemp("", "yamlfmt*.yaml")
 	assert.NoError(t, err)
 	defer os.Remove(f.Name())
-	err = ioutil.WriteFile(f.Name(), []byte("\n\n"+string(testyaml.UnformattedYaml1)+"\n\n"), 0600)
+	err = os.WriteFile(f.Name(), []byte("\n\n"+string(testyaml.UnformattedYaml1)+"\n\n"), 0600)
 	assert.NoError(t, err)
 
 	err = FormatFileOrDirectory(f.Name())
 	assert.NoError(t, err)
 
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	assert.NoError(t, err)
 
 	assert.Equal(t, string(testyaml.FormattedYaml1), string(b))
@@ -1024,11 +1023,11 @@ metadata:
 	for i := range testCases {
 		test := testCases[i]
 		t.Run(test.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "yamlfmt*.yaml")
+			f, err := os.CreateTemp("", "yamlfmt*.yaml")
 			assert.NoError(t, err)
 			defer os.Remove(f.Name())
 
-			err = ioutil.WriteFile(f.Name(), test.input, 0600)
+			err = os.WriteFile(f.Name(), test.input, 0600)
 			assert.NoError(t, err)
 
 			err = FormatFileOrDirectory(f.Name())
@@ -1038,7 +1037,7 @@ metadata:
 			}
 			assert.NoError(t, err)
 
-			b, err := ioutil.ReadFile(f.Name())
+			b, err := os.ReadFile(f.Name())
 			assert.NoError(t, err)
 
 			assert.Equal(t, strings.TrimSpace(string(test.expectedOutput)),

--- a/kyaml/kio/ignorefilesmatcher_test.go
+++ b/kyaml/kio/ignorefilesmatcher_test.go
@@ -4,7 +4,7 @@
 package kio
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,10 +46,10 @@ func TestIgnoreFilesMatcher_readIgnoreFile(t *testing.T) {
 
 			if writeIgnoreFile {
 				ignoreFilePath := filepath.Join(dir, ignoreFileName)
-				require.NoError(t, ioutil.WriteFile(ignoreFilePath, []byte(ignoreFileBody), 0600))
+				require.NoError(t, os.WriteFile(ignoreFilePath, []byte(ignoreFileBody), 0600))
 			}
 			testFilePath := filepath.Join(dir, testFileName)
-			require.NoError(t, ioutil.WriteFile(testFilePath, []byte{}, 0600))
+			require.NoError(t, os.WriteFile(testFilePath, []byte{}, 0600))
 			return dir, nil
 		},
 

--- a/kyaml/kio/pkgio_writer_test.go
+++ b/kyaml/kio/pkgio_writer_test.go
@@ -333,7 +333,7 @@ metadata:
 `)
 	require.NoError(t, err)
 
-	// These two lines are similar to calling ioutil.TempDir, but we don't actually create any directory.
+	// These two lines are similar to calling os.MkdirTemp, but we don't actually create any directory.
 	rand.Seed(time.Now().Unix())
 	path := filepath.Join(os.TempDir(), fmt.Sprintf("kyaml-test%d", rand.Int31())) //nolint:gosec
 	require.NoError(t, mockFS.MkdirAll(filepath.Join(path, "a")))

--- a/kyaml/kio/testing_test.go
+++ b/kyaml/kio/testing_test.go
@@ -4,7 +4,6 @@
 package kio
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ type Setup struct {
 // SetupDirectories creates directories for reading test configuration from
 func SetupDirectories(t *testing.T, dirs ...string) Setup {
 	t.Helper()
-	d, err := ioutil.TempDir("", "kyaml-test")
+	d, err := os.MkdirTemp("", "kyaml-test")
 	require.NoError(t, err)
 	err = os.Chdir(d)
 	require.NoError(t, err)
@@ -37,7 +36,7 @@ func (s Setup) WriteFile(t *testing.T, path string, value []byte) {
 	t.Helper()
 	err := os.MkdirAll(filepath.Dir(filepath.Join(s.Root, path)), 0700)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(filepath.Join(s.Root, path), value, 0600)
+	err = os.WriteFile(filepath.Join(s.Root, path), value, 0600)
 	require.NoError(t, err)
 }
 

--- a/kyaml/openapi/kustomizationapi/swagger.go
+++ b/kyaml/openapi/kustomizationapi/swagger.go
@@ -11,7 +11,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -215,7 +214,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -6,7 +6,7 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -220,7 +220,7 @@ func definitionRefsFromRNode(object *yaml.RNode) ([]string, error) {
 
 // parseOpenAPI reads openAPIPath yaml and converts it to RNode
 func parseOpenAPI(openAPIPath string) (*yaml.RNode, error) {
-	b, err := ioutil.ReadFile(openAPIPath)
+	b, err := os.ReadFile(openAPIPath)
 	if err != nil {
 		return nil, err
 	}

--- a/kyaml/openapi/openapi_test.go
+++ b/kyaml/openapi/openapi_test.go
@@ -5,7 +5,7 @@ package openapi
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -116,11 +116,11 @@ openAPI:
           name: image-name
           value: "nginx"
  `
-	f, err := ioutil.TempFile("", "openapi-")
+	f, err := os.CreateTemp("", "openapi-")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	if !assert.NoError(t, ioutil.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
+	if !assert.NoError(t, os.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
 		t.FailNow()
 	}
 
@@ -168,11 +168,11 @@ openAPI:
             ref: "#/definitions/io.k8s.cli.setters.image-tag"
  `
 
-	f, err := ioutil.TempFile("", "openapi-")
+	f, err := os.CreateTemp("", "openapi-")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	if !assert.NoError(t, ioutil.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
+	if !assert.NoError(t, os.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
 		t.FailNow()
 	}
 
@@ -203,11 +203,11 @@ func TestAddSchemaFromFile_empty(t *testing.T) {
 kind: Example
  `
 
-	f, err := ioutil.TempFile("", "openapi-")
+	f, err := os.CreateTemp("", "openapi-")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	if !assert.NoError(t, ioutil.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
+	if !assert.NoError(t, os.WriteFile(f.Name(), []byte(inputyaml), 0600)) {
 		t.FailNow()
 	}
 

--- a/kyaml/pathutil/pathutil_test.go
+++ b/kyaml/pathutil/pathutil_test.go
@@ -4,7 +4,6 @@
 package pathutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,15 +77,15 @@ func createTestDirStructure(dir string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg1", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg1", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "subpkg2", "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "subpkg2", "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(dir, "Krmfile"), []byte(""), 0644)
 	if err != nil {
 		return err
 	}

--- a/kyaml/runfn/runfn_test.go
+++ b/kyaml/runfn/runfn_test.go
@@ -6,7 +6,6 @@ package runfn
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -679,7 +678,7 @@ metadata:
 					if !assert.NoError(t, err) {
 						t.FailNow()
 					}
-					err := ioutil.WriteFile(filepath.Join(dir, f.path), []byte(f.value), 0600)
+					err := os.WriteFile(filepath.Join(dir, f.path), []byte(f.value), 0600)
 					if !assert.NoError(t, err) {
 						t.FailNow()
 					}
@@ -913,7 +912,7 @@ func TestCmd_Execute(t *testing.T) {
 	dir := setupTest(t)
 
 	// write a test filter to the directory of configuration
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
@@ -922,7 +921,7 @@ func TestCmd_Execute(t *testing.T) {
 	if !assert.NoError(t, instance.Execute()) {
 		t.FailNow()
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -948,7 +947,7 @@ func TestCmd_Execute_deferFailure(t *testing.T) {
 	dir := setupTest(t)
 
 	// write a test filter to the directory of configuration
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter1.yaml"), []byte(`apiVersion: v1
 kind: ValueReplacer
 metadata:
@@ -964,7 +963,7 @@ replace: StatefulSet
 	}
 
 	// write a test filter to the directory of configuration
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter2.yaml"), []byte(`apiVersion: v1
 kind: ValueReplacer
 metadata:
@@ -1007,7 +1006,7 @@ replace: StatefulSet
 	if !assert.EqualError(t, err, "message: 1\n---\nmessage: 2") {
 		t.FailNow()
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -1021,12 +1020,12 @@ func TestCmd_Execute_setFunctionPaths(t *testing.T) {
 	dir := setupTest(t)
 
 	// write a test filter to a separate directory
-	tmpF, err := ioutil.TempFile("", "filter*.yaml")
+	tmpF, err := os.CreateTemp("", "filter*.yaml")
 	if !assert.NoError(t, err) {
 		return
 	}
 	os.RemoveAll(tmpF.Name())
-	if !assert.NoError(t, ioutil.WriteFile(tmpF.Name(), []byte(ValueReplacerYAMLData), 0600)) {
+	if !assert.NoError(t, os.WriteFile(tmpF.Name(), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
 
@@ -1043,7 +1042,7 @@ func TestCmd_Execute_setFunctionPaths(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		return
@@ -1056,7 +1055,7 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 	dir := setupTest(t)
 
 	// write a test filter
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
@@ -1073,7 +1072,7 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 	if !assert.NoError(t, instance.Execute()) {
 		return
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		return
@@ -1085,7 +1084,7 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 // TestCmd_Execute_setInput tests the execution of a filter using an io.Reader as input
 func TestCmd_Execute_setInput(t *testing.T) {
 	dir := setupTest(t)
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
@@ -1101,7 +1100,7 @@ func TestCmd_Execute_setInput(t *testing.T) {
 
 	outDir := t.TempDir()
 
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
@@ -1117,7 +1116,7 @@ func TestCmd_Execute_setInput(t *testing.T) {
 	if !assert.NoError(t, instance.Execute()) {
 		return
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(outDir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -1130,7 +1129,7 @@ func TestCmd_Execute_enableLogSteps(t *testing.T) {
 	dir := setupTest(t)
 
 	// write a test filter to the directory of configuration
-	if !assert.NoError(t, ioutil.WriteFile(
+	if !assert.NoError(t, os.WriteFile(
 		filepath.Join(dir, "filter.yaml"), []byte(ValueReplacerYAMLData), 0600)) {
 		return
 	}
@@ -1145,7 +1144,7 @@ func TestCmd_Execute_enableLogSteps(t *testing.T) {
 	if !assert.NoError(t, instance.Execute()) {
 		t.FailNow()
 	}
-	b, err := ioutil.ReadFile(
+	b, err := os.ReadFile(
 		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
 	if !assert.NoError(t, err) {
 		t.FailNow()

--- a/kyaml/setters2/add_test.go
+++ b/kyaml/setters2/add_test.go
@@ -4,7 +4,6 @@
 package setters2
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,7 +281,7 @@ func TestAdd_Filter2(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile")
 
 	// write initial resourcefile to temp path
-	err := ioutil.WriteFile(path, []byte(resourcefile), 0666)
+	err := os.WriteFile(path, []byte(resourcefile), 0666)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -311,7 +310,7 @@ func TestAdd_Filter2(t *testing.T) {
 		t.FailNow()
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.FailNow()
 	}
@@ -343,7 +342,7 @@ func TestAddUpdateSubstitution(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile")
 
 	// write initial resourcefile to temp path
-	err := ioutil.WriteFile(path, []byte(resourcefile), 0666)
+	err := os.WriteFile(path, []byte(resourcefile), 0666)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -385,7 +384,7 @@ func TestAddUpdateSubstitution(t *testing.T) {
 		t.FailNow()
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.FailNow()
 	}

--- a/kyaml/setters2/add_test.go
+++ b/kyaml/setters2/add_test.go
@@ -281,7 +281,7 @@ func TestAdd_Filter2(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile")
 
 	// write initial resourcefile to temp path
-	err := os.WriteFile(path, []byte(resourcefile), 0666)
+	err := os.WriteFile(path, []byte(resourcefile), 0644)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -342,7 +342,7 @@ func TestAddUpdateSubstitution(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile")
 
 	// write initial resourcefile to temp path
-	err := os.WriteFile(path, []byte(resourcefile), 0666)
+	err := os.WriteFile(path, []byte(resourcefile), 0644)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/setters2/delete_test.go
+++ b/kyaml/setters2/delete_test.go
@@ -4,7 +4,6 @@
 package setters2
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func TestDelete_Filter2(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile2")
 
 	// write initial resourcefile to temp path
-	err := ioutil.WriteFile(path, []byte(resourcefile2), 0666)
+	err := os.WriteFile(path, []byte(resourcefile2), 0666)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -59,7 +58,7 @@ func TestDelete_Filter2(t *testing.T) {
 		t.FailNow()
 	}
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.FailNow()
 	}

--- a/kyaml/setters2/delete_test.go
+++ b/kyaml/setters2/delete_test.go
@@ -42,7 +42,7 @@ func TestDelete_Filter2(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "resourcefile2")
 
 	// write initial resourcefile to temp path
-	err := os.WriteFile(path, []byte(resourcefile2), 0666)
+	err := os.WriteFile(path, []byte(resourcefile2), 0644)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/setters2/list_test.go
+++ b/kyaml/setters2/list_test.go
@@ -4,7 +4,6 @@
 package setters2
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -253,22 +252,22 @@ spec:
 			// reset the openAPI afterward
 			defer openapi.ResetOpenAPI()
 
-			f, err := ioutil.TempFile("", "k8s-cli-")
+			f, err := os.CreateTemp("", "k8s-cli-")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			defer os.Remove(f.Name())
-			err = ioutil.WriteFile(f.Name(), []byte(test.openapi), 0600)
+			err = os.WriteFile(f.Name(), []byte(test.openapi), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 
-			r, err := ioutil.TempFile("", "k8s-cli-*.yaml")
+			r, err := os.CreateTemp("", "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
 			defer os.Remove(r.Name())
-			err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/setters2/set_test.go
+++ b/kyaml/setters2/set_test.go
@@ -4,7 +4,7 @@
 package setters2
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1003,7 +1003,7 @@ spec:
 func SettersSchema(t *testing.T, s string) *spec.Schema {
 	t.Helper()
 	dir := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(s), 0600)
+	err := os.WriteFile(filepath.Join(dir, "Krmfile"), []byte(s), 0600)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/setters2/settersutil/deletecreator_test.go
+++ b/kyaml/setters2/settersutil/deletecreator_test.go
@@ -4,7 +4,6 @@
 package settersutil
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -43,24 +42,24 @@ spec:
 func TestDeleterCreator_Delete(t *testing.T) {
 	openapi.ResetOpenAPI()
 	defer openapi.ResetOpenAPI()
-	openAPI, err := ioutil.TempFile("", "openAPI.yaml")
+	openAPI, err := os.CreateTemp("", "openAPI.yaml")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 	defer os.Remove(openAPI.Name())
 	// write openapi to temp dir
-	err = ioutil.WriteFile(openAPI.Name(), []byte(openAPIFile), 0666)
+	err = os.WriteFile(openAPI.Name(), []byte(openAPIFile), 0666)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 
 	// write resource file to temp dir
-	resource, err := ioutil.TempFile("", "k8s-cli-*.yaml")
+	resource, err := os.CreateTemp("", "k8s-cli-*.yaml")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 	defer os.Remove(resource.Name())
-	err = ioutil.WriteFile(resource.Name(), []byte(resourceFile), 0666)
+	err = os.WriteFile(resource.Name(), []byte(resourceFile), 0666)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -84,12 +83,12 @@ func TestDeleterCreator_Delete(t *testing.T) {
 		t.FailNow()
 	}
 
-	actualOpenAPI, err := ioutil.ReadFile(openAPI.Name())
+	actualOpenAPI, err := os.ReadFile(openAPI.Name())
 	if err != nil {
 		t.FailNow()
 	}
 
-	actualResource, err := ioutil.ReadFile(resource.Name())
+	actualResource, err := os.ReadFile(resource.Name())
 	if err != nil {
 		t.FailNow()
 	}

--- a/kyaml/setters2/settersutil/deletecreator_test.go
+++ b/kyaml/setters2/settersutil/deletecreator_test.go
@@ -48,7 +48,7 @@ func TestDeleterCreator_Delete(t *testing.T) {
 	}
 	defer os.Remove(openAPI.Name())
 	// write openapi to temp dir
-	err = os.WriteFile(openAPI.Name(), []byte(openAPIFile), 0666)
+	err = os.WriteFile(openAPI.Name(), []byte(openAPIFile), 0644)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -59,7 +59,7 @@ func TestDeleterCreator_Delete(t *testing.T) {
 		t.FailNow()
 	}
 	defer os.Remove(resource.Name())
-	err = os.WriteFile(resource.Name(), []byte(resourceFile), 0666)
+	err = os.WriteFile(resource.Name(), []byte(resourceFile), 0644)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/kyaml/setters2/settersutil/fieldsetter.go
+++ b/kyaml/setters2/settersutil/fieldsetter.go
@@ -4,7 +4,6 @@
 package settersutil
 
 import (
-	"io/ioutil"
 	"os"
 
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -70,7 +69,7 @@ func (fs *FieldSetter) Set() (int, error) {
 		return 0, err
 	}
 
-	curOpenAPI, err := ioutil.ReadFile(fs.OpenAPIPath)
+	curOpenAPI, err := os.ReadFile(fs.OpenAPIPath)
 	if err != nil {
 		return 0, err
 	}
@@ -100,7 +99,7 @@ func (fs *FieldSetter) Set() (int, error) {
 
 	// revert openAPI file if set operation fails
 	if err != nil {
-		if writeErr := ioutil.WriteFile(fs.OpenAPIPath, curOpenAPI, stat.Mode().Perm()); writeErr != nil {
+		if writeErr := os.WriteFile(fs.OpenAPIPath, curOpenAPI, stat.Mode().Perm()); writeErr != nil {
 			return 0, writeErr
 		}
 	}

--- a/kyaml/setters2/settersutil/fieldsetter_test.go
+++ b/kyaml/setters2/settersutil/fieldsetter_test.go
@@ -4,7 +4,7 @@
 package settersutil
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -85,15 +85,15 @@ spec:
 			srcDir := t.TempDir()
 			destDir := t.TempDir()
 
-			err := ioutil.WriteFile(filepath.Join(srcDir, "Krmfile"), []byte(test.srcOpenAPIFile), 0600)
+			err := os.WriteFile(filepath.Join(srcDir, "Krmfile"), []byte(test.srcOpenAPIFile), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			err = ioutil.WriteFile(filepath.Join(destDir, "destFile.yaml"), []byte(test.destFile), 0600)
+			err = os.WriteFile(filepath.Join(destDir, "destFile.yaml"), []byte(test.destFile), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			err = ioutil.WriteFile(filepath.Join(destDir, "Krmfile"), []byte(test.destOpenAPI), 0600)
+			err = os.WriteFile(filepath.Join(destDir, "Krmfile"), []byte(test.destOpenAPI), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -103,7 +103,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualDestFile1, err := ioutil.ReadFile(filepath.Join(destDir, "destFile.yaml"))
+			actualDestFile1, err := os.ReadFile(filepath.Join(destDir, "destFile.yaml"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -111,7 +111,7 @@ spec:
 				t.FailNow()
 			}
 
-			actualDestOpenAPIFile1, err := ioutil.ReadFile(filepath.Join(destDir, "Krmfile"))
+			actualDestOpenAPIFile1, err := os.ReadFile(filepath.Join(destDir, "Krmfile"))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/setters2/settersutil/substitutioncreator.go
+++ b/kyaml/setters2/settersutil/substitutioncreator.go
@@ -5,7 +5,6 @@ package settersutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -85,7 +84,7 @@ func (c SubstitutionCreator) Create() error {
 		return err
 	}
 
-	curOpenAPI, err := ioutil.ReadFile(c.OpenAPIPath)
+	curOpenAPI, err := os.ReadFile(c.OpenAPIPath)
 	if err != nil {
 		return err
 	}
@@ -131,7 +130,7 @@ func (c SubstitutionCreator) Create() error {
 
 	// revert openAPI file if there are cycles detected in created input substitution
 	if err := c.checkForCycles(ext, visited); err != nil {
-		if writeErr := ioutil.WriteFile(c.OpenAPIPath, curOpenAPI, stat.Mode().Perm()); writeErr != nil {
+		if writeErr := os.WriteFile(c.OpenAPIPath, curOpenAPI, stat.Mode().Perm()); writeErr != nil {
 			return writeErr
 		}
 		return err

--- a/kyaml/setters2/util_test.go
+++ b/kyaml/setters2/util_test.go
@@ -5,7 +5,7 @@ package setters2
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -141,7 +141,7 @@ openAPI:
 			openapi.ResetOpenAPI()
 			defer openapi.ResetOpenAPI()
 			dir := t.TempDir()
-			err := ioutil.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.inputOpenAPIfile), 0600)
+			err := os.WriteFile(filepath.Join(dir, "Krmfile"), []byte(test.inputOpenAPIfile), 0600)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -6,8 +6,8 @@ package yaml
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -53,7 +53,7 @@ func Parse(value string) (*RNode, error) {
 // ReadFile parses a single Resource from a yaml file.
 // To parse multiple resources, consider a kio.ByteReader
 func ReadFile(path string) (*RNode, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func WriteFile(node *RNode, path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, []byte(out), 0600)
+	return os.WriteFile(path, []byte(out), 0600)
 }
 
 // UpdateFile reads the file at path, applies the filter to it, and write the result back.

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -66,7 +66,7 @@ func WriteFile(node *RNode, path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(out), 0600)
+	return errors.WrapPrefixf(os.WriteFile(path, []byte(out), 0600), "writing RNode to file")
 }
 
 // UpdateFile reads the file at path, applies the filter to it, and write the result back.

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -10,7 +10,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +77,7 @@ func (p *HelmChartInflationGeneratorPlugin) establishTmpDir() (err error) {
 		// already done.
 		return nil
 	}
-	p.tmpDir, err = ioutil.TempDir("", "kustomize-helm-")
+	p.tmpDir, err = os.MkdirTemp("", "kustomize-helm-")
 	return err
 }
 
@@ -216,7 +215,7 @@ func (p *HelmChartInflationGeneratorPlugin) writeValuesBytes(
 		return "", fmt.Errorf("cannot create tmp dir to write helm values")
 	}
 	path := filepath.Join(p.tmpDir, p.Name+"-kustomize-values.yaml")
-	return path, ioutil.WriteFile(path, b, 0644)
+	return path, os.WriteFile(path, b, 0644)
 }
 
 func (p *HelmChartInflationGeneratorPlugin) cleanup() {

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -215,7 +215,7 @@ func (p *HelmChartInflationGeneratorPlugin) writeValuesBytes(
 		return "", fmt.Errorf("cannot create tmp dir to write helm values")
 	}
 	path := filepath.Join(p.tmpDir, p.Name+"-kustomize-values.yaml")
-	return path, os.WriteFile(path, b, 0644)
+	return path, errors.Wrap(os.WriteFile(path, b, 0644), "failed to write values file")
 }
 
 func (p *HelmChartInflationGeneratorPlugin) cleanup() {

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -5,7 +5,7 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -473,7 +473,7 @@ func TestHelmChartInflationGeneratorWithIncludeCRDs(t *testing.T) {
 
 	// we store this data outside of the _test.go file as its sort of huge
 	// and has backticks, which makes string literals wonky
-	testData, err := ioutil.ReadFile("include_crds_testdata.txt")
+	testData, err := os.ReadFile("include_crds_testdata.txt")
 	if err != nil {
 		t.Error(fmt.Errorf("unable to read test data for includeCRDs: %w", err))
 	}


### PR DESCRIPTION
The only one that is not a direct replacement with exactly the internals of the ioutil function is `os.ReadDir`: https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/io/ioutil/ioutil.go;l=49-81. We were only using that one in two places, one of which is a test and the other of which is a utility (cmd/mdtogo/main.go); I read the surrounding code in both and the replacement seems fine.

This should see the staticcheck linter error all PRs are seeing in CI right now. ~~I'm still looking into why we can't reproduce the linter error locally, and why it started in CI this week on a LOC last modified 4 months ago (and none of the many other places this PR shows we are using deprecated ioutil functions).~~ This started happening when CI upgraded itself to Go 1.19, which contains https://github.com/golang/go/commit/a208aa7f339db75f4b79a61be12616b846477a18, allowing the linter to detect this stdlib deprecation.

Closes https://github.com/kubernetes-sigs/kustomize/issues/4760