### PR TITLE
KRM function file output

### DIFF
--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -71,12 +71,11 @@ follows:
 1. Orchestrator runs the function container and provides the input on `stdin`.
    The input is a Kubernetes object of kind `ResourceList` as described below.
 2. Function reads the input from `stdin` and performs its computations.
-4. Function provides the output as a `ResourceList`, by default to `stdout`.
+3. Function provides the output as a `ResourceList`, by default to `stdout`.
    Alternatively the Orchestrator can instruct the Function, via annotation on 
    the resource list, to write the result to a Orchestrator-defined file, 
    instead of `stdout`.
-5. Function then MAY emit non-structured error message on `stderr`.
-6. Orchestrator uses the `stdout` or provided file, `stderr`, and the exit code 
+4. Orchestrator uses the `stdout` or provided file, `stderr`, and the exit code 
    of the function as it sees fit following to the semantics described below.
    
 ### Input / Output
@@ -85,6 +84,8 @@ A function MUST accept input from `stdin`.
 
 A function MUST implement `stdout` and file output. It is not necessary to output 
 to both `stdout` and file, but both options must be available.
+
+A function MAY emit non-structured error message on `stderr`.
 
 ### Schema
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -1,6 +1,6 @@
 # KRM Functions Specification
 
-_apiVersion: v1_
+_apiVersion: v1.1_
 
 ## Overview
 
@@ -20,6 +20,11 @@ This document references terms described in [Kubernetes API Conventions][1].
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][2].
+
+## Version Compatibility
+
+Version 1.1 is backwards-compatible with Version 1, but for a function to be
+conformant with the new version it is REQUIRED to support file output.
 
 ## Use Cases
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -88,7 +88,8 @@ to both `stdout` and file, but both options must be available.
 
 ### Schema
 
-Input and output MUST be a Kubernetes object of kind `ResourceList` with the following OpenAPI schema.
+Input and output MUST be a Kubernetes object of kind `ResourceList` with the
+following OpenAPI schema.
 
 ```yaml
 swagger: "2.0"

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -345,11 +345,11 @@ functions.
 ### Internal Annotations
 
 For orchestration purposes, the orchestrator will use a set of annotations,
-referred to as _internal annotations_, on resources in `Resources.items`. These
-annotations are not persisted to resource manifests on the filesystem: The
-orchestrator sets this annotation when reading files from the local filesystem
-and removes the annotation when writing the output of functions back to the
-filesystem.
+referred to as _internal annotations_, on resources in `Resources.items` or 
+the `Resources` itself. These annotations are not persisted to resource manifests
+on the filesystem: The orchestrator sets this annotation when reading files from
+the local filesystem and removes the annotation when writing the output of functions
+back to the filesystem.
 
 Annotation prefix `internal.config.kubernetes.io` is reserved for use for
 internal annotations. In general, a function MUST NOT modify these annotations with
@@ -396,8 +396,8 @@ This represents the third resource in the file.
 Records the slash-delimited, OS-agnostic, absolute file path to an output file.
 The Orchestrator ensures the file can written to by the Function.
 
-When this annotation is present the Function should write it's output to the specified
-file, instead of stdout.
+When this annotation is present the function MUST write it's output to the specified
+file, the output MUST NOT be written to `stdout`.
 
 A function SHOULD NOT modify these annotations.
 

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -65,16 +65,25 @@ follows:
 
 1. Orchestrator runs the function container and provides the input on `stdin`.
    The input is a Kubernetes object of kind `ResourceList` as described below.
-2. Function reads the input from `stdin`, performs computations, and provides
-   the output as a `ResourceList` to `stdout`. The function MAY also emit
-   non-structured error message on `stderr`.
-3. Orchestrator uses the `stdout`, `stderr`, and the exit code of the function
-   as it sees fit following to the semantics described below.
+2. Function reads the input from `stdin` and performs its computations.
+4. Function provides the output as a `ResourceList`, by default to `stdout`.
+   Alternatively the Orchestrator can instruct the Function, via annotation on 
+   the resource list, to write the result to a Orchestrator-defined file, 
+   instead of `stdout`.
+5. Function then MAY emit non-structured error message on `stderr`.
+6. Orchestrator uses the `stdout` or provided file, `stderr`, and the exit code 
+   of the function as it sees fit following to the semantics described below.
+   
+### Input / Output
+
+A function MUST accept input from `stdin`.
+
+A function MUST implement `stdout` and file output. It is not necessary to output 
+to both `stdout` and file, but both options must be available.
 
 ### Schema
 
-A function MUST accept input from `stdin` and MUST output to `stdout` a
-Kubernetes object of kind `ResourceList` with the following OpenAPI schema:
+Input and output MUST be a Kubernetes object of kind `ResourceList` with the following OpenAPI schema.
 
 ```yaml
 swagger: "2.0"
