### PR TITLE
Revert strict decoding of Kustomization due to regression in anchor handling

### DIFF
--- a/api/internal/localizer/localizer_test.go
+++ b/api/internal/localizer/localizer_test.go
@@ -263,7 +263,7 @@ suffix: invalid`,
 
 	_, err := Run("/a", "", "", fSysTest)
 	require.EqualError(t, err,
-		`unable to localize target "/a": invalid Kustomization: error unmarshaling JSON: while decoding JSON: json: unknown field "suffix"`)
+		`unable to localize target "/a": invalid Kustomization: json: unknown field "suffix"`)
 
 	checkFSys(t, fSysExpected, fSysTest)
 }

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -278,7 +278,7 @@ unknown: foo`)
 	if err == nil {
 		t.Fatalf("expect an error")
 	}
-	expect := "invalid Kustomization: error unmarshaling JSON: while decoding JSON: json: unknown field \"unknown\""
+	expect := "invalid Kustomization: json: unknown field \"unknown\""
 	if err.Error() != expect {
 		t.Fatalf("expect %v but got: %v", expect, err.Error())
 	}

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -382,7 +382,7 @@ foo:
 	}
 
 	_, err = mf.Read()
-	if err == nil || err.Error() != "invalid Kustomization: error unmarshaling JSON: while decoding JSON: json: unknown field \"foo\"" {
+	if err == nil || err.Error() != "invalid Kustomization: json: unknown field \"foo\"" {
 		t.Fatalf("Expect an unknown field error but got: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #5061 
Closes #5069 
Partial revert of https://github.com/kubernetes-sigs/kustomize/pull/4929 (not reverting all the unintentional duplicate keys in our tests!)

As stated on that issue, AFAICT none of the yaml libs we use has a mode that fulfills all of the following requirements:
- error on duplicate keys (both ok)
- error on unknown keys (both ok)
- proper anchor support (kyaml/go-yaml.v3 does, sigs-yaml does not) --> see #5061 
- case-insensitive keys (sigs-yaml does, kyaml/go-yaml.v3 does not) --> see #5069 

In the long run, having the sigs-yaml fork of go-yaml.v3 (which kyaml will rebase onto) support case-insensitive keys is a potential solution. In that sense, this is related to https://github.com/kubernetes-sigs/yaml/issues/72.