### PR TITLE
Update golangci-lint version (1.49.0 -> 1.50.1) and enable linters: dupword and testableexamples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - dupword
     - durationcheck
     - errcheck
     - errname
@@ -74,6 +75,7 @@ linters:
     - tagliatelle
     - tenv
     - testpackage
+    - testableexamples
     - thelper
     - tparallel
     - typecheck
@@ -88,7 +90,7 @@ linters:
     - asasalint
     - usestdlibvars
     - interfacebloat
-    - logrlint
+    - loggercheck
     - reassign
 
 linters-settings:

--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -1,7 +1,7 @@
 # Copyright 2022 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-GOLANGCI_LINT_VERSION=v1.49.0
+GOLANGCI_LINT_VERSION=v1.50.1
 
 MYGOBIN = $(shell go env GOBIN)
 ifeq ($(MYGOBIN),)

--- a/cmd/pluginator/internal/krmfunction/converter.go
+++ b/cmd/pluginator/internal/krmfunction/converter.go
@@ -108,6 +108,7 @@ func (c *Converter) prepareWrapper(content string) string {
 		}
 		// assign to plugin variable
 		if strings.TrimSpace(line) == "var plugin resmap.Configurable" {
+			//nolint:dupword
 			line += `
 	// KustomizePlugin is a global variable defined in every plugin
 	plugin = &KustomizePlugin

--- a/kyaml/filesys/util.go
+++ b/kyaml/filesys/util.go
@@ -93,7 +93,7 @@ func PathJoin(incoming []string) string {
 //     relative paths; if it weren't, this function could convert absolute
 //     paths to relative paths, which is not desirable.
 //
-//   - For robustness (liberal input, conservative output) Pos values that
+//   - For robustness (liberal input, conservative output) Pos values
 //     that are too small (large) to index the split filepath result in a
 //     prefix (postfix) rather than an error.  Use extreme position values
 //     to assure a prefix or postfix (e.g. 0 will always prefix, and


### PR DESCRIPTION
* Update golangci-lint version from 1.49.0 -> 1.50.1
* In golangci-lint 1.50.0 logrlint was renamed loggercheck. Referencehttps://github.com/golangci/golangci-lint/releases/tag/v1.50.0
* Enable new linters: dupword and testableexamples introduced in 1.50.0