### PR TITLE
perf: optimize Gvk.ApiVersion()

### DIFF
--- a/kyaml/resid/gvk.go
+++ b/kyaml/resid/gvk.go
@@ -122,13 +122,10 @@ func (x Gvk) stableSortString() string {
 
 // ApiVersion returns the combination of Group and Version
 func (x Gvk) ApiVersion() string {
-	var sb strings.Builder
 	if x.Group != "" {
-		sb.WriteString(x.Group)
-		sb.WriteString("/")
+		return x.Group + "/" + x.Version
 	}
-	sb.WriteString(x.Version)
-	return sb.String()
+	return x.Version
 }
 
 // StringWoEmptyField returns a string representation of the GVK. Non-exist

--- a/kyaml/resid/gvk_test.go
+++ b/kyaml/resid/gvk_test.go
@@ -4,6 +4,7 @@
 package resid
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,6 +127,23 @@ func TestApiVersion(t *testing.T) {
 		{Gvk{Group: "g", Version: "v", Kind: "k"}, "g/v"},
 	} {
 		assert.Equal(t, hey.exp, hey.x.ApiVersion())
+	}
+}
+
+func BenchmarkApiVersion(b *testing.B) {
+	for i, bench := range []Gvk{
+		{Kind: "k"},
+		{Version: "v", Kind: "k"},
+		{Group: "g", Kind: "k"},
+		{Group: "g", Version: "v"},
+		{Group: "g", Version: "v", Kind: "k"},
+		{Group: "bitnami.com", Version: "v1alpha1", Kind: "SealedSecret"},
+	} {
+		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = bench.ApiVersion()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Convert Gvk.ApiVersion() from using strings.Builder to raw string concatenation. The logic in Gvk.ApiVersion() is simple enough that raw concatenation executes quicker and consumes less memory.

This commit provides performance improvements that help the code flow prior to OpenAPI parsing, #4569.

For the current master branch, the new benchmark test shows:

```
$ go test ./kyaml/resid -bench=BenchmarkApiVersion -benchmem -run='^$'
goos: windows
goarch: amd64
pkg: sigs.k8s.io/kustomize/kyaml/resid
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
BenchmarkApiVersion/0-8         199093560                5.821 ns/op           0 B/op          0 allocs/op
BenchmarkApiVersion/1-8         49935914                25.02 ns/op            8 B/op          1 allocs/op
BenchmarkApiVersion/2-8         37500937                29.12 ns/op            8 B/op          1 allocs/op
BenchmarkApiVersion/3-8         44452182                27.99 ns/op            8 B/op          1 allocs/op
BenchmarkApiVersion/4-8         45229936                29.36 ns/op            8 B/op          1 allocs/op
BenchmarkApiVersion/5-8         16000682                67.16 ns/op           48 B/op          2 allocs/op
PASS
ok      sigs.k8s.io/kustomize/kyaml/resid       8.565s
```

For this commit, the new benchmark test shows:

```
$ go test ./kyaml/resid -bench=BenchmarkApiVersion -benchmem -run='^$'
goos: windows
goarch: amd64
pkg: sigs.k8s.io/kustomize/kyaml/resid
cpu: Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
BenchmarkApiVersion/0-8         892631328                1.388 ns/op           0 B/op          0 allocs/op
BenchmarkApiVersion/1-8         884411148                1.356 ns/op           0 B/op          0 allocs/op
BenchmarkApiVersion/2-8         55792155                21.04 ns/op            0 B/op          0 allocs/op
BenchmarkApiVersion/3-8         57150204                21.14 ns/op            0 B/op          0 allocs/op
BenchmarkApiVersion/4-8         60002700                21.23 ns/op            0 B/op          0 allocs/op
BenchmarkApiVersion/5-8         55470295                22.03 ns/op            0 B/op          0 allocs/op
PASS
ok      sigs.k8s.io/kustomize/kyaml/resid       8.322s
```