### PR TITLE
Follow up fixes

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -79,7 +79,7 @@ const (
 	refQuery         = "?ref="
 	gitSuffix        = ".git"
 	gitRootDelimiter = "_git/"
-	pathSeparator    = string(filepath.Separator)
+	pathSeparator    = "/" // do not use filepath.Separator, as this is a URL
 )
 
 // NewRepoSpecFromURL parses git-like urls.
@@ -198,8 +198,8 @@ func tryDefaultLengthSplit(n string, defaultSegmentLength int) (string, string, 
 }
 
 func kustRootPathExitsRepo(kustRootPath string) bool {
-	cleanedPath := filepath.Clean(strings.TrimPrefix(kustRootPath, pathSeparator))
-	pathElements := strings.Split(cleanedPath, pathSeparator)
+	cleanedPath := filepath.Clean(strings.TrimPrefix(kustRootPath, string(filepath.Separator)))
+	pathElements := strings.Split(cleanedPath, string(filepath.Separator))
 	return len(pathElements) > 0 &&
 		pathElements[0] == filesys.ParentDir
 }

--- a/api/krusty/generatoroptions_test.go
+++ b/api/krusty/generatoroptions_test.go
@@ -94,8 +94,6 @@ metadata:
 func TestGeneratorOptionsOverlayDisableNameSuffixHash(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK("base", `
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 generatorOptions:
   disableNameSuffixHash: false
   labels:
@@ -106,8 +104,6 @@ configMapGenerator:
   - foo=bar
 `)
 	th.WriteK("overlay", `
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 resources:
 - ../base
 generatorOptions:


### PR DESCRIPTION
Fixes the test failure on master caused by my tagging an old PR that needed to be rebased: https://github.com/kubernetes-sigs/kustomize/commit/8f75682b9c96f16d2e59e3a2e433b39a07d5e58a

Follows up on one of Anna's comments in: https://github.com/kubernetes-sigs/kustomize/pull/4985