### PR TITLE
add GitHub token to install_kustomize.sh

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -134,7 +134,12 @@ s390x)
     ;;
 esac
 
-releases=$(curl -s "$release_url")
+# You can authenticate by exporting the GITHUB_TOKEN in the environment
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+    releases=$(curl -s "$release_url")
+else
+    releases=$(curl -s "$release_url" --header "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
 
 if [[ $releases == *"API rate limit exceeded"* ]]; then
   echo "Github rate-limiter failed the request. Either authenticate or wait a couple of minutes."


### PR DESCRIPTION
Problem: I started to use `make` and `make install` in CI runs that used a matrix, and was seeing this issue regularly:

![image](https://user-images.githubusercontent.com/814322/209302058-8c11d437-6a9a-4cea-9652-30678be6a59e.png)

```
Github rate-limiter failed the request. Either authenticate or wait a couple of minutes.
```
I suspect the expected use case is manually running locally, and it would make sense to wait and try again.  But for automation I definitely wanted to authenticate! So I started to look into "how to authenticate with the GitHub API" and stumbled on your script here:
https://github.com/kubernetes-sigs/kustomize/blob/aec35009ed55c2fa1c597b7249d1957f206e3ab7/hack/install_kustomize.sh#L137-L142

But the request using curl doesn't give any opportunity to actually add a token, so there was no way to respond! 

Solution: I thought it would be easy enough to check for GITHUB_TOKEN in the environment, and if present, to add it as a header. For my own workflows, when I modified the script and did this, that error (which was showing up more times than not) has gone away. So I think (assuming that others would want this in automation) this would be good to have! Here is an example use case from my workflow:

```yaml
    - name: Build and Install Operator
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      run: |
        make 
        make manifests
        make kustomize
```

I'm a new contributor here so please let me know what else you need me to do. Thank you!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>