### PR TITLE
Expose path to `localize` destination

### DIFF
--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -38,10 +38,11 @@ type localizer struct {
 }
 
 // Run attempts to localize the kustomization root at target with the given localize arguments
-func Run(target string, scope string, newDir string, fSys filesys.FileSystem) error {
+// and returns the path to the created newDir.
+func Run(target, scope, newDir string, fSys filesys.FileSystem) (string, error) {
 	ldr, args, err := NewLoader(target, scope, newDir, fSys)
 	if err != nil {
-		return errors.Wrap(err)
+		return "", errors.Wrap(err)
 	}
 	defer func() { _ = ldr.Cleanup() }()
 
@@ -51,7 +52,7 @@ func Run(target string, scope string, newDir string, fSys filesys.FileSystem) er
 	}
 	dst := args.NewDir.Join(toDst)
 	if err = fSys.MkdirAll(dst); err != nil {
-		return errors.WrapPrefixf(err, "unable to create directory in localize destination")
+		return "", errors.WrapPrefixf(err, "unable to create directory in localize destination")
 	}
 
 	err = (&localizer{
@@ -66,9 +67,9 @@ func Run(target string, scope string, newDir string, fSys filesys.FileSystem) er
 		if errCleanup != nil {
 			log.Printf("unable to clean localize destination: %s", errCleanup)
 		}
-		return errors.WrapPrefixf(err, "unable to localize target %q", target)
+		return "", errors.WrapPrefixf(err, "unable to localize target %q", target)
 	}
-	return nil
+	return args.NewDir.String(), nil
 }
 
 // localize localizes the root that lc is at

--- a/api/krusty/localizer/runner.go
+++ b/api/krusty/localizer/runner.go
@@ -9,7 +9,9 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-// Run `kustomize localize`s files referenced by kustomization target in scope to destination newDir on fSys.
-func Run(fSys filesys.FileSystem, target, scope, newDir string) error {
-	return errors.Wrap(localizer.Run(target, scope, newDir, fSys))
+// Run executes `kustomize localize` on fSys given the `localize` arguments and
+// returns the path to the created newDir.
+func Run(fSys filesys.FileSystem, target, scope, newDir string) (string, error) {
+	dst, err := localizer.Run(target, scope, newDir, fSys)
+	return dst, errors.Wrap(err)
 }


### PR DESCRIPTION
This PR allows the `kustomize/commands/localize` layer to print a success message with the destination directory in response to the following comment in #4959: https://github.com/kubernetes-sigs/kustomize/pull/4959#pullrequestreview-1275773560.

This PR exposes the `localize` destination directory path to the upper layer. This change gives the upper layer access to the default `localize` destination directory path.

