### PR TITLE
Allow metadata.name or metadata.generateName in GetValidatedMetadata()

### DIFF
--- a/kyaml/yaml/const.go
+++ b/kyaml/yaml/const.go
@@ -18,13 +18,14 @@ const (
 
 // Field names
 const (
-	AnnotationsField = "annotations"
-	APIVersionField  = "apiVersion"
-	KindField        = "kind"
-	MetadataField    = "metadata"
-	DataField        = "data"
-	BinaryDataField  = "binaryData"
-	NameField        = "name"
-	NamespaceField   = "namespace"
-	LabelsField      = "labels"
+	AnnotationsField  = "annotations"
+	APIVersionField   = "apiVersion"
+	KindField         = "kind"
+	MetadataField     = "metadata"
+	DataField         = "data"
+	BinaryDataField   = "binaryData"
+	NameField         = "name"
+	NamespaceField    = "namespace"
+	GenerateNameField = "generateName"
+	LabelsField       = "labels"
 )

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -293,6 +293,10 @@ func (rn *RNode) GetMeta() (ResourceMeta, error) {
 		m.Name = f.Value.YNode().Value
 		missingMeta = false
 	}
+	if f := meta.Field(GenerateNameField); !f.IsNilOrEmpty() {
+		m.GenerateName = f.Value.YNode().Value
+		missingMeta = false
+	}
 	if f := meta.Field(NamespaceField); !f.IsNilOrEmpty() {
 		m.Namespace = GetValue(f.Value)
 		missingMeta = false
@@ -1071,8 +1075,9 @@ func (rn *RNode) GetValidatedMetadata() (ResourceMeta, error) {
 		// A list doesn't require a name.
 		return m, nil
 	}
-	if m.NameMeta.Name == "" {
-		return m, fmt.Errorf("missing metadata.name in object %v", m)
+	fmt.Printf("name: %s, generateName: %s\n", m.NameMeta.Name, m.NameMeta.GenerateName)
+	if m.NameMeta.Name == "" && m.NameMeta.GenerateName == "" {
+		return m, fmt.Errorf("missing metadata.name and metadata.generateName in object %v", m)
 	}
 	return m, nil
 }

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -1075,7 +1075,6 @@ func (rn *RNode) GetValidatedMetadata() (ResourceMeta, error) {
 		// A list doesn't require a name.
 		return m, nil
 	}
-	fmt.Printf("name: %s, generateName: %s\n", m.NameMeta.Name, m.NameMeta.GenerateName)
 	if m.NameMeta.Name == "" && m.NameMeta.GenerateName == "" {
 		return m, fmt.Errorf("missing metadata.name and metadata.generateName in object %v", m)
 	}

--- a/kyaml/yaml/rnode_test.go
+++ b/kyaml/yaml/rnode_test.go
@@ -403,7 +403,7 @@ func TestRNodeGetValidatedMetadata(t *testing.T) {
 				"kind":       "ConfigMap",
 			},
 			rsExp: resultExpected{
-				errMsg: "missing metadata.name",
+				errMsg: "missing metadata.name and metadata.generateName",
 			},
 		},
 		"configmap": {
@@ -454,6 +454,28 @@ func TestRNodeGetValidatedMetadata(t *testing.T) {
 					TypeMeta: TypeMeta{
 						APIVersion: "v1",
 						Kind:       "ConfigMapList",
+					},
+				},
+			},
+		},
+		"jobGenerateName": {
+			theMap: map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"generateName": "winnie-",
+				},
+			},
+			rsExp: resultExpected{
+				out: ResourceMeta{
+					TypeMeta: TypeMeta{
+						APIVersion: "batch/v1",
+						Kind:       "Job",
+					},
+					ObjectMeta: ObjectMeta{
+						NameMeta: NameMeta{
+							GenerateName: "winnie-",
+						},
 					},
 				},
 			},

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -133,6 +133,8 @@ type NameMeta struct {
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Namespace is the metadata.namespace field of a Resource
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	// GenerateName is the metadata.generateName field of a Resource
+	GenerateName string `json:"generateName,omitempty" yaml:"generateName,omitempty"`
 }
 
 // ResourceMeta contains the metadata for a both Resource Type and Resource.


### PR DESCRIPTION
Modify GetValidatedMetadata to pass when at least one of `metadata.name` and `metadata.generateName` is defined.  #641 