### PR TITLE
Fix regression with scp-style urls with only one path element

### DIFF
--- a/api/internal/git/repospec.go
+++ b/api/internal/git/repospec.go
@@ -370,8 +370,9 @@ func trimPrefixIgnoreCase(s, prefix string) (string, bool) {
 func findPathSeparator(hostPath string, acceptSCP bool) int {
 	sepIndex := strings.Index(hostPath, pathSeparator)
 	if acceptSCP {
+		colonIndex := strings.Index(hostPath, ":")
 		// The colon acts as a delimiter in scp-style ssh URLs only if not prefixed by '/'.
-		if colonIndex := strings.Index(hostPath, ":"); colonIndex > 0 && colonIndex < sepIndex {
+		if sepIndex == -1 || (colonIndex > 0 && colonIndex < sepIndex) {
 			sepIndex = colonIndex
 		}
 	}

--- a/api/internal/git/repospec_test.go
+++ b/api/internal/git/repospec_test.go
@@ -659,6 +659,26 @@ func TestNewRepoSpecFromUrl_Smoke(t *testing.T) {
 				RepoPath: "kubernetes-sigs/kustomize",
 			},
 		},
+		{
+			name:      "scp format gist url",
+			input:     "git@gist.github.com:bc7947cb727d7f9217e7862d961a1ffd.git",
+			cloneSpec: "git@gist.github.com:bc7947cb727d7f9217e7862d961a1ffd.git",
+			absPath:   notCloned.String(),
+			repoSpec: RepoSpec{
+				Host:     "git@gist.github.com:",
+				RepoPath: "bc7947cb727d7f9217e7862d961a1ffd.git",
+			},
+		},
+		{
+			name:      "https gist url",
+			input:     "https://gist.github.com/bc7947cb727d7f9217e7862d961a1ffd.git",
+			cloneSpec: "https://gist.github.com/bc7947cb727d7f9217e7862d961a1ffd.git",
+			absPath:   notCloned.String(),
+			repoSpec: RepoSpec{
+				Host:     "https://gist.github.com/",
+				RepoPath: "bc7947cb727d7f9217e7862d961a1ffd.git",
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/4998