### PR TITLE
Load built-in plugins for `kustomize localize`

### DIFF
--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package localizer
+
+import "sigs.k8s.io/kustomize/kyaml/yaml"
+
+// localizeBuiltinPlugin localizes built-in plugins with file paths.
+type localizeBuiltinPlugin struct {
+}
+
+// Filter localizes the built-in plugins with file paths. Filter returns an error if
+// plugins contains a resource that is not a built-in plugin, cannot contain a file path,
+// or is not localizable.
+// TODO(annasong): implement
+func (lbp *localizeBuiltinPlugin) Filter(plugins []*yaml.RNode) ([]*yaml.RNode, error) {
+	return plugins, nil
+}

--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -3,12 +3,17 @@
 
 package localizer
 
-import "sigs.k8s.io/kustomize/kyaml/yaml"
+import (
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
 
 // localizeBuiltinGenerators localizes built-in generators with file paths.
 // Note that this excludes helm, which needs a repo.
 type localizeBuiltinGenerators struct {
 }
+
+var _ kio.Filter = &localizeBuiltinGenerators{}
 
 // Filter localizes the built-in generators with file paths. Filter returns an error if
 // generators contains a resource that is not a built-in generator, cannot contain a file path,
@@ -21,6 +26,8 @@ func (lbg *localizeBuiltinGenerators) Filter(generators []*yaml.RNode) ([]*yaml.
 // localizeBuiltinTransformers localizes built-in transformers with file paths.
 type localizeBuiltinTransformers struct {
 }
+
+var _ kio.Filter = &localizeBuiltinTransformers{}
 
 // Filter localizes the built-in transformers with file paths. Filter returns an error if
 // transformers contains a resource that is not a built-in transformer, cannot contain a file path,

--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -5,14 +5,27 @@ package localizer
 
 import "sigs.k8s.io/kustomize/kyaml/yaml"
 
-// localizeBuiltinPlugin localizes built-in plugins with file paths.
-type localizeBuiltinPlugin struct {
+// localizeBuiltinGenerators localizes built-in generators with file paths.
+// Note that this excludes helm, which needs a repo.
+type localizeBuiltinGenerators struct {
 }
 
-// Filter localizes the built-in plugins with file paths. Filter returns an error if
-// plugins contains a resource that is not a built-in plugin, cannot contain a file path,
+// Filter localizes the built-in generators with file paths. Filter returns an error if
+// generators contains a resource that is not a built-in generator, cannot contain a file path,
+// needs more than a file path like helm, or is not localizable.
+// TODO(annasong): implement
+func (lbg *localizeBuiltinGenerators) Filter(generators []*yaml.RNode) ([]*yaml.RNode, error) {
+	return generators, nil
+}
+
+// localizeBuiltinTransformers localizes built-in transformers with file paths.
+type localizeBuiltinTransformers struct {
+}
+
+// Filter localizes the built-in transformers with file paths. Filter returns an error if
+// transformers contains a resource that is not a built-in transformer, cannot contain a file path,
 // or is not localizable.
 // TODO(annasong): implement
-func (lbp *localizeBuiltinPlugin) Filter(plugins []*yaml.RNode) ([]*yaml.RNode, error) {
-	return plugins, nil
+func (lbt *localizeBuiltinTransformers) Filter(transformers []*yaml.RNode) ([]*yaml.RNode, error) {
+	return transformers, nil
 }

--- a/api/internal/localizer/errors.go
+++ b/api/internal/localizer/errors.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package localizer
+
+import "fmt"
+
+type ResourceLoadError struct {
+	InlineError error
+	FileError   error
+}
+
+var _ error = ResourceLoadError{}
+
+func (rle ResourceLoadError) Error() string {
+	return fmt.Sprintf(`when parsing as inline received error: %s
+when parsing as filepath received error: %s`, rle.InlineError, rle.FileError)
+}

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -141,7 +141,6 @@ func (lc *Localizer) localizeBuiltinPlugins(kust *types.Kustomization) error {
 	for fieldName, plugins := range map[string][]string{
 		"generator":   kust.Generators,
 		"transformer": kust.Transformers,
-		"validator":   kust.Validators,
 	} {
 		for i, entry := range plugins {
 			var isPath bool
@@ -169,6 +168,9 @@ when parsing as filepath received error`, fieldName, entry, inlineErr)
 			}
 			plugins[i] = newEntry
 		}
+	}
+	if len(kust.Validators) > 0 {
+		return errors.Errorf("no built-in validators with file paths, but validators field non-empty")
 	}
 	return nil
 }

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -300,7 +300,7 @@ patches:
 	require.Error(t, lclzr.Localize())
 }
 
-func TestLocalizePlugins(t *testing.T) {
+func TestLocalizeBuiltinPlugins(t *testing.T) {
 	fSys := makeMemoryFs(t)
 	kustAndPlugins := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
@@ -348,7 +348,7 @@ target:
 	require.Equal(t, fSysExpected, fSys)
 }
 
-func TestLocalizePluginsNotBuiltin(t *testing.T) {
+func TestLocalizeBuiltinPluginsNotBuiltin(t *testing.T) {
 	fSys := makeMemoryFs(t)
 	kustAndPlugins := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -10,8 +10,6 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/git"
-	"sigs.k8s.io/kustomize/api/konfig"
-	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -126,8 +124,4 @@ func cleanFilePath(fSys filesys.FileSystem, root filesys.ConfirmedDir, file stri
 // TODO(annasong): implement
 func locFilePath(_ string) string {
 	return filepath.Join(LocalizeDir, "")
-}
-
-func isBuiltinPlugin(res *resource.Resource) bool {
-	return res.GetGvk().Group == "" && res.GetGvk().Version == konfig.BuiltinPluginApiVersion
 }

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -10,6 +10,8 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/git"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -124,4 +126,8 @@ func cleanFilePath(fSys filesys.FileSystem, root filesys.ConfirmedDir, file stri
 // TODO(annasong): implement
 func locFilePath(_ string) string {
 	return filepath.Join(LocalizeDir, "")
+}
+
+func isBuiltinPlugin(res *resource.Resource) bool {
+	return res.GetGvk().Group == "" && res.GetGvk().Version == konfig.BuiltinPluginApiVersion
 }


### PR DESCRIPTION
This PR begins to handle built-in plugins for `kustomize localize`. 

This PR loads the plugins under the `generators`, `transformers`, and `validators` fields as resources. It also sets up the `Filter` skeleton that will be used to localize the plugins.

EDIT: This PR no longer checks that the loaded plugins are `builtin`. This and the localization will happen in separate PRs.