### PR TITLE
HelmChartInflationGenerator: split on yaml document end markers

### DIFF
--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -258,7 +258,7 @@ func (p *plugin) Generate() (rm resmap.ResMap, err error) {
 	// try to remove the contents before first "---" because
 	// helm may produce messages to stdout before it
 	stdoutStr := string(stdout)
-	if idx := strings.Index(stdoutStr, "---"); idx != -1 {
+	if idx := strings.Index(stdoutStr, "\n---\n"); idx != -1 {
 		return p.h.ResmapFactory().NewResMapFromBytes([]byte(stdoutStr[idx:]))
 	}
 	return nil, err


### PR DESCRIPTION
As per the [yaml spec](https://yaml.org/spec/1.2.2/#912-document-markers), split on document end markers (e.g. - `---` on line by itself) as opposed to `---` anywhere in the string. The latter was splitting in the bodies of configmaps, [CRD description fields](https://github.com/rook/rook/pull/11332), etc.

Thanks

CC: @yuwenma @natasha41575  