### PR TITLE
Refactor mapping node traversal and optimize RNode.GetAnnotations and RNode.GetLabels

### DIFF
--- a/api/internal/utils/makeResIds.go
+++ b/api/internal/utils/makeResIds.go
@@ -35,7 +35,10 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 	var ids []resid.ResId
 	// TODO: merge previous names and namespaces into one list of
 	//     pairs on one annotation so there is no chance of error
-	annotations := n.GetAnnotations()
+	annotations := n.GetAnnotations(
+		BuildAnnotationPreviousNames,
+		BuildAnnotationPreviousNamespaces,
+		BuildAnnotationPreviousKinds)
 	if _, ok := annotations[BuildAnnotationPreviousNames]; !ok {
 		return nil, nil
 	}
@@ -51,6 +54,7 @@ func PrevIds(n *yaml.RNode) ([]resid.ResId, error) {
 	}
 	apiVersion := n.GetApiVersion()
 	group, version := resid.ParseGroupVersion(apiVersion)
+	ids = make([]resid.ResId, 0, len(names))
 	for i := range names {
 		gvk := resid.Gvk{
 			Group:   group,

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -647,16 +647,16 @@ func (s MapEntrySetter) Filter(rn *RNode) (*RNode, error) {
 	}
 
 	content := rn.Content()
-	stillMissing := true
+	fieldStillNotFound := true
 	visitFieldsWhileTrue(content, func(key, value *yaml.Node, keyIndex int) bool {
 		if key.Value == s.Name {
 			content[keyIndex] = s.Key.YNode()
 			content[keyIndex+1] = s.Value.YNode()
-			stillMissing = false
+			fieldStillNotFound = false
 		}
-		return stillMissing
+		return fieldStillNotFound
 	})
-	if !stillMissing {
+	if !fieldStillNotFound {
 		return rn, nil
 	}
 

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -197,36 +197,37 @@ func (c FieldClearer) Filter(rn *RNode) (*RNode, error) {
 		return nil, err
 	}
 
-	for i := 0; i < len(rn.Content()); i += 2 {
-		// if name matches, remove these 2 elements from the list because
-		// they are treated as a fieldName/fieldValue pair.
-		if rn.Content()[i].Value == c.Name {
-			if c.IfEmpty {
-				if len(rn.Content()[i+1].Content) > 0 {
-					continue
-				}
-			}
-
-			// save the item we are about to remove
-			removed := NewRNode(rn.Content()[i+1])
-			if len(rn.YNode().Content) > i+2 {
-				l := len(rn.YNode().Content)
-				// remove from the middle of the list
-				rn.YNode().Content = rn.Content()[:i]
-				rn.YNode().Content = append(
-					rn.YNode().Content,
-					rn.Content()[i+2:l]...)
-			} else {
-				// remove from the end of the list
-				rn.YNode().Content = rn.Content()[:i]
-			}
-
-			// return the removed field name and value
-			return removed, nil
+	var removed *RNode
+	visitFieldsWhileTrue(rn.Content(), func(key, value *yaml.Node, keyIndex int) bool {
+		if key.Value != c.Name {
+			return true
 		}
-	}
-	// nothing removed
-	return nil, nil
+
+		// the name matches: remove these 2 elements from the list because
+		// they are treated as a fieldName/fieldValue pair.
+		if c.IfEmpty {
+			if len(value.Content) > 0 {
+				return true
+			}
+		}
+
+		// save the item we are about to remove
+		removed = NewRNode(value)
+		if len(rn.YNode().Content) > keyIndex+2 {
+			l := len(rn.YNode().Content)
+			// remove from the middle of the list
+			rn.YNode().Content = rn.Content()[:keyIndex]
+			rn.YNode().Content = append(
+				rn.YNode().Content,
+				rn.Content()[keyIndex+2:l]...)
+		} else {
+			// remove from the end of the list
+			rn.YNode().Content = rn.Content()[:keyIndex]
+		}
+		return false
+	})
+
+	return removed, nil
 }
 
 func MatchElement(field, value string) ElementMatcher {
@@ -402,14 +403,15 @@ func (f FieldMatcher) Filter(rn *RNode) (*RNode, error) {
 		return nil, err
 	}
 
-	for i := 0; i < len(rn.Content()); i = IncrementFieldIndex(i) {
-		isMatchingField := rn.Content()[i].Value == f.Name
-		if isMatchingField {
-			requireMatchFieldValue := f.Value != nil
-			if !requireMatchFieldValue || rn.Content()[i+1].Value == f.Value.YNode().Value {
-				return NewRNode(rn.Content()[i+1]), nil
-			}
+	var returnNode *RNode
+	requireMatchFieldValue := f.Value != nil
+	visitMappingNodeFields(rn.Content(), func(key, value *yaml.Node) {
+		if !requireMatchFieldValue || value.Value == f.Value.YNode().Value {
+			returnNode = NewRNode(value)
 		}
+	}, f.Name)
+	if returnNode != nil {
+		return returnNode, nil
 	}
 
 	if f.Create != nil {
@@ -643,13 +645,19 @@ func (s MapEntrySetter) Filter(rn *RNode) (*RNode, error) {
 	if s.Name == "" {
 		s.Name = GetValue(s.Key)
 	}
-	for i := 0; i < len(rn.Content()); i = IncrementFieldIndex(i) {
-		isMatchingField := rn.Content()[i].Value == s.Name
-		if isMatchingField {
-			rn.Content()[i] = s.Key.YNode()
-			rn.Content()[i+1] = s.Value.YNode()
-			return rn, nil
+
+	content := rn.Content()
+	stillMissing := true
+	visitFieldsWhileTrue(content, func(key, value *yaml.Node, keyIndex int) bool {
+		if key.Value == s.Name {
+			content[keyIndex] = s.Key.YNode()
+			content[keyIndex+1] = s.Value.YNode()
+			stillMissing = false
 		}
+		return stillMissing
+	})
+	if !stillMissing {
+		return rn, nil
 	}
 
 	// create the field
@@ -867,10 +875,4 @@ func SplitIndexNameValue(p string) (string, string, error) {
 		return "", "", fmt.Errorf("list path element must contain fieldName=fieldValue for element to match")
 	}
 	return parts[0], parts[1], nil
-}
-
-// IncrementFieldIndex increments i to point to the next field name element in
-// a slice of Contents.
-func IncrementFieldIndex(i int) int {
-	return i + 2
 }

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -242,11 +242,7 @@ func (rn *RNode) IsTaggedNull() bool {
 // IsNilOrEmpty is true if the node is nil,
 // has no YNode, or has YNode that appears empty.
 func (rn *RNode) IsNilOrEmpty() bool {
-	return rn.IsNil() ||
-		IsYNodeTaggedNull(rn.YNode()) ||
-		IsYNodeEmptyMap(rn.YNode()) ||
-		IsYNodeEmptySeq(rn.YNode()) ||
-		IsYNodeZero(rn.YNode())
+	return rn.IsNil() || IsYNodeNilOrEmpty(rn.YNode())
 }
 
 // IsStringValue is true if the RNode is not nil and is scalar string node
@@ -420,12 +416,11 @@ func (rn *RNode) SetApiVersion(av string) {
 // given field, so this function cannot be used to make distinctions
 // between these cases.
 func (rn *RNode) getMapFieldValue(field string) *yaml.Node {
-	for i := 0; i < len(rn.Content()); i = IncrementFieldIndex(i) {
-		if rn.Content()[i].Value == field {
-			return rn.Content()[i+1]
-		}
-	}
-	return nil
+	var result *yaml.Node
+	visitMappingNodeFields(rn.Content(), func(key, value *yaml.Node) {
+		result = value
+	}, field)
+	return result
 }
 
 // GetName returns the name, or empty string if
@@ -696,9 +691,9 @@ func (rn *RNode) Fields() ([]string, error) {
 		return nil, errors.Wrap(err)
 	}
 	var fields []string
-	for i := 0; i < len(rn.Content()); i += 2 {
-		fields = append(fields, rn.Content()[i].Value)
-	}
+	visitMappingNodeFields(rn.Content(), func(key, value *yaml.Node) {
+		fields = append(fields, key.Value)
+	})
 	return fields, nil
 }
 
@@ -709,13 +704,12 @@ func (rn *RNode) FieldRNodes() ([]*RNode, error) {
 		return nil, errors.Wrap(err)
 	}
 	var fields []*RNode
-	for i := 0; i < len(rn.Content()); i += 2 {
-		yNode := rn.Content()[i]
+	visitMappingNodeFields(rn.Content(), func(key, value *yaml.Node) {
 		// for each key node in the input mapping node contents create equivalent rNode
 		rNode := &RNode{}
-		rNode.SetYNode(yNode)
+		rNode.SetYNode(key)
 		fields = append(fields, rNode)
-	}
+	})
 	return fields, nil
 }
 
@@ -725,13 +719,11 @@ func (rn *RNode) Field(field string) *MapNode {
 	if rn.YNode().Kind != yaml.MappingNode {
 		return nil
 	}
-	for i := 0; i < len(rn.Content()); i = IncrementFieldIndex(i) {
-		isMatchingField := rn.Content()[i].Value == field
-		if isMatchingField {
-			return &MapNode{Key: NewRNode(rn.Content()[i]), Value: NewRNode(rn.Content()[i+1])}
-		}
-	}
-	return nil
+	var result *MapNode
+	visitMappingNodeFields(rn.Content(), func(key, value *yaml.Node) {
+		result = &MapNode{Key: NewRNode(key), Value: NewRNode(value)}
+	}, field)
+	return result
 }
 
 // VisitFields calls fn for each field in the RNode.
@@ -750,6 +742,47 @@ func (rn *RNode) VisitFields(fn func(node *MapNode) error) error {
 		}
 	}
 	return nil
+}
+
+// visitMappingNodeFields calls fn for fields in the content, in content order.
+// The caller is responsible to ensure the node is a mapping node. If fieldNames
+// are specified, then fn is called only for the fields that match the given
+// fieldNames. fieldNames must contain unique values.
+func visitMappingNodeFields(content []*yaml.Node, fn func(key, value *yaml.Node), fieldNames ...string) {
+	switch len(fieldNames) {
+	case 0: // visit all fields
+		visitFieldsWhileTrue(content, func(key, value *yaml.Node, _ int) bool {
+			fn(key, value)
+			return true
+		})
+	default: // visit specified fields
+		// assumption: fields in content have unique names
+		found := 0
+		visitFieldsWhileTrue(content, func(key, value *yaml.Node, _ int) bool {
+			if key == nil {
+				return true
+			}
+			if !sliceutil.Contains(fieldNames, key.Value) {
+				return true
+			}
+			fn(key, value)
+			found++
+			return found < len(fieldNames)
+		})
+	}
+}
+
+// visitFieldsWhileTrue calls fn for the fields in content, in content order,
+// until either fn returns false or all fields have been visited. The caller
+// should ensure that content is from a mapping node, or fits the same expected
+// pattern (consecutive key/value entries in the slice).
+func visitFieldsWhileTrue(content []*yaml.Node, fn func(key, value *yaml.Node, keyIndex int) bool) {
+	for i := 0; i < len(content); i += 2 {
+		continueVisiting := fn(content[i], content[i+1], i)
+		if !continueVisiting {
+			return
+		}
+	}
 }
 
 // Elements returns the list of elements in the RNode.
@@ -1003,17 +1036,19 @@ func findMergeValues(yn *yaml.Node) ([]*yaml.Node, error) {
 // it fails.
 func getMergeTagValue(yn *yaml.Node) (*yaml.Node, error) {
 	var result *yaml.Node
-	for i := 0; i < len(yn.Content); i += 2 {
-		key := yn.Content[i]
-		value := yn.Content[i+1]
+	var err error
+	visitFieldsWhileTrue(yn.Content, func(key, value *yaml.Node, _ int) bool {
 		if isMerge(key) {
 			if result != nil {
-				return nil, fmt.Errorf("duplicate merge key")
+				err = fmt.Errorf("duplicate merge key")
+				result = nil
+				return false
 			}
 			result = value
 		}
-	}
-	return result, nil
+		return true
+	})
+	return result, err
 }
 
 // removeMergeTags removes all merge tags and returns a ordered list of yaml

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -2311,6 +2311,28 @@ func TestGetAnnotations(t *testing.T) {
 	}
 }
 
+func BenchmarkGetAnnotations(b *testing.B) {
+	counts := []int{0, 2, 5, 8}
+	for _, count := range counts {
+		appliedAnnotations := make(map[string]string, count)
+		for i := 1; i <= count; i++ {
+			key := fmt.Sprintf("annotation-key-%d", i)
+			value := fmt.Sprintf("annotation-value-%d", i)
+			appliedAnnotations[key] = value
+		}
+		rn := NewRNode(nil)
+		if err := rn.UnmarshalJSON([]byte(deploymentBiggerJson)); err != nil {
+			b.Fatalf("unexpected unmarshaljson err: %v", err)
+		}
+		assert.NoError(b, rn.SetAnnotations(appliedAnnotations))
+		b.Run(fmt.Sprintf("%02d", count), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = rn.GetAnnotations()
+			}
+		})
+	}
+}
+
 func TestGetFieldValueWithDot(t *testing.T) {
 	const input = `
 kind: Pod

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -39,9 +39,18 @@ func IsYNodeEmptyMap(n *yaml.Node) bool {
 	return n != nil && n.Kind == yaml.MappingNode && len(n.Content) == 0
 }
 
-// IsYNodeEmptyMap is true if the Node is a non-nil empty sequence.
+// IsYNodeEmptySeq is true if the Node is a non-nil empty sequence.
 func IsYNodeEmptySeq(n *yaml.Node) bool {
 	return n != nil && n.Kind == yaml.SequenceNode && len(n.Content) == 0
+}
+
+// IsYNodeNilOrEmpty is true if the Node is nil or appears empty.
+func IsYNodeNilOrEmpty(n *yaml.Node) bool {
+	return n == nil ||
+		IsYNodeTaggedNull(n) ||
+		IsYNodeEmptyMap(n) ||
+		IsYNodeEmptySeq(n) ||
+		IsYNodeZero(n)
 }
 
 // IsYNodeEmptyDoc is true if the node is a Document with no content.


### PR DESCRIPTION
This PR has two purposes.

First, it refactors mapping node traversal so that all code paths execute through the same function.

Second, it optimizes RNode's GetAnnotations and GetLabels in three ways:

1. For heavily used functions, allocate memory to avoid overhead associated with map and array re-sizing.
2. Where appropriate, limit annotation and label retrievals to only the desired keys.
3. Adjust annotation and label retrieval to avoid unnecessary temporary object creation.

The execution time and memory use improvements over master can be significant. The results shown here are for current master and for the refactored and optimized code. One test case (ds) is a moderately sized and has a somewhat simple set of kustomizations. One (na) is very large and has a complex set of kustomizations. One (ro) is a large set of resources, with no kustomizations - it's just a resource load. kustomize builds using master match exactly with the builds using the PR.

Using go's profiling tools, here's how things look with the current master (a1bfab382) and with this PR (20b0d3c7c):

```
CPU
ds-cpu-mmasterr-a1bfab382.svg: Duration: 12.22s, Total samples = 13.41s (109.72%)
ds-cpu-refactor-20b0d3c7c.svg: Duration: 9.53s, Total samples = 9.12s (95.74%)
na-cpu-mmasterr-a1bfab382.svg: Duration: 186.21s, Total samples = 207.21s (111.28%)
na-cpu-refactor-20b0d3c7c.svg: Duration: 112.41s, Total samples = 110.55s (98.35%)
ro-cpu-mmasterr-a1bfab382.svg: Duration: 44.21s, Total samples = 49.45s (111.86%)
ro-cpu-refactor-20b0d3c7c.svg: Duration: 15.91s, Total samples = 12.80s (80.43%)

Memory
ds-mem-mmasterr-a1bfab382.svg: Showing nodes accounting for 5903.69MB, 76.03% of 7764.73MB total
ds-mem-refactor-20b0d3c7c.svg: Showing nodes accounting for 3108.60MB, 63.65% of 4884.12MB total
na-mem-mmasterr-a1bfab382.svg: Showing nodes accounting for 109331.30MB, 89.11% of 122696.48MB total
na-mem-refactor-20b0d3c7c.svg: Showing nodes accounting for 37047.11MB, 75.00% of 49398.96MB total
ro-mem-mmasterr-a1bfab382.svg: Showing nodes accounting for 26387.54MB, 97.10% of 27174.74MB total
ro-mem-refactor-20b0d3c7c.svg: Showing nodes accounting for 2146.75MB, 82.69% of 2596.03MB total
```

This PR also includes a benchmark test for GetAnnotations. Here's the run against master, followed by the run against the PR:

```
$ go test ./kyaml/yaml/ -bench=. -benchmem -run nope
goos: windows
goarch: amd64
pkg: sigs.k8s.io/kustomize/kyaml/yaml
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
BenchmarkGetAnnotations/00-8             5349039               229.1 ns/op           192 B/op          4 allocs/op
BenchmarkGetAnnotations/02-8             1225515               997.3 ns/op           960 B/op         16 allocs/op
BenchmarkGetAnnotations/05-8              631647              1830 ns/op            1584 B/op         27 allocs/op
BenchmarkGetAnnotations/08-8              463942              2500 ns/op            2016 B/op         36 allocs/op
PASS
ok      sigs.k8s.io/kustomize/kyaml/yaml        6.607s
```

```
$ go test ./kyaml/yaml/ -bench=. -benchmem -run nope
goos: windows
goarch: amd64
pkg: sigs.k8s.io/kustomize/kyaml/yaml
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
BenchmarkGetAnnotations/00-8            12776966                96.90 ns/op           48 B/op          1 allocs/op
BenchmarkGetAnnotations/02-8             4175845               285.9 ns/op           336 B/op          2 allocs/op
BenchmarkGetAnnotations/05-8             3299260               341.5 ns/op           336 B/op          2 allocs/op
BenchmarkGetAnnotations/08-8             2961939               417.2 ns/op           336 B/op          2 allocs/op
PASS
ok      sigs.k8s.io/kustomize/kyaml/yaml        6.544s
```

Closes #4940