### PR TITLE
Update Versioning to Improve Output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,9 @@ $(MYGOBIN)/pluginator:
 # Build from local source.
 $(MYGOBIN)/kustomize: build-kustomize-api
 	cd kustomize; \
-	go install .
+	go install -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	-X sigs.k8s.io/kustomize/api/provenance.version=(devel)" \
+	.
 
 kustomize: $(MYGOBIN)/kustomize
 

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,7 @@ $(MYGOBIN)/pluginator:
 # Build from local source.
 $(MYGOBIN)/kustomize: build-kustomize-api
 	cd kustomize; \
-	go install -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	-X sigs.k8s.io/kustomize/api/provenance.version=(devel)" \
+	go install -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
 	.
 
 kustomize: $(MYGOBIN)/kustomize

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,10 +4,10 @@
 include ../Makefile-modules.mk
 
 test:
-	go test -v -timeout 45m -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=v444.333.222"
+	go test -v -timeout 45m -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=(test)"
 
 build:
-	go build -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=v444.333.222" ./...
+	go build ./...
 
 generate: $(MYGOBIN)/k8scopy $(MYGOBIN)/stringer
 	go generate ./...

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,10 +4,10 @@
 include ../Makefile-modules.mk
 
 test:
-	go test -v -timeout 45m -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.version=(test)"
+	go test -v -timeout 45m -cover ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=2023-01-31T23:38:41Z -X sigs.k8s.io/kustomize/api/provenance.version=(test)"
 
 build:
-	go build ./...
+	go build -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" ./...
 
 generate: $(MYGOBIN)/k8scopy $(MYGOBIN)/stringer
 	go generate ./...

--- a/api/krusty/managedbylabel_test.go
+++ b/api/krusty/managedbylabel_test.go
@@ -13,14 +13,14 @@ const expected = `apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/managed-by: kustomize-v444.333.222
+    app.kubernetes.io/managed-by: kustomize-(test)
   name: myService
 spec:
   ports:
   - port: 7002
 `
 
-// This test may failed when running on package tests using the go command because `v444.333.222` is set on makefile.
+// This test may fail when running on package tests using the go command because `(test)` is set on makefile.
 func TestAddManagedbyLabel(t *testing.T) {
 	tests := []struct {
 		kustFile      string

--- a/api/provenance/provenance.go
+++ b/api/provenance/provenance.go
@@ -6,42 +6,62 @@ package provenance
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
+//nolint:gochecknoglobals
 var (
 	version = "unknown"
 	// sha1 from git, output of $(git rev-parse HEAD)
-	gitCommit = "$Format:%H$"
+	gitCommit = "unknown"
 	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	buildDate = "1970-01-01T00:00:00Z"
-	goos      = runtime.GOOS
-	goarch    = runtime.GOARCH
+	buildDate = "unknown"
 )
 
 // Provenance holds information about the build of an executable.
 type Provenance struct {
 	// Version of the kustomize binary.
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	// GitCommit is a git commit
-	GitCommit string `json:"gitCommit,omitempty"`
+	GitCommit string `json:"gitCommit,omitempty" yaml:"gitCommit,omitempty"`
 	// BuildDate is date of the build.
-	BuildDate string `json:"buildDate,omitempty"`
+	BuildDate string `json:"buildDate,omitempty" yaml:"buildDate,omitempty"`
 	// GoOs holds OS name.
-	GoOs string `json:"goOs,omitempty"`
+	GoOs string `json:"goOs,omitempty" yaml:"goOs,omitempty"`
 	// GoArch holds architecture name.
-	GoArch string `json:"goArch,omitempty"`
+	GoArch string `json:"goArch,omitempty" yaml:"goArch,omitempty"`
+	// GoVersion holds Go version.
+	GoVersion string `json:"goVersion,omitempty" yaml:"goVersion,omitempty"`
 }
 
 // GetProvenance returns an instance of Provenance.
 func GetProvenance() Provenance {
-	return Provenance{
-		version,
-		gitCommit,
-		buildDate,
-		goos,
-		goarch,
+	p := Provenance{
+		BuildDate: buildDate,
+		Version:   version,
+		GitCommit: gitCommit,
+		GoOs:      runtime.GOOS,
+		GoArch:    runtime.GOARCH,
+		GoVersion: runtime.Version(),
 	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return p
+	}
+
+	// override with values from BuildInfo
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if p.Version == "(devel)" {
+				p.GitCommit = setting.Value
+			}
+		case "GOOS":
+			p.GoOs = setting.Value
+		}
+	}
+	return p
 }
 
 // Full returns the full provenance stamp.
@@ -49,14 +69,9 @@ func (v Provenance) Full() string {
 	return fmt.Sprintf("%+v", v)
 }
 
-// Short returns the shortened provenance stamp.
+// Short returns the semantic version.
 func (v Provenance) Short() string {
-	return fmt.Sprintf(
-		"%v",
-		Provenance{
-			Version:   v.Version,
-			BuildDate: v.BuildDate,
-		})
+	return v.Semver()
 }
 
 // Semver returns the semantic version of kustomize.

--- a/api/provenance/provenance.go
+++ b/api/provenance/provenance.go
@@ -65,14 +65,14 @@ func GetProvenance() Provenance {
 	return p
 }
 
-// Full returns the full provenance stamp.
-func (v Provenance) Full() string {
-	return fmt.Sprintf("%+v", v)
-}
-
-// Short returns the semantic version.
+// Short returns the shortened provenance stamp.
 func (v Provenance) Short() string {
-	return v.Semver()
+	return fmt.Sprintf(
+		"%v",
+		Provenance{
+			Version:   v.Version,
+			BuildDate: v.BuildDate,
+		})
 }
 
 // Semver returns the semantic version of kustomize.

--- a/api/provenance/provenance_test.go
+++ b/api/provenance/provenance_test.go
@@ -4,17 +4,22 @@
 package provenance_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/provenance"
 )
 
