### PR TITLE
Only strip surrounding quotes if there are at least two characters.

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -571,3 +571,23 @@ metadata:
   name: test-k9cc55dfm5
 `)
 }
+
+func TestDataIsSingleQuote(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+configMapGenerator:
+  - name: test
+    literals:
+      - TEST='
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `apiVersion: v1
+data:
+  TEST: ''''
+kind: ConfigMap
+metadata:
+  name: test-m8t7bmb6g2
+`)
+}

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -187,7 +187,7 @@ func parseLiteralSource(source string) (keyName, value string, err error) {
 // removeQuotes removes the surrounding quotes from the provided string only if it is surrounded on both sides
 // rather than blindly trimming all quotation marks on either side.
 func removeQuotes(str string) string {
-	if len(str) == 0 || str[0] != str[len(str)-1] {
+	if len(str) < 2 || str[0] != str[len(str)-1] {
 		return str
 	}
 	if str[0] == '"' || str[0] == '\'' {


### PR DESCRIPTION
Otherwise, a value consisting of a single quote character triggers a panic:

    go test krusty/configmaps_test.go
    --- FAIL: TestDataIsSingleQuote (0.00s)
    panic: runtime error: slice bounds out of range [1:0] [recovered]
    	panic: runtime error: slice bounds out of range [1:0]