### PR TITLE
Don't Remove Kind with Suffix List if Empty

### DIFF
--- a/api/krusty/issue_5042_test.go
+++ b/api/krusty/issue_5042_test.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// test for https://github.com/kubernetes-sigs/kustomize/issues/4240
+func TestSuffix5042(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- resource.yaml
+`)
+
+	th.WriteF("resource.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyResource
+metadata:
+  name: service
+---
+apiVersion: example.com/v1alpha1
+kind: MyResourceTwo
+metadata:
+  name: test
+rules: []
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyResource
+metadata:
+  name: service
+---
+apiVersion: example.com/v1alpha1
+kind: MyResourceTwo
+metadata:
+  name: test
+rules: []
+`)
+}
+
+func TestListSuffix5042(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- resource.yaml
+`)
+
+	th.WriteF("resource.yaml", `
+apiVersion: example.com/v1alpha1
+kind: MyResource
+metadata:
+  name: service
+---
+apiVersion: example.com/v1alpha1
+kind: MyResourceList
+metadata:
+  name: test
+rules: []
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+
+	th.AssertActualEqualsExpected(m, `
+apiVersion: example.com/v1alpha1
+kind: MyResource
+metadata:
+  name: service
+---
+apiVersion: example.com/v1alpha1
+kind: MyResourceList
+metadata:
+  name: test
+rules: []
+`)
+}

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -196,7 +196,8 @@ func (rf *Factory) inlineAnyEmbeddedLists(
 		}
 		items, ok := m["items"]
 		if !ok {
-			// treat as an empty list
+			// list is empty nothing to replace node with
+			result = append(result, n0)
 			continue
 		}
 		slice, ok := items.([]interface{})


### PR DESCRIPTION
Fixes: #5042

The previous behaviour would replace any resource with kid `*List` with the items in the node, this results in resources not being included if they do not contain a list of other resources and end with List.

Now if a resource has no items it will not be replaced (with nothing).

Notes:
This does change the output