@@ -374,6 +383,24 @@ metadata:
 ```
 
 This represents the third resource in the file.
+
+#### `internal.config.kubernetes.io/output-file`
+
+Records the slash-delimited, OS-agnostic, absolute file path to an output file.
+The Orchestrator ensures the file can written to by the Function.
+
+When this annotation is present the Function should write it's output to the specified
+file, instead of stdout.
+
+A function SHOULD NOT modify these annotations.
+
+Example:
+
+```yaml
+metadata:
+  annotations:
+    internal.config.kubernetes.io/output-file: "/media/output/output.yml"
+```
 
 [1]:
   https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md

--- a/cmd/config/docs/api-conventions/functions-spec.md
+++ b/cmd/config/docs/api-conventions/functions-spec.md
@@ -71,10 +71,10 @@ follows:
 1. Orchestrator runs the function container and provides the input on `stdin`.
    The input is a Kubernetes object of kind `ResourceList` as described below.
 2. Function reads the input from `stdin` and performs its computations.
-3. Function provides the output as a `ResourceList`, by default to `stdout`.
-   Alternatively the Orchestrator can instruct the Function, via annotation on 
-   the resource list, to write the result to a Orchestrator-defined file, 
-   instead of `stdout`.
+3. Function provides the output as a `ResourceList`, by default to `stdout`.  
+   Alternatively the Orchestrator can instruct the Function, trough an *internal
+   annotation* on the resource list, to write the result to a Orchestrator-defined
+   file, instead of `stdout`.
 4. Orchestrator uses the `stdout` or provided file, `stderr`, and the exit code 
    of the function as it sees fit following to the semantics described below.
    
@@ -82,8 +82,8 @@ follows:
 
 A function MUST accept input from `stdin`.
 
-A function MUST implement `stdout` and file output. It is not necessary to output 
-to both `stdout` and file, but both options must be available.
+A function MUST implement `stdout` and file output.  
+It is not necessary to output to both `stdout` and file, but both options must be available.
 
 A function MAY emit non-structured error message on `stderr`.
 


### PR DESCRIPTION
KRM functions are quite useful for packaging transformers and generators.

But in an environment with just kubernetes, e.g. kustomize/kubectl without docker, or even GitOps (ArgoCD), the function writing to stdout is problematic as stdout is also captured by the logging driver.

I would like to suggest to extend the function spec to allow the Orchestrator (kustomize, ArgoCD) to request the Function to write it's output to a file within the container (or a volume), which the Orchestrator can read the result from without flooding the logging driver with function outputs.

This could for example allow kustomize or ArgoCD to run containerized KRM function plugins via kubernetes API:

* by scheduling a Pod with the given function image
    * with a sidecar to prevent the Pod from exiting too early
* attaching to the pod and sending stdin
* waiting for the main container to finish
* fetch the result from the container or volume
    * for example via exec to the container
    * or somehow via sidecar

Attaching / Writing to stdin in kubernetes also is not a simple HTTP request, which might also be another hurdle, so the proposal might even be extended to stdin.

For functions in Linux containers the difference for the function should minimal -- stdin and stdout could be consumed as files via /dev/stdin and and /dev/stdout...

