### PR TITLE
Localize helm `additionalValuesFiles` field

### DIFF
--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -53,6 +53,10 @@ func (lbp *localizeBuiltinPlugins) Filter(plugins []*yaml.RNode) ([]*yaml.RNode,
 					Path: "valuesFile",
 				},
 				types.FieldSpec{
+					Gvk:  resid.Gvk{Version: konfig.BuiltinPluginApiVersion, Kind: builtinhelpers.HelmChartInflationGenerator.String()},
+					Path: "additionalValuesFiles",
+				},
+				types.FieldSpec{
 					Gvk:  resid.Gvk{Version: konfig.BuiltinPluginApiVersion, Kind: builtinhelpers.PatchTransformer.String()},
 					Path: "path",
 				},

--- a/api/internal/localizer/localizer.go
+++ b/api/internal/localizer/localizer.go
@@ -280,6 +280,14 @@ func (lc *localizer) localizeHelmCharts(kust *types.Kustomization) error {
 			return errors.WrapPrefixf(err, "unable to localize helmCharts entry %d valuesFile", i)
 		}
 		kust.HelmCharts[i].ValuesFile = locFile
+
+		for j, valuesFile := range chart.AdditionalValuesFiles {
+			locFile, err = lc.localizeFile(valuesFile)
+			if err != nil {
+				return errors.WrapPrefixf(err, "unable to localize helmCharts entry %d additionalValuesFiles", i)
+			}
+			kust.HelmCharts[i].AdditionalValuesFiles[j] = locFile
+		}
 	}
 	if kust.HelmGlobals != nil {
 		locDir, err := lc.copyChartHomeEntry(kust.HelmGlobals.ChartHome)

--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -1273,8 +1273,13 @@ func TestLocalizeHelmCharts(t *testing.T) {
 - includeCRDs: true
   name: localize-valuesFile
   valuesFile: file
+- additionalValuesFiles:
+  - another
+  - third
 `,
 				"file":                                   valuesFile,
+				"another":                                valuesFile,
+				"third":                                  valuesFile,
 				"charts/nothing-to-localize/values.yaml": valuesFile,
 				"charts/localize-valuesFile/values.yaml": valuesFile,
 			},
@@ -1513,7 +1518,11 @@ releaseName: moria
 repo: https://itzg.github.io/minecraft-server-charts
 version: 3.1.3
 `,
-		"explicit.yaml": `apiVersion: builtin
+		"explicit.yaml": `additionalValuesFiles:
+- time.yaml
+- life.yaml
+- light.yaml
+apiVersion: builtin
 chartHome: home
 kind: HelmChartInflationGenerator
 metadata:
@@ -1521,6 +1530,9 @@ metadata:
 name: mapleStory
 valuesFile: mapleValues.yaml
 `,
+		"time.yaml":                    valuesFile,
+		"life.yaml":                    valuesFile,
+		"light.yaml":                   valuesFile,
 		"mapleValues.yaml":             valuesFile,
 		"home/mapleStory/values.yaml":  valuesFile,
 		"charts/minecraft/values.yaml": valuesFile,


### PR DESCRIPTION
This PR localizes the new `additionalValuesFiles` field on `types.HelmChart` introduced in #4926.