### PR TITLE
[WIP]: Deprecate Reorder Flag in Favour of Field

### DIFF
--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -5,7 +5,6 @@ package krusty
 
 import (
 	"fmt"
-	"log"
 
 	"sigs.k8s.io/kustomize/api/internal/builtins"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
@@ -137,12 +136,6 @@ func (b *Kustomizer) applySortOrder(m resmap.ResMap, kt *target.KustTarget) erro
 
 	// Case 1: Sort order set in kustomization file.
 	if kt.Kustomization().SortOptions != nil {
-		// If set in CLI flag too, warn the user.
-		if b.options.Reorder != ReorderOptionUnspecified {
-			log.Println("Warning: Sorting order is set both in 'kustomization.yaml'" +
-				" ('sortOptions') and in a CLI flag ('--reorder'). Using the" +
-				" kustomization file over the CLI flag.")
-		}
 		pl := &builtins.SortOrderTransformerPlugin{
 			SortOptions: kt.Kustomization().SortOptions,
 		}
@@ -150,14 +143,6 @@ func (b *Kustomizer) applySortOrder(m resmap.ResMap, kt *target.KustTarget) erro
 		if err != nil {
 			return errors.Wrap(err)
 		}
-	} else if b.options.Reorder == ReorderOptionLegacy || b.options.Reorder == ReorderOptionUnspecified {
-		// Case 2: Sort order set in CLI flag only or not at all.
-		pl := &builtins.SortOrderTransformerPlugin{
-			SortOptions: &types.SortOptions{
-				Order: types.LegacySortOrder,
-			},
-		}
-		return errors.Wrap(pl.Transform(m))
 	}
 	return nil
 }

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -134,16 +134,12 @@ func Validate(args []string) error {
 	} else {
 		theArgs.kustomizationPath = args[0]
 	}
-	if err := validateFlagLoadRestrictor(); err != nil {
-		return err
-	}
-	return validateFlagReorderOutput()
+	return validateFlagLoadRestrictor()
 }
 
 // HonorKustomizeFlags feeds command line data to the krusty options.
 // Flags and such are held in private package variables.
 func HonorKustomizeFlags(kOpts *krusty.Options, flags *flag.FlagSet) *krusty.Options {
-	kOpts.Reorder = getFlagReorderOutput(flags)
 	kOpts.LoadRestrictions = getFlagLoadRestrictorValue()
 	if theFlags.enable.plugins {
 		c := types.EnabledPluginConfig(types.BploUseStaticallyLinked)

--- a/kustomize/commands/build/reorderoutput.go
+++ b/kustomize/commands/build/reorderoutput.go
@@ -4,10 +4,7 @@
 package build
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
-	flag "github.com/spf13/pflag"
 	"sigs.k8s.io/kustomize/api/krusty"
 )
 
@@ -15,36 +12,8 @@ const flagReorderOutputName = "reorder"
 
 func AddFlagReorderOutput(set *pflag.FlagSet) {
 	set.StringVar(
-		&theFlags.reorderOutput, flagReorderOutputName,
-		string(krusty.ReorderOptionLegacy),
-		"Reorder the resources just before output. Use '"+string(krusty.ReorderOptionLegacy)+"' to"+
-			" apply a legacy reordering (Namespaces first, Webhooks last, etc)."+
-			" Use '"+string(krusty.ReorderOptionNone)+"' to suppress a final reordering.")
-}
-
-func validateFlagReorderOutput() error {
-	switch theFlags.reorderOutput {
-	case string(krusty.ReorderOptionNone), string(krusty.ReorderOptionLegacy):
-		return nil
-	default:
-		return fmt.Errorf(
-			"illegal flag value --%s %s; legal values: %v",
-			flagReorderOutputName, theFlags.reorderOutput,
-			[]string{string(krusty.ReorderOptionLegacy), string(krusty.ReorderOptionNone)})
-	}
-}
-
-func getFlagReorderOutput(flags *flag.FlagSet) krusty.ReorderOption {
-	isReorderSet := flags.Changed(flagReorderOutputName)
-	if !isReorderSet {
-		return krusty.ReorderOptionUnspecified
-	}
-	switch theFlags.reorderOutput {
-	case string(krusty.ReorderOptionNone):
-		return krusty.ReorderOptionNone
-	case string(krusty.ReorderOptionLegacy):
-		return krusty.ReorderOptionLegacy
-	default:
-		return krusty.ReorderOptionUnspecified
-	}
+		&theFlags.reorderOutput,
+		flagReorderOutputName,
+		string(krusty.ReorderOptionUnspecified),
+		"enable adding to the new 'sortOptions' field in kustomization.yaml instead")
 }


### PR DESCRIPTION
Addresses: #3947 

#4019 made kustomize's ordering of resources customizable from the kustomization.yaml file. We can now safely deprecate the `reorder` flag.