### PR TITLE
be error when no path matching

### DIFF
--- a/kustomize/commands/create/create_test.go
+++ b/kustomize/commands/create/create_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
@@ -51,6 +52,14 @@ func TestCreateWithResources(t *testing.T) {
 	if !reflect.DeepEqual(m.Resources, expected) {
 		t.Fatalf("expected %+v but got %+v", expected, m.Resources)
 	}
+}
+
+func TestCreateWithResourcesWithFileNotFound(t *testing.T) {
+	fSys := filesys.MakeEmptyDirInMemory()
+	assert.NoError(t, fSys.WriteFile("foo.yaml", []byte("")))
+	opts := createFlags{resources: "foo.yaml,bar.yaml"}
+	err := runCreate(opts, fSys, factory)
+	assert.EqualError(t, err, "bar.yaml has no match: must build at directory: not a valid directory: 'bar.yaml' doesn't exist")
 }
 
 func TestCreateWithNamespace(t *testing.T) {

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -73,3 +73,13 @@ func TestAddComponentNoArgs(t *testing.T) {
 	err := cmd.Execute()
 	assert.EqualError(t, err, "must specify a component file")
 }
+
+func TestAddComponentFileNotFound(t *testing.T) {
+	fSys := filesys.MakeEmptyDirInMemory()
+
+	cmd := newCmdAddComponent(fSys)
+	args := []string{componentFileName}
+
+	err := cmd.RunE(cmd, args)
+	assert.EqualError(t, err, componentFileName+" has no match: must build at directory: not a valid directory: '"+componentFileName+"' doesn't exist")
+}

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -38,7 +38,7 @@ func TestAddComponentHappyPath(t *testing.T) {
 }
 
 func TestAddComponentAlreadyThere(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
+	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
@@ -52,7 +52,7 @@ func TestAddComponentAlreadyThere(t *testing.T) {
 }
 
 func TestAddKustomizationFileAsComponent(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
+	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
@@ -63,7 +63,7 @@ func TestAddKustomizationFileAsComponent(t *testing.T) {
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	require.NoError(t, err)
-	assert.NotContains(t, string(content), componentFileName)
+	assert.Contains(t, string(content), componentFileName)
 }
 
 func TestAddComponentNoArgs(t *testing.T) {

--- a/kustomize/commands/edit/add/addcomponent_test.go
+++ b/kustomize/commands/edit/add/addcomponent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/konfig"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -51,19 +52,19 @@ func TestAddComponentAlreadyThere(t *testing.T) {
 	assert.NoError(t, cmd.RunE(cmd, args))
 }
 
+// Test for trying to add the kustomization.yaml file itself for resources.
+// This adding operation is not allowed.
 func TestAddKustomizationFileAsComponent(t *testing.T) {
 	fSys := filesys.MakeEmptyDirInMemory()
-	err := fSys.WriteFile(componentFileName, []byte(componentFileContent))
-	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
 
 	cmd := newCmdAddComponent(fSys)
-	args := []string{componentFileName}
+	args := []string{konfig.DefaultKustomizationFileName()}
 	require.NoError(t, cmd.RunE(cmd, args))
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), componentFileName)
+	assert.NotContains(t, string(content), konfig.DefaultKustomizationFileName())
 }
 
 func TestAddComponentNoArgs(t *testing.T) {

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/konfig"
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -70,20 +71,20 @@ func TestAddResourceAlreadyThere(t *testing.T) {
 	assert.NoError(t, cmd.RunE(cmd, args))
 }
 
+// Test for trying to add the kustomization.yaml file itself for resources.
+// This adding operation is not allowed.
 func TestAddKustomizationFileAsResource(t *testing.T) {
 	fSys := filesys.MakeEmptyDirInMemory()
-	err := fSys.WriteFile(resourceFileName, []byte(resourceFileContent))
-	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
 
 	cmd := newCmdAddResource(fSys)
-	args := []string{resourceFileName}
+	args := []string{konfig.DefaultKustomizationFileName()}
 	assert.NoError(t, cmd.RunE(cmd, args))
 
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	assert.NoError(t, err)
 
-	assert.Contains(t, string(content), resourceFileName)
+	assert.NotContains(t, string(content), konfig.DefaultKustomizationFileName())
 }
 
 func TestAddResourceNoArgs(t *testing.T) {

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -57,7 +57,7 @@ replacements:
 }
 
 func TestAddResourceAlreadyThere(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
+	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(resourceFileName, []byte(resourceFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
@@ -71,7 +71,7 @@ func TestAddResourceAlreadyThere(t *testing.T) {
 }
 
 func TestAddKustomizationFileAsResource(t *testing.T) {
-	fSys := filesys.MakeFsInMemory()
+	fSys := filesys.MakeEmptyDirInMemory()
 	err := fSys.WriteFile(resourceFileName, []byte(resourceFileContent))
 	require.NoError(t, err)
 	testutils_test.WriteTestKustomization(fSys)
@@ -83,7 +83,7 @@ func TestAddKustomizationFileAsResource(t *testing.T) {
 	content, err := testutils_test.ReadTestKustomization(fSys)
 	assert.NoError(t, err)
 
-	assert.NotContains(t, string(content), resourceFileName)
+	assert.Contains(t, string(content), resourceFileName)
 }
 
 func TestAddResourceNoArgs(t *testing.T) {

--- a/kustomize/commands/edit/add/addresource_test.go
+++ b/kustomize/commands/edit/add/addresource_test.go
@@ -94,3 +94,13 @@ func TestAddResourceNoArgs(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "must specify a resource file", err.Error())
 }
+
+func TestAddResourceFileNotFound(t *testing.T) {
+	fSys := filesys.MakeEmptyDirInMemory()
+
+	cmd := newCmdAddResource(fSys)
+	args := []string{resourceFileName}
+
+	err := cmd.RunE(cmd, args)
+	assert.EqualError(t, err, resourceFileName+" has no match: must build at directory: not a valid directory: '"+resourceFileName+"' doesn't exist")
+}

--- a/kustomize/commands/internal/util/util.go
+++ b/kustomize/commands/internal/util/util.go
@@ -30,8 +30,8 @@ func GlobPatterns(fSys filesys.FileSystem, patterns []string) ([]string, error) 
 	return result, nil
 }
 
-// GlobPatterns accepts a slice of glob strings and returns the set of
-// matching file paths. If files are not found, will try load from remote.
+// GlobPatterns accepts a slice of glob strings and returns the set of matching file paths. If files are not found, will try load from remote.
+// It returns an error if there are no matching files or it can't load from remote.
 func GlobPatternsWithLoader(fSys filesys.FileSystem, ldr ifc.Loader, patterns []string) ([]string, error) {
 	var result []string
 	for _, pattern := range patterns {

--- a/kustomize/commands/internal/util/util.go
+++ b/kustomize/commands/internal/util/util.go
@@ -42,7 +42,7 @@ func GlobPatternsWithLoader(fSys filesys.FileSystem, ldr ifc.Loader, patterns []
 		if len(files) == 0 {
 			loader, err := ldr.New(pattern)
 			if err != nil {
-				return nil, fmt.Errorf("%s has no match", pattern)
+				return nil, fmt.Errorf("%s has no match: %w", pattern, err)
 			} else {
 				result = append(result, pattern)
 				if loader != nil {

--- a/kustomize/commands/internal/util/util.go
+++ b/kustomize/commands/internal/util/util.go
@@ -42,7 +42,7 @@ func GlobPatternsWithLoader(fSys filesys.FileSystem, ldr ifc.Loader, patterns []
 		if len(files) == 0 {
 			loader, err := ldr.New(pattern)
 			if err != nil {
-				log.Printf("%s has no match", pattern)
+				return nil, fmt.Errorf("%s has no match", pattern)
 			} else {
 				result = append(result, pattern)
 				if loader != nil {

--- a/kustomize/commands/internal/util/util_test.go
+++ b/kustomize/commands/internal/util/util_test.go
@@ -91,7 +91,9 @@ func TestGlobPatternsWithLoaderRemoteFile(t *testing.T) {
 	// test load invalid file
 	invalidURL := "http://invalid"
 	resources, err = GlobPatternsWithLoader(fSys, ldr, []string{invalidURL})
-	if err != nil && err.Error() != invalidURL+" has no match: "+invalidURL+" not exist" {
+	if err == nil {
+		t.Fatalf("expected error but did not receive one")
+	} else if err.Error() != invalidURL+" has no match: "+invalidURL+" not exist" {
 		t.Fatalf("unexpected load error: %v", err)
 	}
 	if len(resources) > 0 {

--- a/kustomize/commands/internal/util/util_test.go
+++ b/kustomize/commands/internal/util/util_test.go
@@ -89,8 +89,9 @@ func TestGlobPatternsWithLoaderRemoteFile(t *testing.T) {
 	}
 
 	// test load invalid file
-	resources, err = GlobPatternsWithLoader(fSys, ldr, []string{"http://invalid"})
-	if err == nil {
+	invalidURL := "http://invalid"
+	resources, err = GlobPatternsWithLoader(fSys, ldr, []string{invalidURL})
+	if err != nil && err.Error() != invalidURL+" has no match: "+invalidURL+" not exist" {
 		t.Fatalf("unexpected load error: %v", err)
 	}
 	if len(resources) > 0 {

--- a/kustomize/commands/internal/util/util_test.go
+++ b/kustomize/commands/internal/util/util_test.go
@@ -90,7 +90,7 @@ func TestGlobPatternsWithLoaderRemoteFile(t *testing.T) {
 
 	// test load invalid file
 	resources, err = GlobPatternsWithLoader(fSys, ldr, []string{"http://invalid"})
-	if err != nil {
+	if err == nil {
 		t.Fatalf("unexpected load error: %v", err)
 	}
 	if len(resources) > 0 {


### PR DESCRIPTION
## What happened?

`kustomize edit` command does not return an error when adding no matching path.

```
$ kustomize init
$ ls
kustomization.yaml
$ kustomize edit add resource do-not-exist
2023/02/04 01:08:18 do-not-exist has no match
$ echo $?
0
```

## What doing?
It was caused by [this line](https://github.com/kubernetes-sigs/kustomize/blob/0fd385d7197026b92272dc8688ec66593be91fba/kustomize/commands/internal/util/util.go#L45) only show the warning message.
I think better return the error on this line.

Maybe this fix is not the best, please write your opinions if you have any.