### PR TITLE
Pin to cmd config

### DIFF
--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/text v0.6.0
 	sigs.k8s.io/kustomize/api v0.12.1
-	sigs.k8s.io/kustomize/cmd/config v0.10.9
+	sigs.k8s.io/kustomize/cmd/config v0.11.0
 	sigs.k8s.io/kustomize/kyaml v0.14.0
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/releasing/cloudbuild.yaml
+++ b/releasing/cloudbuild.yaml
@@ -43,6 +43,8 @@ steps:
   entrypoint: /bin/bash
   dir: myClone
   secretEnv: ['GITHUB_TOKEN']
+  env:
+  - 'GITHUB_USERNAME=KnVerey' # used to make authenticated curl requests to Github in releasing/compile-changelog.sh
   args:
   - releasing/cloudbuild.sh
   - $TAG_NAME
@@ -59,6 +61,7 @@ timeout: 14m
 # The base64 of that is shown below.  It's decrypted by cloud build
 # and provided back to goreleaser.
 # IMPORTANT: make sure the token does not end with a newline when you encrypt it!
+# IMPORTANT: update the GITHUB_USERNAME env var above to match the github user whose token this is
 secrets:
 - kmsKeyName: projects/k8s-staging-kustomize/locations/global/keyRings/kust-cloud-key-ring/cryptoKeys/kust-cloud-key-name
   secretEnv:


### PR DESCRIPTION
Also attempts to allow cloud build to run the changelog script authenticated. It already had a github token in the env, but it needs a username as well.