### PR TITLE
optimize RNode.GetAnnotations and RNode.GetLabels

### DIFF
--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -35,7 +35,10 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 	var ids []resid.ResId
 	// TODO: merge previous names and namespaces into one list of
 	//     pairs on one annotation so there is no chance of error
-	annotations := n.GetAnnotations()
+	annotations := n.GetAnnotations(
+		BuildAnnotationPreviousNames,
+		BuildAnnotationPreviousNamespaces,
+		BuildAnnotationPreviousKinds)
 	if _, ok := annotations[BuildAnnotationPreviousNames]; !ok {
 		return nil, nil
 	}

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -569,17 +569,9 @@ func fieldsAsStringMapAll(n *yaml.Node) map[string]string {
 func fieldsAsStringMapSome(n *yaml.Node, fields ...string) map[string]string {
 	size := len(fields)
 	result := make(map[string]string, size)
-	isMatchFn := func(checkKey string) bool {
-		for _, desiredKey := range fields {
-			if checkKey == desiredKey {
-				return true
-			}
-		}
-		return false
-	}
 	for i := 0; i < len(n.Content); i = i + 2 {
 		key := n.Content[i].Value
-		if isMatchFn(key) {
+		if sliceutil.Contains(fields, key) {
 			result[key] = n.Content[i+1].Value
 			if len(result) >= size {
 				break


### PR DESCRIPTION
Convert GetAnnotations and GetLabels so they create fewer new objects and so they can restrict to just a few desired fields. Adjust PrevIds to use the new support, reducing memory use and execution time.

Currently GetAnnotations (and GetLabels) work through VisitFields, which creates a new object (via Field) for every iterated entry. Field creates a MapNode that houses a new RNode for both a key and a value. Optimizing to avoid new object creation and to restrict to only the desired annotations, there can be a significant performance improvement in both run time and memory use.

I use three test cases to determine where to focus for performance improvements. One test case (ds) is a moderately sized and has a somewhat simple set of kustomizations. One (na) is very large and has a complex set of kustomizations. One (ro) is a large set of resources, with no kustomizations - it's just a resource load. Using go's profiling tools, here's how things look with the current master (482e8930) and with this PR (9b54511d):

```
CPU
ds-cpu-482e8930.svg: Duration: 13.74s, Total samples = 14.77s (107.46%)
ds-cpu-9b54511d.svg: Duration: 11.39s, Total samples = 11.09s (97.36%)
na-cpu-482e8930.svg: Duration: 199.52s, Total samples = 219.34s (109.94%)
na-cpu-9b54511d.svg: Duration: 121.82s, Total samples = 131.10s (107.62%)
ro-cpu-482e8930.svg: Duration: 46.25s, Total samples = 50.10s (108.31%)
ro-cpu-9b54511d.svg: Duration: 13.13s, Total samples = 10.51s (80.06%)

Memory
ds-mem-482e8930.svg: Showing nodes accounting for 5930.56MB, 75.27% of 7878.98MB total
ds-mem-9b54511d.svg: Showing nodes accounting for 3596.07MB, 68.12% of 5279.01MB total
na-mem-482e8930.svg: Showing nodes accounting for 114155.51MB, 88.59% of 128855.94MB total
na-mem-9b54511d.svg: Showing nodes accounting for 52626.53MB, 81.43% of 64625.14MB total
ro-mem-482e8930.svg: Showing nodes accounting for 26620.80MB, 97.01% of 27440.78MB total
ro-mem-9b54511d.svg: Showing nodes accounting for 2102.33MB, 80.63% of 2607.53MB total
```