### PR TITLE
use enable-all on golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,96 +6,34 @@ run:
   go: '1.19'
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
-  enable:
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - contextcheck
-#    - cyclop
-    - depguard
-    - dogsled
-    - dupl
-    - dupword
-    - durationcheck
-    - errcheck
-    - errname
-    - errorlint
-    - exhaustive
-#    - exhaustivestruct
-    - exportloopref
-#    - forbidigo
-    - forcetypeassert
-#    - funlen
-#    - gci
-    - gochecknoglobals
-    - gochecknoinits
-#    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-#    - godot
-#    - godox
-#    - goerr113
-    - gofmt
-#    - gofumpt
-    - goheader
-    - goimports
-    - gomnd
-    - gomoddirectives
-    - gomodguard
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-#    - ifshort # too many false positives
-    - importas
-    - ineffassign
-#    - ireturn
-    - lll
-    - makezero
-    - misspell
-    - nakedret
-    - nestif
-    - nilerr
-#    - nilnil
-#    - nlreturn
-#    - noctx
-    - nolintlint
-#    - paralleltest
-    - prealloc
-    - predeclared
-    - promlinter
-    - revive
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-#    - stylecheck
-    - tagliatelle
-    - tenv
-    - testpackage
-    - testableexamples
-    - thelper
-    - tparallel
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-#    - varnamelen
-    - wastedassign
-    - whitespace
-    - wrapcheck
-#    - wsl
-    - asasalint
-    - usestdlibvars
-    - interfacebloat
-    - loggercheck
-    - reassign
-    - ginkgolinter
-    - gocheckcompilerdirectives
-    - musttag
+  enable-all: true
+  disable:
+    - cyclop
+    - exhaustivestruct
+    - forbidigo
+    - funlen
+    - gci
+    - gocognit
+    - godot
+    - godox
+    - goerr113
+    - gofumpt
+    - ifshort # too many false positives
+    - ireturn
+    - nilnil
+    - nlreturn
+    - noctx
+    - paralleltest
+    - stylecheck
+    - varnamelen
+    - wsl
+    - exhaustruct
+    - deadcode
+    - scopelint
+    - nonamedreturns
+    - golint
+    - maintidx
+    - nosnakecase
 
 linters-settings:
   dupl:


### PR DESCRIPTION
enable-all option from ` golangci-lint` is Un-deprecated.
https://github.com/golangci/golangci-lint/issues/1888

And, when updating golangci-lint version, we need to check the release note for golangci-lint and add enable lint list for every new linter. I think that is an unscalable update operation. 
We already [pinned golangci-lint version on Makefile](https://github.com/kubernetes-sigs/kustomize/pull/5085/files#diff-5f29625c1963efca7efccc111a5a86c878b0cf1221f75a5fc00e39e26e55bbdfR4) And I think it was better for using `enable-all` options.

It is already talked at: https://github.com/kubernetes-sigs/kustomize/pull/5085/commits/39264a7057929ee9f2c9b193d2e18d580b819218#r1132609869