### PR TITLE
enable file transfer for the sake of testing

### DIFF
--- a/api/krusty/remoteloader_test.go
+++ b/api/krusty/remoteloader_test.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+const XdgConfigHome = "XDG_CONFIG_HOME"
+
 func TestRemoteLoad_LocalProtocol(t *testing.T) {
 	type testRepos struct {
 		root          string
@@ -58,6 +60,13 @@ export GIT_AUTHOR_EMAIL=nobody@kustomize.io
 export GIT_AUTHOR_NAME=Nobody
 export GIT_COMMITTER_EMAIL=nobody@kustomize.io
 export GIT_COMMITTER_NAME=Nobody
+export XDG_CONFIG_HOME="$ROOT"
+
+mkdir $XDG_CONFIG_HOME/git
+cat <<GitConfig > $XDG_CONFIG_HOME/git/config
+[protocol "file"]
+	allow=always
+GitConfig
 
 cp -r testdata/remoteload/simple $ROOT/simple.git
 (
@@ -264,6 +273,9 @@ resources:
 		},
 	}
 
+	xdgConfigHome := os.Getenv(XdgConfigHome)
+	os.Setenv(XdgConfigHome, repos.root)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.skip {
@@ -287,6 +299,8 @@ resources:
 			}
 		})
 	}
+
+	os.Setenv(XdgConfigHome, xdgConfigHome)
 }
 
 func TestRemoteLoad_RemoteProtocols(t *testing.T) {


### PR DESCRIPTION
This change fixes an `api/krusty` test, which broke recently due to a security patch for [CVE-2022-39253](https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253)  in git v2.38.1, also backported to v2.30.6, v2.31.5, v2.32.4, v2.33.5, v2.34.5, v2.35.5, v2.36.3, and v2.37.4.

We have two options: remove the offending test, as it's considered being unsafe, or, we can play along, enabling this feature.

This patch certainly does the latter, but I'd understand if the decision was to delete the unsafe scenario.