### PR TITLE
remove string initialization to eliminate memory allocation in hasher

### DIFF
--- a/api/hasher/hasher.go
+++ b/api/hasher/hasher.go
@@ -7,8 +7,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sort"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // SortArrayAndComputeHash sorts a string array and

--- a/api/hasher/hasher_test.go
+++ b/api/hasher/hasher_test.go
@@ -35,7 +35,13 @@ func TestSortArrayAndComputeHash(t *testing.T) {
 func Test_hex256(t *testing.T) {
 	// hash the empty string to be sure that sha256 is being used
 	expect := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	sum := hex256("")
+	sum := hex256([]byte(""))
+	if expect != sum {
+		t.Errorf("expected hash %q but got %q", expect, sum)
+	}
+
+	// hash the nil slice to be sure that sha256 is being used
+	sum = hex256(nil)
 	if expect != sum {
 		t.Errorf("expected hash %q but got %q", expect, sum)
 	}
@@ -270,7 +276,7 @@ binaryData:
 		if SkipRest(t, c.desc, err, c.err) {
 			continue
 		}
-		if s != c.expect {
+		if string(s) != c.expect {
 			t.Errorf("case %q, expect %q but got %q from encode %#v", c.desc, c.expect, s, c.cmYaml)
 		}
 	}
@@ -330,7 +336,7 @@ data:
 		if SkipRest(t, c.desc, err, c.err) {
 			continue
 		}
-		if s != c.expect {
+		if string(s) != c.expect {
 			t.Errorf("case %q, expect %q but got %q from encode %#v", c.desc, c.expect, s, c.secretYaml)
 		}
 	}


### PR DESCRIPTION
I wrote a simple benchmark test and it shows that less allocation is made:

Before:

![image](https://user-images.githubusercontent.com/12763626/192716020-6cd2b4f3-a6bf-4a2f-bbc8-ab5ac0a59aac.png)

After:

![image](https://user-images.githubusercontent.com/12763626/192716128-7c67891e-0be2-4105-85c1-e5f52eb56efa.png)


Benchmark code:
```go
func BenchmarkHash(b *testing.B) {
	h := &Hasher{}
	node, _ := yaml.Parse(`
apiVersion: v1
kind: Secret
type: my-type
data:
  two: 2
  one: ""
  three: 3`)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		h.Hash(node)
	}
}
```