### PR TITLE
WIP Add --skip-validation flag to edit add resource

### DIFF
--- a/kustomize/commands/edit/add/addresource.go
+++ b/kustomize/commands/edit/add/addresource.go
@@ -16,6 +16,7 @@ import (
 
 type addResourceOptions struct {
 	resourceFilePaths []string
+	skipValidation    bool
 }
 
 // newCmdAddResource adds the name of a file containing a resource to the kustomization file.
@@ -35,6 +36,12 @@ func newCmdAddResource(fSys filesys.FileSystem) *cobra.Command {
 			return o.RunAddResource(fSys)
 		},
 	}
+	cmd.Flags().BoolVar(
+		&o.skipValidation,
+		"skip-validation",
+		false,
+		"Skip resources validation",
+	)
 	return cmd
 }
 
@@ -49,7 +56,7 @@ func (o *addResourceOptions) Validate(args []string) error {
 
 // RunAddResource runs addResource command (do real work).
 func (o *addResourceOptions) RunAddResource(fSys filesys.FileSystem) error {
-	resources, err := util.GlobPatternsWithLoader(fSys, loader.NewFileLoaderAtCwd(fSys), o.resourceFilePaths)
+	resources, err := util.GlobPatternsWithLoader(fSys, loader.NewFileLoaderAtCwd(fSys), o.resourceFilePaths, o.skipValidation)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This very early proposal to address #3276.

Current behavior for `kustomize edit add resource <pattern>`:
- it tries to `fSys.Glob(pattern)`, if it finds files, it stops there
- if it doesn't find any files, it tries to `ldr.New(pattern)` which will fail if `<pattern>` is an inaccessible remote repository

Proposed behavior for `kustomize edit add resource <pattern> --skip-validation`:
- it tries to `fSys.Glob(pattern)`, if it finds files, it stops there
- if it doesn't find any files, it tries to `ldr.New(pattern)` **unless** the `--skip-validation` flag is passed (in which case it just adds the pattern to the list of results)

This is my first contribution here and I wanted to gather feedback with this very-drafty PR before going further.
Please let me know what you think. Thanks!