### PR TITLE
Fix using same helm chart with different versions

### DIFF
--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -97,7 +97,11 @@ func (p *plugin) validateArgs() (err error) {
 	// be under the loader root (unless root restrictions are
 	// disabled).
 	if p.ValuesFile == "" {
-		p.ValuesFile = filepath.Join(p.ChartHome, p.Name, "values.yaml")
+		if p.Version != "" {
+			p.ValuesFile = filepath.Join(p.ChartHome, fmt.Sprintf("%s-%s", p.Name, p.Version), p.Name, "values.yaml")
+		} else {
+			p.ValuesFile = filepath.Join(p.ChartHome, p.Name, "values.yaml")
+		}
 	}
 	for i, file := range p.AdditionalValuesFiles {
 		// use Load() to enforce root restrictions

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -642,9 +642,11 @@ releaseName: %s
 			rm := th.LoadAndRunGenerator(config)
 			assert.True(t, len(rm.Resources()) > 0)
 
-			chartDir := fmt.Sprintf("charts/%s", tt.chartName)
+			var chartDir string
 			if tt.version != "" {
 				chartDir = fmt.Sprintf("charts/%s-%s/%s", tt.chartName, tt.version, tt.chartName)
+			} else {
+				chartDir = fmt.Sprintf("charts/%s", tt.chartName)
 			}
 
 			d, err := th.GetFSys().ReadFile(filepath.Join(th.GetRoot(), chartDir, "Chart.yaml"))


### PR DESCRIPTION
Fixes #4813

When a helm chart version is specified it sets `--untardir` to include `name-version` i.e. `charts/terraform-1.1.2`. 

If no version is specified the behavior stays the same in that it pulls the latest version with `--untardir` set to the charts directory ex.`charts`

### Example

```yaml
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
helmCharts:
  - name: terraform
    releaseName: terraform-1
    namespace: terraform-1
    repo: https://helm.releases.hashicorp.com
  - name: terraform
    version: 1.1.1
    releaseName: terraform-2
    namespace: terraform-2
    repo: https://helm.releases.hashicorp.com
  - name: terraform
    version: 1.1.1
    releaseName: terraform-3
    namespace: terraform-3
    repo: https://helm.releases.hashicorp.com
  - name: terraform
    version: 1.1.2
    releaseName: terraform-4
    namespace: terraform-4
    repo: https://helm.releases.hashicorp.com
```

Running `kustomize build --enable-helm` produces the following in the `charts` directory

```
❯ tree -L 3 charts
charts
├── terraform
...
│   ├── Chart.yaml
...
│   ├── templates
...
│   └── values.yaml
├── terraform-1.1.1
│   ├── terraform
...
│   │   ├── Chart.yaml
...
│   │   ├── templates
...
│   │   └── values.yaml
│   └── terraform-1.1.1.tgz
├── terraform-1.1.2
│   ├── terraform
...
│   │   ├── Chart.yaml
...
│   │   ├── templates
...
│   │   └── values.yaml
│   └── terraform-1.1.2.tgz
└── terraform-1.1.2.tgz
```