### PR TITLE
[address #4717] Re-do create template/metadata when using includeTemplates if not present

### DIFF
--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -4,13 +4,13 @@
 package builtinconfig
 
 import (
-	"fmt"
 	"log"
 	"sort"
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 // TransformerConfig holds the data needed to perform transformations.
@@ -111,44 +111,44 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 	merged = &TransformerConfig{}
 	merged.NamePrefix, err = t.NamePrefix.MergeAll(input.NamePrefix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NamePrefix fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge NamePrefix fieldSpec")
 	}
 	merged.NameSuffix, err = t.NameSuffix.MergeAll(input.NameSuffix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameSuffix fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge NameSuffix fieldSpec")
 	}
 	merged.NameSpace, err = t.NameSpace.MergeAll(input.NameSpace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameSpace fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge NameSpace fieldSpec")
 	}
 	merged.CommonAnnotations, err = t.CommonAnnotations.MergeAll(
 		input.CommonAnnotations)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge CommonAnnotations fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge CommonAnnotations fieldSpec")
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge CommonLabels fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge CommonLabels fieldSpec")
 	}
 	merged.TemplateLabels, err = t.TemplateLabels.MergeAll(input.TemplateLabels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge TemplateLabels fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge TemplateLabels fieldSpec")
 	}
 	merged.VarReference, err = t.VarReference.MergeAll(input.VarReference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge VarReference fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge VarReference fieldSpec")
 	}
 	merged.NameReference, err = t.NameReference.mergeAll(input.NameReference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameReference fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge NameReference fieldSpec")
 	}
 	merged.Images, err = t.Images.MergeAll(input.Images)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge Images fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge Images fieldSpec")
 	}
 	merged.Replicas, err = t.Replicas.MergeAll(input.Replicas)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge Replicas fieldSpec: %w", err)
+		return nil, errors.WrapPrefixf(err, "failed to merge Replicas fieldSpec")
 	}
 	merged.sortFields()
 	return merged, nil

