### PR TITLE
Remove local-only resources at the last minute

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -158,6 +158,11 @@ func (kt *KustTarget) makeCustomizedResMap() (resmap.ResMap, error) {
 		return nil, err
 	}
 
+	err = kt.IgnoreLocal(ra)
+	if err != nil {
+		return nil, err
+	}
+
 	return ra.ResMap(), nil
 }
 
@@ -237,10 +242,6 @@ func (kt *KustTarget) accumulateTarget(ra *accumulator.ResAccumulator) (
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "merging vars %v", kt.kustomization.Vars)
-	}
-	err = kt.IgnoreLocal(ra)
-	if err != nil {
-		return nil, err
 	}
 	return ra, nil
 }


### PR DESCRIPTION
This allows name references to local-only objects to be correctly resolved before the objects are removed from the set to be printed. The use case that made me think of this is the common Ingress situation from https://github.com/kubernetes-sigs/kustomize/issues/4884, where there are several related values that are list items. If we can formally identify those values as names, then we can update them intelligently, even across multiple objects.

The side-effect is that local resources from a base will be exposed to overlays. Can you think of any reason that's undesirable? I was surprised it wasn't already the case, personally.