### PR TITLE
Add support for extra fieldspecs in configurations for Labels

### DIFF
--- a/api/internal/plugins/builtinconfig/transformerconfig.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig.go
@@ -18,6 +18,7 @@ type TransformerConfig struct {
 	NamePrefix        types.FsSlice `json:"namePrefix,omitempty" yaml:"namePrefix,omitempty"`
 	NameSuffix        types.FsSlice `json:"nameSuffix,omitempty" yaml:"nameSuffix,omitempty"`
 	NameSpace         types.FsSlice `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels            types.FsSlice `json:"labels,omitempty" yaml:"labels,omitempty"`
 	CommonLabels      types.FsSlice `json:"commonLabels,omitempty" yaml:"commonLabels,omitempty"`
 	TemplateLabels    types.FsSlice `json:"templateLabels,omitempty" yaml:"templateLabels,omitempty"`
 	CommonAnnotations types.FsSlice `json:"commonAnnotations,omitempty" yaml:"commonAnnotations,omitempty"`
@@ -62,6 +63,7 @@ func (t *TransformerConfig) sortFields() {
 	sort.Sort(t.NamePrefix)
 	sort.Sort(t.NameSuffix)
 	sort.Sort(t.NameSpace)
+	sort.Sort(t.Labels)
 	sort.Sort(t.CommonLabels)
 	sort.Sort(t.TemplateLabels)
 	sort.Sort(t.CommonAnnotations)
@@ -126,6 +128,10 @@ func (t *TransformerConfig) Merge(input *TransformerConfig) (
 		input.CommonAnnotations)
 	if err != nil {
 		return nil, errors.WrapPrefixf(err, "failed to merge CommonAnnotations fieldSpec")
+	}
+	merged.Labels, err = t.Labels.MergeAll(input.Labels)
+	if err != nil {
+		return nil, errors.WrapPrefixf(err, "failed to merge Labels fieldSpec")
 	}
 	merged.CommonLabels, err = t.CommonLabels.MergeAll(input.CommonLabels)
 	if err != nil {

--- a/api/internal/plugins/builtinconfig/transformerconfig_test.go
+++ b/api/internal/plugins/builtinconfig/transformerconfig_test.go
@@ -130,11 +130,15 @@ func TestMerge(t *testing.T) {
 	cfga.AddNamereferenceFieldSpec(nameReference[0])
 	cfga.AddPrefixFieldSpec(fieldSpecs[0])
 	cfga.AddSuffixFieldSpec(fieldSpecs[0])
+	cfga.Labels, _ = cfga.Labels.MergeOne(fieldSpecs[0])
+	cfga.AddLabelFieldSpec(fieldSpecs[0])
 
 	cfgb := &TransformerConfig{}
 	cfgb.AddNamereferenceFieldSpec(nameReference[1])
 	cfgb.AddPrefixFieldSpec(fieldSpecs[1])
-	cfga.AddSuffixFieldSpec(fieldSpecs[1])
+	cfgb.AddSuffixFieldSpec(fieldSpecs[1])
+	cfgb.Labels, _ = cfgb.Labels.MergeOne(fieldSpecs[1])
+	cfgb.AddLabelFieldSpec(fieldSpecs[1])
 
 	actual, err := cfga.Merge(cfgb)
 	if err != nil {
@@ -149,6 +153,14 @@ func TestMerge(t *testing.T) {
 		t.Fatal("merge failed for nameSuffix FieldSpec")
 	}
 
+	if len(actual.Labels) != 2 {
+		t.Fatal("merge failed for labels FieldSpec")
+	}
+
+	if len(actual.CommonLabels) != 2 {
+		t.Fatal("merge failed for commonLabels FieldSpec")
+	}
+
 	if len(actual.NameReference) != 1 {
 		t.Fatal("merge failed for namereference FieldSpec")
 	}
@@ -160,6 +172,10 @@ func TestMerge(t *testing.T) {
 	expected.AddPrefixFieldSpec(fieldSpecs[1])
 	expected.AddSuffixFieldSpec(fieldSpecs[0])
 	expected.AddSuffixFieldSpec(fieldSpecs[1])
+	expected.Labels, _ = expected.Labels.MergeOne(fieldSpecs[0])
+	expected.Labels, _ = expected.Labels.MergeOne(fieldSpecs[1])
+	expected.AddLabelFieldSpec(fieldSpecs[0])
+	expected.AddLabelFieldSpec(fieldSpecs[1])
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("expected: %v\n but got: %v\n", expected, actual)

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -282,7 +282,12 @@ var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 			}
 			c.Labels = label.Pairs
 			fss := types.FsSlice(label.FieldSpecs)
-			// merge the custom fieldSpecs with the default
+			// merge the custom fieldSpecs of Labels with the default
+			fss, err = fss.MergeAll(tc.Labels)
+			if err != nil {
+				return nil, err
+			}
+			// merge the custom fieldSpecs of commonLabels with the default
 			if label.IncludeSelectors {
 				fss, err = fss.MergeAll(tc.CommonLabels)
 			} else {

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -75,9 +75,9 @@ nameSuffix:
 
 ## Labels transformer
 
-The labels transformer adds labels to the `metadata/labels` field for all resources. It also adds labels to the `spec/selector` field in all Service resources as well as the `spec/selector/matchLabels` field in all Deployment resources.
+The labels transformer (`commonLabels` and `labels`) adds labels to the `metadata/labels` field for all resources. `commonLabels` also adds labels to the `spec/selector` field in all Service resources as well as the `spec/selector/matchLabels` field in all Deployment resources.
 
-Example:
+### Example (`commonLabels`):
 
 ```yaml
 commonLabels:
@@ -101,6 +101,28 @@ commonLabels:
   someName: someValue
   owner: alice
   app: bingo
+```
+
+### Example (`labels`):
+
+```yaml
+labels:
+- path: metadata/labels
+  create: true
+```
+
+Example kustomization.yaml:
+
+```yaml
+labels:
+- pairs:
+    someName: someValue
+- pairs:
+    owner: alice
+  includeSelectors: true
+- pairs:
+    app: bingo
+  includeTemplates: true
 ```
 
 ## Annotations transformer


### PR DESCRIPTION
worked on #4816 

I added the support for `Labels` so that users can specify extra `fieldspecs` as well as `commonLabels`.

Here is the example kustomization.yaml.

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
labels:
- pairs:
    someName: someValue
resources:
  # resources.yaml contains a Gorilla and a AnimalPark
  - resources.yaml
configurations:
- labels.yaml
```

resources.yaml

```yaml
apiVersion: animal/v1
kind: Gorilla
metadata:
  name: gg
---
apiVersion: animal/v1
kind: AnimalPark
metadata:
  name: ap
spec:
  gorillaRef:
    name: gg
    kind: Gorilla
    apiVersion: animal/v1
```

labels.yaml

```yaml
labels:
  - path: spec/gorillaRef/metadata/labels
    kind: AnimalPark
    create: true
```

The output of `kustomize build` is as follows

```yaml
apiVersion: animal/v1
kind: AnimalPark
metadata:
  labels:
    someName: someValue
  name: ap
spec:
  gorillaRef:
    apiVersion: animal/v1
    kind: Gorilla
    metadata:
      labels:
        someName: someValue
    name: gg
  template:
    name: template
```

Also, I added an example about this support in `examples/transformerconfigs/README.md`
I'm not very sure where I can add the test case for this support.
I would be grateful if we can discuss this.