### PR TITLE
feat: Allow path starting with slash

### DIFF
--- a/kyaml/utils/pathsplitter.go
+++ b/kyaml/utils/pathsplitter.go
@@ -11,6 +11,13 @@ import "strings"
 func PathSplitter(path string, delimiter string) []string {
 	ps := strings.Split(path, delimiter)
 	var res []string
+
+	// allow path to start with forward slash
+	// i.e. /a/b/c
+	if len(ps) > 1 && ps[0] == "" {
+		ps = ps[1:]
+	}
+
 	res = append(res, ps[0])
 	for i := 1; i < len(ps); i++ {
 		last := len(res) - 1

--- a/kyaml/utils/pathsplitter_test.go
+++ b/kyaml/utils/pathsplitter_test.go
@@ -28,6 +28,10 @@ func TestPathSplitter(t *testing.T) {
 			exp:  []string{"a", "b", "c"},
 		},
 		{
+			path: "/a/b/c",
+			exp:  []string{"a", "b", "c"},
+		},
+		{
 			path: `a/b[]/c`,
 			exp:  []string{"a", "b[]", "c"},
 		},


### PR DESCRIPTION
Problem : 
I started using `Transformer Configurations` with the following spec: 

directory structure: 
```
├── kustomization.yaml
├── namespace.yaml
└── resource.yaml
```

➜  cat kustomization.yaml
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: ns1

resources:
- resource.yaml

configurations:
  - namespace.yaml
 ```


➜   cat resource.yaml      
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: web-1
  name: web-1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: web-1
  strategy: {}
  template:
    metadata:
      labels:
        app: web-1
    spec:
      containers:
      - image: nginx
        name: nginx
```
➜  cat namespace.yaml 
```
namespace:
  - kind: Deployment
    path: metadata/namespace
    create: true
```

I noticed when `path` in `namespace.yaml ` starts with a slash i.e `/metadata/namespace` [PathSplitter](https://github.com/Azhovan/kustomize/blob/188e35fbfd5fcaee208e01027b37db11ee183b49/kyaml/utils/pathsplitter.go#L12) function returns a slice of strings where first element is an empty string, causing kustomize to return an error like this, when I ran: 
`kustomize build .` 
in root of the directory. 

```
Error: namespace transformation failed: considering field '/metadata/namespace' 
of object Deployment.v1.apps/web-1.ns1: cannot set or create an empty field name
```

handling this forward slash at the beginning of a `path` seems to make working with kustomize easier
