### PR TITLE
Allow `kustomize localize` to process directories

### DIFF
--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -145,3 +145,12 @@ func locFilePath(fileURL string) string {
 	// so we can use it as is.
 	return filepath.Join(LocalizeDir, u.Hostname(), path)
 }
+
+// locRootPath returns the relative localized path of the validated root url rootURL, where the local copy of its repo
+// is at repoDir and the copy of its root is at rootDir
+// TODO(annasong): implement
+func locRootPath(rootURL string, repoDir string, rootDir filesys.ConfirmedDir) string {
+	_ = rootURL
+	_, _ = repoDir, rootDir
+	return ""
+}


### PR DESCRIPTION
This PR adds directory processing to `kustomize localize`. Certain remote-handling code introduces additional complexity, and so will be implemented in a separate PR. The directory localization logic is tested on the `Components` field.