### PR TITLE
Refactor parseGitURL

### DIFF
--- a/api/krusty/remoteloader_test.go
+++ b/api/krusty/remoteloader_test.go
@@ -192,14 +192,6 @@ resources:
 			expected: simpleBuild,
 		},
 		{
-			name: "triple slash absolute path",
-			kustomization: `
-resources:
-- file:///$ROOT/simple.git
-`,
-			expected: simpleBuild,
-		},
-		{
 			name: "has submodule but not initialized",
 			kustomization: `
 resources:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/kustomize/issues/4866 
Refactors the code that splits the RepoPath from the KustRootPath, and fixes inconsistencies and bugs in doing so:
* Uses a common path splitting strategy for all URLs--no more completely separate parsing for .git, _git, local etc.
* Eliminates the special case where URLs containing _git didn't even use extractHost
* Makes the documented `//` delimiter work for all URLs (we had skipped tests showing this was broken in some cases)
* Removes the pseudo-validation of the path segment using url.Parse ([see this inline comment](https://github.com/kubernetes-sigs/kustomize/pull/4983/files#r1070222458))

TIL while working on PR that the error messages `NewRepoSpecFromURL` never seem to make it to the user AFAICT. Instead, the return of an error is interpreted as "this is probably not a URL at all". For example,`(fl *fileLoader) New` then tries to load it as a local file, and `(fl *fileLoader) httpClientGetContent` returns an HTTP error instead of a "this was a remote repo" error. Stuff like this is (part of) why our error messages are so terrible. This PR does not attempt to change this, but the unusual implication of an error return value is good to keep in mind for review.

Remaining follow-ups:
- (fairly simple) Stop messing with the conventional `.git` suffix entirely (originally included here but removed for clarity: [see this comment](https://github.com/kubernetes-sigs/kustomize/pull/4983#discussion_r1071592140))
- (simple) Add arbitrary username support 
- (unlikely to make the release) Fix the overloading of the error return value? "This URL is invalid" (what we're giving) is not the same as "This doesn't look like a URL" (what the callers seem to need). Could the callers be using something that just validates the URL generically? I'd like to experiment with a dedicated function that does that, and compare it to the results of our error and smoke RepoSpec tests. I think this has a big potential for impact on Kustomize's most confusing error messages.