### PR TITLE
Replace deprecated k8s registry references

### DIFF
--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: mySvcAcct
       containers:
       - name: whatever
-        image: k8s.gcr.io/governmentCheese
+        image: registry.k8s.io/governmentCheese
 `)
 	th.WriteF("base/serviceAccount.yaml", `
 apiVersion: v1
@@ -61,7 +61,7 @@ spec:
   template:
     spec:
       containers:
-      - image: k8s.gcr.io/governmentCheese
+      - image: registry.k8s.io/governmentCheese
         name: whatever
       serviceAccountName: mySvcAcct
 ---
@@ -80,7 +80,7 @@ spec:
   template:
     spec:
       containers:
-      - image: k8s.gcr.io/governmentCheese
+      - image: registry.k8s.io/governmentCheese
         name: whatever
       serviceAccountName: mySvcAcct-private
 ---
@@ -115,7 +115,7 @@ commonLabels:
   app: external-dns
   instance: public
 images:
-- name: k8s.gcr.io/external-dns/external-dns
+- name: registry.k8s.io/external-dns/external-dns
   newName: xxx.azurecr.io/external-dns
   newTag: v0.7.4_sylr.1
 - name: quay.io/sylr/external-dns
@@ -153,7 +153,7 @@ commonLabels:
   app: external-dns
   instance: private
 images:
-- name: k8s.gcr.io/external-dns/external-dns
+- name: registry.k8s.io/external-dns/external-dns
   newName: xxx.azurecr.io/external-dns
   newTag: v0.7.4_sylr.1
 - name: quay.io/sylr/external-dns
@@ -192,7 +192,7 @@ commonLabels:
   app: external-dns
   instance: public
 images:
-- name: k8s.gcr.io/external-dns/external-dns
+- name: registry.k8s.io/external-dns/external-dns
   newName: quay.io/sylr/external-dns
   newTag: v0.7.4-73-g00a9a0c7
 secretGenerator:
@@ -243,7 +243,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: k8s.gcr.io/external-dns/external-dns
+        image: registry.k8s.io/external-dns/external-dns
         args:
         - --domain-filter=""
         - --txt-owner-id=""

--- a/api/krusty/transformersarrays_test.go
+++ b/api/krusty/transformersarrays_test.go
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web
@@ -116,7 +116,7 @@ spec:
         notIn: arrays
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      - image: registry.k8s.io/nginx-slim:0.8
         name: nginx
         ports:
         - containerPort: 80
@@ -142,7 +142,7 @@ spec:
         notIn: arrays
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      - image: registry.k8s.io/nginx-slim:0.8
         name: nginx
         ports:
         - containerPort: 80

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -1848,7 +1848,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web
@@ -2123,7 +2123,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: k8s.gcr.io/nginx-slim:0.8
+      - image: registry.k8s.io/nginx-slim:0.8
         name: nginx
         ports:
         - containerPort: 80

--- a/site/content/en/docs/Getting started/installation.md
+++ b/site/content/en/docs/Getting started/installation.md
@@ -54,8 +54,8 @@ See [GCR page] for available images.
 The following commands are how to pull and run kustomize {{<example-semver-version>}} docker image.
 
 ```bash
-docker pull k8s.gcr.io/kustomize/kustomize:{{< example-version >}}
-docker run k8s.gcr.io/kustomize/kustomize:{{< example-version >}} version
+docker pull registry.k8s.io/kustomize/kustomize:{{< example-version >}}
+docker run registry.k8s.io/kustomize/kustomize:{{< example-version >}} version
 ```
 
 ## Go Source


### PR DESCRIPTION
Problem: Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp. Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution: As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This pull request migrates remaining references for kubernetes-sigs/kustomize to registry.k8s.io.