### PR TITLE
remove PSP as v1.25 remove it

### DIFF
--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -26,8 +26,7 @@ interpreted as described in [RFC 2119][2].
 KRM functions enable shift-left practices (client-side) through:
 
 - Pre-commit / delivery validation and linting of configuration
-  - e.g. Fail if any containers don't have PodSecurityPolicy or CPU / Memory
-    limits
+  - e.g. Fail if any containers don't have CPU / Memory limits
 - Implementation of abstractions as client actuated APIs
   - e.g. Create a client-side _"CRD"_ for generating configuration checked into
     git

--- a/cmd/config/internal/generateddocs/api/docs.go
+++ b/cmd/config/internal/generateddocs/api/docs.go
@@ -255,7 +255,7 @@ interpreted as described in [RFC 2119][2].
 
 
 - Pre-commit / delivery validation and linting of configuration
-  - e.g. Fail if any containers don't have PodSecurityPolicy or CPU / Memory limits
+  - e.g. Fail if any containers don't have CPU / Memory limits
 - Implementation of abstractions as client actuated APIs (e.g. templating)
   - e.g. Create a client-side _"CRD"_ for generating configuration checked into git
 - Aspect Orient configuration / Injection of cross-cutting configuration

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -104,7 +104,7 @@ var precomputedIsNamespaceScoped = map[yaml.TypeMeta]bool{
 	{APIVersion: "node.k8s.io/v1beta1", Kind: "RuntimeClass"}:                                    false,
 	{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"}:                                       true,
 	{APIVersion: "policy/v1beta1", Kind: "PodDisruptionBudget"}:                                  true,
-	{APIVersion: "policy/v1beta1", Kind: "PodSecurityPolicy"}:                                    false,
+	{APIVersion: "policy/v1beta1", Kind: "PodSecurityPolicy"}:                                    false, // remove after openapi upgrades to v1.25.
 	{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"}:                            false,
 	{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"}:                     false,
 	{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"}:                                   true,


### PR DESCRIPTION
See more in https://github.com/kubernetes/kubernetes/pull/113467

PodSecurityPolicy was removed since v1.25 Kuberentes.