### PR TITLE
perf: Intersection: Avoid callid AllIds inside inner loop

### DIFF
--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -170,9 +170,10 @@ func (ra *ResAccumulator) FixBackReferences() (err error) {
 
 // Intersection drops the resources which "other" does not have.
 func (ra *ResAccumulator) Intersection(other resmap.ResMap) error {
+	otherIds := other.AllIds()
 	for _, curId := range ra.resMap.AllIds() {
 		toDelete := true
-		for _, otherId := range other.AllIds() {
+		for _, otherId := range otherIds {
 			if otherId == curId {
 				toDelete = false
 				break


### PR DESCRIPTION
This shaves of another 8.5 seconds (one third) of the remaining execution time for a kustomization tree with 4000 documents, reducing the execution time from 27.46s to 18.94s

     0.02s 0.062% 11.14%      8.45s 26.36%  sigs.k8s.io/kustomize/api/internal/accumulator.(*ResAccumulator).Intersection
     0.06s  0.19% 11.32%      8.32s 25.95%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).AllIds

before

    (pprof) top25 -cum
    Showing nodes accounting for 3.63s, 11.32% of 32.06s total
    Dropped 614 nodes (cum <= 0.16s)
    Showing top 25 nodes out of 171
        flat  flat%   sum%        cum   cum%
            0     0%     0%     27.46s 85.65%  github.com/spf13/cobra.(*Command).Execute
            0     0%     0%     27.46s 85.65%  github.com/spf13/cobra.(*Command).ExecuteC
            0     0%     0%     27.46s 85.65%  github.com/spf13/cobra.(*Command).execute
            0     0%     0%     27.46s 85.65%  main.main
            0     0%     0%     27.46s 85.65%  runtime.main
            0     0%     0%     27.46s 85.65%  sigs.k8s.io/kustomize/kustomize/v5/commands/build.NewCmdBuild.func1
            0     0%     0%     26.95s 84.06%  sigs.k8s.io/kustomize/api/krusty.(*Kustomizer).Run
            0     0%     0%     22.09s 68.90%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).MakeCustomizedResMap (inline)
            0     0%     0%     22.09s 68.90%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).makeCustomizedResMap
        0.29s   0.9%   0.9%     20.96s 65.38%  sigs.k8s.io/kustomize/api/resource.(*Resource).CurId
            0     0%   0.9%     13.61s 42.45%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).Append
            0     0%   0.9%     13.60s 42.42%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).GetMatchingResourcesByCurrentId (partial-inline)
        0.14s  0.44%  1.34%     13.60s 42.42%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).filteredById
        0.05s  0.16%  1.50%     12.91s 40.27%  sigs.k8s.io/kustomize/api/resmap.GetCurrentId
        0.25s  0.78%  2.28%     12.48s 38.93%  sigs.k8s.io/kustomize/api/resource.(*Resource).GetGvk (inline)
        0.49s  1.53%  3.81%     12.23s 38.15%  sigs.k8s.io/kustomize/kyaml/resid.GvkFromNode
            0     0%  3.81%     11.61s 36.21%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).IgnoreLocal
            0     0%  3.81%     10.47s 32.66%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).AccumulateTarget
            0     0%  3.81%     10.47s 32.66%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateTarget
        0.01s 0.031%  3.84%     10.46s 32.63%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateResources
            0     0%  3.84%     10.43s 32.53%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateDirectory
        0.64s  2.00%  5.83%     10.12s 31.57%  sigs.k8s.io/kustomize/kyaml/yaml.visitMappingNodeFields
        1.68s  5.24% 11.07%      9.48s 29.57%  sigs.k8s.io/kustomize/kyaml/yaml.visitFieldsWhileTrue
        0.02s 0.062% 11.14%      8.45s 26.36%  sigs.k8s.io/kustomize/api/internal/accumulator.(*ResAccumulator).Intersection
        0.06s  0.19% 11.32%      8.32s 25.95%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).AllIds

after

    (pprof) top30 -cum
    Showing nodes accounting for 5.04s, 22.63% of 22.27s total
    Dropped 540 nodes (cum <= 0.11s)
    Showing top 30 nodes out of 209
        flat  flat%   sum%        cum   cum%
            0     0%     0%     18.94s 85.05%  github.com/spf13/cobra.(*Command).Execute
            0     0%     0%     18.94s 85.05%  github.com/spf13/cobra.(*Command).ExecuteC
            0     0%     0%     18.94s 85.05%  github.com/spf13/cobra.(*Command).execute
            0     0%     0%     18.94s 85.05%  main.main
            0     0%     0%     18.94s 85.05%  runtime.main
            0     0%     0%     18.94s 85.05%  sigs.k8s.io/kustomize/kustomize/v5/commands/build.NewCmdBuild.func1
            0     0%     0%     18.40s 82.62%  sigs.k8s.io/kustomize/api/krusty.(*Kustomizer).Run
            0     0%     0%     13.65s 61.29%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).MakeCustomizedResMap (inline)
            0     0%     0%     13.65s 61.29%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).makeCustomizedResMap
            0     0%     0%     13.52s 60.71%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).Append
            0     0%     0%     13.44s 60.35%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).GetMatchingResourcesByCurrentId (inline)
        0.16s  0.72%  0.72%     13.44s 60.35%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).filteredById
        0.04s  0.18%   0.9%     12.54s 56.31%  sigs.k8s.io/kustomize/api/resmap.GetCurrentId
        0.19s  0.85%  1.75%     12.49s 56.08%  sigs.k8s.io/kustomize/api/resource.(*Resource).CurId
            0     0%  1.75%     10.37s 46.56%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).AccumulateTarget
            0     0%  1.75%     10.37s 46.56%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateResources
            0     0%  1.75%     10.37s 46.56%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateTarget
            0     0%  1.75%     10.34s 46.43%  sigs.k8s.io/kustomize/api/internal/target.(*KustTarget).accumulateDirectory
        0.19s  0.85%  2.60%      7.82s 35.11%  sigs.k8s.io/kustomize/api/resource.(*Resource).GetGvk (inline)
        0.42s  1.89%  4.49%      7.63s 34.26%  sigs.k8s.io/kustomize/kyaml/resid.GvkFromNode
        0.26s  1.17%  5.66%      6.01s 26.99%  sigs.k8s.io/kustomize/kyaml/yaml.visitMappingNodeFields
            0     0%  5.66%      5.76s 25.86%  sigs.k8s.io/kustomize/api/internal/accumulator.(*ResAccumulator).MergeAccumulator
        1.12s  5.03% 10.69%      5.75s 25.82%  sigs.k8s.io/kustomize/kyaml/yaml.visitFieldsWhileTrue
            0     0% 10.69%      5.57s 25.01%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).appendAll (inline)
            0     0% 10.69%      5.55s 24.92%  sigs.k8s.io/kustomize/api/internal/accumulator.(*ResAccumulator).AppendAll (inline)
            0     0% 10.69%      5.55s 24.92%  sigs.k8s.io/kustomize/api/resmap.(*resWrangler).AppendAll
            0     0% 10.69%      4.73s 21.24%  sigs.k8s.io/kustomize/api/internal/builtins.(*SortOrderTransformerPlugin).Transform
            0     0% 10.69%      4.73s 21.24%  sigs.k8s.io/kustomize/api/krusty.(*Kustomizer).applySortOrder
            0     0% 10.69%      4.72s 21.19%  sigs.k8s.io/kustomize/api/internal/builtins.applyOrdering
        2.66s 11.94% 22.63%      4.63s 20.79%  sigs.k8s.io/kustomize/kyaml/yaml.visitMappingNodeFields.func2