### PR TITLE
Performance fix for fetching previous resource IDs

### DIFF
--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -51,7 +51,7 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 	}
 	meta, err := n.GetMeta()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot parse resource metadata: %w", err)
 	}
 	group, version := resid.ParseGroupVersion(meta.APIVersion)
 	for i := range names {

--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -49,12 +49,12 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 				"number of previous namespaces, " +
 				"number of previous kinds not equal")
 	}
+	meta, err := n.GetMeta()
+	if err != nil {
+		return nil, err
+	}
+	group, version := resid.ParseGroupVersion(meta.APIVersion)
 	for i := range names {
-		meta, err := n.GetMeta()
-		if err != nil {
-			return nil, err
-		}
-		group, version := resid.ParseGroupVersion(meta.APIVersion)
 		gvk := resid.Gvk{
 			Group:   group,
 			Version: version,


### PR DESCRIPTION
Hello,

This PR addresses a performance issue as detailed by @ephesused when finding previous IDs for RNodes - the resource metadata is redundantly parsed inside of a loop. I have seen this simple fix cut my kustomize build time in half compared to a current 4.5.7 build.

Closes #4790 