### PR TITLE
repospec: support ssh urls with ssh certificates

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -370,8 +371,10 @@ func extractScheme(s string) (string, string) {
 }
 
 func extractUsername(s string) (string, string) {
-	if trimmed, found := trimPrefixIgnoreCase(s, gitUsername); found {
-		return gitUsername, trimmed
+	var userRegexp = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9-]*)@`)
+	if m := userRegexp.FindStringSubmatch(s); m != nil {
+		username := m[1] + "@"
+		return username, s[len(username):]
 	}
 	return "", s
 }
@@ -401,8 +404,6 @@ func findPathSeparator(hostPath string, acceptSCP bool) int {
 	}
 	return sepIndex
 }
-
-const gitUsername = "git@"
 
 func normalizeGithubHostParts(scheme, username string) (string, string, string) {
 	if strings.HasPrefix(scheme, sshScheme) || username != "" {

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -33,6 +33,8 @@ func TestNewRepoSpecFromUrl_Permute(t *testing.T) {
 		{"git@github.com:", "git@github.com:"},
 		{"git@github.com/", "git@github.com:"},
 		{"git::git@github.com:", "git@github.com:"},
+		{"org-12345@github.com:", "org-12345@github.com:"},
+		{"org-12345@github.com/", "org-12345@github.com:"},
 	}
 	var repoPaths = []string{"someOrg/someRepo", "kubernetes/website"}
 	var pathNames = []string{"README.md", "foo/krusty.txt", ""}
@@ -621,6 +623,28 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 				RepoPath:     "org/project/_git/repo",
 				KustRootPath: "path/to/kustomization/root",
 				GitSuffix:    "",
+			},
+		},
+		{
+			name:      "ssh on github with custom username for custom ssh certificate authority",
+			input:     "ssh://org-12345@github.com/kubernetes-sigs/kustomize",
+			cloneSpec: "org-12345@github.com:kubernetes-sigs/kustomize.git",
+			absPath:   notCloned.String(),
+			repoSpec: RepoSpec{
+				Host:      "org-12345@github.com:",
+				RepoPath:  "kubernetes-sigs/kustomize",
+				GitSuffix: ".git",
+			},
+		},
+		{
+			name:      "scp on github with custom username for custom ssh certificate authority",
+			input:     "org-12345@github.com/kubernetes-sigs/kustomize",
+			cloneSpec: "org-12345@github.com:kubernetes-sigs/kustomize.git",
+			absPath:   notCloned.String(),
+			repoSpec: RepoSpec{
+				Host:      "org-12345@github.com:",
+				RepoPath:  "kubernetes-sigs/kustomize",
+				GitSuffix: ".git",
 			},
 		},
 	}


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kustomize/pull/4741

With all the work we've put into RepoSpec lately, this is now _much_ easier to do.

Copying that PR's description:

> Organizations that use a custom SSH Certificate Authority with GitHub
Enterprise Cloud will have a host that starts with org-12345@ instead
of git@. This removes the hard-coded git@ in the repo spec parsing
for a regexp match on a valid username instead.
>
> E.g. now it will be able to parse specs like org-12345@github.com:someOrg/someRepo/README.md?ref=someBranch.

Docs for the SSH Certificate feature are here: https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-git-access-to-your-organizations-repositories/about-ssh-certificate-authorities#about-ssh-urls-with-ssh-certificates

We can see in the git documentation that the username segment is universally valid for the ssh protocol and the scp-like format: https://git-scm.com/docs/git-fetch#_git_urls. We could validate against it being used with other protocols, but falling back on the leave-validation-to-git stance, I'm inclined not to. (Yes, this is a reversal of my stance on the original PR. I've learned a lot about RepoSpec in the interim!)