### PR TITLE
convert PrevIds to use apiVersion instead meta

### DIFF
--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -49,11 +49,8 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 				"number of previous namespaces, " +
 				"number of previous kinds not equal")
 	}
-	meta, err := n.GetMeta()
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse resource metadata: %w", err)
-	}
-	group, version := resid.ParseGroupVersion(meta.APIVersion)
+	apiVersion := n.GetApiVersion()
+	group, version := resid.ParseGroupVersion(apiVersion)
 	for i := range names {
 		gvk := resid.Gvk{
 			Group:   group,


### PR DESCRIPTION
Since PrevIds uses only the apiVersion information from the metadata, change the retrieval from the full meta to just the apiVersion.

Since PrevIds is a heavily-used function, this change yields a meaningful performance improvement.

Closes #4793