### PR TITLE
Replacements should throw errors on invalid targets

### DIFF
--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -1198,11 +1198,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deploy1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deploy2
 `,
 			replacements: `replacements:
 - source:
@@ -1216,15 +1211,6 @@ metadata:
     - spec.template.spec.containers
     options:
       create: true
-- source:
-    kind: Pod
-    name: pod
-    fieldPath: spec.containers
-  targets:
-  - select:
-      name: deploy2
-    fieldPaths:
-    - spec.template.spec.containers
 `,
 			expected: `apiVersion: v1
 kind: Pod
@@ -1245,11 +1231,6 @@ spec:
       containers:
       - image: busybox
         name: myapp-container
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: deploy2
 `,
 		},
 		"complex type with delimiter in source": {

--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -6,7 +6,6 @@ package krusty_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
@@ -546,104 +545,4 @@ kind: ConfigMap
 metadata:
   name: red-dc6gc5btkc
 `)
-}
-
-func TestIssue4761_path_not_in_target_with_create_true(t *testing.T) {
-	th := kusttest_test.MakeEnhancedHarness(t)
-	defer th.Reset()
-
-	th.WriteF("resources.yaml", `
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: request-id
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-    - applyTo: NETWORK_FILTER
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-version
-  annotations:
-    config.kubernetes.io/local-config: true
-data:
-  ISTIO_REGEX: '^1\.14.*'
-`)
-
-	th.WriteK(".", `
-resources:
-- resources.yaml
-
-replacements:
-  - source:
-      kind: ConfigMap
-      name: istio-version
-      fieldPath: data.ISTIO_REGEX
-    targets:
-      - select:
-          kind: EnvoyFilter
-        fieldPaths:
-          - spec.configPatches.0.match.proxy.proxyVersion
-          - spec.configPatches.1.match.proxy.proxyVersion
-          - spec.configPatches.2.match.proxy.proxyVersion
-          - spec.configPatches.3.match.proxy.proxyVersion
-        options:
-          create: true
-`)
-
-	err := th.RunWithErr(".", th.MakeDefaultOptions())
-	require.EqualError(t, err, "unable to find or create field spec.configPatches.2.match.proxy.proxyVersion in replacement target")
-}
-
-func TestIssue4761_path_not_in_target_with_create_false(t *testing.T) {
-	th := kusttest_test.MakeEnhancedHarness(t)
-	defer th.Reset()
-
-	th.WriteF("resources.yaml", `
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  name: request-id
-spec:
-  configPatches:
-    - applyTo: NETWORK_FILTER
-    - applyTo: NETWORK_FILTER
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-version
-  annotations:
-    config.kubernetes.io/local-config: true
-data:
-  ISTIO_REGEX: '^1\.14.*'
-`)
-
-	th.WriteK(".", `
-resources:
-- resources.yaml
-
-replacements:
-  - source:
-      kind: ConfigMap
-      name: istio-version
-      fieldPath: data.ISTIO_REGEX
-    targets:
-      - select:
-          kind: EnvoyFilter
-        fieldPaths:
-          - spec.configPatches.0.match.proxy.proxyVersion
-          - spec.configPatches.1.match.proxy.proxyVersion
-          - spec.configPatches.2.match.proxy.proxyVersion
-          - spec.configPatches.3.match.proxy.proxyVersion
-        options:
-          create: false
-`)
-
-	err := th.RunWithErr(".", th.MakeDefaultOptions())
-	require.EqualError(t, err, "unable to find field spec.configPatches.0.match.proxy.proxyVersion in replacement target")
 }


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kustomize/issues/4761
by fixing the panic.

However, I concluded that this is not a true regression, in that the original behaviour was also a bug: we were ignoring replacement specifications that were invalid instead of throwing errors. Specifically, if the given path did not exist and options include `create: false`, we would silently do nothing.

The real fix for the issue author's use case is https://github.com/kubernetes-sigs/kustomize/issues/4561, which I'm also working on and intend to include in the same release if possible.

Please take a look at the commits individually. The fix itself is in the first commit and is a small change. The second commit is a refactor for clarity, since the linter (rightfully) complained that the complexity of this function had grown too high with this PR.