### PR TITLE
DO NOT MERGE: minimal repro for origin annotation bug

### DIFF
--- a/api/krusty/remoteload_test.go
+++ b/api/krusty/remoteload_test.go
@@ -385,6 +385,33 @@ spec:
 	testRemoteResource(require.New(t), &test)
 }
 
+func TestRemoteResourceAnnoOriginFailing(t *testing.T) {
+	test := remoteResourceCase{
+		kustomization: `
+resources:
+- https://github.com/mightyguava/kustomize-bug.git
+buildMetadata: [originAnnotations]
+`,
+		expected: `apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    config.kubernetes.io/origin: |
+      repo: https://github.com/mightyguava/kustomize-bug.git
+      path: pod.yaml
+  labels:
+    app: myapp
+  name: myapp-pod
+spec:
+  containers:
+  - image: nginx:1.7.9
+    name: nginx
+`,
+	}
+
+	testRemoteResource(require.New(t), &test)
+}
+
 func TestRemoteResourceAsBaseWithAnnoOrigin(t *testing.T) {
 	req := require.New(t)
 


### PR DESCRIPTION
Context: https://github.com/kubernetes-sigs/kustomize/pull/4783#discussion_r973513545

I believe the root cause is this line https://github.com/kubernetes-sigs/kustomize/blob/d6e40a3f6c698c1f22dcbb00173f000a9ff9d2de/api/resource/origin.go#L57. This is where `/notCloned` is trimmed, but this only works if the kustomization is not at the repo root, and has a path.

```
=== RUN   TestRemoteResourceAnnoOriginFailing
    remoteload_test.go:62: 
        	Error Trace:	remoteload_test.go:62
        	            				remoteload_test.go:78
        	            				remoteload_test.go:412
        	Error:      	Not equal: 
        	            	expected: "apiVersion: v1\nkind: Pod\nmetadata:\n  annotations:\n    config.kubernetes.io/origin: |\n      repo: https://github.com/mightyguava/kustomize-bug.git\n      path: pod.yaml\n  labels:\n    app: myapp\n  name: myapp-pod\nspec:\n  containers:\n  - image: nginx:1.7.9\n    name: nginx\n"
        	            	actual  : "apiVersion: v1\nkind: Pod\nmetadata:\n  annotations:\n    config.kubernetes.io/origin: |\n      path: notCloned/pod.yaml\n      repo: https://github.com/mightyguava/kustomize-bug\n  labels:\n    app: myapp\n  name: myapp-pod\nspec:\n  containers:\n  - image: nginx:1.7.9\n    name: nginx\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -5,4 +5,4 @@
        	            	     config.kubernetes.io/origin: |
        	            	-      repo: https://github.com/mightyguava/kustomize-bug.git
        	            	-      path: pod.yaml
        	            	+      path: notCloned/pod.yaml
        	            	+      repo: https://github.com/mightyguava/kustomize-bug
        	            	   labels:
        	Test:       	TestRemoteResourceAnnoOriginFailing
--- FAIL: TestRemoteResourceAnnoOriginFailing (0.64s)
```