### PR TITLE
handle generateName as a replacement of name in ObjectMeta v1

### DIFF
--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -402,8 +402,13 @@ func (f Filter) confirmNodeMatchesReferrer(node *yaml.RNode) error {
 		return err
 	}
 	if err = checkEqual(
-		"Name", meta.Name, f.Referrer.GetName()); err != nil {
-		return err
+		"generateName",
+		meta.GenerateName,
+		f.Referrer.GetGenerateName()); err != nil {
+		if err = checkEqual(
+			"Name", meta.Name, f.Referrer.GetName()); err != nil {
+			return err
+		}
 	}
 	if err = checkEqual(
 		"Namespace", meta.Namespace, f.Referrer.GetNamespace()); err != nil {

--- a/api/krusty/generatename_test.go
+++ b/api/krusty/generatename_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// Coverage for issue #641
+func TestGenerateName(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteK(".", `
+resources:
+- job.yaml
+namePrefix: pre-
+nameSuffix: -post
+`)
+	th.WriteF("job.yaml", `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - name: job
+        image: run/job:1.0
+        command:
+        - echo
+        - done
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
+`)
+}

--- a/api/krusty/resourceconflict_test.go
+++ b/api/krusty/resourceconflict_test.go
@@ -13,12 +13,28 @@ import (
 func writeBase(th kusttest_test.Harness) {
 	th.WriteK("base", `
 resources:
+- job.yaml
 - serviceaccount.yaml
 - rolebinding.yaml
 - clusterrolebinding.yaml
 - clusterrole.yaml
 namePrefix: pfx-
 nameSuffix: -sfx
+`)
+	th.WriteF("base/job.yaml", `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - name: job
+        image: run/job:1.0
+        command:
+        - echo
+        - done
 `)
 	th.WriteF("base/serviceaccount.yaml", `
 apiVersion: v1
@@ -94,6 +110,20 @@ func TestBase(t *testing.T) {
 	writeBase(th)
 	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -145,6 +175,20 @@ func TestMidLevelA(t *testing.T) {
 	writeMidOverlays(th)
 	m := th.Run("overlays/a", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -196,6 +240,20 @@ func TestMidLevelB(t *testing.T) {
 	writeMidOverlays(th)
 	m := th.Run("overlays/b", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -248,6 +306,20 @@ func TestMultibasesNoConflict(t *testing.T) {
 	writeTopOverlay(th)
 	m := th.Run("combined", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -290,6 +362,20 @@ rules:
   - get
   - watch
   - list
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - echo
+        - done
+        image: run/job:1.0
+        name: job
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/kyaml/yaml/const.go
+++ b/kyaml/yaml/const.go
@@ -18,13 +18,14 @@ const (
 
 // Field names
 const (
-	AnnotationsField = "annotations"
-	APIVersionField  = "apiVersion"
-	KindField        = "kind"
-	MetadataField    = "metadata"
-	DataField        = "data"
-	BinaryDataField  = "binaryData"
-	NameField        = "name"
-	NamespaceField   = "namespace"
-	LabelsField      = "labels"
+	AnnotationsField  = "annotations"
+	APIVersionField   = "apiVersion"
+	KindField         = "kind"
+	MetadataField     = "metadata"
+	DataField         = "data"
+	BinaryDataField   = "binaryData"
+	NameField         = "name"
+	GenerateNameField = "generateName"
+	NamespaceField    = "namespace"
+	LabelsField       = "labels"
 )

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -443,12 +443,11 @@ func (rn *RNode) GetGenerateName() string {
 // field not found.  The setter is more restrictive.
 func (rn *RNode) GetName() string {
 	name := rn.getMetaStringField(NameField)
-	if name == "" {
+	if name == "" && rn.GetGenerateName() != "" {
 		data := rn.MustString()
 		suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
 
 		name = fmt.Sprintf("%s[%s]", rn.GetGenerateName(), suffix[:10])
-
 	}
 
 	return name

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -4,6 +4,7 @@
 package yaml
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -432,10 +433,25 @@ func (rn *RNode) getMapFieldValue(field string) *yaml.Node {
 	return nil
 }
 
+// GetGenerateName returns the name, or empty string if
+// field not found.  The setter is more restrictive.
+func (rn *RNode) GetGenerateName() string {
+	return rn.getMetaStringField(GenerateNameField)
+}
+
 // GetName returns the name, or empty string if
 // field not found.  The setter is more restrictive.
 func (rn *RNode) GetName() string {
-	return rn.getMetaStringField(NameField)
+	name := rn.getMetaStringField(NameField)
+	if name == "" {
+		data := rn.MustString()
+		suffix := fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+
+		name = fmt.Sprintf("%s[%s]", rn.GetGenerateName(), suffix[:10])
+
+	}
+
+	return name
 }
 
 // getMetaStringField returns the value of a string field in metadata.

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -293,6 +293,10 @@ func (rn *RNode) GetMeta() (ResourceMeta, error) {
 		m.Name = f.Value.YNode().Value
 		missingMeta = false
 	}
+	if f := meta.Field(GenerateNameField); !f.IsNilOrEmpty() {
+		m.GenerateName = f.Value.YNode().Value
+		missingMeta = false
+	}
 	if f := meta.Field(NamespaceField); !f.IsNilOrEmpty() {
 		m.Namespace = GetValue(f.Value)
 		missingMeta = false
@@ -1071,7 +1075,7 @@ func (rn *RNode) GetValidatedMetadata() (ResourceMeta, error) {
 		// A list doesn't require a name.
 		return m, nil
 	}
-	if m.NameMeta.Name == "" {
+	if m.NameMeta.Name == "" && m.NameMeta.GenerateName == "" {
 		return m, fmt.Errorf("missing metadata.name in object %v", m)
 	}
 	return m, nil

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -1076,7 +1076,10 @@ func (rn *RNode) GetValidatedMetadata() (ResourceMeta, error) {
 		return m, nil
 	}
 	if m.NameMeta.Name == "" && m.NameMeta.GenerateName == "" {
-		return m, fmt.Errorf("missing metadata.name in object %v", m)
+		return m, fmt.Errorf(
+			"missing metadata.name or metadata.generateName in object %v",
+			m,
+		)
 	}
 	return m, nil
 }

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -406,6 +406,28 @@ func TestRNodeGetValidatedMetadata(t *testing.T) {
 				errMsg: "missing metadata.name",
 			},
 		},
+		"generateNameConfigMap": {
+			theMap: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"generateName": "winnie-",
+				},
+			},
+			rsExp: resultExpected{
+				out: ResourceMeta{
+					TypeMeta: TypeMeta{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+					},
+					ObjectMeta: ObjectMeta{
+						NameMeta: NameMeta{
+							GenerateName: "winnie-",
+						},
+					},
+				},
+			},
+		},
 		"configmap": {
 			theMap: testConfigMap,
 			rsExp: resultExpected{

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -131,6 +131,8 @@ type TypeMeta struct {
 type NameMeta struct {
 	// Name is the metadata.name field of a Resource
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// GenerateName is the metadata.generateName field of a Resource if metadata.name is not set
+	GenerateName string `json:"generateName,omitempty" yaml:"generateName,omitempty"`
 	// Namespace is the metadata.namespace field of a Resource
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }


### PR DESCRIPTION
Fixes #641 

As per Kubernetes API, ObjectMeta v1 has a "generateName" field which is used by the server as a prefix to make the object's final name from. This field is consumed only when "name" field is not provided. See: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency

This change makes kyaml understand "generateName", and honoring this field if "name" is not specified.