### PR TITLE
Improve panic error message to include the parse error.

### DIFF
--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -609,7 +609,7 @@ func initSchema() {
 	if customSchema != nil {
 		err := parse(customSchema, JsonOrYaml)
 		if err != nil {
-			panic("invalid schema file")
+			panic(fmt.Errorf("invalid schema file: %w", err))
 		}
 	} else {
 		if kubernetesOpenAPIVersion == "" {


### PR DESCRIPTION
This came up while investigating issue #4988.

If my openapi json file fails to parse (due to a missing curly brace), the error message provides only this error message:
```
panic: invalid schema file
```

This PR adds the error message to the panic.  

The new message will provide more details about the problem:
```
panic: invalid schema file: json: cannot unmarshal Go value of type spec.Swagger: unexpected EOF
```