--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -18,6 +18,7 @@ type TransformerConfig struct {
 	NameSuffix        types.FsSlice `json:"nameSuffix,omitempty" yaml:"nameSuffix,omitempty"`
 	NameSpace         types.FsSlice `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	CommonLabels      types.FsSlice `json:"commonLabels,omitempty" yaml:"commonLabels,omitempty"`
+	TemplateLabels    types.FsSlice `json:"templateLabels,omitempty" yaml:"templateLabels,omitempty"`
 	CommonAnnotations types.FsSlice `json:"commonAnnotations,omitempty" yaml:"commonAnnotations,omitempty"`
 	NameReference     nbrSlice      `json:"nameReference,omitempty" yaml:"nameReference,omitempty"`
 	VarReference      types.FsSlice `json:"varReference,omitempty" yaml:"varReference,omitempty"`
@@ -60,6 +61,7 @@ func (t *TransformerConfig) sortFields() {
 	sort.Sort(t.NamePrefix)
 	sort.Sort(t.NameSpace)
 	sort.Sort(t.CommonLabels)
+	sort.Sort(t.TemplateLabels)
 	sort.Sort(t.CommonAnnotations)
 	sort.Sort(t.NameReference)
 	sort.Sort(t.VarReference)
@@ -124,6 +126,10 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 		return nil, err
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
+	if err != nil {
+		return nil, err
+	}
+	merged.TemplateLabels, err = t.TemplateLabels.MergeAll(input.TemplateLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"sort"
 
+	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/types"
@@ -110,44 +111,44 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 	merged = &TransformerConfig{}
 	merged.NamePrefix, err = t.NamePrefix.MergeAll(input.NamePrefix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge NamePrefix fieldSpec")
 	}
 	merged.NameSuffix, err = t.NameSuffix.MergeAll(input.NameSuffix)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge NameSuffix fieldSpec")
 	}
 	merged.NameSpace, err = t.NameSpace.MergeAll(input.NameSpace)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge NameSpace fieldSpec")
 	}
 	merged.CommonAnnotations, err = t.CommonAnnotations.MergeAll(
 		input.CommonAnnotations)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge CommonAnnotations fieldSpec")
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge CommonLabels fieldSpec")
 	}
 	merged.TemplateLabels, err = t.TemplateLabels.MergeAll(input.TemplateLabels)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge TemplateLabels fieldSpec")
 	}
 	merged.VarReference, err = t.VarReference.MergeAll(input.VarReference)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge VarReference fieldSpec")
 	}
 	merged.NameReference, err = t.NameReference.mergeAll(input.NameReference)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge NameReference fieldSpec")
 	}
 	merged.Images, err = t.Images.MergeAll(input.Images)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge Images fieldSpec")
 	}
 	merged.Replicas, err = t.Replicas.MergeAll(input.Replicas)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to merge Replicas fieldSpec")
 	}
 	merged.sortFields()
 	return merged, nil

--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -4,10 +4,10 @@
 package builtinconfig
 
 import (
+	"fmt"
 	"log"
 	"sort"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/konfig/builtinpluginconsts"
 	"sigs.k8s.io/kustomize/api/types"
@@ -111,44 +111,44 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 	merged = &TransformerConfig{}
 	merged.NamePrefix, err = t.NamePrefix.MergeAll(input.NamePrefix)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge NamePrefix fieldSpec")
+		return nil, fmt.Errorf("failed to merge NamePrefix fieldSpec: %v", err)
 	}
 	merged.NameSuffix, err = t.NameSuffix.MergeAll(input.NameSuffix)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge NameSuffix fieldSpec")
+		return nil, fmt.Errorf("failed to merge NameSuffix fieldSpec: %v", err)
 	}
 	merged.NameSpace, err = t.NameSpace.MergeAll(input.NameSpace)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge NameSpace fieldSpec")
+		return nil, fmt.Errorf("failed to merge NameSpace fieldSpec: %v", err)
 	}
 	merged.CommonAnnotations, err = t.CommonAnnotations.MergeAll(
 		input.CommonAnnotations)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge CommonAnnotations fieldSpec")
+		return nil, fmt.Errorf("failed to merge CommonAnnotations fieldSpec: %v", err)
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge CommonLabels fieldSpec")
+		return nil, fmt.Errorf("failed to merge CommonLabels fieldSpec: %v", err)
 	}
 	merged.TemplateLabels, err = t.TemplateLabels.MergeAll(input.TemplateLabels)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge TemplateLabels fieldSpec")
+		return nil, fmt.Errorf("failed to merge TemplateLabels fieldSpec: %v", err)
 	}
 	merged.VarReference, err = t.VarReference.MergeAll(input.VarReference)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge VarReference fieldSpec")
+		return nil, fmt.Errorf("failed to merge VarReference fieldSpec: %v", err)
 	}
 	merged.NameReference, err = t.NameReference.mergeAll(input.NameReference)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge NameReference fieldSpec")
+		return nil, fmt.Errorf("failed to merge NameReference fieldSpec: %v", err)
 	}
 	merged.Images, err = t.Images.MergeAll(input.Images)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge Images fieldSpec")
+		return nil, fmt.Errorf("failed to merge Images fieldSpec: %v", err)
 	}
 	merged.Replicas, err = t.Replicas.MergeAll(input.Replicas)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to merge Replicas fieldSpec")
+		return nil, fmt.Errorf("failed to merge Replicas fieldSpec: %v", err)
 	}
 	merged.sortFields()
 	return merged, nil

--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -111,44 +111,44 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 	merged = &TransformerConfig{}
 	merged.NamePrefix, err = t.NamePrefix.MergeAll(input.NamePrefix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NamePrefix fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge NamePrefix fieldSpec: %w", err)
 	}
 	merged.NameSuffix, err = t.NameSuffix.MergeAll(input.NameSuffix)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameSuffix fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge NameSuffix fieldSpec: %w", err)
 	}
 	merged.NameSpace, err = t.NameSpace.MergeAll(input.NameSpace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameSpace fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge NameSpace fieldSpec: %w", err)
 	}
 	merged.CommonAnnotations, err = t.CommonAnnotations.MergeAll(
 		input.CommonAnnotations)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge CommonAnnotations fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge CommonAnnotations fieldSpec: %w", err)
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge CommonLabels fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge CommonLabels fieldSpec: %w", err)
 	}
 	merged.TemplateLabels, err = t.TemplateLabels.MergeAll(input.TemplateLabels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge TemplateLabels fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge TemplateLabels fieldSpec: %w", err)
 	}
 	merged.VarReference, err = t.VarReference.MergeAll(input.VarReference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge VarReference fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge VarReference fieldSpec: %w", err)
 	}
 	merged.NameReference, err = t.NameReference.mergeAll(input.NameReference)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge NameReference fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge NameReference fieldSpec: %w", err)
 	}
 	merged.Images, err = t.Images.MergeAll(input.Images)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge Images fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge Images fieldSpec: %w", err)
 	}
 	merged.Replicas, err = t.Replicas.MergeAll(input.Replicas)
 	if err != nil {
-		return nil, fmt.Errorf("failed to merge Replicas fieldSpec: %v", err)
+		return nil, fmt.Errorf("failed to merge Replicas fieldSpec: %w", err)
 	}
 	merged.sortFields()
 	return merged, nil

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -288,7 +288,7 @@ var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 			} else {
 				// merge spec/template/metadata fieldSpec if includeTemplate flag is true
 				if label.IncludeTemplates {
-					fss, err = fss.MergeOne(types.FieldSpec{Path: "spec/template/metadata/labels", CreateIfNotPresent: false})
+					fss, err = fss.MergeOne(types.FieldSpec{Path: "spec/template/metadata/labels", CreateIfNotPresent: true})
 					if err != nil {
 						return nil, errors.Wrap(err, "failed to merge template fieldSpec")
 					}

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -286,9 +286,9 @@ var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 			if label.IncludeSelectors {
 				fss, err = fss.MergeAll(tc.CommonLabels)
 			} else {
-				// merge spec/template/metadata fieldSpec if includeTemplate flag is true
+				// merge spec/template/metadata fieldSpecs if includeTemplate flag is true
 				if label.IncludeTemplates {
-					fss, err = fss.MergeOne(types.FieldSpec{Path: "spec/template/metadata/labels", CreateIfNotPresent: true})
+					fss, err = fss.MergeAll(tc.TemplateLabels)
 					if err != nil {
 						return nil, errors.Wrap(err, "failed to merge template fieldSpec")
 					}

--- a/api/konfig/builtinpluginconsts/commonlabels.go
+++ b/api/konfig/builtinpluginconsts/commonlabels.go
@@ -5,9 +5,6 @@ package builtinpluginconsts
 
 const commonLabelFieldSpecs = `
 commonLabels:
-- path: metadata/labels
-  create: true
-
 - path: spec/selector
   create: true
   version: v1
@@ -17,17 +14,7 @@ commonLabels:
   create: true
   version: v1
   kind: ReplicationController
-
-- path: spec/template/metadata/labels
-  create: true
-  version: v1
-  kind: ReplicationController
-
 - path: spec/selector/matchLabels
-  create: true
-  kind: Deployment
-
-- path: spec/template/metadata/labels
   create: true
   kind: Deployment
 
@@ -60,24 +47,11 @@ commonLabels:
   create: true
   kind: ReplicaSet
 
-- path: spec/template/metadata/labels
-  create: true
-  kind: ReplicaSet
-
 - path: spec/selector/matchLabels
   create: true
   kind: DaemonSet
 
-- path: spec/template/metadata/labels
-  create: true
-  kind: DaemonSet
-
 - path: spec/selector/matchLabels
-  create: true
-  group: apps
-  kind: StatefulSet
-
-- path: spec/template/metadata/labels
   create: true
   group: apps
   kind: StatefulSet
@@ -107,33 +81,13 @@ commonLabels:
   group: apps
   kind: StatefulSet
 
-- path: spec/volumeClaimTemplates[]/metadata/labels
-  create: true
-  group: apps
-  kind: StatefulSet
-
 - path: spec/selector/matchLabels
   create: false
-  group: batch
-  kind: Job
-
-- path: spec/template/metadata/labels
-  create: true
   group: batch
   kind: Job
 
 - path: spec/jobTemplate/spec/selector/matchLabels
   create: false
-  group: batch
-  kind: CronJob
-
-- path: spec/jobTemplate/metadata/labels
-  create: true
-  group: batch
-  kind: CronJob
-
-- path: spec/jobTemplate/spec/template/metadata/labels
-  create: true
   group: batch
   kind: CronJob
 
@@ -156,4 +110,4 @@ commonLabels:
   create: false
   group: networking.k8s.io
   kind: NetworkPolicy
-`
+` + metadataLabelsFieldSpecs

--- a/api/konfig/builtinpluginconsts/defaultconfig.go
+++ b/api/konfig/builtinpluginconsts/defaultconfig.go
@@ -13,6 +13,7 @@ func GetDefaultFieldSpecs() []byte {
 		[]byte(namePrefixFieldSpecs),
 		[]byte(nameSuffixFieldSpecs),
 		[]byte(commonLabelFieldSpecs),
+		[]byte(templateLabelFieldSpecs),
 		[]byte(commonAnnotationFieldSpecs),
 		[]byte(namespaceFieldSpecs),
 		[]byte(varReferenceFieldSpecs),
@@ -30,6 +31,7 @@ func GetDefaultFieldSpecsAsMap() map[string]string {
 	result["nameprefix"] = namePrefixFieldSpecs
 	result["namesuffix"] = nameSuffixFieldSpecs
 	result["commonlabels"] = commonLabelFieldSpecs
+	result["templatelabels"] = templateLabelFieldSpecs
 	result["commonannotations"] = commonAnnotationFieldSpecs
 	result["namespace"] = namespaceFieldSpecs
 	result["varreference"] = varReferenceFieldSpecs

--- a/api/konfig/builtinpluginconsts/metadatalabels.go
+++ b/api/konfig/builtinpluginconsts/metadatalabels.go
@@ -1,0 +1,51 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package builtinpluginconsts
+
+const metadataLabelsFieldSpecs = `
+- path: metadata/labels
+  create: true
+
+- path: spec/template/metadata/labels
+  create: true
+  version: v1
+  kind: ReplicationController
+
+- path: spec/template/metadata/labels
+  create: true
+  kind: Deployment
+
+- path: spec/template/metadata/labels
+  create: true
+  kind: ReplicaSet
+
+- path: spec/template/metadata/labels
+  create: true
+  kind: DaemonSet
+
+- path: spec/template/metadata/labels
+  create: true
+  group: apps
+  kind: StatefulSet
+
+- path: spec/volumeClaimTemplates[]/metadata/labels
+  create: true
+  group: apps
+  kind: StatefulSet
+
+- path: spec/template/metadata/labels
+  create: true
+  group: batch
+  kind: Job
+
+- path: spec/jobTemplate/metadata/labels
+  create: true
+  group: batch
+  kind: CronJob
+
+- path: spec/jobTemplate/spec/template/metadata/labels
+  create: true
+  group: batch
+  kind: CronJob
+`

--- a/api/konfig/builtinpluginconsts/templatelabels.go
+++ b/api/konfig/builtinpluginconsts/templatelabels.go
@@ -1,0 +1,8 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package builtinpluginconsts
+
+const templateLabelFieldSpecs = `
+templateLabels:
+` + metadataLabelsFieldSpecs

--- a/api/krusty/inlinelabels_test.go
+++ b/api/krusty/inlinelabels_test.go
@@ -224,7 +224,7 @@ spec:
 `)
 }
 
-func TestKustomizationLabelsInTemplateWhenResourceHasNoTemplate(t *testing.T) {
+func TestKustomizationLabelsDoesNotCreateInvalidTemplatePaths(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteF("app/deployment.yaml", `
 apiVersion: apps/v1

--- a/api/krusty/inlinelabels_test.go
+++ b/api/krusty/inlinelabels_test.go
@@ -324,25 +324,16 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: daemon
   name: daemon
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: a
-      app.kubernetes.io/instance: b
-      app.kubernetes.io/name: c
-      app.kubernetes.io/part-of: d
+      app.kubernetes.io/name: daemon
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: daemon
 `)
 	th.WriteK("/app", `
 resources:
@@ -360,26 +351,17 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: daemon
     foo: bar
   name: daemon
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: a
-      app.kubernetes.io/instance: b
-      app.kubernetes.io/name: c
-      app.kubernetes.io/part-of: d
+      app.kubernetes.io/name: daemon
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: daemon
         foo: bar
 `)
 }
@@ -391,27 +373,18 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: set
   name: set
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: a
-      app.kubernetes.io/instance: b
-      app.kubernetes.io/name: c
-      app.kubernetes.io/part-of: d
+      app.kubernetes.io/name: set
   serviceName: set
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: set
 `)
 	th.WriteK("/app", `
 resources:
@@ -429,28 +402,19 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: set
     foo: bar
   name: set
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: a
-      app.kubernetes.io/instance: b
-      app.kubernetes.io/name: c
-      app.kubernetes.io/part-of: d
+      app.kubernetes.io/name: set
   serviceName: set
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: set
         foo: bar
 `)
 }
@@ -462,10 +426,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: job
   name: job
 spec:
   jobTemplate:
@@ -474,10 +435,7 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/component: a
-            app.kubernetes.io/instance: b
-            app.kubernetes.io/name: c
-            app.kubernetes.io/part-of: d
+            app.kubernetes.io/name: job
         spec:
           restartPolicy: Never
   schedule: '* * * * *'
@@ -498,10 +456,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: job
     foo: bar
   name: job
 spec:
@@ -514,10 +469,7 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/component: a
-            app.kubernetes.io/instance: b
-            app.kubernetes.io/name: c
-            app.kubernetes.io/part-of: d
+            app.kubernetes.io/name: job
             foo: bar
         spec:
           restartPolicy: Never
@@ -532,20 +484,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: job
   name: job
 spec:
   backoffLimit: 4
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: job
     spec:
       restartPolicy: Never
 `)
@@ -565,10 +511,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: a
-    app.kubernetes.io/instance: b
-    app.kubernetes.io/name: c
-    app.kubernetes.io/part-of: d
+    app.kubernetes.io/name: job
     foo: bar
   name: job
 spec:
@@ -576,10 +519,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: a
-        app.kubernetes.io/instance: b
-        app.kubernetes.io/name: c
-        app.kubernetes.io/part-of: d
+        app.kubernetes.io/name: job
         foo: bar
     spec:
       restartPolicy: Never


### PR DESCRIPTION
Hi all, I'm attempting to re-do #4751 to fix #4717, I added a new test to reproduce the bug the old PR had.

It's not clear to me how can I add resource-specific fieldspecs for the `includeTemplates` flag in the labels plugin (as @KnVerey and @wolfmah mentioned [here](https://github.com/kubernetes-sigs/kustomize/pull/4751#issuecomment-1211073634) and [here](https://github.com/kubernetes-sigs/kustomize/pull/4751#issuecomment-1211125254)), can anyone provide some guidance?

Thanks! 