### PR TITLE
Load legacy kustomization fields for `localize`

### DIFF
--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -9,6 +9,7 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/generators"
+	"sigs.k8s.io/kustomize/api/internal/target"
 	"sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -96,9 +97,9 @@ func (lc *localizer) localize() error {
 
 // load returns the kustomization at lc.root and the file name under which it was found
 func (lc *localizer) load() (*types.Kustomization, string, error) {
-	content, kustFileName, err := loadKustFile(lc.ldr)
+	content, kustFileName, err := target.LoadKustFile(lc.ldr)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.Wrap(err)
 	}
 	content, err = types.FixKustomizationPreUnmarshalling(content)
 	if err != nil {

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -50,6 +50,17 @@ func addFiles(t *testing.T, fSys filesys.FileSystem, parentDir string, files map
 	}
 }
 
+func makeFileSystems(t *testing.T, target string, files map[string]string) (expected filesys.FileSystem, actual filesys.FileSystem) {
+	t.Helper()
+
+	copies := make([]filesys.FileSystem, 2)
+	for i := range copies {
+		copies[i] = makeMemoryFs(t)
+		addFiles(t, copies[i], target, files)
+	}
+	return copies[0], copies[1]
+}
+
 func checkFSys(t *testing.T, fSysExpected filesys.FileSystem, fSysActual filesys.FileSystem) {
 	t.Helper()
 
@@ -95,25 +106,22 @@ func reportFSysDiff(t *testing.T, fSysExpected filesys.FileSystem, fSysActual fi
 }
 
 func TestTargetIsScope(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustomization := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: my-
 `,
 	}
-	addFiles(t, fSys, "/a", kustomization)
-	err := Run("/a", "", "/a/b/dst", fSys)
+	fSysExpected, fSysActual := makeFileSystems(t, "/a", kustomization)
+
+	err := Run("/a", "", "/a/b/dst", fSysActual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustomization)
 	addFiles(t, fSysExpected, "/a/b/dst", kustomization)
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, fSysExpected, fSysActual)
 }
 
 func TestTargetNestedInScope(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustomization := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -127,18 +135,16 @@ patches:
     labelSelector: env=dev
 `,
 	}
-	addFiles(t, fSys, "/a/b", kustomization)
-	err := Run("/a/b", "/", "/a/b/dst", fSys)
+	fSysExpected, fSysActual := makeFileSystems(t, "/a/b", kustomization)
+
+	err := Run("/a/b", "/", "/a/b/dst", fSysActual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a/b", kustomization)
 	addFiles(t, fSysExpected, "/a/b/dst/a/b", kustomization)
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, fSysExpected, fSysActual)
 }
 
