### PR TITLE
Issue-4292: ConfigMaps items are generated with random order

### DIFF
--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
+
+	gyaml "gopkg.in/yaml.v2"
 )
 
 // Resource is an RNode, representing a Kubernetes Resource Model object,
@@ -361,7 +363,12 @@ func (r *Resource) AsYAML() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return yaml.JSONToYAML(json)
+
+	m := gyaml.MapSlice{}
+	if err := gyaml.Unmarshal(json, &m); err != nil {
+		return nil, err
+	}
+	return gyaml.Marshal(m)
 }
 
 // MustYaml returns YAML or panics.

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -58,6 +58,42 @@ metadata:
 	}
 }
 
+func TestAsYAMLSorted(t *testing.T) {
+	given := factory.FromMap(
+		map[string]interface{}{
+			"configMapGenerator": map[string]interface{}{
+				"literals": map[string]interface{}{
+					"32E0817AE855A845": "foo",
+					"024233B4DFB484FC": "foo",
+					"EE10D2E63AF9F498": "foo",
+					"6E7E3021F1821943": "foo",
+					"FDC41072BFC0BC7F": "foo",
+					"DFD86A289C3857EF": "foo",
+					"0C6B462C403217C4": "foo",
+				},
+			},
+		})
+	expected := `configMapGenerator:
+  literals:
+    024233B4DFB484FC: foo
+    0C6B462C403217C4: foo
+    32E0817AE855A845: foo
+    6E7E3021F1821943: foo
+    DFD86A289C3857EF: foo
+    EE10D2E63AF9F498: foo
+    FDC41072BFC0BC7F: foo
+`
+	t.Logf("%v", given)
+
+	yaml, err := given.AsYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(yaml) != expected {
+		t.Fatalf("--- expected\n%s\n--- got\n%s\n", expected, string(yaml))
+	}
+}
+
 func TestResourceString(t *testing.T) {
 	tests := []struct {
 		in *Resource


### PR DESCRIPTION
Hi everybody,

in this PR I  fixed the Issue #4292. The configMap keys will keep the default order (now they are sorted alphabetically)

Looking forward to your feedback!

Cheers,
Sascha