### PR TITLE
Added architecture aarch64 for installation script

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -104,7 +104,7 @@ elif [[ "$OSTYPE" == darwin* ]]; then
   opsys=darwin
 fi
 
-# Supported values of 'arch': amd64, arm64, ppc64le, s390x
+# Supported values of 'arch': amd64, arm64, aarch64, ppc64le, s390x
 case $(uname -m) in
 x86_64)
     arch=amd64

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -112,6 +112,9 @@ x86_64)
 arm64)
     arch=arm64
     ;;
+aarch64)
+    arch=arm64
+    ;;
 ppc64le)
     arch=ppc64le
     ;;


### PR DESCRIPTION
Can happen when using docker on apple silicon, but  probably also on any Linux on arm 64bit. Without this, it defaulted to amd64, which didn't work.