-func TestLocalizeKustomizationName(t *testing.T) {
-	fSys := makeMemoryFs(t)
+func TestLoadKustomizationName(t *testing.T) {
 	kustomization := map[string]string{
 		"Kustomization": `apiVersion: kustomize.config.k8s.io/v1beta1
 commonLabels:
@@ -147,17 +153,105 @@ commonLabels:
 kind: Kustomization
 `,
 	}
-	addFiles(t, fSys, "/a", kustomization)
+	fSysExpected, fSysActual := makeFileSystems(t, "/a", kustomization)
 
-	err := Run("/a", "/", "/dst", fSys)
+	err := Run("/a", "/", "/dst", fSysActual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustomization)
-	addFiles(t, fSysExpected, "/dst/a", map[string]string{
-		"kustomization.yaml": kustomization["Kustomization"],
+	addFiles(t, fSysExpected, "/dst/a", kustomization)
+	checkFSys(t, fSysExpected, fSysActual)
+}
+
+func TestLoadGVKNN(t *testing.T) {
+	for name, kustomization := range map[string]string{
+		"missing": `namePrefix: my-
+`,
+		"wrong": `kind: NotChecked
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			files := map[string]string{
+				"kustomization.yaml": kustomization,
+			}
+			fSysExpected, fSysActual := makeFileSystems(t, "/a", files)
+
+			err := Run("/a", "/a", "/dst", fSysActual)
+			require.NoError(t, err)
+
+			addFiles(t, fSysExpected, "/dst", files)
+			checkFSys(t, fSysExpected, fSysActual)
+		})
+	}
+}
+
+func TestLoadLegacyFields(t *testing.T) {
+	// TODO(annasong): add referenced files when implement legacy field localization
+	kustomization := map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- beta
+configMapGenerator:
+- env: env.properties
+imageTags:
+- name: postgres
+  newName: my-registry/my-postgres
+  newTag: v1
+kind: Kustomization
+`,
+	}
+	fSysExpected, fSysActual := makeFileSystems(t, "/alpha", kustomization)
+
+	err := Run("/alpha", "/alpha", "/beta", fSysActual)
+	require.NoError(t, err)
+
+	addFiles(t, fSysExpected, "/beta", map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- beta
+configMapGenerator:
+- env: env.properties
+images:
+- name: postgres
+  newName: my-registry/my-postgres
+  newTag: v1
+kind: Kustomization
+`,
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, fSysExpected, fSysActual)
+}
+
+func TestLoadKustomizationError(t *testing.T) {
+	for name, test := range map[string]struct {
+		errSuffix string
+		files     map[string]string
+	}{
+		"missing": {
+			errSuffix: `unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/a'`,
+		},
+		"multiple": {
+			errSuffix: `found multiple kustomization files under: /a`,
+			files: map[string]string{
+				"kustomization.yml": `namePrefix: one`,
+				"Kustomization":     `namePrefix: two`,
+			},
+		},
+		"unknown_fields": {
+			errSuffix: `invalid kustomization: json: unknown field "suffix"`,
+			files: map[string]string{
+				"kustomization.yaml": `namePrefix: valid
+suffix: invalid`,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fSysExpected, fSysTest := makeFileSystems(t, "/a", test.files)
+
+			err := Run("/a", "", "", fSysTest)
+			require.EqualError(t, err, `unable to localize target "/a": `+test.errSuffix)
+
+			checkFSys(t, fSysExpected, fSysTest)
+		})
+	}
 }
 
 func TestLocalizeFileName(t *testing.T) {
@@ -169,7 +263,6 @@ func TestLocalizeFileName(t *testing.T) {
 		"kustomization_name":                  "a/kustomization.yaml",
 	} {
 		t.Run(name, func(t *testing.T) {
-			fSys := makeMemoryFs(t)
 			kustAndPatch := map[string]string{
 				"kustomization.yaml": fmt.Sprintf(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -178,21 +271,18 @@ patches:
 `, path),
 				path: podConfiguration,
 			}
-			addFiles(t, fSys, "/a", kustAndPatch)
+			expected, actual := makeFileSystems(t, "/a", kustAndPatch)
 
-			err := Run("/a", "/", "/a/dst", fSys)
+			err := Run("/a", "/", "/a/dst", actual)
 			require.NoError(t, err)
 
-			fSysExpected := makeMemoryFs(t)
-			addFiles(t, fSysExpected, "/a", kustAndPatch)
-			addFiles(t, fSysExpected, "/a/dst/a", kustAndPatch)
-			checkFSys(t, fSysExpected, fSys)
+			addFiles(t, expected, "/a/dst/a", kustAndPatch)
+			checkFSys(t, expected, actual)
 		})
 	}
 }
 
 func TestLocalizeFileCleaned(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPatch := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -201,14 +291,12 @@ patches:
 `,
 		"patch.yaml": podConfiguration,
 	}
-	addFiles(t, fSys, "/alpha/beta/gamma", kustAndPatch)
+	expected, actual := makeFileSystems(t, "/alpha/beta/gamma", kustAndPatch)
 
-	err := Run("/alpha/beta/gamma", "/", "", fSys)
+	err := Run("/alpha/beta/gamma", "/", "", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha/beta/gamma", kustAndPatch)
-	addFiles(t, fSysExpected, "/localized-gamma/alpha/beta/gamma", map[string]string{
+	addFiles(t, expected, "/localized-gamma/alpha/beta/gamma", map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
@@ -216,11 +304,10 @@ patches:
 `,
 		"patch.yaml": podConfiguration,
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeUnreferencedIgnored(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	targetAndUnreferenced := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 configMapGenerator:
@@ -233,22 +320,19 @@ kind: Kustomization
 		"env.properties": "USERNAME=password",
 		"resource.yaml":  podConfiguration,
 	}
-	addFiles(t, fSys, "/alpha/beta", targetAndUnreferenced)
+	expected, actual := makeFileSystems(t, "/alpha/beta", targetAndUnreferenced)
 
-	err := Run("/alpha/beta", "/alpha", "/beta", fSys)
+	err := Run("/alpha/beta", "/alpha", "/beta", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha/beta", targetAndUnreferenced)
-	addFiles(t, fSysExpected, "/beta/beta", map[string]string{
+	addFiles(t, expected, "/beta/beta", map[string]string{
 		"kustomization.yaml": targetAndUnreferenced["kustomization.yaml"],
 		"env":                targetAndUnreferenced["env"],
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizePatches(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPatch := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -278,19 +362,16 @@ spec:
         image: nginx:1.21.0
 `,
 	}
-	addFiles(t, fSys, "/", kustAndPatch)
+	expected, actual := makeFileSystems(t, "/", kustAndPatch)
 
-	err := Run("/", "", "", fSys)
+	err := Run("/", "", "", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", kustAndPatch)
-	addFiles(t, fSysExpected, "/localized", kustAndPatch)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/localized", kustAndPatch)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizePatchesJson(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPatches := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -319,19 +400,16 @@ patchesJson6902:
    {"op": "remove", "path": "/some/existing/path"},
  ]`,
 	}
-	addFiles(t, fSys, "/alpha/beta", kustAndPatches)
+	expected, actual := makeFileSystems(t, "/alpha/beta", kustAndPatches)
 
-	err := Run("/alpha/beta", "/", "/beta", fSys)
+	err := Run("/alpha/beta", "/", "/beta", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha/beta", kustAndPatches)
-	addFiles(t, fSysExpected, "/beta/alpha/beta", kustAndPatches)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/beta/alpha/beta", kustAndPatches)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizePatchesSM(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPatches := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -347,19 +425,16 @@ patchesStrategicMerge:
 `,
 		"patch.yaml": podConfiguration,
 	}
-	addFiles(t, fSys, "/a", kustAndPatches)
+	expected, actual := makeFileSystems(t, "/a", kustAndPatches)
 
-	err := Run("/a", "", "/dst", fSys)
+	err := Run("/a", "", "/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndPatches)
-	addFiles(t, fSysExpected, "/dst", kustAndPatches)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/dst", kustAndPatches)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeReplacements(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndReplacement := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -389,19 +464,16 @@ targets:
   select:
     namespace: my`,
 	}
-	addFiles(t, fSys, "/a", kustAndReplacement)
+	expected, actual := makeFileSystems(t, "/a", kustAndReplacement)
 
-	err := Run("/a", "/", "/dst", fSys)
+	err := Run("/a", "/", "/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndReplacement)
-	addFiles(t, fSysExpected, "/dst/a", kustAndReplacement)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/dst/a", kustAndReplacement)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeConfigMapGenerator(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndData := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 configMapGenerator:
@@ -423,19 +495,16 @@ metadata:
 IS_GLOBAL=true`,
 		"key.properties": "value",
 	}
-	addFiles(t, fSys, "/a/b", kustAndData)
+	expected, actual := makeFileSystems(t, "/a/b", kustAndData)
 
-	err := Run("/a/b", "", "", fSys)
+	err := Run("/a/b", "", "", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a/b", kustAndData)
-	addFiles(t, fSysExpected, "/localized-b", kustAndData)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/localized-b", kustAndData)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeSecretGenerator(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndData := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -459,19 +528,16 @@ secretGenerator:
 		"b/value.properties": "dmFsdWU=",
 		"b/value":            "dmFsdWU=",
 	}
-	addFiles(t, fSys, "/a", kustAndData)
+	expected, actual := makeFileSystems(t, "/a", kustAndData)
 
-	err := Run("/a", "/", "/localized-a", fSys)
+	err := Run("/a", "/", "/localized-a", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndData)
-	addFiles(t, fSysExpected, "/localized-a/a", kustAndData)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/localized-a/a", kustAndData)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeFileNoFile(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPatch := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -479,18 +545,15 @@ patches:
 - path: name-DNE.yaml
 `,
 	}
-	addFiles(t, fSys, "/a/b", kustAndPatch)
+	expected, actual := makeFileSystems(t, "/a/b", kustAndPatch)
 
-	err := Run("/a/b", "", "/dst", fSys)
+	err := Run("/a/b", "", "/dst", actual)
 	require.Error(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a/b", kustAndPatch)
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeGenerators(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPlugins := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 generators:
@@ -520,21 +583,18 @@ metadata:
   name: map
 `,
 	}
-	addFiles(t, fSys, "/a", kustAndPlugins)
+	expected, actual := makeFileSystems(t, "/a", kustAndPlugins)
 
-	err := Run("/a", "", "/alpha/dst", fSys)
+	err := Run("/a", "", "/alpha/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndPlugins)
-	addFiles(t, fSysExpected, "/alpha/dst", map[string]string{
+	addFiles(t, expected, "/alpha/dst", map[string]string{
 		"kustomization.yaml": kustAndPlugins["kustomization.yaml"],
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeTransformers(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPlugins := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -571,21 +631,18 @@ paths:
 - pod.yaml
 `,
 	}
-	addFiles(t, fSys, "/a", kustAndPlugins)
+	expected, actual := makeFileSystems(t, "/a", kustAndPlugins)
 
-	err := Run("/a", "", "/dst", fSys)
+	err := Run("/a", "", "/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/a", kustAndPlugins)
-	addFiles(t, fSysExpected, "/dst", map[string]string{
+	addFiles(t, expected, "/dst", map[string]string{
 		"kustomization.yaml": kustAndPlugins["kustomization.yaml"],
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeValidators(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndPlugin := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -622,16 +679,15 @@ replacements:
       namespace: test
 `,
 	}
-	addFiles(t, fSys, "/", kustAndPlugin)
-	err := Run("/", "", "/dst", fSys)
+	expected, actual := makeFileSystems(t, "/", kustAndPlugin)
+
+	err := Run("/", "", "/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", kustAndPlugin)
-	addFiles(t, fSysExpected, "/dst", map[string]string{
+	addFiles(t, expected, "/dst", map[string]string{
 		"kustomization.yaml": kustAndPlugin["kustomization.yaml"],
 	})
-	checkFSys(t, fSysExpected, fSys)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeBuiltinPluginsNotResource(t *testing.T) {
@@ -679,9 +735,9 @@ metadata:
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			fSys := makeMemoryFs(t)
-			addFiles(t, fSys, "/", test.files)
-			err := Run("/", "", "/dst", fSys)
+			expected, actual := makeFileSystems(t, "/", test.files)
+
+			err := Run("/", "", "/dst", actual)
 
 			var actualErr ResourceLoadError
 			require.ErrorAs(t, err, &actualErr)
@@ -691,9 +747,7 @@ metadata:
 			require.EqualError(t, err, fmt.Sprintf(`unable to localize target "/": %s: when parsing as inline received error: %s
 when parsing as filepath received error: %s`, test.errPrefix, test.inlineErrMsg, test.fileErrMsg))
 
-			fSysExpected := makeMemoryFs(t)
-			addFiles(t, fSysExpected, "/", test.files)
-			checkFSys(t, fSysExpected, fSys)
+			checkFSys(t, expected, actual)
 		})
 	}
 }
@@ -789,22 +843,18 @@ namespace: kustomize-namespace
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			fSys := makeMemoryFs(t)
-			addFiles(t, fSys, "/alpha/beta/gamma", tc.files)
+			expected, actual := makeFileSystems(t, "/alpha/beta/gamma", tc.files)
 
-			err := Run("/alpha/beta/gamma", "/alpha/beta", "/dst", fSys)
+			err := Run("/alpha/beta/gamma", "/alpha/beta", "/dst", actual)
 			require.NoError(t, err)
 
-			fSysExpected := makeMemoryFs(t)
-			addFiles(t, fSysExpected, "/alpha/beta/gamma", tc.files)
-			addFiles(t, fSysExpected, "/dst/gamma", tc.files)
-			checkFSys(t, fSysExpected, fSys)
+			addFiles(t, expected, "/dst/gamma", tc.files)
+			checkFSys(t, expected, actual)
 		})
 	}
 }
 
 func TestLocalizeDirCleanedSibling(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndComponents := map[string]string{
 		// This test checks that winding paths that might traverse through directories
 		// outside of scope, which will not be present at destination, are cleaned.
@@ -817,13 +867,11 @@ kind: Component
 namespace: kustomize-namespace
 `,
 	}
-	addFiles(t, fSys, "/alpha", kustAndComponents)
+	expected, actual := makeFileSystems(t, "/alpha", kustAndComponents)
 
-	err := Run("/alpha/beta/gamma", "/alpha", "/alpha/beta/dst", fSys)
+	err := Run("/alpha/beta/gamma", "/alpha", "/alpha/beta/dst", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/alpha", kustAndComponents)
 	cleanedFiles := map[string]string{
 		"beta/gamma/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 components:
@@ -832,12 +880,11 @@ kind: Kustomization
 `,
 		"beta/sibling/kustomization.yaml": kustAndComponents["beta/sibling/kustomization.yaml"],
 	}
-	addFiles(t, fSysExpected, "/alpha/beta/dst", cleanedFiles)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/alpha/beta/dst", cleanedFiles)
+	checkFSys(t, expected, actual)
 }
 
 func TestLocalizeComponents(t *testing.T) {
-	fSys := makeMemoryFs(t)
 	kustAndComponents := map[string]string{
 		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 components:
@@ -854,13 +901,11 @@ kind: Component
 nameSuffix: -test
 `,
 	}
-	addFiles(t, fSys, "/", kustAndComponents)
+	expected, actual := makeFileSystems(t, "/", kustAndComponents)
 
-	err := Run("/", "", "", fSys)
+	err := Run("/", "", "", actual)
 	require.NoError(t, err)
 
-	fSysExpected := makeMemoryFs(t)
-	addFiles(t, fSysExpected, "/", kustAndComponents)
-	addFiles(t, fSysExpected, "/localized", kustAndComponents)
-	checkFSys(t, fSysExpected, fSys)
+	addFiles(t, expected, "/localized", kustAndComponents)
+	checkFSys(t, expected, actual)
 }

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -220,38 +220,16 @@ kind: Kustomization
 	checkFSys(t, fSysExpected, fSysActual)
 }
 
-func TestLoadKustomizationError(t *testing.T) {
-	for name, test := range map[string]struct {
-		errSuffix string
-		files     map[string]string
-	}{
-		"missing": {
-			errSuffix: `unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/a'`,
-		},
-		"multiple": {
-			errSuffix: `found multiple kustomization files under: /a`,
-			files: map[string]string{
-				"kustomization.yml": `namePrefix: one`,
-				"Kustomization":     `namePrefix: two`,
-			},
-		},
-		"unknown_fields": {
-			errSuffix: `invalid kustomization: json: unknown field "suffix"`,
-			files: map[string]string{
-				"kustomization.yaml": `namePrefix: valid
+func TestLoadUnknownKustFields(t *testing.T) {
+	fSysExpected, fSysTest := makeFileSystems(t, "/a", map[string]string{
+		"kustomization.yaml": `namePrefix: valid
 suffix: invalid`,
-			},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			fSysExpected, fSysTest := makeFileSystems(t, "/a", test.files)
+	})
 
-			err := Run("/a", "", "", fSysTest)
-			require.EqualError(t, err, `unable to localize target "/a": `+test.errSuffix)
+	err := Run("/a", "", "", fSysTest)
+	require.EqualError(t, err, `unable to localize target "/a": invalid kustomization: json: unknown field "suffix"`)
 
-			checkFSys(t, fSysExpected, fSysTest)
-		})
-	}
+	checkFSys(t, fSysExpected, fSysTest)
 }
 
 func TestLocalizeFileName(t *testing.T) {

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -11,8 +11,6 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/git"
-	"sigs.k8s.io/kustomize/api/internal/target"
-	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -155,26 +153,4 @@ func locRootPath(rootURL string, repoDir string, rootDir filesys.ConfirmedDir) s
 	_ = rootURL
 	_, _ = repoDir, rootDir
 	return ""
-}
-
-func loadKustFile(ldr ifc.Loader) ([]byte, string, error) {
-	var content []byte
-	match := 0
-	var kustFileName string
-	for _, kf := range konfig.RecognizedKustomizationFileNames() {
-		c, err := ldr.Load(kf)
-		if err == nil {
-			match += 1
-			content = c
-			kustFileName = kf
-		}
-	}
-	switch match {
-	case 0:
-		return nil, "", target.NewErrMissingKustomization(ldr.Root())
-	case 1:
-		return content, kustFileName, nil
-	default:
-		return nil, "", errors.Errorf("found multiple kustomization files under: %s", ldr.Root())
-	}
 }

--- a/api/internal/localizer/util.go
+++ b/api/internal/localizer/util.go
@@ -11,6 +11,8 @@ import (
 
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/git"
+	"sigs.k8s.io/kustomize/api/internal/target"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -153,4 +155,26 @@ func locRootPath(rootURL string, repoDir string, rootDir filesys.ConfirmedDir) s
 	_ = rootURL
 	_, _ = repoDir, rootDir
 	return ""
+}
+
+func loadKustFile(ldr ifc.Loader) ([]byte, string, error) {
+	var content []byte
+	match := 0
+	var kustFileName string
+	for _, kf := range konfig.RecognizedKustomizationFileNames() {
+		c, err := ldr.Load(kf)
+		if err == nil {
+			match += 1
+			content = c
+			kustFileName = kf
+		}
+	}
+	switch match {
+	case 0:
+		return nil, "", target.NewErrMissingKustomization(ldr.Root())
+	case 1:
+		return content, kustFileName, nil
+	default:
+		return nil, "", errors.Errorf("found multiple kustomization files under: %s", ldr.Root())
+	}
 }

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/internal/accumulator"
 	"sigs.k8s.io/kustomize/api/internal/builtins"
@@ -55,7 +54,7 @@ func NewKustTarget(
 
 // Load attempts to load the target's kustomization file.
 func (kt *KustTarget) Load() error {
-	content, kustFileName, err := loadKustFile(kt.ldr)
+	content, kustFileName, err := LoadKustFile(kt.ldr)
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func (kt *KustTarget) Kustomization() types.Kustomization {
 	return result
 }
 
-func loadKustFile(ldr ifc.Loader) ([]byte, string, error) {
+func LoadKustFile(ldr ifc.Loader) ([]byte, string, error) {
 	var content []byte
 	match := 0
 	var kustFileName string


### PR DESCRIPTION
This PR loads kustomization files in `localize` without overwriting legacy kustomization fields such as `bases`. 

Essentially, the `localize` `load` is `kusttarget.Load` without calls to 
* `types.Kustomization.CheckDeprecatedFields`
* `types.Kustomization.FixKustomizationPostUnmarshalling`
* `types.Kustomization.EnforceFields`

I also added a helper function to shorten my tests.