### PR TITLE
Run `test-go-mod` on local modules 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,19 +108,10 @@ verify-kustomize-repo: \
 prow-presubmit-check: \
 	install-tools \
 	test-unit-kustomize-plugins \
+	test-go-mod \
 	build-non-plugin-all \
 	test-examples-kustomize-against-HEAD \
 	test-examples-kustomize-against-v4-release
-	# TODO(annasong): Find permanent solution.
-	# We have temporarily commented out this job because it fails for public
-	# cross-module changes, given that we've removed replace directives with go
-	# workspace and the job runs on the latest released modules. This
-	# complicates releases.
-	# This job is also less effective than intended because it only detects
-	# go mod tidy errors, instead of any changes to the original code that
-	# go mod tidy makes.
-
-	# test-go-mod
 
 .PHONY: license
 license: $(MYGOBIN)/addlicense
@@ -161,7 +152,9 @@ functions-examples-all:
 	done
 
 test-go-mod:
-	./hack/for-each-module.sh "go list -m -json all > /dev/null && go mod tidy -v"
+	./hack/for-each-module.sh $$(pwd)/hack/replace.sh; \
+	./hack/for-each-module.sh "go mod tidy -v"; \
+	./hack/for-each-module.sh $$(pwd)/hack/dropReplace.sh
 
 .PHONY:
 verify-kustomize-e2e: $(MYGOBIN)/mdrip $(MYGOBIN)/kind

--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,19 @@ verify-kustomize-repo: \
 prow-presubmit-check: \
 	install-tools \
 	test-unit-kustomize-plugins \
-	test-go-mod \
 	build-non-plugin-all \
 	test-examples-kustomize-against-HEAD \
 	test-examples-kustomize-against-v4-release
+	# TODO(annasong): Find permanent solution.
+	# We have temporarily commented out this job because it fails for public
+	# cross-module changes, given that we've removed replace directives with go
+	# workspace and the job runs on the latest released modules. This
+	# complicates releases.
+	# This job is also less effective than intended because it only detects
+	# go mod tidy errors, instead of any changes to the original code that
+	# go mod tidy makes.
+
+	# test-go-mod
 
 .PHONY: license
 license: $(MYGOBIN)/addlicense

--- a/hack/dropReplace.sh
+++ b/hack/dropReplace.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+read -a modules <<< $(go list -m)
+
+for i in ${!modules[@]}; do
+  go mod edit -dropreplace=${modules[i]}
+done

--- a/hack/replace.sh
+++ b/hack/replace.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+read -a modules <<< $(go list -m)
+read -a module_paths <<< $(go list -m -f {{.Dir}})
+
+for i in ${!modules[@]}; do
+  replace_path=$(realpath --relative-to=$(pwd) ${module_paths[i]})
+  if [ $replace_path == . ]; then
+    continue
+  fi
+  go mod edit -replace=${modules[i]}=$replace_path
+done


### PR DESCRIPTION
~~This PR comments out the `test-go-mod` prow-presubmit job.~~ 

This PR changes `test-go-mod` so that `go mod tidy` is run with local module dependencies instead of the latest released modules. This makes the CI much friendlier to changes that across multiple modules.

The failed job as a result of cross-module changes in #4959 motivated this change.