### PR TITLE
feat: add remove secret command

### DIFF
--- a/kustomize/commands/edit/remove/all.go
+++ b/kustomize/commands/edit/remove/all.go
@@ -22,6 +22,9 @@ func NewCmdRemove(
 	kustomize edit remove resource {filepath} {filepath}
 	kustomize edit remove resource {pattern}
 
+	# Removes one or more secret from the kustomization file
+	kustomize edit remove secret {name1},{name2}
+
 	# Removes one or more patches from the kustomization file
 	kustomize edit remove patch --path {filepath} --group {target group name} --version {target version}
 
@@ -37,6 +40,7 @@ func NewCmdRemove(
 		Args: cobra.MinimumNArgs(1),
 	}
 	c.AddCommand(
+		newCmdRemoveSecret(fSys),
 		newCmdRemoveResource(fSys),
 		newCmdRemoveLabel(fSys, v.MakeLabelNameValidator()),
 		newCmdRemoveAnnotation(fSys, v.MakeAnnotationNameValidator()),

--- a/kustomize/commands/edit/remove/removesecret.go
+++ b/kustomize/commands/edit/remove/removesecret.go
@@ -1,0 +1,92 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package remove
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kustomize/v4/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type removeSecretOptions struct {
+	secretNames []string
+}
+
+// newCmdRemoveSecret remove the name of a file containing a secret to the kustomization file.
+func newCmdRemoveSecret(fSys filesys.FileSystem) *cobra.Command {
+	var o removeSecretOptions
+
+	cmd := &cobra.Command{
+		Use: "secret",
+		Short: "Removes specified secret" +
+			konfig.DefaultKustomizationFileName(),
+		Example: `
+		remove secret my-secret
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := o.Validate(args)
+			if err != nil {
+				return err
+			}
+			return o.RunRemoveSecret(fSys)
+		},
+	}
+	return cmd
+}
+
+// Validate validates removeSecret command.
+func (o *removeSecretOptions) Validate(args []string) error {
+	if len(args) == 0 {
+		return errors.New("must specify a secret name")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: %s; to provide multiple config map options, please separate options by comma", args)
+	}
+	o.secretNames = strings.Split(args[0], ",")
+	return nil
+}
+
+// RunRemoveSecret runs Secret command (do real work).
+func (o *removeSecretOptions) RunRemoveSecret(fSys filesys.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
+	if err != nil {
+		return err
+	}
+
+	m, err := mf.Read()
+	if err != nil {
+		return err
+	}
+
+	var newSecrets []types.SecretArgs
+	foundSecrets := make(map[string]bool)
+	for _, removeName := range o.secretNames {
+		foundSecrets[removeName] = false
+	}
+
+	for _, currentSecret := range m.SecretGenerator {
+		if kustfile.StringInSlice(currentSecret.Name, o.secretNames) {
+			foundSecrets[currentSecret.Name] = true
+			continue
+		}
+		newSecrets = append(newSecrets, currentSecret)
+	}
+
+	for name, found := range foundSecrets {
+		if !found {
+			log.Printf("secret %s doesn't exist in kustomization file", name)
+		}
+	}
+
+	m.SecretGenerator = newSecrets
+	return mf.Write(m)
+}

--- a/kustomize/commands/edit/remove/removesecret_test.go
+++ b/kustomize/commands/edit/remove/removesecret_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package remove
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v4/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestRemoveSecret(t *testing.T) {
+	const secretName01 = "example-secret-01"
+	const secretName02 = "example-secret-02"
+
+	tests := map[string]struct {
+		input       string
+		args        []string
+		expectedErr string
+	}{
+		"happy path": {
+			input: fmt.Sprintf(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+- name: %s
+  files:
+  - longsecret.txt
+`, secretName01),
+			args: []string{secretName01},
+		},
+		"multiple": {
+			input: fmt.Sprintf(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+- name: %s
+  files:
+  - longsecret.txt
+- name: %s
+  files:
+  - longsecret.txt
+`, secretName01, secretName02),
+			args: []string{
+				fmt.Sprintf("%s,%s", secretName01, secretName02),
+			},
+		},
+		"miss": {
+			input: fmt.Sprintf(`
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+- name: %s
+  files:
+  - longsecret.txt
+`, secretName01),
+			args: []string{"foo"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fSys := filesys.MakeFsInMemory()
+			testutils_test.WriteTestKustomizationWith(fSys, []byte(tc.input))
+			cmd := newCmdRemoveSecret(fSys)
+			err := cmd.RunE(cmd, tc.args)
+			if tc.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				content, err := testutils_test.ReadTestKustomization(fSys)
+				assert.NoError(t, err)
+				for _, opt := range strings.Split(tc.args[0], ",") {
+					assert.NotContains(t, string(content), opt)
+				}
+			}
+		})
+	}
+}

--- a/kustomize/commands/edit/remove/removesecret_test.go
+++ b/kustomize/commands/edit/remove/removesecret_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package remove
+package remove //nolint:testpackage
 
 import (
 	"fmt"


### PR DESCRIPTION
If someone need update the file list of the `secretGenerator` from directory, they can use `add secret` and `remove secret` together.

Related to #4796 