+const expectedBuildDateFromLdFlag = "2023-01-31T23:38:41Z"
+const expectedVersionFromLdFlag = "(test)"
+
 func TestGetProvenance(t *testing.T) {
 	p := provenance.GetProvenance()
-	// These are not set during go test: https://github.com/golang/go/issues/33976
+	// These are set by ldflags in our Makefile
 	assert.Equal(t, "(test)", p.Version)
-	assert.Equal(t, "unknown", p.BuildDate)
+	assert.Equal(t, expectedBuildDateFromLdFlag, p.BuildDate)
+	// This comes from BuildInfo, which is not set during go test: https://github.com/golang/go/issues/33976
 	assert.Equal(t, "unknown", p.GitCommit)
 
 	// These are set properly during go test
@@ -35,7 +40,7 @@ func TestProvenance_Short(t *testing.T) {
 func TestProvenance_Full(t *testing.T) {
 	p := provenance.GetProvenance()
 	// Most values are not set during go test: https://github.com/golang/go/issues/33976
-	assert.Contains(t, p.Full(), "{Version:(test) GitCommit:unknown BuildDate:unknown")
+	assert.Contains(t, p.Full(), fmt.Sprintf("{Version:%s GitCommit:unknown BuildDate:%s", expectedVersionFromLdFlag, expectedBuildDateFromLdFlag))
 	assert.Regexp(t, "GoOs:\\w+ GoArch:\\w+ GoVersion:go1", p.Full())
 }
 

--- a/api/provenance/provenance_test.go
+++ b/api/provenance/provenance_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package provenance_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/provenance"
+)
+
+func TestGetProvenance(t *testing.T) {
+	p := provenance.GetProvenance()
+	// These are not set during go test: https://github.com/golang/go/issues/33976
+	assert.Equal(t, "(test)", p.Version)
+	assert.Equal(t, "unknown", p.BuildDate)
+	assert.Equal(t, "unknown", p.GitCommit)
+
+	// These are set properly during go test
+	assert.NotEmpty(t, p.GoArch)
+	assert.NotEmpty(t, p.GoOs)
+	assert.Contains(t, p.GoVersion, "go1.")
+}
+
+func TestProvenance_Short(t *testing.T) {
+	p := provenance.GetProvenance()
+	// The version not set during go test, so this comes from an ldflag: https://github.com/golang/go/issues/33976
+	assert.Equal(t, "(test)", p.Short())
+
+	p.Version = "kustomize/v4.11.12"
+	assert.Equal(t, "v4.11.12", p.Short())
+}
+
+func TestProvenance_Full(t *testing.T) {
+	p := provenance.GetProvenance()
+	// Most values are not set during go test: https://github.com/golang/go/issues/33976
+	assert.Contains(t, p.Full(), "{Version:(test) GitCommit:unknown BuildDate:unknown")
+	assert.Regexp(t, "GoOs:\\w+ GoArch:\\w+ GoVersion:go1", p.Full())
+}
+
+func TestProvenance_Semver(t *testing.T) {
+	p := provenance.GetProvenance()
+	// The version not set during go test
+	assert.Equal(t, "(test)", p.Semver())
+
+	p.Version = "kustomize/v4.11.12"
+	assert.Equal(t, "v4.11.12", p.Semver())
+}

--- a/api/provenance/provenance_test.go
+++ b/api/provenance/provenance_test.go
@@ -17,7 +17,7 @@ const expectedVersionFromLdFlag = "(test)"
 func TestGetProvenance(t *testing.T) {
 	p := provenance.GetProvenance()
 	// These are set by ldflags in our Makefile
-	assert.Equal(t, "(test)", p.Version)
+	assert.Equal(t, expectedVersionFromLdFlag, p.Version)
 	assert.Equal(t, expectedBuildDateFromLdFlag, p.BuildDate)
 	// This comes from BuildInfo, which is not set during go test: https://github.com/golang/go/issues/33976
 	assert.Equal(t, "unknown", p.GitCommit)
@@ -31,17 +31,10 @@ func TestGetProvenance(t *testing.T) {
 func TestProvenance_Short(t *testing.T) {
 	p := provenance.GetProvenance()
 	// The version not set during go test, so this comes from an ldflag: https://github.com/golang/go/issues/33976
-	assert.Equal(t, "(test)", p.Short())
+	assert.Equal(t, fmt.Sprintf("{%s  %s   }", expectedVersionFromLdFlag, expectedBuildDateFromLdFlag), p.Short())
 
 	p.Version = "kustomize/v4.11.12"
-	assert.Equal(t, "v4.11.12", p.Short())
-}
-
-func TestProvenance_Full(t *testing.T) {
-	p := provenance.GetProvenance()
-	// Most values are not set during go test: https://github.com/golang/go/issues/33976
-	assert.Contains(t, p.Full(), fmt.Sprintf("{Version:%s GitCommit:unknown BuildDate:%s", expectedVersionFromLdFlag, expectedBuildDateFromLdFlag))
-	assert.Regexp(t, "GoOs:\\w+ GoArch:\\w+ GoVersion:go1", p.Full())
+	assert.Equal(t, fmt.Sprintf("{kustomize/v4.11.12  %s   }", expectedBuildDateFromLdFlag), p.Short())
 }
 
 func TestProvenance_Semver(t *testing.T) {

--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -12,7 +12,6 @@ ADD . /build/
 WORKDIR /build/kustomize
 RUN CGO_ENABLED=0 GO111MODULE=on go build \
     -ldflags="-s -X sigs.k8s.io/kustomize/api/provenance.version=${VERSION} \
-    -X sigs.k8s.io/kustomize/api/provenance.gitCommit=${COMMIT} \
     -X sigs.k8s.io/kustomize/api/provenance.buildDate=${DATE}"
 
 # only copy binary

--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -4,30 +4,83 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/api/provenance"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+type Options struct {
+	Short  bool
+	Output string
+	Writer io.Writer
+}
 
 // NewCmdVersion makes a new version command.
 func NewCmdVersion(w io.Writer) *cobra.Command {
-	var short bool
-
+	o := NewOptions(w)
 	versionCmd := cobra.Command{
 		Use:     "version",
 		Short:   "Prints the kustomize version",
 		Example: `kustomize version`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if short {
-				fmt.Fprintln(w, provenance.GetProvenance().Short())
-			} else {
-				fmt.Fprintln(w, provenance.GetProvenance().Full())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Validate(args); err != nil {
+				return err
 			}
+			if err := o.Run(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 
-	versionCmd.Flags().BoolVar(&short, "short", false, "short form")
+	versionCmd.Flags().BoolVar(&o.Short, "short", false, "short form")
+	_ = versionCmd.Flags().MarkDeprecated("short", "and will be removed in the future. The --short output will become the default.")
+	versionCmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return &versionCmd
+}
+
+func NewOptions(w io.Writer) *Options {
+	if w == nil {
+		w = io.Writer(os.Stdout)
+	}
+	return &Options{Writer: w}
+}
+
+func (o *Options) Validate(_ []string) error {
+	if o.Short {
+		if o.Output != "" {
+			return fmt.Errorf("--short and --output are mutually exclusive")
+		}
+	}
+	return nil
+}
+
+func (o *Options) Run() error {
+	switch o.Output {
+	case "":
+		if o.Short {
+			fmt.Fprintln(o.Writer, provenance.GetProvenance().Short())
+		} else {
+			fmt.Fprintln(o.Writer, provenance.GetProvenance().Full())
+		}
+	case "yaml":
+		marshalled, err := yaml.Marshal(provenance.GetProvenance())
+		if err != nil {
+			return errors.WrapPrefixf(err, "marshalling provenance to yaml")
+		}
+		fmt.Fprintln(o.Writer, string(marshalled))
+	case "json":
+		marshalled, err := json.MarshalIndent(provenance.GetProvenance(), "", "  ")
+		if err != nil {
+			return errors.WrapPrefixf(err, "marshalling provenance to json")
+		}
+		fmt.Fprintln(o.Writer, string(marshalled))
+	}
+	return nil
 }

--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -67,6 +67,9 @@ func (o *Options) Run() error {
 		if o.Short {
 			fmt.Fprintln(o.Writer, provenance.GetProvenance().Short())
 		} else {
+			fmt.Fprintln(os.Stderr, "WARNING: This version information is deprecated and "+
+				"will be replaced with the output from kustomize version --short. "+
+				"Use --output=yaml|json to get the full version.")
 			fmt.Fprintln(o.Writer, provenance.GetProvenance().Full())
 		}
 	case "yaml":

--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -40,7 +40,7 @@ func NewCmdVersion(w io.Writer) *cobra.Command {
 	}
 
 	versionCmd.Flags().BoolVar(&o.Short, "short", false, "short form")
-	_ = versionCmd.Flags().MarkDeprecated("short", "and will be removed in the future. The --short output will become the default.")
+	_ = versionCmd.Flags().MarkDeprecated("short", "and will be removed in the future.")
 	versionCmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return &versionCmd
 }
@@ -67,10 +67,7 @@ func (o *Options) Run() error {
 		if o.Short {
 			fmt.Fprintln(o.Writer, provenance.GetProvenance().Short())
 		} else {
-			fmt.Fprintln(os.Stderr, "WARNING: This version information is deprecated and "+
-				"will be replaced with the output from kustomize version --short. "+
-				"Use --output=yaml|json to get the full version.")
-			fmt.Fprintln(o.Writer, provenance.GetProvenance().Full())
+			fmt.Fprintln(o.Writer, provenance.GetProvenance().Semver())
 		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(provenance.GetProvenance())

--- a/releasing/run-goreleaser.sh
+++ b/releasing/run-goreleaser.sh
@@ -101,7 +101,6 @@ builds:
   ldflags: >
     -s
     -X sigs.k8s.io/kustomize/api/provenance.version={{.Version}}
-    -X sigs.k8s.io/kustomize/api/provenance.gitCommit={{.Commit}}
     -X sigs.k8s.io/kustomize/api/provenance.buildDate={{.Date}}
 
   goos:


### PR DESCRIPTION
Working from: #4630 

[directly updated by Katrina Jan 31 because Cailyn is OOO]

- Take advantage of go1.18's [BuildInfo](https://pkg.go.dev/runtime/debug) as the source of the git commit version. Testing indicates this is reliably available.
  -  Unlike the PR this picks up from, this no longer uses BuildInfo for anything else. There is some nuance to how the module version gets populated in BuildInfo, and in our testing, it was never actually set. Possibly related to https://github.com/golang/go/issues/29228. So, I do not think this addresses https://github.com/kubernetes-sigs/kustomize/issues/4617 in the end; that will require subsequent investigation, but the other improvements are still worth merging.

- Continue to use ldflags for the build date and version data. Make sure the build date ldflag is set in our makefile.

- Add json and yaml output formats.

- Replace the Go struct dump with a simple semver string as the main version output. kubectl is doing the same: https://github.com/kubernetes/kubernetes/pull/108987

- Deprecate the short output flag.

- Add go version from build info

## Local Build Before
```
༶ kustomize version                                                                                                                           
{Version:unknown GitCommit:$Format:%H$ BuildDate:1970-01-01T00:00:00Z GoOs:darwin GoArch:arm64}

༶ kustomize version --short                                                                                                                 
{unknown  1970-01-01T00:00:00Z  }
```

## Local Build After
```
༶ kustomize version                                                                                                                           
(devel)

༶ kustomize version --short                                                                                                                 
Flag --short has been deprecated, and will be removed in the future.
{(devel)  2023-02-01T19:02:33Z   }

༶ kustomize version -o yaml                                                                                                                    
version: (devel)
gitCommit: 681f21f05a0d3483ecf6fdadb83e4dd41f70b5c9
buildDate: "2023-02-01T19:02:33Z"
goOs: darwin
goArch: arm64
goVersion: go1.19.2

༶ kustomize version -o json                                                                                                             
{
  "version": "(devel)",
  "gitCommit": "681f21f05a0d3483ecf6fdadb83e4dd41f70b5c9",
  "buildDate": "2023-02-01T19:02:33Z",
  "goOs": "darwin",
  "goArch": "arm64",
  "goVersion": "go1.19.2"
}
```