### PR TITLE
Set go version on github actions from gowork file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,26 +10,21 @@ permissions:
   contents: read
 
 jobs:
-
   lint:
     name: Lint
     runs-on: [ubuntu-latest]
     steps:
-
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v3
-      with:
-        go-version: '^1.19.0'
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.work
+      id: go
     - name: Lint
       run: make lint
-
     - name: Verify boilerplate
       run: make check-license
 
@@ -37,66 +32,56 @@ jobs:
     name: Test Linux
     runs-on: [ubuntu-latest]
     steps:
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.19.0'
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: Test all modules
-        run: make test-unit-non-plugin
-        env:
-          KUSTOMIZE_DOCKER_E2E: true
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.work
+      id: go
+    - name: Test all modules
+      run: make test-unit-non-plugin
+      env:
+        KUSTOMIZE_DOCKER_E2E: true
 
   test-macos:
     name: Test MacOS
     runs-on: [macos-latest]
     steps:
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.19.0'
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: Test all modules
-        run: make test-unit-non-plugin
-        env:
-          KUSTOMIZE_DOCKER_E2E: false # docker not installed on mac
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.work
+      id: go
+    - name: Test all modules
+      run: make test-unit-non-plugin
+      env:
+        KUSTOMIZE_DOCKER_E2E: false # docker not installed on mac
 
   test-windows:
     name: Test Windows
     runs-on: [windows-latest]
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.work
+      id: go
+    - name: Test kyaml
+      run: go test -cover ./...
+      working-directory: ./kyaml
+    - name: Test cmd/config
+      run: go test -cover ./...
+      working-directory: ./cmd/config
+      env:
+        KUSTOMIZE_DOCKER_E2E: false # docker on windows not working well yet
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.19.0'
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-
-      - name: Test kyaml
-        run: go test -cover ./...
-        working-directory: ./kyaml
-
-      - name: Test cmd/config
-        run: go test -cover ./...
-        working-directory: ./cmd/config
-        env:
-          KUSTOMIZE_DOCKER_E2E: false # docker on windows not working well yet
-
-      # TODO (#4001): replace specific modules above with this once Windows tests are passing.
-      #- name: Test all modules
-      #  run: make test-unit-non-plugin
-      #  env:
-      #    KUSTOMIZE_DOCKER_E2E: false # docker on windows not working well yet
+    # TODO (#4001): replace specific modules above with this once Windows tests are passing.
+    #- name: Test all modules
+    #  run: make test-unit-non-plugin
+    #  env:
+    #    KUSTOMIZE_DOCKER_E2E: false # docker on windows not working well yet


### PR DESCRIPTION
[actions/setup-go](https://github.com/actions/setup-go)  can retrieve the version of go used in the repository from the `go.work` file.
I think it reduces to lines that need rewriting when we update the go version.

## reference
- https://github.com/actions/setup-go/blob/30c39bfe0c7338d0d8e99486938f1066b2f92108/README.md#getting-go-version-from-the-gomod-file