### PR TITLE
Localize PatchTransformer, PatchJson6902Transformer

### DIFF
--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -4,35 +4,50 @@
 package localizer
 
 import (
+	"sigs.k8s.io/kustomize/api/filters/filtersutil"
+	"sigs.k8s.io/kustomize/api/filters/fsslice"
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// localizeBuiltinGenerators localizes built-in generators with file paths.
+// localizeBuiltinPlugins localizes built-in plugins with file paths.
 // Note that this excludes helm, which needs a repo.
-type localizeBuiltinGenerators struct {
+type localizeBuiltinPlugins struct {
+	lc *localizer
 }
 
-var _ kio.Filter = &localizeBuiltinGenerators{}
+var _ kio.Filter = &localizeBuiltinPlugins{}
 
-// Filter localizes the built-in generators with file paths. Filter returns an error if
-// generators contains a resource that is not a built-in generator, cannot contain a file path,
-// needs more than a file path like helm, or is not localizable.
-// TODO(annasong): implement
-func (lbg *localizeBuiltinGenerators) Filter(generators []*yaml.RNode) ([]*yaml.RNode, error) {
-	return generators, nil
+// Filter localizes the built-in plugins with file paths.
+func (lbp *localizeBuiltinPlugins) Filter(plugins []*yaml.RNode) ([]*yaml.RNode, error) {
+	newPlugins, err := kio.FilterAll(fsslice.Filter{
+		FsSlice: types.FsSlice{
+			types.FieldSpec{
+				Gvk:  resid.Gvk{Version: konfig.BuiltinPluginApiVersion, Kind: builtinhelpers.PatchTransformer.String()},
+				Path: "path",
+			},
+			types.FieldSpec{
+				Gvk:  resid.Gvk{Version: konfig.BuiltinPluginApiVersion, Kind: builtinhelpers.PatchJson6902Transformer.String()},
+				Path: "path",
+			},
+		},
+		SetValue: lbp.evaluateField,
+	}).Filter(plugins)
+
+	// TODO(annasong): localize replacements, patchesStrategicMerge, configMapGenerator, secretGenerator
+
+	return newPlugins, errors.Wrap(err)
 }
 
-// localizeBuiltinTransformers localizes built-in transformers with file paths.
-type localizeBuiltinTransformers struct {
-}
-
-var _ kio.Filter = &localizeBuiltinTransformers{}
-
-// Filter localizes the built-in transformers with file paths. Filter returns an error if
-// transformers contains a resource that is not a built-in transformer, cannot contain a file path,
-// or is not localizable.
-// TODO(annasong): implement
-func (lbt *localizeBuiltinTransformers) Filter(transformers []*yaml.RNode) ([]*yaml.RNode, error) {
-	return transformers, nil
+func (lbp *localizeBuiltinPlugins) evaluateField(node *yaml.RNode) error {
+	newPath, err := lbp.lc.localizeFile(node.YNode().Value)
+	if err != nil {
+		return errors.WrapPrefixf(err, "unable to localize built-in plugin path")
+	}
+	return filtersutil.SetScalar(newPath)(node)
 }

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
-	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/yaml"
 )
 
@@ -227,7 +226,11 @@ func (lc *localizer) localizeFile(path string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err)
 	}
+	return lc.localizeFileWithContent(path, content)
+}
 
+// localizeFileWithContent writes content to the localized file path and returns the localized path.
+func (lc *localizer) localizeFileWithContent(path string, content []byte) (string, error) {
 	var locPath string
 	if loader.IsRemoteFile(path) {
 		// TODO(annasong): You need to check if you can add a localize directory here to store
@@ -246,10 +249,10 @@ func (lc *localizer) localizeFile(path string) (string, error) {
 		locPath = cleanFilePath(lc.fSys, lc.root, path)
 	}
 	absPath := filepath.Join(lc.dst, locPath)
-	if err = lc.fSys.MkdirAll(filepath.Dir(absPath)); err != nil {
+	if err := lc.fSys.MkdirAll(filepath.Dir(absPath)); err != nil {
 		return "", errors.WrapPrefixf(err, "unable to create directories to localize file %q", path)
 	}
-	if err = lc.fSys.WriteFile(absPath, content); err != nil {
+	if err := lc.fSys.WriteFile(absPath, content); err != nil {
 		return "", errors.WrapPrefixf(err, "unable to localize file %q", path)
 	}
 	return locPath, nil
@@ -300,29 +303,17 @@ func (lc *localizer) localizeDir(path string) (string, error) {
 //
 // Note that the localization in this function has not been implemented yet.
 func (lc *localizer) localizeBuiltinPlugins(kust *types.Kustomization) error {
-	for fieldName, plugins := range map[string]struct {
-		entries   []string
-		localizer kio.Filter
-	}{
-		"generators": {
-			kust.Generators,
-			&localizeBuiltinGenerators{},
-		},
-		"transformers": {
-			kust.Transformers,
-			&localizeBuiltinTransformers{},
-		},
-		"validators": {
-			kust.Validators,
-			&localizeBuiltinTransformers{},
-		},
+	for fieldName, entries := range map[string][]string{
+		"generators":   kust.Generators,
+		"transformers": kust.Transformers,
+		"validators":   kust.Validators,
 	} {
-		for i, entry := range plugins.entries {
+		for i, entry := range entries {
 			rm, isPath, err := lc.loadResource(entry)
 			if err != nil {
 				return errors.WrapPrefixf(err, "unable to load %s entry", fieldName)
 			}
-			err = rm.ApplyFilter(plugins.localizer)
+			err = rm.ApplyFilter(&localizeBuiltinPlugins{lc})
 			if err != nil {
 				return errors.Wrap(err)
 			}
@@ -332,12 +323,14 @@ func (lc *localizer) localizeBuiltinPlugins(kust *types.Kustomization) error {
 			}
 			var newEntry string
 			if isPath {
-				// TODO(annasong): write localizedPlugin to dst
-				newEntry = entry
+				newEntry, err = lc.localizeFileWithContent(entry, localizedPlugin)
+				if err != nil {
+					return errors.WrapPrefixf(err, "unable to localize %s entry", fieldName)
+				}
 			} else {
 				newEntry = string(localizedPlugin)
 			}
-			plugins.entries[i] = newEntry
+			entries[i] = newEntry
 		}
 	}
 	return nil

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -321,16 +321,16 @@ func (lc *localizer) localizeBuiltinPlugins(kust *types.Kustomization) error {
 			if err != nil {
 				return errors.WrapPrefixf(err, "unable to serialize localized %s entry %q", fieldName, entry)
 			}
-			var newEntry string
+			var localizedEntry string
 			if isPath {
-				newEntry, err = lc.localizeFileWithContent(entry, localizedPlugin)
+				localizedEntry, err = lc.localizeFileWithContent(entry, localizedPlugin)
 				if err != nil {
 					return errors.WrapPrefixf(err, "unable to localize %s entry", fieldName)
 				}
 			} else {
-				newEntry = string(localizedPlugin)
+				localizedEntry = string(localizedPlugin)
 			}
-			entries[i] = newEntry
+			entries[i] = localizedEntry
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR localizes the built-in plugins: `PatchTransformer`, `PatchJson6902Transformer`.

As side effects, it also:
* consolidates `localizeBuiltinGenerators` and `localizeBuiltinTransformers`, as it is the job of `kustomize build` to ensure `generators` entries aren't `transformers`, and vice versa. It isn't the job of `localize` to duplicate that functionality
* copies non-built-in plugins to the localized destination
* writes localized file entries under `generators`, `transformers`, and `validators` to the localize destination