### PR TITLE
Implement `localizer` skeleton for `kustomize localize`

### DIFF
--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -27,7 +27,7 @@ type Localizer struct {
 	rFactory  *resmap.Factory
 	pLdr      *plgnsLdr.Loader
 
-	// should be LocLoader
+	// underlying type is LocLoader
 	ldr ifc.Loader
 
 	// destination directory in newDir that mirrors ldr's current root.
@@ -63,7 +63,7 @@ func (lc *Localizer) Localize() error {
 		return errors.Wrap(err)
 	}
 
-	kust, err := lc.processKust(kt)
+	kust, err := processKustFn(lc, kt)
 	if err != nil {
 		return err
 	}
@@ -78,8 +78,9 @@ func (lc *Localizer) Localize() error {
 	return nil
 }
 
-// processKust returns a copy of the kustomization at the KustTarget with all paths localized.
-func (lc *Localizer) processKust(_ *target.KustTarget) (*types.Kustomization, error) {
-	// TODO(annasong): Implement
+// TODO(annasong): test only, will be replaced by Localizer.processKust
+var processKustFn = processKust //nolint:gochecknoglobals
+
+func processKust(_ *Localizer, _ *target.KustTarget) (*types.Kustomization, error) {
 	return nil, nil
 }

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package localizer
+
+import (
+	"log"
+	"path/filepath"
+
+	"sigs.k8s.io/kustomize/api/ifc"
+	plgnsLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
+	"sigs.k8s.io/kustomize/api/internal/target"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
+)
+
+// Localizer encapsulates all state needed to localize the root at ldr.
+type Localizer struct {
+	fSys filesys.FileSystem
+
+	// kusttarget fields
+	validator ifc.Validator
+	rFactory  *resmap.Factory
+	pLdr      *plgnsLdr.Loader
+
+	// should be LocLoader
+	ldr ifc.Loader
+
+	// destination directory in newDir that mirrors ldr's current root.
+	dst filesys.ConfirmedDir
+}
+
+// NewLocalizer is the factory method for Localizer
+func NewLocalizer(ldr *LocLoader, validator ifc.Validator, rFactory *resmap.Factory, pLdr *plgnsLdr.Loader) (*Localizer, error) {
+	toDst, err := filepath.Rel(ldr.args.Scope.String(), ldr.Root())
+	if err != nil {
+		log.Fatalf("cannot find path from directory %q to %q inside directory: %s", ldr.args.Scope.String(),
+			ldr.Root(), err.Error())
+	}
+	dst := ldr.args.NewDir.Join(toDst)
+	if err = ldr.fSys.MkdirAll(dst); err != nil {
+		return nil, errors.WrapPrefixf(err, "unable to create directory in localize destination")
+	}
+	return &Localizer{
+		fSys:      ldr.fSys,
+		validator: validator,
+		rFactory:  rFactory,
+		pLdr:      pLdr,
+		ldr:       ldr,
+		dst:       filesys.ConfirmedDir(dst),
+	}, nil
+}
+
+// Localize localizes the root that lc is at
+func (lc *Localizer) Localize() error {
+	kt := target.NewKustTarget(lc.ldr, lc.validator, lc.rFactory, lc.pLdr)
+	err := kt.Load()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	kust, err := lc.processKust(kt)
+	if err != nil {
+		return err
+	}
+
+	content, err := yaml.Marshal(kust)
+	if err != nil {
+		return errors.WrapPrefixf(err, "unable to serialize localized kustomization file")
+	}
+	if err = lc.fSys.WriteFile(lc.dst.Join(konfig.DefaultKustomizationFileName()), content); err != nil {
+		return errors.WrapPrefixf(err, "unable to write localized kustomization file")
+	}
+	return nil
+}
+
+// processKust returns a copy of the kustomization at the KustTarget with all paths localized.
+func (lc *Localizer) processKust(_ *target.KustTarget) (*types.Kustomization, error) {
+	// TODO(annasong): Implement
+	return nil, nil
+}

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -63,7 +63,7 @@ func (lc *Localizer) Localize() error {
 		return errors.Wrap(err)
 	}
 
-	kust, err := processKustFn(lc, kt)
+	kust, err := ProcessKustFn(lc, kt)
 	if err != nil {
 		return err
 	}
@@ -78,8 +78,9 @@ func (lc *Localizer) Localize() error {
 	return nil
 }
 
+// ProcessKustFn should return a kustomization with paths localized.
 // TODO(annasong): test only, will be replaced by Localizer.processKust
-var processKustFn = processKust //nolint:gochecknoglobals
+var ProcessKustFn = processKust //nolint:gochecknoglobals
 
 // TODO(annasong): implement
 // processKust returns a copy of the kustomization at KustTarget with paths localized.

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kustomize/api/ifc"
-	plgnsLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
+	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/internal/target"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -25,7 +25,7 @@ type Localizer struct {
 	// kusttarget fields
 	validator ifc.Validator
 	rFactory  *resmap.Factory
-	pLdr      *plgnsLdr.Loader
+	pLdr      *pLdr.Loader
 
 	// underlying type is LocLoader
 	ldr ifc.Loader
@@ -35,7 +35,7 @@ type Localizer struct {
 }
 
 // NewLocalizer is the factory method for Localizer
-func NewLocalizer(ldr *LocLoader, validator ifc.Validator, rFactory *resmap.Factory, pLdr *plgnsLdr.Loader) (*Localizer, error) {
+func NewLocalizer(ldr *LocLoader, validator ifc.Validator, rFactory *resmap.Factory, pLdr *pLdr.Loader) (*Localizer, error) {
 	toDst, err := filepath.Rel(ldr.args.Scope.String(), ldr.Root())
 	if err != nil {
 		log.Fatalf("cannot find path from directory %q to %q inside directory: %s", ldr.args.Scope.String(),
@@ -81,6 +81,8 @@ func (lc *Localizer) Localize() error {
 // TODO(annasong): test only, will be replaced by Localizer.processKust
 var processKustFn = processKust //nolint:gochecknoglobals
 
+// TODO(annasong): implement
+// processKust returns a copy of the kustomization at KustTarget with paths localized.
 func processKust(_ *Localizer, _ *target.KustTarget) (*types.Kustomization, error) {
 	return nil, nil
 }

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -63,10 +63,7 @@ func (lc *Localizer) Localize() error {
 		return errors.Wrap(err)
 	}
 
-	kust, err := ProcessKustFn(lc, kt)
-	if err != nil {
-		return err
-	}
+	kust := lc.processKust(kt)
 
 	content, err := yaml.Marshal(kust)
 	if err != nil {
@@ -78,12 +75,9 @@ func (lc *Localizer) Localize() error {
 	return nil
 }
 
-// ProcessKustFn should return a kustomization with paths localized.
-// TODO(annasong): test only, will be replaced by Localizer.processKust
-var ProcessKustFn = processKust //nolint:gochecknoglobals
-
 // TODO(annasong): implement
-// processKust returns a copy of the kustomization at KustTarget with paths localized.
-func processKust(_ *Localizer, _ *target.KustTarget) (*types.Kustomization, error) {
-	return nil, nil
+// processKust returns a copy of the kustomization at kt with paths localized.
+func (lc *Localizer) processKust(kt *target.KustTarget) *types.Kustomization {
+	kust := kt.Kustomization()
+	return &kust
 }

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package localizer //nolint:testpackage
+package localizer_test
 
 import (
 	"path/filepath"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/api/hasher"
+	. "sigs.k8s.io/kustomize/api/internal/localizer"
 	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/internal/target"
 	"sigs.k8s.io/kustomize/api/internal/validate"
@@ -103,7 +104,7 @@ configMapGenerator:
 	addFiles(t, fSys, "/a", kustomization)
 
 	lclzr := createLocalizer(t, fSys, "/a", "/", "/dst")
-	processKustFn = func(_ *Localizer, kt *target.KustTarget) (*types.Kustomization, error) {
+	ProcessKustFn = func(_ *Localizer, kt *target.KustTarget) (*types.Kustomization, error) {
 		kust := kt.Kustomization()
 		kust.NamePrefix = "my-"
 		return &kust, nil

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -18,13 +18,25 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
+const podConfiguration = `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    -containerPort: 80
+`
+
 func makeMemoryFs(t *testing.T) filesys.FileSystem {
 	t.Helper()
 	req := require.New(t)
 
 	fSys := filesys.MakeFsInMemory()
 	req.NoError(fSys.MkdirAll("/a/b"))
-	req.NoError(fSys.WriteFile("/a/pod.yaml", []byte("pod configuration")))
+	req.NoError(fSys.WriteFile("/a/pod.yaml", []byte(podConfiguration)))
 
 	dirChain := "/alpha/beta/gamma/delta"
 	req.NoError(fSys.MkdirAll(dirChain))

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -1,23 +1,20 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package localizer_test
+package localizer //nolint:testpackage
 
 import (
-	"bytes"
-	"log"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/api/hasher"
-	"sigs.k8s.io/kustomize/api/internal/localizer"
 	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
+	"sigs.k8s.io/kustomize/api/internal/target"
 	"sigs.k8s.io/kustomize/api/internal/validate"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -41,428 +38,80 @@ func addFiles(t *testing.T, fSys filesys.FileSystem, parentDir string, files map
 
 	// in-memory file system makes all necessary dirs when writing files
 	for file, content := range files {
-		require.NoError(t, fSys.WriteFile(filepath.Join(parentDir, file), []byte(content))) /**/
+		require.NoError(t, fSys.WriteFile(filepath.Join(parentDir, file), []byte(content)))
 	}
 }
 
-func RunLocalize(t *testing.T, fSys filesys.FileSystem, target string, scope string, newDir string) error {
+func createLocalizer(t *testing.T, fSys filesys.FileSystem, target string, scope string, newDir string) *Localizer {
 	t.Helper()
 
 	// no need to re-test LocLoader
-	ldr, _, err := localizer.NewLocLoader(target, scope, newDir, fSys)
+	ldr, _, err := NewLocLoader(target, scope, newDir, fSys)
 	require.NoError(t, err)
 	rmFactory := resmap.NewFactory(resource.NewFactory(&hasher.Hasher{}))
-	lc, err := localizer.NewLocalizer(
+	lc, err := NewLocalizer(
 		ldr,
 		validate.NewFieldValidator(),
 		rmFactory,
 		// file system can be in memory, as plugin configuration will prevent the use of file system anyway
 		loader.NewLoader(types.DisabledPluginConfig(), rmFactory, fSys))
 	require.NoError(t, err)
-	return errors.Wrap(lc.Localize())
+	return lc
 }
 
-func TestPatchStrategicMergeOnFile(t *testing.T) {
-	t.Skip()
-	req := require.New(t)
-
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
+func TestNewLocalizerTargetIsScope(t *testing.T) {
 	fSys := makeMemoryFs(t)
-
-	// tests both inline and file patches
-	// tests localize handles nested directory and winding path
-	files := map[string]string{
-		"kustomization.yaml": `patchesStrategicMerge:
-- ../beta/say/patch.yaml
-- |-
-  apiVersion: v1
-  metadata:
-    name: myPod
-  kind: Pod
-  spec:
-    containers:
-    - name: nginx
-      image: nginx:1.14.2
-      ports:
-      - containerPort: 80
-resources:
-- localized-files`,
-		// in the absence of remote references, localize directory name can be used by other files
-		"localized-files": "deployment configuration",
-		"say/patch.yaml": `apiVersion: v1
-metadata:
- name: myPod
-kind: Pod
-spec:
- containers:
- - name: app
-   image: images.my-company.example/app:v4`,
-	}
-	addFiles(t, fSys, "/alpha/beta", files)
-	err := RunLocalize(t, fSys, "/alpha/beta", "", "/alpha/newDir")
-	req.NoError(err)
-	req.Empty(buf.String())
+	_ = createLocalizer(t, fSys, "/a", "", "/a/b/dst")
 
 	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha/beta", files)
-	files["kustomization.yaml"] = `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-patchesStrategicMerge:
-- say/patch.yaml
-- |-
-  apiVersion: v1
-  metadata:
-    name: myPod
-  kind: Pod
-  spec:
-    containers:
-    - name: nginx
-      image: nginx:1.14.2
-      ports:
-      - containerPort: 80
-resources:
-- localized-files
-`
-	// directories in scope, but not referenced should not be copied to destination
-	addFiles(t, fSysExpected, "/alpha/newDir", files)
-	req.Equal(fSysExpected, fSys)
-}
-
-func TestSecretGenerator(t *testing.T) {
-	t.Skip()
-	req := require.New(t)
-
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	fSys := makeMemoryFs(t)
-
-	files := map[string]string{
-		// test configurations
-		// test generatorOptions does not affect secretGenerator
-		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-configurations:
-- name-suffix-config
-generatorOptions:
-  disableNameSuffixHash: true
-kind: Kustomization
-nameSuffix: -my
-secretGenerator:
-- envs:
-  - data
-  name: my-secret
-  options:
-    labels:
-      type: fruit
-`,
-		// test no file extensions
-		"name-suffix-config": "nameSuffix field specs",
-		"data":               "APPLE=orange",
-	}
-	addFiles(t, fSys, "/alpha/beta", files)
-	req.NoError(RunLocalize(t, fSys, "/alpha/beta", "", "/alpha/newDir"))
-	req.Empty(buf.String())
-
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha/beta", files)
-	addFiles(t, fSysExpected, "/alpha/newDir", map[string]string{
-		"kustomization.yaml": files["kustomization.yaml"],
-	})
-	req.Equal(fSysExpected, fSys)
-}
-
-func TestComponents(t *testing.T) {
-	t.Skip()
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	fSys := makeMemoryFs(t)
-
-	// components test directory references
-	files := map[string]string{
-		// winding directory path
-		"a/kustomization.yaml": `
-components:
-- b/../../alpha/beta/..
-- localized-files
-resources:
-- pod.yaml
-- job.yaml
-`,
-
-		"a/job.yaml": "job configuration",
-
-		// should recognize different kustomization names
-		// inline and file replacements
-		"alpha/kustomization.yml": `apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-replacements:
-- source:
-    fieldPath: metadata.name
-    kind: Job
-  targets:
-  - fieldPaths:
-    - metadata.name
-    select:
-      kind: Pod
-- path: my-replacement.yaml
-`,
-
-		"alpha/my-replacement.yaml": "replacement configuration",
-
-		// test inline and file patchesJson6902
-		// in the absence of remote references, directories can share localize directory name
-		"a/localized-files/Kustomization": `apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-patchesJson6902:
-- patch: |-
-    - op: replace
-      path: /spec/containers/0/name
-      value: my-nginx
-  target:
-    kind: Pod
-- path: patch.yaml
-  target:
-    kind: Pod
-`,
-
-		"a/localized-files/patch.yaml": "patch configuration",
-	}
-	addFiles(t, fSys, "/", files)
-
-	err := RunLocalize(t, fSys, "/a", "/", "")
-	require.NoError(t, err)
-	require.Empty(t, buf.String())
-
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", files)
-
-	filesExpected := map[string]string{
-		"a/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-components:
-- ../alpha
-- localized-files
-kind: Kustomization
-resources:
-- pod.yaml
-- job.yaml
-`,
-		"a/pod.yaml":                           "pod configuration",
-		"a/job.yaml":                           files["a/job.yaml"],
-		"alpha/kustomization.yaml":             files["alpha/kustomization.yml"],
-		"alpha/my-replacement.yaml":            files["alpha/my-replacement.yaml"],
-		"a/localized-files/kustomization.yaml": files["a/localized-files/Kustomization"],
-		"a/localized-files/patch.yaml":         files["a/localized-files/patch.yaml"],
-	}
-	addFiles(t, fSysExpected, "/localized-a", filesExpected)
+	require.NoError(t, fSysExpected.MkdirAll("/a/b/dst"))
 	require.Equal(t, fSysExpected, fSys)
 }
 
-func TestOpenAPI(t *testing.T) {
-	t.Skip()
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
+func TestNewLocalizerTargetNestedInScope(t *testing.T) {
 	fSys := makeMemoryFs(t)
-
-	files := map[string]string{
-		// test patches
-		"a/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-openapi:
-  path: custom-api.json
-patches:
-- patch: |-
-    - op: replace
-      path: /spec/count
-      value: 2
-  target:
-    kind: CustomObject
-- path: patch.yaml
-resources:
-- custom-object.yaml
-`,
-
-		"a/custom-api.json":    "schema",
-		"a/patch.yaml":         "strategic merge patch",
-		"a/custom-object.yaml": "custom object configuration",
-	}
-	addFiles(t, fSys, "/", files)
-
-	require.NoError(t, RunLocalize(t, fSys, "/a", "/", ""))
-	require.Empty(t, buf.String())
+	_ = createLocalizer(t, fSys, "/a/b", "/", "/a/b/dst")
 
 	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", files)
-	addFiles(t, fSysExpected, "/localized-a", files)
+	require.NoError(t, fSysExpected.MkdirAll("/a/b/dst/a/b"))
 	require.Equal(t, fSysExpected, fSys)
 }
 
-func TestNestedRoots(t *testing.T) {
-	t.Skip()
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-
+func TestLocalizeKustomizationName(t *testing.T) {
 	fSys := makeMemoryFs(t)
-	files := map[string]string{
-		// both file and directory resources
-		// kustomization fields without paths should also be copied
-		"beta/gamma/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namePrefix: nested-roots-
-resources:
-- delta/deployment.yaml
-- ../say
-`,
-
-		// configMapGenerator with envs and files, with both the default filename and keys
-		"beta/say/kustomization.yaml": `
-resources:
-- ../gamma/./delta/
-- ../../beta/gamma/delta/epsilon
+	kustomization := map[string]string{
+		"Kustomization": `resources:
+- pod.yaml
 configMapGenerator:
-- name: my-config-map
+- name: map
   behavior: create
-  files:
-  - application.properties
-  - environment.properties=../gamma/../say/weird-name
   literals:
-  - THIS_KEY=/really/does/not/matter
-  envs:
-  - ./more.properties`,
-
-		"beta/say/application.properties": "application properties",
-
-		"beta/say/weird-name": "weird-name properties",
-
-		"beta/say/more.properties": "more properties",
-
-		// test crds
-		"beta/gamma/delta/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-commonLabels:
-  label: value
-crds:
-- epsilon/type-new-kind.yaml
-kind: Kustomization
-resources:
-- new-kind.yaml
-`,
-
-		"beta/gamma/delta/new-kind.yaml": "new-kind configuration",
-
-		"beta/gamma/delta/epsilon/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-commonLabels:
-  label: anotherValue
-crds:
-- type-new-kind.yaml
-kind: Kustomization
-resources:
-- new-kind.yaml
-`,
-
-		"beta/gamma/delta/epsilon/new-kind.yaml": "another new-kind configuration",
-
-		// referenced more than once
-		"beta/gamma/delta/epsilon/type-new-kind.yaml": "new-kind definition",
+  - APPLE=orange`,
 	}
-	addFiles(t, fSys, "/alpha", files)
-	err := RunLocalize(t, fSys, "/alpha/beta/gamma", "/alpha", "/alpha/beta/gamma/delta/newDir")
-	require.NoError(t, err)
-	require.Empty(t, buf.String())
+	addFiles(t, fSys, "/a", kustomization)
+
+	lclzr := createLocalizer(t, fSys, "/a", "/", "/dst")
+	processKustFn = func(_ *Localizer, kt *target.KustTarget) (*types.Kustomization, error) {
+		kust := kt.Kustomization()
+		kust.NamePrefix = "my-"
+		return &kust, nil
+	}
+	require.NoError(t, lclzr.Localize())
 
 	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha", files)
-	files["beta/say/kustomization.yaml"] = `apiVersion: kustomize.config.k8s.io/v1beta1
+	addFiles(t, fSysExpected, "/a", kustomization)
+	addFiles(t, fSysExpected, "/dst/a", map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 configMapGenerator:
 - behavior: create
-  envs:
-  - more.properties
-  files:
-  - application.properties
-  - environment.properties=weird-name
   literals:
-  - THIS_KEY=/really/does/not/matter
-  name: my-config-map
-kind: Kustomization
-resources:
-- ../gamma/delta
-- ../gamma/delta/epsilon
-`
-	files["beta/gamma/delta/deployment.yaml"] = "deployment configuration"
-	addFiles(t, fSysExpected, "/alpha/beta/gamma/delta/newDir", files)
-	require.Equal(t, fSysExpected, fSys)
-}
-
-func TestDeprecatedFields(t *testing.T) {
-	t.Skip()
-	req := require.New(t)
-
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	fSys := makeMemoryFs(t)
-
-	files := map[string]string{
-		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-images:
-- name: postgres
-  newName: my-registry/my-postgres
-imageTags:
-- name: postgres
-  newTag: v1
-kind: Kustomization
-patches:
-- deprecated-patch.yaml
-patchesStrategicMerge:
-- patch.yaml
-`,
-
-		"deprecated-patch.yaml": `apiVersion: v1
-kind: ConfigMap
-metadata:
+  - APPLE=orange
   name: map
-data:
-- APPLE: orange`,
-
-		"patch.yaml": `apiVersion: v1
-metadata:
- name: myPod
-kind: Pod
-spec:
- containers:
- - name: app
-   image: images.my-company.example/app:v4`,
-	}
-	addFiles(t, fSys, "/", files)
-	err := RunLocalize(t, fSys, "/", "", "/newDir")
-	req.NoError(err)
-	req.Empty(buf.String())
-
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", files)
-	addFiles(t, fSysExpected, "/newDir", files)
-	req.Equal(fSysExpected, fSys)
-}
-
-func TestBadKustomization(t *testing.T) {
-	t.Skip()
-	tests := map[string]string{
-		"repeated_fields": `namePrefix: my-
-namePrefix: map-`,
-		"unknown_fields": `namePrefix: my-
-random: field`,
-	}
-	for name, kustomization := range tests {
-		t.Run(name, func(t *testing.T) {
-			req := require.New(t)
-			var buf bytes.Buffer
-			log.SetOutput(&buf)
-			fSys := makeMemoryFs(t)
-			files := map[string]string{
-				"kustomization.yaml": kustomization,
-			}
-			addFiles(t, fSys, "/", files)
-
-			err := RunLocalize(t, fSys, "/", "", "/newDir")
-			req.Error(err)
-			req.Empty(buf.String())
-		})
-	}
+kind: Kustomization
+namePrefix: my-
+resources:
+- pod.yaml
+`,
+	})
+	require.Equal(t, fSysExpected, fSys)
 }

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -1,0 +1,468 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package localizer_test
+
+import (
+	"bytes"
+	"log"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/hasher"
+	"sigs.k8s.io/kustomize/api/internal/localizer"
+	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
+	"sigs.k8s.io/kustomize/api/internal/validate"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func makeMemoryFs(t *testing.T) filesys.FileSystem {
+	t.Helper()
+	req := require.New(t)
+
+	fSys := filesys.MakeFsInMemory()
+	req.NoError(fSys.MkdirAll("/a/b"))
+	req.NoError(fSys.WriteFile("/a/pod.yaml", []byte("pod configuration")))
+
+	dirChain := "/alpha/beta/gamma/delta"
+	req.NoError(fSys.MkdirAll(dirChain))
+	req.NoError(fSys.WriteFile(filepath.Join(dirChain, "deployment.yaml"), []byte("deployment configuration")))
+	req.NoError(fSys.Mkdir("/alpha/beta/say"))
+	return fSys
+}
+
+func addFiles(t *testing.T, fSys filesys.FileSystem, parentDir string, files map[string]string) {
+	t.Helper()
+
+	// in-memory file system makes all necessary dirs when writing files
+	for file, content := range files {
+		require.NoError(t, fSys.WriteFile(filepath.Join(parentDir, file), []byte(content))) /**/
+	}
+}
+
+func RunLocalize(t *testing.T, fSys filesys.FileSystem, target string, scope string, newDir string) error {
+	t.Helper()
+
+	// no need to re-test LocLoader
+	ldr, _, err := localizer.NewLocLoader(target, scope, newDir, fSys)
+	require.NoError(t, err)
+	rmFactory := resmap.NewFactory(resource.NewFactory(&hasher.Hasher{}))
+	lc, err := localizer.NewLocalizer(
+		ldr,
+		validate.NewFieldValidator(),
+		rmFactory,
+		// file system can be in memory, as plugin configuration will prevent the use of file system anyway
+		loader.NewLoader(types.DisabledPluginConfig(), rmFactory, fSys))
+	require.NoError(t, err)
+	return errors.Wrap(lc.Localize())
+}
+
+func TestPatchStrategicMergeOnFile(t *testing.T) {
+	t.Skip()
+	req := require.New(t)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	fSys := makeMemoryFs(t)
+
+	// tests both inline and file patches
+	// tests localize handles nested directory and winding path
+	files := map[string]string{
+		"kustomization.yaml": `patchesStrategicMerge:
+- ../beta/say/patch.yaml
+- |-
+  apiVersion: v1
+  metadata:
+    name: myPod
+  kind: Pod
+  spec:
+    containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+      - containerPort: 80
+resources:
+- localized-files`,
+		// in the absence of remote references, localize directory name can be used by other files
+		"localized-files": "deployment configuration",
+		"say/patch.yaml": `apiVersion: v1
+metadata:
+ name: myPod
+kind: Pod
+spec:
+ containers:
+ - name: app
+   image: images.my-company.example/app:v4`,
+	}
+	addFiles(t, fSys, "/alpha/beta", files)
+	err := RunLocalize(t, fSys, "/alpha/beta", "", "/alpha/newDir")
+	req.NoError(err)
+	req.Empty(buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/alpha/beta", files)
+	files["kustomization.yaml"] = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+- say/patch.yaml
+- |-
+  apiVersion: v1
+  metadata:
+    name: myPod
+  kind: Pod
+  spec:
+    containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+      - containerPort: 80
+resources:
+- localized-files
+`
+	// directories in scope, but not referenced should not be copied to destination
+	addFiles(t, fSysExpected, "/alpha/newDir", files)
+	req.Equal(fSysExpected, fSys)
+}
+
+func TestSecretGenerator(t *testing.T) {
+	t.Skip()
+	req := require.New(t)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	fSys := makeMemoryFs(t)
+
+	files := map[string]string{
+		// test configurations
+		// test generatorOptions does not affect secretGenerator
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+configurations:
+- name-suffix-config
+generatorOptions:
+  disableNameSuffixHash: true
+kind: Kustomization
+nameSuffix: -my
+secretGenerator:
+- envs:
+  - data
+  name: my-secret
+  options:
+    labels:
+      type: fruit
+`,
+		// test no file extensions
+		"name-suffix-config": "nameSuffix field specs",
+		"data":               "APPLE=orange",
+	}
+	addFiles(t, fSys, "/alpha/beta", files)
+	req.NoError(RunLocalize(t, fSys, "/alpha/beta", "", "/alpha/newDir"))
+	req.Empty(buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/alpha/beta", files)
+	addFiles(t, fSysExpected, "/alpha/newDir", map[string]string{
+		"kustomization.yaml": files["kustomization.yaml"],
+	})
+	req.Equal(fSysExpected, fSys)
+}
+
+func TestComponents(t *testing.T) {
+	t.Skip()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	fSys := makeMemoryFs(t)
+
+	// components test directory references
+	files := map[string]string{
+		// winding directory path
+		"a/kustomization.yaml": `
+components:
+- b/../../alpha/beta/..
+- localized-files
+resources:
+- pod.yaml
+- job.yaml
+`,
+
+		"a/job.yaml": "job configuration",
+
+		// should recognize different kustomization names
+		// inline and file replacements
+		"alpha/kustomization.yml": `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+replacements:
+- source:
+    fieldPath: metadata.name
+    kind: Job
+  targets:
+  - fieldPaths:
+    - metadata.name
+    select:
+      kind: Pod
+- path: my-replacement.yaml
+`,
+
+		"alpha/my-replacement.yaml": "replacement configuration",
+
+		// test inline and file patchesJson6902
+		// in the absence of remote references, directories can share localize directory name
+		"a/localized-files/Kustomization": `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patchesJson6902:
+- patch: |-
+    - op: replace
+      path: /spec/containers/0/name
+      value: my-nginx
+  target:
+    kind: Pod
+- path: patch.yaml
+  target:
+    kind: Pod
+`,
+
+		"a/localized-files/patch.yaml": "patch configuration",
+	}
+	addFiles(t, fSys, "/", files)
+
+	err := RunLocalize(t, fSys, "/a", "/", "")
+	require.NoError(t, err)
+	require.Empty(t, buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/", files)
+
+	filesExpected := map[string]string{
+		"a/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../alpha
+- localized-files
+kind: Kustomization
+resources:
+- pod.yaml
+- job.yaml
+`,
+		"a/pod.yaml":                           "pod configuration",
+		"a/job.yaml":                           files["a/job.yaml"],
+		"alpha/kustomization.yaml":             files["alpha/kustomization.yml"],
+		"alpha/my-replacement.yaml":            files["alpha/my-replacement.yaml"],
+		"a/localized-files/kustomization.yaml": files["a/localized-files/Kustomization"],
+		"a/localized-files/patch.yaml":         files["a/localized-files/patch.yaml"],
+	}
+	addFiles(t, fSysExpected, "/localized-a", filesExpected)
+	require.Equal(t, fSysExpected, fSys)
+}
+
+func TestOpenAPI(t *testing.T) {
+	t.Skip()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	fSys := makeMemoryFs(t)
+
+	files := map[string]string{
+		// test patches
+		"a/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+openapi:
+  path: custom-api.json
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/count
+      value: 2
+  target:
+    kind: CustomObject
+- path: patch.yaml
+resources:
+- custom-object.yaml
+`,
+
+		"a/custom-api.json":    "schema",
+		"a/patch.yaml":         "strategic merge patch",
+		"a/custom-object.yaml": "custom object configuration",
+	}
+	addFiles(t, fSys, "/", files)
+
+	require.NoError(t, RunLocalize(t, fSys, "/a", "/", ""))
+	require.Empty(t, buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/", files)
+	addFiles(t, fSysExpected, "/localized-a", files)
+	require.Equal(t, fSysExpected, fSys)
+}
+
+func TestNestedRoots(t *testing.T) {
+	t.Skip()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	fSys := makeMemoryFs(t)
+	files := map[string]string{
+		// both file and directory resources
+		// kustomization fields without paths should also be copied
+		"beta/gamma/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: nested-roots-
+resources:
+- delta/deployment.yaml
+- ../say
+`,
+
+		// configMapGenerator with envs and files, with both the default filename and keys
+		"beta/say/kustomization.yaml": `
+resources:
+- ../gamma/./delta/
+- ../../beta/gamma/delta/epsilon
+configMapGenerator:
+- name: my-config-map
+  behavior: create
+  files:
+  - application.properties
+  - environment.properties=../gamma/../say/weird-name
+  literals:
+  - THIS_KEY=/really/does/not/matter
+  envs:
+  - ./more.properties`,
+
+		"beta/say/application.properties": "application properties",
+
+		"beta/say/weird-name": "weird-name properties",
+
+		"beta/say/more.properties": "more properties",
+
+		// test crds
+		"beta/gamma/delta/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  label: value
+crds:
+- epsilon/type-new-kind.yaml
+kind: Kustomization
+resources:
+- new-kind.yaml
+`,
+
+		"beta/gamma/delta/new-kind.yaml": "new-kind configuration",
+
+		"beta/gamma/delta/epsilon/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  label: anotherValue
+crds:
+- type-new-kind.yaml
+kind: Kustomization
+resources:
+- new-kind.yaml
+`,
+
+		"beta/gamma/delta/epsilon/new-kind.yaml": "another new-kind configuration",
+
+		// referenced more than once
+		"beta/gamma/delta/epsilon/type-new-kind.yaml": "new-kind definition",
+	}
+	addFiles(t, fSys, "/alpha", files)
+	err := RunLocalize(t, fSys, "/alpha/beta/gamma", "/alpha", "/alpha/beta/gamma/delta/newDir")
+	require.NoError(t, err)
+	require.Empty(t, buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/alpha", files)
+	files["beta/say/kustomization.yaml"] = `apiVersion: kustomize.config.k8s.io/v1beta1
+configMapGenerator:
+- behavior: create
+  envs:
+  - more.properties
+  files:
+  - application.properties
+  - environment.properties=weird-name
+  literals:
+  - THIS_KEY=/really/does/not/matter
+  name: my-config-map
+kind: Kustomization
+resources:
+- ../gamma/delta
+- ../gamma/delta/epsilon
+`
+	files["beta/gamma/delta/deployment.yaml"] = "deployment configuration"
+	addFiles(t, fSysExpected, "/alpha/beta/gamma/delta/newDir", files)
+	require.Equal(t, fSysExpected, fSys)
+}
+
+func TestDeprecatedFields(t *testing.T) {
+	t.Skip()
+	req := require.New(t)
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	fSys := makeMemoryFs(t)
+
+	files := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+images:
+- name: postgres
+  newName: my-registry/my-postgres
+imageTags:
+- name: postgres
+  newTag: v1
+kind: Kustomization
+patches:
+- deprecated-patch.yaml
+patchesStrategicMerge:
+- patch.yaml
+`,
+
+		"deprecated-patch.yaml": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: map
+data:
+- APPLE: orange`,
+
+		"patch.yaml": `apiVersion: v1
+metadata:
+ name: myPod
+kind: Pod
+spec:
+ containers:
+ - name: app
+   image: images.my-company.example/app:v4`,
+	}
+	addFiles(t, fSys, "/", files)
+	err := RunLocalize(t, fSys, "/", "", "/newDir")
+	req.NoError(err)
+	req.Empty(buf.String())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/", files)
+	addFiles(t, fSysExpected, "/newDir", files)
+	req.Equal(fSysExpected, fSys)
+}
+
+func TestBadKustomization(t *testing.T) {
+	t.Skip()
+	tests := map[string]string{
+		"repeated_fields": `namePrefix: my-
+namePrefix: map-`,
+		"unknown_fields": `namePrefix: my-
+random: field`,
+	}
+	for name, kustomization := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := require.New(t)
+			var buf bytes.Buffer
+			log.SetOutput(&buf)
+			fSys := makeMemoryFs(t)
+			files := map[string]string{
+				"kustomization.yaml": kustomization,
+			}
+			addFiles(t, fSys, "/", files)
+
+			err := RunLocalize(t, fSys, "/", "", "/newDir")
+			req.Error(err)
+			req.Empty(buf.String())
+		})
+	}
+}

--- a/api/internal/localizer/locloader.go
+++ b/api/internal/localizer/locloader.go
@@ -28,8 +28,8 @@ type LocArgs struct {
 	NewDir filesys.ConfirmedDir
 }
 
-// locLoader is the Loader for kustomize localize. It is an ifc.Loader that enforces localize constraints.
-type locLoader struct {
+// LocLoader is the Loader for kustomize localize. It is an ifc.Loader that enforces localize constraints.
+type LocLoader struct {
 	fSys filesys.FileSystem
 
 	args *LocArgs
@@ -41,11 +41,11 @@ type locLoader struct {
 	local bool
 }
 
-var _ ifc.Loader = &locLoader{}
+var _ ifc.Loader = &LocLoader{}
 
-// NewLocLoader is the factory method for Loader, under localize constraints, at targetArg. For invalid localize arguments,
+// NewLocLoader is the factory method for LocLoader, under localize constraints, at targetArg. For invalid localize arguments,
 // NewLocLoader returns an error.
-func NewLocLoader(targetArg string, scopeArg string, newDirArg string, fSys filesys.FileSystem) (ifc.Loader, LocArgs, error) {
+func NewLocLoader(targetArg string, scopeArg string, newDirArg string, fSys filesys.FileSystem) (*LocLoader, LocArgs, error) {
 	// check earlier to avoid cleanup
 	repoSpec, err := git.NewRepoSpecFromURL(targetArg)
 	if err == nil && repoSpec.Ref == "" {
@@ -76,7 +76,7 @@ func NewLocLoader(targetArg string, scopeArg string, newDirArg string, fSys file
 		Scope:  scope,
 		NewDir: newDir,
 	}
-	return &locLoader{
+	return &LocLoader{
 		fSys:   fSys,
 		args:   &args,
 		Loader: ldr,
@@ -86,7 +86,7 @@ func NewLocLoader(targetArg string, scopeArg string, newDirArg string, fSys file
 
 // Load returns the contents of path if path is a valid localize file.
 // Otherwise, Load returns an error.
-func (ll *locLoader) Load(path string) ([]byte, error) {
+func (ll *LocLoader) Load(path string) ([]byte, error) {
 	// checks in root, and thus in scope
 	content, err := ll.Loader.Load(path)
 	if err != nil {
@@ -115,7 +115,7 @@ func (ll *locLoader) Load(path string) ([]byte, error) {
 
 // New returns a Loader at path if path is a valid localize root.
 // Otherwise, New returns an error.
-func (ll *locLoader) New(path string) (ifc.Loader, error) {
+func (ll *LocLoader) New(path string) (ifc.Loader, error) {
 	ldr, err := ll.Loader.New(path)
 	if err != nil {
 		return nil, errors.WrapPrefixf(err, "invalid root reference")
@@ -133,7 +133,7 @@ func (ll *locLoader) New(path string) (ifc.Loader, error) {
 		return nil, errors.Errorf("localize remote root %q missing ref query string parameter", path)
 	}
 
-	return &locLoader{
+	return &LocLoader{
 		fSys:   ll.fSys,
 		args:   ll.args,
 		Loader: ldr,

--- a/api/internal/localizer/locloader.go
+++ b/api/internal/localizer/locloader.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-const dstPrefix = "localized"
+const DstPrefix = "localized"
 
 // LocArgs holds localize arguments
 type LocArgs struct {

--- a/api/internal/localizer/locloader_test.go
+++ b/api/internal/localizer/locloader_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package localizer //nolint:testpackage
+package localizer_test
 
 import (
 	"bytes"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/api/ifc"
+	. "sigs.k8s.io/kustomize/api/internal/localizer"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -86,7 +87,7 @@ func TestNewLocLoaderDefaultForRootTarget(t *testing.T) {
 
 			ldr, args, err := NewLocLoader(params.target, params.scope, "", fSys)
 			req.NoError(err)
-			checkNewLocLoader(req, ldr, &args, "/", "/", "/"+dstPrefix, fSys)
+			checkNewLocLoader(req, ldr, &args, "/", "/", "/"+DstPrefix, fSys)
 
 			// file in root, but nested
 			content, err := ldr.Load("a/pod.yaml")
@@ -113,7 +114,7 @@ func TestNewMultiple(t *testing.T) {
 	// destination outside of scope
 	ldr, args, err := NewLocLoader("/alpha/beta", "/alpha", "", fSys)
 	req.NoError(err)
-	checkNewLocLoader(req, ldr, &args, "/alpha/beta", "/alpha", "/"+dstPrefix+"-beta", fSys)
+	checkNewLocLoader(req, ldr, &args, "/alpha/beta", "/alpha", "/"+DstPrefix+"-beta", fSys)
 
 	// nested child root that isn't cleaned
 	descLdr, err := ldr.New("../beta/gamma/delta")

--- a/api/internal/localizer/locloader_test.go
+++ b/api/internal/localizer/locloader_test.go
@@ -16,22 +16,7 @@ import (
 
 const dstPrefix = "localized"
 
-func makeMemoryFs(t *testing.T) filesys.FileSystem {
-	t.Helper()
-	req := require.New(t)
-
-	fSys := filesys.MakeFsInMemory()
-	req.NoError(fSys.MkdirAll("/a/b"))
-	req.NoError(fSys.WriteFile("/a/kustomization.yaml", []byte("/a")))
-
-	dirChain := "/alpha/beta/gamma/delta"
-	req.NoError(fSys.MkdirAll(dirChain))
-	req.NoError(fSys.WriteFile(dirChain+"/kustomization.yaml", []byte(dirChain)))
-	req.NoError(fSys.Mkdir("/alpha/beta/c"))
-	return fSys
-}
-
-func checkNewLocLoader(req *require.Assertions, ldr ifc.Loader, args *lclzr.LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
+func checkNewLocLoader(req *require.Assertions, ldr *lclzr.LocLoader, args *lclzr.LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
 	checkLoader(req, ldr, target)
 	checkLocArgs(req, args, target, scope, newDir, fSys)
 }
@@ -64,9 +49,9 @@ func TestLocalLoadNewAndCleanup(t *testing.T) {
 	req.Equal(fSysCopy, fSys)
 
 	// easy load directly in root
-	content, err := ldr.Load("kustomization.yaml")
+	content, err := ldr.Load("pod.yaml")
 	req.NoError(err)
-	req.Equal([]byte("/a"), content)
+	req.Equal([]byte("pod configuration"), content)
 
 	// typical sibling root reference
 	sibLdr, err := ldr.New("../alpha")
@@ -107,18 +92,18 @@ func TestNewLocLoaderDefaultForRootTarget(t *testing.T) {
 			checkNewLocLoader(req, ldr, &args, "/", "/", "/"+dstPrefix, fSys)
 
 			// file in root, but nested
-			content, err := ldr.Load("a/kustomization.yaml")
+			content, err := ldr.Load("a/pod.yaml")
 			req.NoError(err)
-			req.Equal([]byte("/a"), content)
+			req.Equal([]byte("pod configuration"), content)
 
 			childLdr, err := ldr.New("a")
 			req.NoError(err)
 			checkLoader(req, childLdr, "/a")
 
 			// messy, uncleaned path
-			content, err = childLdr.Load("./../a/kustomization.yaml")
+			content, err = childLdr.Load("./../a/pod.yaml")
 			req.NoError(err)
-			req.Equal([]byte("/a"), content)
+			req.Equal([]byte("pod configuration"), content)
 		})
 	}
 }
@@ -139,9 +124,9 @@ func TestNewMultiple(t *testing.T) {
 	checkLoader(req, descLdr, "/alpha/beta/gamma/delta")
 
 	// upwards traversal
-	higherLdr, err := descLdr.New("../../c")
+	higherLdr, err := descLdr.New("../../say")
 	req.NoError(err)
-	checkLoader(req, higherLdr, "/alpha/beta/c")
+	checkLoader(req, higherLdr, "/alpha/beta/say")
 }
 
 func makeWdFs(t *testing.T) map[string]filesys.FileSystem {
@@ -215,7 +200,7 @@ func TestNewLocLoaderFails(t *testing.T) {
 			"/newDir",
 		},
 		"file target": {
-			"/a/kustomization.yaml",
+			"/a/pod.yaml",
 			"/",
 			"/newDir",
 		},
@@ -260,7 +245,7 @@ func TestNewFails(t *testing.T) {
 		"at dst":            "newDir",
 		"ancestor":          "../../beta",
 		"non-existent root": "delt",
-		"file":              "delta/kustomization.yaml",
+		"file":              "delta/deployment.yaml",
 	}
 	for name, root := range cases {
 		root := root
@@ -285,11 +270,11 @@ func TestLoadFails(t *testing.T) {
 	checkNewLocLoader(req, ldr, &args, "/a", "/a", "/a/newDir", fSys)
 
 	cases := map[string]string{
-		"absolute path":     "/a/kustomization.yaml",
+		"absolute path":     "/a/pod.yaml",
 		"directory":         "b",
 		"non-existent file": "kubectl.yaml",
-		"file outside root": "../alpha/beta/gamma/delta/kustomization.yaml",
-		"inside dst":        "newDir/kustomization.yaml",
+		"file outside root": "../alpha/beta/gamma/delta/deployment.yaml",
+		"inside dst":        "newDir/pod.yaml",
 	}
 	for name, file := range cases {
 		file := file
@@ -300,7 +285,7 @@ func TestLoadFails(t *testing.T) {
 			ldr, _, err := lclzr.NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
 			req.NoError(err)
 
-			req.NoError(fSys.WriteFile("/a/newDir/kustomization.yaml", []byte("/a/newDir")))
+			req.NoError(fSys.WriteFile("/a/newDir/pod.yaml", []byte("pod configuration")))
 
 			_, err = ldr.Load(file)
 			req.Error(err)

--- a/api/internal/localizer/locloader_test.go
+++ b/api/internal/localizer/locloader_test.go
@@ -48,7 +48,7 @@ func TestLocalLoadNewAndCleanup(t *testing.T) {
 	// easy load directly in root
 	content, err := ldr.Load("pod.yaml")
 	req.NoError(err)
-	req.Equal([]byte("pod configuration"), content)
+	req.Equal([]byte(podConfiguration), content)
 
 	// typical sibling root reference
 	sibLdr, err := ldr.New("../alpha")
@@ -91,7 +91,7 @@ func TestNewLocLoaderDefaultForRootTarget(t *testing.T) {
 			// file in root, but nested
 			content, err := ldr.Load("a/pod.yaml")
 			req.NoError(err)
-			req.Equal([]byte("pod configuration"), content)
+			req.Equal([]byte(podConfiguration), content)
 
 			childLdr, err := ldr.New("a")
 			req.NoError(err)
@@ -100,7 +100,7 @@ func TestNewLocLoaderDefaultForRootTarget(t *testing.T) {
 			// messy, uncleaned path
 			content, err = childLdr.Load("./../a/pod.yaml")
 			req.NoError(err)
-			req.Equal([]byte("pod configuration"), content)
+			req.Equal([]byte(podConfiguration), content)
 		})
 	}
 }
@@ -282,7 +282,7 @@ func TestLoadFails(t *testing.T) {
 			ldr, _, err := NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
 			req.NoError(err)
 
-			req.NoError(fSys.WriteFile("/a/newDir/pod.yaml", []byte("pod configuration")))
+			req.NoError(fSys.WriteFile("/a/newDir/pod.yaml", []byte(podConfiguration)))
 
 			_, err = ldr.Load(file)
 			req.Error(err)

--- a/api/internal/localizer/locloader_test.go
+++ b/api/internal/localizer/locloader_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package localizer_test
+package localizer //nolint:testpackage
 
 import (
 	"bytes"
@@ -10,13 +10,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/api/ifc"
-	lclzr "sigs.k8s.io/kustomize/api/internal/localizer"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-const dstPrefix = "localized"
-
-func checkNewLocLoader(req *require.Assertions, ldr *lclzr.LocLoader, args *lclzr.LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
+func checkNewLocLoader(req *require.Assertions, ldr *LocLoader, args *LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
 	checkLoader(req, ldr, target)
 	checkLocArgs(req, args, target, scope, newDir, fSys)
 }
@@ -26,7 +23,7 @@ func checkLoader(req *require.Assertions, ldr ifc.Loader, root string) {
 	req.Empty(ldr.Repo())
 }
 
-func checkLocArgs(req *require.Assertions, args *lclzr.LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
+func checkLocArgs(req *require.Assertions, args *LocArgs, target string, scope string, newDir string, fSys filesys.FileSystem) {
 	req.Equal(target, args.Target.String())
 	req.Equal(scope, args.Scope.String())
 	req.Equal(newDir, args.NewDir.String())
@@ -40,7 +37,7 @@ func TestLocalLoadNewAndCleanup(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
 	// typical setup
-	ldr, args, err := lclzr.NewLocLoader("a", "/", "/newDir", fSys)
+	ldr, args, err := NewLocLoader("a", "/", "/newDir", fSys)
 	req.NoError(err)
 	checkNewLocLoader(req, ldr, &args, "/a", "/", "/newDir", fSys)
 
@@ -87,7 +84,7 @@ func TestNewLocLoaderDefaultForRootTarget(t *testing.T) {
 			req := require.New(t)
 			fSys := makeMemoryFs(t)
 
-			ldr, args, err := lclzr.NewLocLoader(params.target, params.scope, "", fSys)
+			ldr, args, err := NewLocLoader(params.target, params.scope, "", fSys)
 			req.NoError(err)
 			checkNewLocLoader(req, ldr, &args, "/", "/", "/"+dstPrefix, fSys)
 
@@ -114,7 +111,7 @@ func TestNewMultiple(t *testing.T) {
 
 	// default destination for non-file system root target
 	// destination outside of scope
-	ldr, args, err := lclzr.NewLocLoader("/alpha/beta", "/alpha", "", fSys)
+	ldr, args, err := NewLocLoader("/alpha/beta", "/alpha", "", fSys)
 	req.NoError(err)
 	checkNewLocLoader(req, ldr, &args, "/alpha/beta", "/alpha", "/"+dstPrefix+"-beta", fSys)
 
@@ -175,7 +172,7 @@ func TestNewLocLoaderCwdNotRoot(t *testing.T) {
 			req := require.New(t)
 			fSys := makeWdFs(t)[test.wd]
 
-			ldr, args, err := lclzr.NewLocLoader(test.target, test.scope, test.newDir, fSys)
+			ldr, args, err := NewLocLoader(test.target, test.scope, test.newDir, fSys)
 			req.NoError(err)
 			checkLoader(req, ldr, "a/b/c/d/e")
 
@@ -225,7 +222,7 @@ func TestNewLocLoaderFails(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var buf bytes.Buffer
 			log.SetOutput(&buf)
-			_, _, err := lclzr.NewLocLoader(params.target, params.scope, params.dest, makeMemoryFs(t))
+			_, _, err := NewLocLoader(params.target, params.scope, params.dest, makeMemoryFs(t))
 			require.Error(t, err)
 			require.Empty(t, buf.String())
 		})
@@ -236,7 +233,7 @@ func TestNewFails(t *testing.T) {
 	req := require.New(t)
 	fSys := makeMemoryFs(t)
 
-	ldr, args, err := lclzr.NewLocLoader("/alpha/beta/gamma", "alpha", "alpha/beta/gamma/newDir", fSys)
+	ldr, args, err := NewLocLoader("/alpha/beta/gamma", "alpha", "alpha/beta/gamma/newDir", fSys)
 	req.NoError(err)
 	checkNewLocLoader(req, ldr, &args, "/alpha/beta/gamma", "/alpha", "/alpha/beta/gamma/newDir", fSys)
 
@@ -252,7 +249,7 @@ func TestNewFails(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fSys := makeMemoryFs(t)
 
-			ldr, _, err := lclzr.NewLocLoader("/alpha/beta/gamma", "alpha", "alpha/beta/gamma/newDir", fSys)
+			ldr, _, err := NewLocLoader("/alpha/beta/gamma", "alpha", "alpha/beta/gamma/newDir", fSys)
 			require.NoError(t, err)
 
 			_, err = ldr.New(root)
@@ -265,7 +262,7 @@ func TestLoadFails(t *testing.T) {
 	req := require.New(t)
 	fSys := makeMemoryFs(t)
 
-	ldr, args, err := lclzr.NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
+	ldr, args, err := NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
 	req.NoError(err)
 	checkNewLocLoader(req, ldr, &args, "/a", "/a", "/a/newDir", fSys)
 
@@ -282,7 +279,7 @@ func TestLoadFails(t *testing.T) {
 			req := require.New(t)
 			fSys := makeMemoryFs(t)
 
-			ldr, _, err := lclzr.NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
+			ldr, _, err := NewLocLoader("./a/../a", "/a/../a", "/a/newDir", fSys)
 			req.NoError(err)
 
 			req.NoError(fSys.WriteFile("/a/newDir/pod.yaml", []byte("pod configuration")))

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -72,13 +72,13 @@ func defaultNewDir(targetLdr ifc.Loader, spec *git.RepoSpec) string {
 		if repo == targetLdr.Root() {
 			targetDir = urlBase(spec.OrgRepo)
 		}
-		return strings.Join([]string{dstPrefix, targetDir, strings.ReplaceAll(spec.Ref, "/", "-")}, "-")
+		return strings.Join([]string{DstPrefix, targetDir, strings.ReplaceAll(spec.Ref, "/", "-")}, "-")
 	}
 	// special case for local target directory since destination directory cannot have "/" in name
 	if targetDir == string(filepath.Separator) {
-		return dstPrefix
+		return DstPrefix
 	}
-	return strings.Join([]string{dstPrefix, targetDir}, "-")
+	return strings.Join([]string{DstPrefix, targetDir}, "-")
 }
 
 // urlBase is the url equivalent of filepath.Base

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -14,13 +14,14 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-// establishScope returns the scope given localize arguments and targetLdr at targetArg
+// establishScope returns the effective scope given localize arguments and targetLdr at targetArg. For remote targetArg,
+// the effective scope is the downloaded repo.
 func establishScope(scopeArg string, targetArg string, targetLdr ifc.Loader, fSys filesys.FileSystem) (filesys.ConfirmedDir, error) {
-	if targetLdr.Repo() != "" {
+	if repo := targetLdr.Repo(); repo != "" {
 		if scopeArg != "" {
 			return "", errors.Errorf("scope '%s' specified for remote localize target '%s'", scopeArg, targetArg)
 		}
-		return "", nil
+		return filesys.ConfirmedDir(repo), nil
 	}
 	// default scope
 	if scopeArg == "" {


### PR DESCRIPTION
This PR implements the skeleton for the `localizer` struct, which contains the central logic for `kustomize localize`. This PR aims to extract the essence of #4797 