### PR TITLE
[Proposal] Add a match option for select to the index in replacements

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -213,8 +213,8 @@ func fieldRetrievalError(fieldPath string, isCreate bool) string {
 	return fmt.Sprintf("unable to find field %q in replacement target", fieldPath)
 }
 
-func setFieldValue(options *types.FieldOptions, targetField *yaml.RNode, value *yaml.RNode) error {
-	value = value.Copy()
+func setFieldValue(options *types.FieldOptions, targetField *yaml.RNode, ovalue *yaml.RNode) error {
+	value := ovalue.Copy()
 	if options != nil && options.Delimiter != "" {
 		if targetField.YNode().Kind != yaml.ScalarNode {
 			return fmt.Errorf("delimiter option can only be used with scalar nodes")
@@ -222,6 +222,15 @@ func setFieldValue(options *types.FieldOptions, targetField *yaml.RNode, value *
 		tv := strings.Split(targetField.YNode().Value, options.Delimiter)
 		v := yaml.GetValue(value)
 		// TODO: Add a way to remove an element
+
+		if options.Match != "" {
+			for i, s := range tv {
+				if s == options.Match {
+					options.Index = i
+					break
+				}
+			}
+		}
 		switch {
 		case options.Index < 0: // prefix
 			tv = append([]string{v}, tv...)

--- a/api/filters/replacement/replacement_test.go
+++ b/api/filters/replacement/replacement_test.go
@@ -1184,6 +1184,82 @@ spec:
 `,
 			expectedErr: "options.index -1 is out of bounds for value group2",
 		},
+		"partial string replacement with match value": {
+			input: `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  volumes:
+  - projected:
+      sources:
+      - configMap:
+          name: myconfigmap
+          items:
+          - key: config
+            path: my/target
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+spec:
+  volumes:
+  - projected:
+      sources:
+      - configMap:
+          name: myconfigmap
+          items:
+          - key: config
+            path: group2
+`,
+			replacements: `replacements:
+- source:
+    kind: Pod
+    name: pod2
+    fieldPath: spec.volumes.0.projected.sources.0.configMap.items.0.path
+    options:
+      delimiter: '/'
+      index: 0
+  targets:
+  - select:
+      kind: Pod
+      name: pod1
+    fieldPaths:
+    - spec.volumes.0.projected.sources.0.configMap.items.0.path
+    options:
+      delimiter: '/'
+      match: target
+`,
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  volumes:
+  - projected:
+      sources:
+      - configMap:
+          name: myconfigmap
+          items:
+          - key: config
+            path: my/group2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+spec:
+  volumes:
+  - projected:
+      sources:
+      - configMap:
+          name: myconfigmap
+          items:
+          - key: config
+            path: group2
+`,
+		},
 		"create": {
 			input: `apiVersion: v1
 kind: Pod
@@ -2779,7 +2855,7 @@ spec:
           name: myingress
         fieldPaths:
           - spec.tls.0.hosts.0
-          - spec.tls.0.secretName          
+          - spec.tls.0.secretName
         options:
           create: true
 `,

--- a/api/types/replacement.go
+++ b/api/types/replacement.go
@@ -71,6 +71,9 @@ type FieldOptions struct {
 	// Which position in the split to consider.
 	Index int `json:"index,omitempty" yaml:"index,omitempty"`
 
+	// What string in the split to consider.
+	Match string `json:"match,omitempty" yaml:"match,omitempty"`
+
 	// TODO (#3492): Implement use of this option
 	// None, Base64, URL, Hex, etc
 	Encoding string `json:"encoding,omitempty" yaml:"encoding,omitempty"`


### PR DESCRIPTION
## why
Currently, [replacements](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/) have a `delimiter` options that splits string literals and select with index.
But, the `Index` option is unclear which position is targetted with that replacements.
And we found replacements delimiter option replaces different positions when the replacements source string contains delimiter strings.

### Example: Replacements replaces different positions

#### source

```yaml
# pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
  labels:
    app: myapp
spec:
  containers:
  - name: nginx
    image: nginx:1.7.9
    env:
    - name: domain
      value: www.example.com
```

```yaml
# kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- pod.yaml
configMapGenerator:
- name: config-data
  options:
    annotations:
      config.kubernetes.io/local-config: "true" # ignore to build output
  literals:
  - SubDomain=www.site ## replacement source has delimiter string
  - TLD=co.jp
replacements:
- source:
    kind: ConfigMap
    name: config-data
    fieldPath: data.SubDomain
  targets:
  - select:
      name: myapp
    fieldPaths:
    - spec.containers.[name=nginx].env.0.value
    options:
      delimiter: "."
      index: 0
- source:
    kind: ConfigMap
    name: config-data
    fieldPath: data.TLD
  targets:
  - select:
      name: myapp
    fieldPaths:
    - spec.containers.[name=nginx].env.0.value
    options:
      delimiter: "."
      index: 2
```

### actual
```yaml
$ kustomize build .
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: myapp
  name: myapp
spec:
  containers:
  - env:
    - name: domain
      value: www.site.co.jp.com  # replaced different place than expected
    image: nginx:1.7.9
    name: nginx
```

### expect
```yaml
  - env:
    - name: domain
      value: www.site.example.co.jp
```


## what
I propose to add one option that matches the string lists splits by the `delimiter` option.
That helps to understand easy in which selected to target the replacements in the literals. And avoid upon cases.

#### example
```yaml
    options:
      delimiter: '/'
      # index: 1
      match: target
```
</details>

full: https://github.com/kubernetes-sigs/kustomize/pull/5068/files#diff-909c0819f13e268a60555f0aa78bd8acdbb42c10f3e2a906d62ba4b9d1722947R1216-R1232

## comments

I think this function is changing the interface.
Are you think I need to write [the Enhancement Proposals](https://github.com/kubernetes-sigs/kustomize/tree/master/proposals)?

## appendix
- https://github.com/kubernetes-sigs/kustomize/issues/3492