### PR TITLE
Added test for .prop files

### DIFF
--- a/api/krusty/propfile_test.go
+++ b/api/krusty/propfile_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"strings"
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// TestPropFile tests including prop files
+func TestPropFile(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	// Creates a prop file with lf linebreaks (default)
+	th.WriteF("testPropLf.prop", `# Comment
+ssl.truststore=/truststore.jks
+ssl.keystore=/keystore.jks
+ssl.keystore.password.file=/password.raw
+`)
+
+	// Creates a prop file with Windows (cr-lf) linebreaks
+	th.WriteF("testPropCrLf.prop", strings.Replace(`# Comment
+ssl.truststore=/truststore.jks
+ssl.keystore=/keystore.jks
+ssl.keystore.password.file=/password.raw
+`, "\n", "\r\n", -1))
+
+	// Create a simple kustomize file which uses the above prop files
+	th.WriteK(".", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: prop
+    files:
+    - testPropLf.prop
+    - testPropCrLf.prop
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+
+	// The test asserts that both prop files (with lf and crlf)
+	// are included the same way
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+data:
+  testPropCrLf.prop: |
+    # Comment
+    ssl.truststore=/truststore.jks
+    ssl.keystore=/keystore.jks
+    ssl.keystore.password.file=/password.raw
+  testPropLf.prop: |
+    # Comment
+    ssl.truststore=/truststore.jks
+    ssl.keystore=/keystore.jks
+    ssl.keystore.password.file=/password.raw
+kind: ConfigMap
+metadata:
+  name: prop-mb4b77m68g
+`)
+}


### PR DESCRIPTION
This PR adds a failing test when a .prop file uses Windows linebreaks (`\r\n`). If that is the case, the file is added a s single string and `\r\n` is placed inside as string as well.
I think it would be better to handle `\r\n` in .prop files the same as `\n`.

Here is the test output for the same prop file, once with `\r\n` and once with `\n`:
```
apiVersion: v1
data:
  testPropCrLf.prop: "# Comment\r\nssl.truststore=/truststore.jks\r\nssl.keystore=/keystore.jks\r\nssl.keystore.password.file=/password.raw\r\n"
  testPropLf.prop: |
    # Comment
    ssl.truststore=/truststore.jks
    ssl.keystore.password.file=/password.raw
kind: ConfigMap
metadata:
  name: prop-747952m9fh
```

One way to fix exactly that would be to modify `api/kv/kv.go` to replace `\r\n` to `\n` directly when appending the value:
`kvs = append(kvs, types.Pair{Key: k, Value: strings.ReplaceAll(string(content), "\r\n", "\n")})`

Replacing that when reading the file would work as well but not for tests, as the tests write the files directly into the fsnode and then the value is just returned without actually reading from a file. So it would need to be added to WriteFile as well. Not sure what would be the best approach.