### PR TITLE
Fix pluginator incompatibility with nolint lines

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -19,16 +19,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// HelmChartInflationGeneratorPlugin is a plugin to generate resources
-// from a remote or local helm chart.
+// Generate resources from a remote or local helm chart.
 type HelmChartInflationGeneratorPlugin struct {
 	h *resmap.PluginHelpers
 	types.HelmGlobals
 	types.HelmChart
 	tmpDir string
 }
-
-var KustomizePlugin HelmChartInflationGeneratorPlugin
 
 const (
 	valuesMergeOptionMerge    = "merge"

--- a/cmd/pluginator/internal/builtinplugin/builtinplugin.go
+++ b/cmd/pluginator/internal/builtinplugin/builtinplugin.go
@@ -72,10 +72,7 @@ func ConvertToBuiltInPlugin() (retErr error) {
 		if strings.HasPrefix(l, "//go:generate") {
 			continue
 		}
-		if strings.HasPrefix(l, "//noinspection") {
-			continue
-		}
-		if l == "var "+konfig.PluginSymbol+" plugin" {
+		if strings.HasPrefix(l, "var "+konfig.PluginSymbol+" plugin") {
 			continue
 		}
 		if strings.Contains(l, " Transform(") {
@@ -136,9 +133,12 @@ func newWriter(r string) (*writer, error) {
 }
 
 // Assume that this command is running with a $PWD of
-//   $HOME/kustomize/plugin/builtin/secretGenerator
+//
+//	$HOME/kustomize/plugin/builtin/secretGenerator
+//
 // (for example).  Then we want to write to
-//   $HOME/kustomize/api/builtins
+//
+//	$HOME/kustomize/api/builtins
 func makeOutputFileName(root string) string {
 	return filepath.Join(
 		"..", "..", "..", "api/internal", packageForGeneratedCode, root+".go")

--- a/cmd/pluginator/internal/krmfunction/converter_test.go
+++ b/cmd/pluginator/internal/krmfunction/converter_test.go
@@ -34,8 +34,7 @@ type plugin struct{
   FieldSpecs       []types.FieldSpec ` + "`json:\"fieldSpecs,omitempty\" yaml:\"fieldSpecs,omitempty\"`" + `
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
   _ *resmap.PluginHelpers, config []byte) (err error) {
@@ -171,8 +170,7 @@ type plugin struct {
 	types.ConfigMapArgs
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.ConfigMapArgs = types.ConfigMapArgs{}

--- a/cmd/pluginator/internal/krmfunction/funcwrappersrc/fakeplugin.go
+++ b/cmd/pluginator/internal/krmfunction/funcwrappersrc/fakeplugin.go
@@ -9,8 +9,7 @@ import (
 
 type plugin struct{}
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, _ []byte) (err error) {

--- a/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
+++ b/plugin/builtin/annotationstransformer/AnnotationsTransformer.go
@@ -17,8 +17,7 @@ type plugin struct {
 	FieldSpecs  []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
+++ b/plugin/builtin/configmapgenerator/ConfigMapGenerator.go
@@ -17,8 +17,7 @@ type plugin struct {
 	types.ConfigMapArgs
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.ConfigMapArgs = types.ConfigMapArgs{}

--- a/plugin/builtin/hashtransformer/HashTransformer.go
+++ b/plugin/builtin/hashtransformer/HashTransformer.go
@@ -15,8 +15,7 @@ type plugin struct {
 	hasher ifc.KustHasher
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	h *resmap.PluginHelpers, _ []byte) (err error) {

--- a/plugin/builtin/iampolicygenerator/IAMPolicyGenerator.go
+++ b/plugin/builtin/iampolicygenerator/IAMPolicyGenerator.go
@@ -15,8 +15,7 @@ type plugin struct {
 	types.IAMPolicyGeneratorArgs
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.IAMPolicyGeneratorArgs = types.IAMPolicyGeneratorArgs{}

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -18,8 +18,7 @@ type plugin struct {
 	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/labeltransformer/LabelTransformer.go
+++ b/plugin/builtin/labeltransformer/LabelTransformer.go
@@ -17,8 +17,7 @@ type plugin struct {
 	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
+++ b/plugin/builtin/legacyordertransformer/LegacyOrderTransformer.go
@@ -19,8 +19,7 @@ import (
 // (like ValidatingWebhookConfiguration) last.
 type plugin struct{}
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 // Nothing needed for configuration.
 func (p *plugin) Config(

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -22,8 +22,7 @@ type plugin struct {
 	SetRoleBindingSubjects namespace.RoleBindingSubjectMode `json:"setRoleBindingSubjects" yaml:"setRoleBindingSubjects"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
+++ b/plugin/builtin/patchjson6902transformer/PatchJson6902Transformer.go
@@ -25,8 +25,7 @@ type plugin struct {
 	JsonOp       string          `json:"jsonOp,omitempty" yaml:"jsonOp,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	h *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
@@ -19,8 +19,7 @@ type plugin struct {
 	Patches       string                      `json:"patches,omitempty" yaml:"patches,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	h *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -26,8 +26,7 @@ type plugin struct {
 	Options      map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	h *resmap.PluginHelpers, c []byte) error {

--- a/plugin/builtin/prefixtransformer/PrefixTransformer.go
+++ b/plugin/builtin/prefixtransformer/PrefixTransformer.go
@@ -20,8 +20,7 @@ type plugin struct {
 	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 // TODO: Make this gvk skip list part of the config.
 var prefixFieldSpecsToSkip = types.FsSlice{

--- a/plugin/builtin/replacementtransformer/ReplacementTransformer.go
+++ b/plugin/builtin/replacementtransformer/ReplacementTransformer.go
@@ -20,8 +20,7 @@ type plugin struct {
 	Replacements    []types.Replacement      `json:"omitempty" yaml:"omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	h *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
+++ b/plugin/builtin/replicacounttransformer/ReplicaCountTransformer.go
@@ -21,8 +21,7 @@ type plugin struct {
 	FieldSpecs []types.FieldSpec `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(
 	_ *resmap.PluginHelpers, c []byte) (err error) {

--- a/plugin/builtin/secretgenerator/SecretGenerator.go
+++ b/plugin/builtin/secretgenerator/SecretGenerator.go
@@ -17,8 +17,7 @@ type plugin struct {
 	types.SecretArgs
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(h *resmap.PluginHelpers, config []byte) (err error) {
 	p.SecretArgs = types.SecretArgs{}

--- a/plugin/builtin/suffixtransformer/SuffixTransformer.go
+++ b/plugin/builtin/suffixtransformer/SuffixTransformer.go
@@ -20,8 +20,7 @@ type plugin struct {
 	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 // TODO: Make this gvk skip list part of the config.
 var suffixFieldSpecsToSkip = types.FsSlice{

--- a/plugin/builtin/valueaddtransformer/ValueAddTransformer.go
+++ b/plugin/builtin/valueaddtransformer/ValueAddTransformer.go
@@ -49,8 +49,7 @@ type Target struct {
 	FilePathPosition int `json:"filePathPosition,omitempty" yaml:"filePathPosition,omitempty"`
 }
 
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 	err := yaml.Unmarshal(c, p)

--- a/plugin/someteam.example.com/v1/calvinduplicator/CalvinDuplicator.go
+++ b/plugin/someteam.example.com/v1/calvinduplicator/CalvinDuplicator.go
@@ -22,9 +22,7 @@ type plugin struct {
 	Count int `json:"count,omitempty" yaml:"count,omitempty"`
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) Config(_ *resmap.PluginHelpers, c []byte) error {
 	return yaml.Unmarshal(c, p)

--- a/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
+++ b/plugin/someteam.example.com/v1/dateprefixer/DatePrefixer.go
@@ -21,9 +21,7 @@ type plugin struct {
 	t resmap.Transformer
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) makePrefixPluginConfig() ([]byte, error) {
 	var s struct {
@@ -55,7 +53,9 @@ func (p *plugin) Config(h *resmap.PluginHelpers, _ []byte) error {
 }
 
 // Returns a constant, rather than
-//   time.Now().Format("2006-01-02")
+//
+//	time.Now().Format("2006-01-02")
+//
 // to make tests happy.
 // This is just an example.
 func getDate() string {

--- a/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
+++ b/plugin/someteam.example.com/v1/secretsfromdatabase/SecretsFromDatabase.go
@@ -19,9 +19,7 @@ type plugin struct {
 	Keys []string `json:"keys,omitempty" yaml:"keys,omitempty"`
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 var database = map[string]string{
 	"TREE":      "oak",

--- a/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
+++ b/plugin/someteam.example.com/v1/someservicegenerator/SomeServiceGenerator.go
@@ -19,9 +19,7 @@ type plugin struct {
 	Port             string `json:"port,omitempty" yaml:"port,omitempty"`
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 const tmpl = `
 apiVersion: v1

--- a/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
+++ b/plugin/someteam.example.com/v1/stringprefixer/StringPrefixer.go
@@ -22,9 +22,7 @@ type plugin struct {
 	t                resmap.Transformer
 }
 
-//nolint: golint
-//noinspection GoUnusedGlobalVariable
-var KustomizePlugin plugin
+var KustomizePlugin plugin //nolint:gochecknoglobals
 
 func (p *plugin) makePrefixPluginConfig(n string) ([]byte, error) {
 	var s struct {


### PR DESCRIPTION
#4019 has a bunch of test/lint failures that are ultimately caused by an incompatibility between the pluginator tooling and a newer lint enforcement. This fixes the problem by: 
- expecting excluded lines to merely _begin_ with the global variable code, allowing for comments at the end (I could more specifically exclude comments--lmk if you think that's necessary)
- getting rid of the redundant `//noinspection GoUnusedGlobalVariable` lines. Those are for Goland specifically. First, we don't generally allow for code specific to one editor. Second, it is redundant with a linter rule we enforce in CI. Third, my own Goland really really wants to put a space after the `//` for some reason, which is not what pluginator expects (very annoying). 😆 