### PR TITLE
prevent all uses of YAML aliases from being overwritten by a transformer

### DIFF
--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -1007,7 +1007,11 @@ func deAnchor(yn *yaml.Node) (res *yaml.Node, err error) {
 	case yaml.ScalarNode:
 		return yn, nil
 	case yaml.AliasNode:
-		return deAnchor(yn.Alias)
+		result, err := deAnchor(yn.Alias)
+		if err != nil {
+			return nil, err
+		}
+		return CopyYNode(result), nil
 	case yaml.MappingNode:
 		toMerge, err := removeMergeTags(yn)
 		if err != nil {

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer_test.go
@@ -409,6 +409,49 @@ spec:
 `)
 }
 
+func TestImageTagTransformerAnchor(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("ImageTagTransformer")
+	defer th.Reset()
+
+	rm := th.LoadAndRunTransformer(`
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: notImportantHere
+imageTag:
+  name: nginx
+  newName: my-nginx
+fieldSpecs:
+- path: spec/template/spec/containers[]/image
+`, `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: &name nginx
+spec:
+  template:
+    spec:
+      containers:
+      - image: *name
+        name: *name
+`)
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `
+apiVersion: v1
+group: apps
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  template:
+    spec:
+      containers:
+      - image: my-nginx
+        name: nginx
+`)
+}
+
 func TestImageTagTransformerTagWithBraces(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarness(t).
 		PrepBuiltin("ImageTagTransformer")

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -828,3 +828,65 @@ spec:
           protocol: TCP
 `)
 }
+
+func TestPatchTransformerAnchor(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: test-transformer
+patch: |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-deployment
+  spec:
+    selector:
+      matchLabels:
+        app: &name test-label
+    template:
+      metadata:
+        labels:
+          app: *name
+target:
+  kind: Deployment
+  name: test-deployment
+`, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name test-deployment
+spec:
+  selector:
+    matchLabels:
+      app: *name
+  template:
+    metadata:
+      labels:
+        app: *name
+    spec:
+      containers:
+      - image: test-image
+        name: *name
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+spec:
+  selector:
+    matchLabels:
+      app: test-label
+  template:
+    metadata:
+      labels:
+        app: test-label
+    spec:
+      containers:
+      - image: test-image
+        name: test-deployment
+`)
+}


### PR DESCRIPTION
Fixes: #4927 

When we use YAML anchors and aliases, all of the aliases point to the same address as a result of [`DeAnchor()`](https://github.com/kubernetes-sigs/kustomize/blob/master/kyaml/yaml/rnode.go#L984). Therefore, if we try to override the value of one alias with a transformer, it can affect all other aliases that have the same anchor name. To prevent this, I propose that each alias `*yaml.Node` should point to a unique address by copying it.

#4927 is a specific case for the images transformer. This can be reproduced with all transformers.

Example YAML files:

```yaml
# deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: &appName foo
spec:
  template:
    spec:
      containers:
        - name: *appName
          image: *appName
```

```yaml
# kustomization.yaml
resources:
  - deployment.yaml
images:
  - name: foo
```


### Output of this branch

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
spec:
  template:
    spec:
      containers:
      - image: bar
        name: foo
```


### Output of current master

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo
spec:
  template:
    spec:
      containers:
      - image: bar
        name: bar
```