### PR TITLE
update golangci-lint to v1.51.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,96 +6,34 @@ run:
   go: '1.19'
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
-  enable:
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - contextcheck
-#    - cyclop
-    - depguard
-    - dogsled
-    - dupl
-    - dupword
-    - durationcheck
-    - errcheck
-    - errname
-    - errorlint
-    - exhaustive
-#    - exhaustivestruct
-    - exportloopref
-#    - forbidigo
-    - forcetypeassert
-#    - funlen
-#    - gci
-    - gochecknoglobals
-    - gochecknoinits
-#    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-#    - godot
-#    - godox
-#    - goerr113
-    - gofmt
-#    - gofumpt
-    - goheader
-    - goimports
-    - gomnd
-    - gomoddirectives
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-#    - ifshort # too many false positives
-    - importas
-    - ineffassign
-#    - ireturn
-    - lll
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - nilerr
-#    - nilnil
-#    - nlreturn
-#    - noctx
-    - nolintlint
-#    - paralleltest
-    - prealloc
-    - predeclared
-    - promlinter
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-#    - stylecheck
-    - tagliatelle
-    - tenv
-    - testpackage
-    - testableexamples
-    - thelper
-    - tparallel
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-#    - varnamelen
-    - wastedassign
-    - whitespace
-    - wrapcheck
-#    - wsl
-    - asasalint
-    - usestdlibvars
-    - interfacebloat
-    - loggercheck
-    - reassign
-    - ginkgolinter
-    - gocheckcompilerdirectives
-    - musttag
+  enable-all: true
+  disable:
+    - cyclop
+    - exhaustivestruct
+    - forbidigo
+    - funlen
+    - gci
+    - gocognit
+    - godot
+    - godox
+    - goerr113
+    - gofumpt
+    - ifshort # too many false positives
+    - ireturn
+    - nilnil
+    - nlreturn
+    - noctx
+    - paralleltest
+    - stylecheck
+    - varnamelen
+    - wsl
+    - exhaustruct
+    - deadcode
+    - scopelint
+    - nonamedreturns
+    - golint
+    - maintidx
+    - nosnakecase
 
 linters-settings:
   dupl:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,9 @@ linters:
     - interfacebloat
     - loggercheck
     - reassign
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - musttag
 
 linters-settings:
   dupl:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,34 +6,96 @@ run:
   go: '1.19'
 
 linters:
-  enable-all: true
-  disable:
-    - cyclop
-    - exhaustivestruct
-    - forbidigo
-    - funlen
-    - gci
-    - gocognit
-    - godot
-    - godox
-    - goerr113
-    - gofumpt
-    - ifshort # too many false positives
-    - ireturn
-    - nilnil
-    - nlreturn
-    - noctx
-    - paralleltest
-    - stylecheck
-    - varnamelen
-    - wsl
-    - exhaustruct
-    - deadcode
-    - scopelint
-    - nonamedreturns
-    - golint
-    - maintidx
-    - nosnakecase
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+#    - cyclop
+    - depguard
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errcheck
+    - errname
+    - errorlint
+    - exhaustive
+#    - exhaustivestruct
+    - exportloopref
+#    - forbidigo
+    - forcetypeassert
+#    - funlen
+#    - gci
+    - gochecknoglobals
+    - gochecknoinits
+#    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+#    - godot
+#    - godox
+#    - goerr113
+    - gofmt
+#    - gofumpt
+    - goheader
+    - goimports
+    - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+#    - ifshort # too many false positives
+    - importas
+    - ineffassign
+#    - ireturn
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+#    - nilnil
+#    - nlreturn
+#    - noctx
+    - nolintlint
+#    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+#    - stylecheck
+    - tagliatelle
+    - tenv
+    - testpackage
+    - testableexamples
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+#    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+#    - wsl
+    - asasalint
+    - usestdlibvars
+    - interfacebloat
+    - loggercheck
+    - reassign
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - musttag
 
 linters-settings:
   dupl:

--- a/Makefile-tools.mk
+++ b/Makefile-tools.mk
@@ -1,7 +1,7 @@
 # Copyright 2022 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-GOLANGCI_LINT_VERSION=v1.50.1
+GOLANGCI_LINT_VERSION=v1.51.2
 
 MYGOBIN = $(shell go env GOBIN)
 ifeq ($(MYGOBIN),)

--- a/api/internal/localizer/builtinplugins.go
+++ b/api/internal/localizer/builtinplugins.go
@@ -131,6 +131,7 @@ func (lbp *localizeBuiltinPlugins) localizeAll(node *yaml.RNode) error {
 	// We rely on the build command to throw errors for nodes in
 	// built-in plugins that are sequences when expected to be scalar,
 	// and vice versa.
+	//nolint: exhaustive
 	switch node.YNode().Kind {
 	case yaml.SequenceNode:
 		return errors.Wrap(node.VisitElements(lbp.localizeScalar))


### PR DESCRIPTION
Update [golangci-lint v1.51.2](https://github.com/golangci/golangci-lint/releases/tag/v1.51.2).