### PR TITLE
Implement `localizeFile()` skeleton for patches

### DIFF
--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -79,19 +79,13 @@ func (lc *Localizer) Localize() error {
 // processKust returns a copy of the kustomization at kt with paths localized.
 func (lc *Localizer) processKust(kt *target.KustTarget) (*types.Kustomization, error) {
 	kust := kt.Kustomization()
-	for fieldName, patches := range map[string][]types.Patch{
-		"patches":         kust.Patches,
-		"patchesJson6902": kust.PatchesJson6902,
-	} {
-		for i := range patches {
-			if patches[i].Path != "" {
-				newPath, err := lc.localizeFile(patches[i].Path)
-				if err != nil {
-					return nil, errors.WrapPrefixf(err, "unable to localize path %q from field %s", patches[i].Path,
-						fieldName)
-				}
-				patches[i].Path = newPath
+	for i := range kust.Patches {
+		if kust.Patches[i].Path != "" {
+			newPath, err := lc.localizeFile(kust.Patches[i].Path)
+			if err != nil {
+				return nil, errors.WrapPrefixf(err, "unable to localize patches path %q", kust.Patches[i].Path)
 			}
+			kust.Patches[i].Path = newPath
 		}
 	}
 	// TODO(annasong): localize all other kustomization fields: resources, components, crds, configurations,

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -105,8 +105,7 @@ func (lc *Localizer) localizeFile(path string) (string, error) {
 
 	var locPath string
 	if loader.IsRemoteFile(path) {
-		// TODO(annasong): check if able to addLocalizeDir() once implemented
-		_ = lc.addLocalizeDir()
+		// TODO(annasong): check if able to add localize directory
 		locPath = locFilePath(path)
 	} else { // path must be relative; subject to change in beta
 		// avoid symlinks; only write file corresponding to actual location in root
@@ -114,8 +113,7 @@ func (lc *Localizer) localizeFile(path string) (string, error) {
 		// temporarily; for example, ../root/config; problematic for rename and
 		// relocation
 		locPath = cleanFilePath(lc.fSys, filesys.ConfirmedDir(lc.ldr.Root()), path)
-		// TODO(annasong): check if hitsLocalizeDir() once implemented
-		_ = lc.hitsLocalizeDir(locPath)
+		// TODO(annasong): check if hits localize directory
 	}
 	absPath := lc.dst.Join(locPath)
 	if err = lc.fSys.MkdirAll(filepath.Dir(absPath)); err != nil {
@@ -125,16 +123,4 @@ func (lc *Localizer) localizeFile(path string) (string, error) {
 		return "", errors.WrapPrefixf(err, "unable to localize file %q", path)
 	}
 	return locPath, nil
-}
-
-// addLocalizeDir returns whether it is able to add a localize directory at dst
-// TODO(annasong): implement
-func (lc *Localizer) addLocalizeDir() bool {
-	return false
-}
-
-// hitsLocalizeDir returns true if local path enters a localize directory, and false otherwise
-// TODO(annasong): implement
-func (lc *Localizer) hitsLocalizeDir(_ string) bool {
-	return false
 }

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -84,6 +84,8 @@ func checkFSys(t *testing.T, fSysExpected filesys.FileSystem, fSysActual filesys
 }
 
 func reportFSysDiff(t *testing.T, fSysExpected filesys.FileSystem, fSysActual filesys.FileSystem) {
+	t.Helper()
+
 	visited := make(map[string]struct{})
 	err := fSysActual.Walk("/", func(path string, info fs.FileInfo, err error) error {
 		require.NoError(t, err)

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -285,47 +285,6 @@ spec:
 	checkFSys(t, fSysExpected, fSys)
 }
 
-func TestLocalizePatchesJson6902(t *testing.T) {
-	fSys := makeMemoryFs(t)
-	kustAndPatch := map[string]string{
-		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-patchesJson6902:
-- options:
-    allowKindChange: true
-  patch: |-
-    - op: add
-      path: /some/new/path
-      value: value
-    - op: move
-      from: /some/existing/path
-      path: /some/existing/destination/path
-  target:
-    kind: Service
-    name: my-service
-    version: v1
-- path: patch.yaml
-  target:
-    name: my-deployment
-`,
-		"patch.yaml": ` [
-   {"op": "copy", "from": "/some/existing/path", "path": "/some/path"},
-   {"op": "remove", "path": "/some/existing/path"},
-   {"op": "test", "path": "/some/path", "value": "my-node-value"}
- ]
-`,
-	}
-	addFiles(t, fSys, "/a", kustAndPatch)
-
-	lclzr := createLocalizer(t, fSys, "/a", "", "")
-	require.NoError(t, lclzr.Localize())
-
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndPatch)
-	addFiles(t, fSysExpected, "/localized-a", kustAndPatch)
-	checkFSys(t, fSysExpected, fSys)
-}
-
 func TestLocalizeFileNoFile(t *testing.T) {
 	fSys := makeMemoryFs(t)
 	kustAndPatch := map[string]string{

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -4,9 +4,12 @@
 package localizer_test
 
 import (
+	"fmt"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/api/hasher"
 	. "sigs.k8s.io/kustomize/api/internal/localizer"
@@ -27,7 +30,7 @@ spec:
   - name: nginx
     image: nginx:1.14.2
     ports:
-    -containerPort: 80
+    - containerPort: 80
 `
 
 func makeMemoryFs(t *testing.T) filesys.FileSystem {
@@ -71,36 +74,99 @@ func createLocalizer(t *testing.T, fSys filesys.FileSystem, target string, scope
 	return lc
 }
 
+func checkFSys(t *testing.T, fSysExpected filesys.FileSystem, fSysActual filesys.FileSystem) {
+	t.Helper()
+
+	assert.Equal(t, fSysExpected, fSysActual)
+	if t.Failed() {
+		reportFSysDiff(t, fSysExpected, fSysActual)
+	}
+}
+
+func reportFSysDiff(t *testing.T, fSysExpected filesys.FileSystem, fSysActual filesys.FileSystem) {
+	visited := make(map[string]struct{})
+	err := fSysActual.Walk("/", func(path string, info fs.FileInfo, err error) error {
+		require.NoError(t, err)
+		visited[path] = struct{}{}
+
+		if info.IsDir() {
+			assert.Truef(t, fSysExpected.IsDir(path), "unexpected directory %q", path)
+		} else {
+			actualContent, readErr := fSysActual.ReadFile(path)
+			require.NoError(t, readErr)
+			expectedContent, findErr := fSysExpected.ReadFile(path)
+			assert.NoError(t, findErr)
+			if findErr == nil {
+				assert.Equal(t, string(expectedContent), string(actualContent))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = fSysExpected.Walk("/", func(path string, info fs.FileInfo, err error) error {
+		require.NoError(t, err)
+		visited[path] = struct{}{}
+
+		if _, exists := visited[path]; !exists {
+			t.Errorf("expected path %q not found", path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 func TestNewLocalizerTargetIsScope(t *testing.T) {
 	fSys := makeMemoryFs(t)
-	_ = createLocalizer(t, fSys, "/a", "", "/a/b/dst")
+	kustomization := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: my-
+`,
+	}
+	addFiles(t, fSys, "/a", kustomization)
+	lclzr := createLocalizer(t, fSys, "/a", "", "/a/b/dst")
+	require.NoError(t, lclzr.Localize())
 
 	fSysExpected := makeMemoryFs(t)
-	require.NoError(t, fSysExpected.MkdirAll("/a/b/dst"))
-	require.Equal(t, fSysExpected, fSys)
+	addFiles(t, fSysExpected, "/a", kustomization)
+	addFiles(t, fSysExpected, "/a/b/dst", kustomization)
+	checkFSys(t, fSysExpected, fSys)
 }
 
 func TestNewLocalizerTargetNestedInScope(t *testing.T) {
 	fSys := makeMemoryFs(t)
-	_ = createLocalizer(t, fSys, "/a/b", "/", "/a/b/dst")
+	kustomization := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- patch: |-
+    - op: replace
+      path: /some/existing/path
+      value: new value
+  target:
+    kind: Deployment
+    labelSelector: env=dev
+`,
+	}
+	addFiles(t, fSys, "/a/b", kustomization)
+	lclzr := createLocalizer(t, fSys, "/a/b", "/", "/a/b/dst")
+	require.NoError(t, lclzr.Localize())
 
 	fSysExpected := makeMemoryFs(t)
-	require.NoError(t, fSysExpected.MkdirAll("/a/b/dst/a/b"))
-	require.Equal(t, fSysExpected, fSys)
+	addFiles(t, fSysExpected, "/a/b", kustomization)
+	addFiles(t, fSysExpected, "/a/b/dst/a/b", kustomization)
+	checkFSys(t, fSysExpected, fSys)
 }
 
 func TestLocalizeKustomizationName(t *testing.T) {
 	fSys := makeMemoryFs(t)
 	kustomization := map[string]string{
 		"Kustomization": `apiVersion: kustomize.config.k8s.io/v1beta1
-configMapGenerator:
-- behavior: create
-  literals:
-  - APPLE=orange
-  name: map
+commonLabels:
+  label-one: value-one
+  label-two: value-two
 kind: Kustomization
-resources:
-- pod.yaml
 `,
 	}
 	addFiles(t, fSys, "/a", kustomization)
@@ -113,5 +179,162 @@ resources:
 	addFiles(t, fSysExpected, "/dst/a", map[string]string{
 		"kustomization.yaml": kustomization["Kustomization"],
 	})
-	require.Equal(t, fSysExpected, fSys)
+	checkFSys(t, fSysExpected, fSys)
+}
+
+func TestLocalizeFileName(t *testing.T) {
+	for name, path := range map[string]string{
+		"nested_directories":               "a/b/c/d/patch.yaml",
+		"localize_dir_name_when_absent":    LocalizeDir,
+		"in_localize_dir_name_when_absent": fmt.Sprintf("%s/patch.yaml", LocalizeDir),
+		"no_file_extension":                "patch",
+		"kustomization_name":               "a/kustomization.yaml",
+	} {
+		t.Run(name, func(t *testing.T) {
+			fSys := makeMemoryFs(t)
+			kustAndPatch := map[string]string{
+				"kustomization.yaml": fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: %s
+`, path),
+				path: podConfiguration,
+			}
+			addFiles(t, fSys, "/a", kustAndPatch)
+
+			lclzr := createLocalizer(t, fSys, "/a", "/", "/a/dst")
+			require.NoError(t, lclzr.Localize())
+
+			fSysExpected := makeMemoryFs(t)
+			addFiles(t, fSysExpected, "/a", kustAndPatch)
+			addFiles(t, fSysExpected, "/a/dst/a", kustAndPatch)
+			checkFSys(t, fSysExpected, fSys)
+		})
+	}
+}
+
+func TestLocalizeFileCleaned(t *testing.T) {
+	fSys := makeMemoryFs(t)
+	kustAndPatch := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: ../gamma/../../../alpha/beta/./gamma/patch.yaml
+`,
+		"patch.yaml": podConfiguration,
+	}
+	addFiles(t, fSys, "/alpha/beta/gamma", kustAndPatch)
+
+	lclzr := createLocalizer(t, fSys, "/alpha/beta/gamma", "/", "")
+	require.NoError(t, lclzr.Localize())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/alpha/beta/gamma", kustAndPatch)
+	addFiles(t, fSysExpected, "/localized-gamma/alpha/beta/gamma", map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patch.yaml
+`,
+		"patch.yaml": podConfiguration,
+	})
+	checkFSys(t, fSysExpected, fSys)
+}
+
+func TestLocalizePatches(t *testing.T) {
+	fSys := makeMemoryFs(t)
+	kustAndPatch := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/version: 1.21.0
+      name: dummy-app
+  target:
+    labelSelector: app.kubernetes.io/name=nginx
+- options:
+    allowNameChange: true
+  path: patch.yaml
+`,
+		"patch.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.21.0
+`,
+	}
+	addFiles(t, fSys, "/", kustAndPatch)
+
+	lclzr := createLocalizer(t, fSys, "/", "", "")
+	require.NoError(t, lclzr.Localize())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/", kustAndPatch)
+	addFiles(t, fSysExpected, "/localized", kustAndPatch)
+	checkFSys(t, fSysExpected, fSys)
+}
+
+func TestLocalizePatchesJson6902(t *testing.T) {
+	fSys := makeMemoryFs(t)
+	kustAndPatch := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesJson6902:
+- options:
+    allowKindChange: true
+  patch: |-
+    - op: add
+      path: /some/new/path
+      value: value
+    - op: move
+      from: /some/existing/path
+      path: /some/existing/destination/path
+  target:
+    kind: Service
+    name: my-service
+    version: v1
+- path: patch.yaml
+  target:
+    name: my-deployment
+`,
+		"patch.yaml": ` [
+   {"op": "copy", "from": "/some/existing/path", "path": "/some/path"},
+   {"op": "remove", "path": "/some/existing/path"},
+   {"op": "test", "path": "/some/path", "value": "my-node-value"}
+ ]
+`,
+	}
+	addFiles(t, fSys, "/a", kustAndPatch)
+
+	lclzr := createLocalizer(t, fSys, "/a", "", "")
+	require.NoError(t, lclzr.Localize())
+
+	fSysExpected := makeMemoryFs(t)
+	addFiles(t, fSysExpected, "/a", kustAndPatch)
+	addFiles(t, fSysExpected, "/localized-a", kustAndPatch)
+	checkFSys(t, fSysExpected, fSys)
+}
+
+func TestLocalizeFileNoFile(t *testing.T) {
+	fSys := makeMemoryFs(t)
+	kustAndPatch := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: name-DNE.yaml
+`,
+	}
+	addFiles(t, fSys, "/a/b", kustAndPatch)
+
+	lclzr := createLocalizer(t, fSys, "/a/b", "", "/dst")
+	require.Error(t, lclzr.Localize())
 }

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -14,7 +14,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
+// DstPrefix prefixes the target and ref, if target is remote, in the default localize destination directory name
 const DstPrefix = "localized"
+
+// LocalizeDir is the name of the localize directories used to store remote content in the localize destination
 const LocalizeDir = "localized-files"
 
 // establishScope returns the effective scope given localize arguments and targetLdr at rawTarget. For remote rawTarget,
@@ -57,7 +60,7 @@ func createNewDir(rawNewDir string, targetLdr ifc.Loader, spec *git.RepoSpec, fS
 	newDir, err := filesys.ConfirmDir(fSys, rawNewDir)
 	if err != nil {
 		if errCleanup := fSys.RemoveAll(newDir.String()); errCleanup != nil {
-			log.Printf("%s", errors.WrapPrefixf(errCleanup, "unable to clean localize destination").Error())
+			log.Printf("%s", errors.WrapPrefixf(errCleanup, "unable to clean localize destination"))
 		}
 		return "", errors.WrapPrefixf(err, "unable to establish localize destination")
 	}
@@ -98,7 +101,7 @@ func urlBase(url string) string {
 func hasRef(repoURL string) bool {
 	repoSpec, err := git.NewRepoSpecFromURL(repoURL)
 	if err != nil {
-		log.Fatalf("unable to parse validated root url: %s", err.Error())
+		log.Fatalf("unable to parse validated root url: %s", err)
 	}
 	return repoSpec.Ref != ""
 }
@@ -108,11 +111,11 @@ func cleanFilePath(fSys filesys.FileSystem, root filesys.ConfirmedDir, file stri
 	abs := root.Join(file)
 	dir, f, err := fSys.CleanedAbs(abs)
 	if err != nil {
-		log.Fatalf("cannot clean validated file path %q: %s", abs, err.Error())
+		log.Fatalf("cannot clean validated file path %q: %s", abs, err)
 	}
 	locPath, err := filepath.Rel(root.String(), dir.Join(f))
 	if err != nil {
-		log.Fatalf("cannot find path from parent %q to file %q: %s", root.String(), dir.Join(f), err.Error())
+		log.Fatalf("cannot find path from parent %q to file %q: %s", root, dir.Join(f), err)
 	}
 	return locPath
 }

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -14,7 +14,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-// establishScope returns the effective scope given localize arguments and targetLdr at rawTarget. For remote targetArg,
+const DstPrefix = "localized"
+const LocalizeDir = "localized-files"
+
+// establishScope returns the effective scope given localize arguments and targetLdr at rawTarget. For remote rawTarget,
 // the effective scope is the downloaded repo.
 func establishScope(rawScope string, rawTarget string, targetLdr ifc.Loader, fSys filesys.FileSystem) (filesys.ConfirmedDir, error) {
 	if repo := targetLdr.Repo(); repo != "" {
@@ -98,4 +101,24 @@ func hasRef(repoURL string) bool {
 		log.Fatalf("unable to parse validated root url: %s", err.Error())
 	}
 	return repoSpec.Ref != ""
+}
+
+// cleanFilePath returns file cleaned, where file is a relative path to root on fSys
+func cleanFilePath(fSys filesys.FileSystem, root filesys.ConfirmedDir, file string) string {
+	abs := root.Join(file)
+	dir, f, err := fSys.CleanedAbs(abs)
+	if err != nil {
+		log.Fatalf("cannot clean validated file path %q: %s", abs, err.Error())
+	}
+	locPath, err := filepath.Rel(root.String(), dir.Join(f))
+	if err != nil {
+		log.Fatalf("cannot find path from parent %q to file %q: %s", root.String(), dir.Join(f), err.Error())
+	}
+	return locPath
+}
+
+// locFilePath returns the relative localized path of validated file url fileURL
+// TODO(annasong): implement
+func locFilePath(_ string) string {
+	return filepath.Join(LocalizeDir, "")
 }


### PR DESCRIPTION
This PR introduces the skeleton for `localizeFile()` and begins to test it on the `patches`, `patchesJson6902` fields.