### PR TITLE
preallocate memory

### DIFF
--- a/kyaml/sets/string.go
+++ b/kyaml/sets/string.go
@@ -10,7 +10,7 @@ func (s String) Len() int {
 }
 
 func (s String) List() []string {
-	var val []string
+	val := make([]string, 0, len(s))
 	for k := range s {
 		val = append(val, k)
 	}

--- a/kyaml/yaml/filters.go
+++ b/kyaml/yaml/filters.go
@@ -68,7 +68,7 @@ func (y *YFilter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type YFilters []YFilter
 
 func (y YFilters) Filters() []Filter {
-	var f []Filter
+	f := make([]Filter, 0, len(y))
 	for i := range y {
 		f = append(f, y[i].Filter)
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

Preallocate memory instead of enforcing an incremental growth. This will result in less work for the garbage collector.