### PR TITLE
api/resource: retain disableNameSuffixHash on merge and replace

### DIFF
--- a/api/krusty/generatormergeandreplace_test.go
+++ b/api/krusty/generatormergeandreplace_test.go
@@ -339,6 +339,8 @@ configMapGenerator:
   behavior: replace
   literals:
   - foo=override-bar
+  options:
+    disableNameSuffixHash: true
 secretGenerator:
 - name: secret-in-base
   behavior: merge
@@ -389,7 +391,7 @@ spec:
           name: staging-configmap-in-overlay-dc6fm46dhm
         name: configmap-in-overlay
       - configMap:
-          name: staging-team-foo-configmap-in-base-hc6g9dk6g9
+          name: staging-team-foo-configmap-in-base
         name: configmap-in-base
 ---
 apiVersion: v1
@@ -424,7 +426,7 @@ metadata:
     env: staging
     org: example.com
     team: override-foo
-  name: staging-team-foo-configmap-in-base-hc6g9dk6g9
+  name: staging-team-foo-configmap-in-base
 ---
 apiVersion: v1
 data:

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -164,10 +164,17 @@ func (r *Resource) CopyMergeMetaDataFieldsFrom(other *Resource) error {
 		mergeStringMaps(other.GetLabels(), r.GetLabels())); err != nil {
 		return fmt.Errorf("copyMerge cannot set labels - %w", err)
 	}
-	if err := r.SetAnnotations(
-		mergeStringMapsWithBuildAnnotations(other.GetAnnotations(), r.GetAnnotations())); err != nil {
+
+	ra := r.GetAnnotations()
+	_, enableNameSuffixHash := ra[utils.BuildAnnotationsGenAddHashSuffix]
+	merged := mergeStringMapsWithBuildAnnotations(other.GetAnnotations(), ra)
+	if !enableNameSuffixHash {
+		delete(merged, utils.BuildAnnotationsGenAddHashSuffix)
+	}
+	if err := r.SetAnnotations(merged); err != nil {
 		return fmt.Errorf("copyMerge cannot set annotations - %w", err)
 	}
+
 	if err := r.SetName(other.GetName()); err != nil {
 		return fmt.Errorf("copyMerge cannot set name - %w", err)
 	}


### PR DESCRIPTION
The generator option `disableNameSuffixHash` being set to true for a given generator which merges or replaces its contents into an imported generator was not being retained.

Handles #4693.