### PR TITLE
Re-enable tests disabled in #3880 

### DIFF
--- a/api/krusty/fnplugin_test.go
+++ b/api/krusty/fnplugin_test.go
@@ -589,6 +589,9 @@ metadata:
       container:
         image: "gcr.io/kustomize-functions/e2econtainerconfig"
 `)
+	build := exec.Command("docker", "build", ".", "-t", "gcr.io/kustomize-functions/e2econtainerconfig")
+	build.Dir = "../../cmd/config/internal/commands/e2e/e2econtainerconfig"
+	assert.NoError(t, build.Run())
 	m := th.Run(tmpDir.String(), o)
 	actual, err := m.AsYaml()
 	assert.NoError(t, err)


### PR DESCRIPTION
worked on #3881 

Basically, I followed what @annasong20 [suggested](https://github.com/kubernetes-sigs/kustomize/issues/3881#issuecomment-1445006217)

- For `TestFnContainerTransformer` test, I used `gcr.io/kustomize-functions/e2econtainerconfig` as [this Makefile](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/internal/commands/e2e/e2econtainerconfig/Makefile) builds. 
- For `TestFnContainerGenerator` test, I chose [`enable-gcp-services`](https://catalog.kpt.dev/enable-gcp-services/v0.1/?id=enable-gcp-services) from [the kpt catalog](https://catalog.kpt.dev/).