### PR TITLE
Contain `RepoSpec` path in repo

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -93,6 +93,11 @@ func NewRepoSpecFromURL(n string) (*RepoSpec, error) {
 	if host == "" {
 		return nil, fmt.Errorf("url lacks host: %s", n)
 	}
+	cleanedPath := filepath.Clean(strings.TrimPrefix(path, string(filepath.Separator)))
+	if pathElements := strings.Split(cleanedPath, string(filepath.Separator)); len(pathElements) > 0 &&
+		pathElements[0] == filesys.ParentDir {
+		return nil, fmt.Errorf("url path exits repo: %s", n)
+	}
 	return &RepoSpec{
 		raw: n, Host: host, OrgRepo: orgRepo,
 		Dir: notCloned, Path: path, Ref: gitRef, GitSuffix: suffix,

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -101,6 +101,10 @@ func TestNewRepoSpecFromUrlErrors(t *testing.T) {
 			"https://host?ref=group/version/minor_version",
 			"url lacks orgRepo",
 		},
+		"path_exits_repo": {
+			"https://github.com/org/repo.git//path/../../exits/repo",
+			"url path exits repo",
+		},
 	}
 
 	for name, testCase := range badData {

--- a/api/loader/fileloader.go
+++ b/api/loader/fileloader.go
@@ -222,6 +222,13 @@ func newLoaderAtGitClone(
 			"'%s' refers to file '%s'; expecting directory",
 			repoSpec.AbsPath(), f)
 	}
+	// Path in repo can contain symlinks that exit repo. We can only
+	// check for this after cloning repo.
+	if !root.HasPrefix(repoSpec.CloneDir()) {
+		_ = cleaner()
+		return nil, fmt.Errorf("%q refers to directory outside of repo %q", repoSpec.AbsPath(),
+			repoSpec.CloneDir())
+	}
 	return &fileLoader{
 		// Clones never allowed to escape root.
 		loadRestrictor: RestrictionRootOnly,


### PR DESCRIPTION
This PR aims to fix issue #4850, that `RepoSpec` path can exit the repo. 