### PR TITLE
fix: ensure key node style in FieldSetter.Filter

### DIFF
--- a/api/filters/annotations/annotations_test.go
+++ b/api/filters/annotations/annotations_test.go
@@ -146,7 +146,7 @@ metadata:
   annotations:
     hero: batman
     fiend: riddler
-    2: ford
+    "2": ford
     clown: "1"
 `,
 			filter: Filter{Annotations: annoMap{

--- a/api/filters/labels/labels_test.go
+++ b/api/filters/labels/labels_test.go
@@ -314,7 +314,7 @@ metadata:
   labels:
     hero: batman
     fiend: riddler
-    1: emmett kelley
+    "1": emmett kelley
     auto: "2"
 `,
 			filter: Filter{

--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -778,6 +778,39 @@ spec:
       some: value
 `,
 		},
+
+		// Issue #4928
+		"support numeric keys": {
+			input: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blabla
+  namespace: blabla-ns
+data:
+  "6443": "foobar"
+`,
+			patch: yaml.MustParse(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blabla
+  namespace: blabla-ns
+data:
+  "6443": "barfoo"
+  "9110": "foo-foo"
+`),
+			expected: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blabla
+  namespace: blabla-ns
+data:
+  "6443": "barfoo"
+  "9110": "foo-foo"
+`,
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -734,16 +734,17 @@ func (s FieldSetter) Filter(rn *RNode) (*RNode, error) {
 	}
 
 	// create the field
-	rn.YNode().Content = append(
-		rn.YNode().Content,
-		&yaml.Node{
-			Kind:        yaml.ScalarNode,
-			Value:       s.Name,
-			HeadComment: s.Comments.HeadComment,
-			LineComment: s.Comments.LineComment,
-			FootComment: s.Comments.FootComment,
-		},
-		s.Value.YNode())
+	fieldKey := &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Value:       s.Name,
+		HeadComment: s.Comments.HeadComment,
+		LineComment: s.Comments.LineComment,
+		FootComment: s.Comments.FootComment,
+	}
+	if IsValueNonString(s.Name) {
+		fieldKey.Style = yaml.DoubleQuotedStyle
+	}
+	rn.YNode().Content = append(rn.YNode().Content, fieldKey, s.Value.YNode())
 	return s.Value, nil
 }
 


### PR DESCRIPTION
When FieldSetter.Filter creates a new field, check the key node's value and apply an appropriate style when needed.

Fixes #4928