### PR TITLE
POC to fix `RepoSpec` bugs

### DIFF
--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -38,7 +38,11 @@ func TestNewRepoSpecFromUrl_Permute(t *testing.T) {
 		{
 			raw:        "git@gitlab.com:",
 			normalized: "git@gitlab.com:",
-			skip:       "incorrectly looks for / as end of host instead of : for relative non-github ssh urls"},
+		},
+		{
+			raw:        "ssh://git@gitlab.com/",
+			normalized: "ssh://git@gitlab.com/",
+		},
 	}
 	var orgRepos = []string{"someOrg/someRepo", "kubernetes/website"}
 	var pathNames = []string{"README.md", "foo/krusty.txt", ""}
@@ -106,6 +110,7 @@ func TestNewRepoSpecFromUrlErrors(t *testing.T) {
 		{"htxxxtp://github.com/", "url lacks host"},
 		{"ssh://git.example.com", "url lacks orgRepo"},
 		{"git::___", "url lacks orgRepo"},
+		{"https://github.com/org/repo//..", "path traverses outside of repo"},
 	}
 
 	for _, testCase := range badData {
@@ -131,6 +136,18 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 		absPath   string
 		skip      string
 	}{
+		{
+			name:      "t0",
+			input:     "https://github.com/someorg/somerepo?ref=group/version",
+			cloneSpec: "https://github.com/someorg/somerepo.git",
+			absPath:   notCloned.String(),
+			repoSpec: RepoSpec{
+				Host:      "https://github.com/",
+				OrgRepo:   "someorg/somerepo",
+				Ref:       "group/version",
+				GitSuffix: ".git",
+			},
+		},
 		{
 			name:      "t1",
 			input:     "https://git-codecommit.us-east-2.amazonaws.com/someorg/somerepo/somedir",


### PR DESCRIPTION
This is a POC to address `RepoSpec` bugs resulting in skipped tests in [`localize`](https://github.com/kubernetes-sigs/kustomize/pull/4797). Specifically, the tests are in [util_test.go](https://github.com/kubernetes-sigs/kustomize/pull/4797/files#diff-5ee09843ce74bb0d4fe70117eea3f48c966068a345f9e2d5b5b8cc1d0dcc54d1) and [remotelocalizer_test.go](https://github.com/kubernetes-sigs/kustomize/pull/4797/files#diff-5bce8892c5c28e9ea5ca5ee37a1f2a74e63b9499656c9616df78d8b7ea23e5f1).

A summary of the bugs are below:
* `RepoSpec` parses "ssh://git@" as host for non-github ssh urls like `ssh://git@gitlab.com/org/repo`
* `RepoSpec` includes org in host for non-github relative ssh urls like `git@gitlab.com:org/repo`
* `RepoSpec` includes `ref` in path for urls that have a slash in `ref` and fewer than 2 slashes in path like `https://github.com/org/repo?ref=group/kind`
* `RepoSpec` accepts paths that exit repo