### PR TITLE
Attempt to fix remoteload_test flakes and add better errors

### DIFF
--- a/api/internal/git/cloner.go
+++ b/api/internal/git/cloner.go
@@ -22,15 +22,11 @@ func ClonerUsingGitExec(repoSpec *RepoSpec) error {
 	if err = r.run("init"); err != nil {
 		return err
 	}
-	if err = r.run(
-		"remote", "add", "origin", repoSpec.CloneSpec()); err != nil {
-		return err
-	}
 	ref := "HEAD"
 	if repoSpec.Ref != "" {
 		ref = repoSpec.Ref
 	}
-	if err = r.run("fetch", "--depth=1", "origin", ref); err != nil {
+	if err = r.run("fetch", "--depth=1", repoSpec.CloneSpec(), ref); err != nil {
 		return err
 	}
 	if err = r.run("checkout", "FETCH_HEAD"); err != nil {

--- a/api/internal/git/gitrunner.go
+++ b/api/internal/git/gitrunner.go
@@ -46,9 +46,9 @@ func (r gitRunner) run(args ...string) error {
 		cmd.String(),
 		r.duration,
 		func() error {
-			_, err := cmd.CombinedOutput()
+			out, err := cmd.CombinedOutput()
 			if err != nil {
-				return errors.Wrapf(err, "git cmd = '%s'", cmd.String())
+				return errors.Wrapf(err, "git cmd = '%s' failed:\n%s", cmd.String(), string(out))
 			}
 			return err
 		})

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -412,11 +412,11 @@ func (kt *KustTarget) accumulateResources(
 			}
 			ldr, err := kt.ldr.New(path)
 			if err != nil {
-				if kusterr.IsMalformedYAMLError(errF) { // Some error occurred while tyring to decode YAML file
-					return nil, errF
+				if kusterr.IsMalformedYAMLError(err) { // Some error occurred while tyring to decode YAML file
+					return nil, err
 				}
 				return nil, errors.Wrapf(
-					err, "accumulation err='%s'", errF.Error())
+					err, "accumulating remote resource: %s", path)
 			}
 			// store the origin, we'll need it later
 			origin := kt.origin.Copy()

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -412,6 +412,14 @@ func (kt *KustTarget) accumulateResources(
 			}
 			ldr, err := kt.ldr.New(path)
 			if err != nil {
+				if strings.Contains(err.Error(), load.ErrRtNotDir.Error()) { // Was neither a remote resource nor a local directory.
+					if kusterr.IsMalformedYAMLError(errF) {
+						// Some error occurred while tyring to decode YAML file
+						return nil, errF
+					}
+					return nil, errors.Wrapf(
+						err, "accumulation err='%s'", errF.Error())
+				}
 				return nil, errors.Wrapf(
 					err, "accumulating remote resource: %s", path)
 			}

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -412,9 +412,6 @@ func (kt *KustTarget) accumulateResources(
 			}
 			ldr, err := kt.ldr.New(path)
 			if err != nil {
-				if kusterr.IsMalformedYAMLError(err) { // Some error occurred while tyring to decode YAML file
-					return nil, err
-				}
 				return nil, errors.Wrapf(
 					err, "accumulating remote resource: %s", path)
 			}

--- a/api/krusty/remoteload_test.go
+++ b/api/krusty/remoteload_test.go
@@ -105,9 +105,8 @@ func runResourceTests(t *testing.T, cases map[string]*remoteResourceCase) {
 	t.Helper()
 
 	for name, test := range cases {
-		savedTest := test // test assignment changes; need assignment in this scope (iteration) of range
 		t.Run(name, func(t *testing.T) {
-			if savedTest.local && !isLocalEnv(t) {
+			if test.local && !isLocalEnv(t) {
 				t.SkipNow()
 			}
 			configureGitSSHCommand(t)

--- a/api/krusty/remoteload_test.go
+++ b/api/krusty/remoteload_test.go
@@ -26,9 +26,6 @@ import (
 
 const resourcesField = `resources:
 - %s`
-const resourceErrorFormat = "accumulating resources: accumulation err='accumulating resources from '%s': "
-const fileError = "evalsymlink failure"
-const repoFindError = "URL is a git repository"
 
 const multibaseDevExampleBuild = `apiVersion: v1
 kind: Pod
@@ -105,6 +102,8 @@ func isLocalEnv(t *testing.T) bool {
 }
 
 func runResourceTests(t *testing.T, cases map[string]*remoteResourceCase) {
+	t.Helper()
+
 	for name, test := range cases {
 		savedTest := test // test assignment changes; need assignment in this scope (iteration) of range
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Another step in #4640.

This PR attempts to address the flakes, but also adds better error messaging to debug the flakes if they aren't addressed.

**Behavior Change**
It adds better error messaging when remote loading fails. Instead of the previous error:

```
accumulating resources: accumulation err='accumulating resources from 'git@github.com:kubernetes-sigs/kustomiz//examples/multibases/dev': evalsymlink failure on '/private/var/folders/9k/72l1zfg94fl9p5c3jdrv0p_40000gn/T/kustomize-868128946/git@github.com:kubernetes-sigs/kustomiz/examples/multibases/dev' : lstat /private/var/folders/9k/72l1zfg94fl9p5c3jdrv0p_40000gn/T/kustomize-868128946/git@github.com:kubernetes-sigs: no such file or directory': git cmd = '/opt/homebrew/bin/git fetch --depth=1 origin HEAD': exit status 128
```

it will now show the output of the git command that failed as well, something like the below.

```
accumulating resources: accumulating remote resource: git@github.com:kubernetes-sigs/kustomiz//examples/multibases/dev?submodules=0: git cmd = '/opt/homebrew/bin/git fetch --depth=1 git@github.com:kubernetes-sigs/kustomiz.git HEAD' failed:
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
: exit status 128
```

**Test changes**
https://github.com/kubernetes-sigs/kustomize/pull/4615/commits/271f39321865696b43f03405b1380b14126706c3 changed all `assert` uses with `require` to prevent panics. It also had the effect of short-circuiting table tests on error. The first failing test will skip all other tests. I changed some `require` back to `assert` so that they do not panic on error and allow all tests to run.

All tests that load from remotes now either have `ref=v1.0.6` or `submodules=0`, both of which will prevent submodules from being fetched. My suspicion is that this will not completely fix the flakes, but it should make them significantly less frequent. A few repeated CI runs will confirm.

**Results**

I ran the test suite 100 times locally using the following command. They all passed, so I think the tests are no longer flaky.

```sh
for i in {1..100}; do echo "run $i"; go test ./api/krusty -run 'TestRemote*' -count 1; done
```

**CI Results**

As can be seen from [this build](https://github.com/kubernetes-sigs/kustomize/runs/8078341024), tests are still flaky. Interestingly though, multiple tests failed on OS X but didn't fail on Linux. I think we don't want to disable these tests on the Mac build... so back to the drawing board.