### PR TITLE
Remove Functionality that Pulls Env Variables from Empty Keys

### DIFF
--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -162,14 +161,8 @@ func (kvl *loader) keyValuesFromLine(line []byte, currentLine int) (types.Pair, 
 	if len(data) == 2 {
 		kv.Value = data[1]
 	} else {
-		// No value (no `=` in the line) is a signal to obtain the value
-		// from the environment. This behaviour was accidentally imported from kubectl code, and
-		// will be removed in the next major release of Kustomize.
-		_, _ = fmt.Fprintln(os.Stderr, "WARNING: "+
-			"This Kustomization is relying on a bug that loads values from the environment "+
-			"when they are omitted from an env file. "+
-			"This behaviour will be removed in the next major release of Kustomize.")
-		kv.Value = os.Getenv(key)
+		// If there is value (no `=` in the line), we set value to an empty string
+		kv.Value = ""
 	}
 	kv.Key = key
 	return kv, nil

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -161,7 +161,7 @@ func (kvl *loader) keyValuesFromLine(line []byte, currentLine int) (types.Pair, 
 	if len(data) == 2 {
 		kv.Value = data[1]
 	} else {
-		// If there is value (no `=` in the line), we set value to an empty string
+		// If there is no value (no `=` in the line), we set the value to an empty string
 		kv.Value = ""
 	}
 	kv.Key = key

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -50,6 +50,26 @@ func TestKeyValuesFromLines(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		{
+			desc: "no value with equals",
+			content: `
+		k1=
+		`,
+			expectedPairs: []types.Pair{
+				{Key: "k1", Value: ""},
+			},
+			expectedErr: false,
+		},
+		{
+			desc: "no value without equals",
+			content: `
+		k1
+		`,
+			expectedPairs: []types.Pair{
+				{Key: "k1", Value: ""},
+			},
+			expectedErr: false,
+		},
 		// TODO: add negative testcases
 	}
 


### PR DESCRIPTION
Addresses: #4731 

Instead of pulling in environment values when a key is added in the env file with out the `=` we will now treat this case the same as if an `=` is present and set the value to an empty string.