### PR TITLE
Remove Log Assignment to Stdout

### DIFF
--- a/api/internal/localizer/locloader_test.go
+++ b/api/internal/localizer/locloader_test.go
@@ -6,6 +6,7 @@ package localizer_test
 import (
 	"bytes"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,9 @@ func TestLocalLoadNewAndCleanup(t *testing.T) {
 
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
 	// typical setup
 	ldr, args, err := NewLoader("a", "/", "/newDir", fSys)
 	req.NoError(err)
@@ -223,6 +227,9 @@ func TestNewLocLoaderFails(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var buf bytes.Buffer
 			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
 
 			_, _, err := NewLoader(params.target, params.scope, params.dest, makeMemoryFs(t))
 			require.Error(t, err)

--- a/kustomize/commands/commands.go
+++ b/kustomize/commands/commands.go
@@ -54,7 +54,7 @@ See https://sigs.k8s.io/kustomize
 		create.NewCmdCreate(fSys, pvd.GetResourceFactory()),
 		version.NewCmdVersion(stdOut),
 		openapi.NewCmdOpenAPI(stdOut),
-		localize.NewCmdLocalize(fSys, stdOut),
+		localize.NewCmdLocalize(fSys),
 	)
 	configcobra.AddCommands(c, konfig.ProgramName)
 

--- a/kustomize/commands/localize/localize.go
+++ b/kustomize/commands/localize/localize.go
@@ -4,8 +4,6 @@
 package localize
 
 import (
-	"fmt"
-	"io"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -26,8 +24,7 @@ type flags struct {
 }
 
 // NewCmdLocalize returns a new localize command.
-func NewCmdLocalize(fs filesys.FileSystem, writer io.Writer) *cobra.Command {
-	log.SetOutput(writer)
+func NewCmdLocalize(fs filesys.FileSystem) *cobra.Command {
 	var f flags
 	cmd := &cobra.Command{
 		Use:   "localize [target [destination]]",
@@ -65,9 +62,8 @@ kustomize localize https://github.com/kubernetes-sigs/kustomize//api/krusty/test
 			if err != nil {
 				return errors.Wrap(err)
 			}
-			successMsg := fmt.Sprintf("SUCCESS: localized %q to directory %s\n", args.target, dst)
-			_, err = writer.Write([]byte(successMsg))
-			return errors.Wrap(err)
+			log.Printf("SUCCESS: localized %q to directory %s\n", args.target, dst)
+			return nil
 		},
 	}
 	// no shorthand to avoid conflation with other flags


### PR DESCRIPTION
fixes: #5039 

The log output was changed to `writer` [here](https://github.com/kubernetes-sigs/kustomize/blob/master/kustomize/commands/localize/localize.go#L3), which is set to stdout [here](https://github.com/kubernetes-sigs/kustomize/blob/master/kustomize/commands/commands.go#L57) causing the log output to not be redirected with errors. 

Questions:
I don't fully understand why the change, and related test were there initially so I'm not confident my strategy of just removing them is the best option.