### PR TITLE
Make TestResourcesRepoNotFile Less Specific

### DIFF
--- a/api/krusty/localizer/runner_test.go
+++ b/api/krusty/localizer/runner_test.go
@@ -452,13 +452,14 @@ func TestResourcesRepoNotFile(t *testing.T) {
 
 	err := localizer.Run(fsActual, testDir.String(), "", testDir.Join("dst"))
 
-	const readmeErr = `yaml: line 28: mapping values are not allowed in this context`
-	fileErr := fmt.Sprintf(`invalid resource at file "%s": MalformedYAMLError: %s`, repo, readmeErr)
+	const readmeErr = `mapping values are not allowed in this context`
+	fileErr := fmt.Sprintf(`invalid resource at file "%s": MalformedYAMLError:`, repo)
 	rootErr := fmt.Sprintf(`unable to localize root "%s": unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization'`, repo)
 	var actualErr PathLocalizeError
 	require.ErrorAs(t, err, &actualErr)
 	require.Equal(t, repo, actualErr.Path)
-	require.EqualError(t, actualErr.FileError, fileErr)
+	require.ErrorContains(t, actualErr.FileError, readmeErr)
+	require.ErrorContains(t, actualErr.FileError, fileErr)
 	require.ErrorContains(t, actualErr.RootError, rootErr)
 
 	SetupDir(t, fsExpected, testDir.String(), kustomization)


### PR DESCRIPTION
Github change is causing a failure [here](https://github.com/kubernetes-sigs/kustomize/actions/runs/4016930808/jobs/6900619041#step:4:7156), and is also failing on master. This change removes the line number specification so the test passes, and will pass if there is another change impacting the line number.