### PR TITLE
Add support for helm --no-hooks flag

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -282,6 +282,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.IncludeCRDs {
 		args = append(args, "--include-crds")
 	}
+	if p.SkipHooks {
+		args = append(args, "--no-hooks")
+	}
 	return args
 }
 

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -72,6 +72,10 @@ type HelmChart struct {
 	// IncludeCRDs specifies if Helm should also generate CustomResourceDefinitions.
 	// Defaults to 'false'.
 	IncludeCRDs bool `json:"includeCRDs,omitempty" yaml:"includeCRDs,omitempty"` //nolint: tagliatelle
+
+	// SkipHooks sets the --no-hooks flag when calling helm template. This prevents
+	// helm from erroneously rendering test templates.
+	SkipHooks bool `json:"skipHooks,omitempty" yaml:"skipHooks,omitempty"`
 }
 
 // HelmChartArgs contains arguments to helm.

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -287,6 +287,9 @@ func (p *HelmChartInflationGeneratorPlugin) templateCommand() []string {
 	if p.IncludeCRDs {
 		args = append(args, "--include-crds")
 	}
+	if p.SkipHooks {
+		args = append(args, "--no-hooks")
+	}
 	return args
 }
 

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -526,6 +526,34 @@ valuesInline:
 	th.AssertActualEqualsExpected(rm, "")
 }
 
+func TestHelmChartInflationGeneratorWithSkipHooks(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	// we choose this helm chart as it has the ability to turn
+	// everything off, except CRDs.
+	rm := th.LoadAndRunGenerator(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: terraform
+name: terraform
+version: 1.0.0
+repo: https://helm.releases.hashicorp.com
+releaseName: terraforming-mars
+includeCRDs: false
+skipHooks: true
+valuesInline:
+  global:
+    enabled: false
+`)
+	th.AssertActualEqualsExpected(rm, "")
+}
+
 func TestHelmChartInflationGeneratorWithIncludeCRDsNotSpecified(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
 		PrepBuiltin("HelmChartInflationGenerator")


### PR DESCRIPTION
This commit adds the `skipHooks` option to the helm chart support in order
to  expose the --no-hooks flag introduced to Helm in [1].

Using Kustomize to inflate a Helm chart would in some situations result in
different results than using `helm install`. This is because `helm
template`, by default, will render chart tests in the `templates/test`
directory, which can lead to undesired resources in the output.

See [2] for additional discussion.

[1]: https://github.com/helm/helm/pull/6444
[2]: https://github.com/helm/helm/issues/6443

Signed-off-by: Lars Kellogg-Stedman <lars@oddbit.com>
