### PR TITLE
add check that kustomization is empty

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -73,6 +73,11 @@ func (kt *KustTarget) Load() error {
 
 	k.FixKustomization()
 
+	// check that Kustomization is empty
+	if err := k.CheckEmpty(); err != nil {
+		return err
+	}
+
 	errs := k.EnforceFields()
 	if len(errs) > 0 {
 		return fmt.Errorf(

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -79,6 +79,7 @@ func TestLoad(t *testing.T) {
 			k: types.Kustomization{
 				TypeMeta: expectedTypeMeta,
 			},
+			errContains: "kustomization.yaml is empty",
 		},
 		"nonsenseLatin": {
 			errContains: "found a tab character that violates indentation",

--- a/api/krusty/directoryarrangement_test.go
+++ b/api/krusty/directoryarrangement_test.go
@@ -9,9 +9,20 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
+const expectedResources = `apiVersion: v1
+kind: Service
+metadata:
+  name: myService
+spec:
+  ports:
+  - port: 7002
+`
+
 func TestIssue596AllowDirectoriesThatAreSubstringsOfEachOther(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
-	th.WriteK("base", "")
+	th.WriteF("base/service.yaml", expectedResources)
+	th.WriteK("base", `resources:
+- service.yaml`)
 	th.WriteK("overlays/aws", `
 resources:
 - ../../base
@@ -25,5 +36,5 @@ resources:
 - ../aws-nonprod
 `)
 	m := th.Run("overlays/aws-sandbox2.us-east-1", th.MakeDefaultOptions())
-	th.AssertActualEqualsExpected(m, "")
+	th.AssertActualEqualsExpected(m, expectedResources)
 }

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -298,6 +298,27 @@ func (k *Kustomization) FixKustomizationPreMarshalling(fSys filesys.FileSystem) 
 	return nil
 }
 
+func (k *Kustomization) CheckEmpty() error {
+	// generate empty Kustomization
+	emptyKustomization := &Kustomization{}
+	emptyKustomization.FixKustomization()
+
+	// compare with yaml string
+	b, err := yaml.Marshal(k)
+	if err != nil {
+		return fmt.Errorf("kustomization marshal error: %w", err)
+	}
+	emptyb, err := yaml.Marshal(emptyKustomization)
+	if err != nil {
+		return fmt.Errorf("empty kustomization marshal error: %w", err)
+	}
+
+	if string(b) == string(emptyb) {
+		return fmt.Errorf("kustomization.yaml is empty")
+	}
+	return nil
+}
+
 func (k *Kustomization) EnforceFields() []string {
 	var errs []string
 	if k.Kind != "" && k.Kind != KustomizationKind && k.Kind != ComponentKind {

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -301,21 +302,14 @@ func (k *Kustomization) FixKustomizationPreMarshalling(fSys filesys.FileSystem) 
 func (k *Kustomization) CheckEmpty() error {
 	// generate empty Kustomization
 	emptyKustomization := &Kustomization{}
-	emptyKustomization.FixKustomization()
 
-	// compare with yaml string
-	b, err := yaml.Marshal(k)
-	if err != nil {
-		return fmt.Errorf("kustomization marshal error: %w", err)
-	}
-	emptyb, err := yaml.Marshal(emptyKustomization)
-	if err != nil {
-		return fmt.Errorf("empty kustomization marshal error: %w", err)
-	}
+	// k.TypeMeta is metadata. It Isn't related to whether empty or not.
+	emptyKustomization.TypeMeta = k.TypeMeta
 
-	if string(b) == string(emptyb) {
+	if reflect.DeepEqual(k, emptyKustomization) {
 		return fmt.Errorf("kustomization.yaml is empty")
 	}
+
 	return nil
 }
 

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -295,7 +295,7 @@ func TestUnmarshal_Failed(t *testing.T) {
 			kustomizationYamls: []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 unknown`),
-			errMsg: "yaml: line 4: could not find expected ':'",
+			errMsg: "invalid Kustomization: yaml: line 4: could not find expected ':'",
 		},
 	}
 	for _, tt := range tests {
@@ -318,6 +318,16 @@ func TestKustomization_CheckEmpty(t *testing.T) {
 			name:          "empty kustomization.yaml",
 			kustomization: &Kustomization{},
 			wantErr:       true,
+		},
+		{
+			name: "empty kustomization.yaml",
+			kustomization: &Kustomization{
+				TypeMeta: TypeMeta{
+					Kind:       KustomizationKind,
+					APIVersion: KustomizationVersion,
+				},
+			},
+			wantErr: true,
 		},
 		{
 			name:          "non empty kustomization.yaml",

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -284,14 +284,54 @@ unknown: foo`)
 	}
 }
 
-func TestUnmarshal_InvalidYaml(t *testing.T) {
-	y := []byte(`
-apiVersion: kustomize.config.k8s.io/v1beta1
+func TestUnmarshal_Failed(t *testing.T) {
+	tests := []struct {
+		name               string
+		kustomizationYamls []byte
+		errMsg             string
+	}{
+		{
+			name: "invalid yaml",
+			kustomizationYamls: []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-unknown`)
-	var k Kustomization
-	err := k.Unmarshal(y)
-	if err == nil {
-		t.Fatalf("expect an error")
+unknown`),
+			errMsg: "yaml: line 4: could not find expected ':'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var k Kustomization
+			if err := k.Unmarshal(tt.kustomizationYamls); err == nil || err.Error() != tt.errMsg {
+				t.Errorf("Kustomization.Unmarshal() error = %v, wantErr %v", err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestKustomization_CheckEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		kustomization *Kustomization
+		wantErr       bool
+	}{
+		{
+			name:          "empty kustomization.yaml",
+			kustomization: &Kustomization{},
+			wantErr:       true,
+		},
+		{
+			name:          "non empty kustomization.yaml",
+			kustomization: &Kustomization{Resources: []string{"res"}},
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := tt.kustomization
+			k.FixKustomization()
+			if err := k.CheckEmpty(); (err != nil) != tt.wantErr {
+				t.Errorf("Kustomization.CheckEmpty() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- check the error at https://github.com/kubernetes-sigs/kustomize/issues/4861
- add check for a struct that is empty while unmarshal `kustomization.yaml`.
  - If we exec `kustomize build` for an empty `kustomization.yaml` file after merging this PR, we'll get the error.
  - maybe this is a breaking change.