### PR TITLE
Fixed bugs in `validators:` in kustomization.yaml

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -381,7 +381,7 @@ func (kt *KustTarget) runValidators(ra *accumulator.ResAccumulator) error {
 		if err = kt.removeValidatedByLabel(newMap); err != nil {
 			return err
 		}
-		if err = orignal.ErrorIfNotEqualSets(newMap); err != nil {
+		if err = orignal.ErrorIfNotEqualLists(newMap); err != nil {
 			return fmt.Errorf("validator shouldn't modify the resource map: %v", err)
 		}
 	}

--- a/kyaml/runfn/runfn.go
+++ b/kyaml/runfn/runfn.go
@@ -190,7 +190,8 @@ func (r RunFns) runFunctions(
 	} else {
 		// write to the output instead of the directory if r.Output is specified or
 		// the output is nil (reading from Input)
-		outputs = append(outputs, kio.ByteWriter{Writer: r.Output})
+		// remove PathAnnotation and LegacyPathAnnotation explicitly because ByteWriter won't clear them by default
+		outputs = append(outputs, kio.ByteWriter{Writer: r.Output, ClearAnnotations: []string{kioutil.PathAnnotation, kioutil.LegacyPathAnnotation}})
 	}
 
 	var err error

--- a/kyaml/runfn/runfn_test.go
+++ b/kyaml/runfn/runfn_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -1160,6 +1161,25 @@ func TestCmd_Execute_setInput(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Contains(t, string(b), "kind: StatefulSet")
+}
+
+func TestCmd_Execute_clearAnnotations(t *testing.T) {
+	dir := setupTest(t)
+
+	out := &bytes.Buffer{}
+	instance := RunFns{
+		Output:                 out, // write to out
+		Path:                   dir,
+		functionFilterProvider: getFilterProvider(t),
+	}
+	// initialize the defaults
+	instance.init()
+
+	if !assert.NoError(t, instance.Execute()) {
+		return
+	}
+	assert.NotContains(t, out.String(), kioutil.PathAnnotation)
+	assert.NotContains(t, out.String(), kioutil.LegacyPathAnnotation)
 }
 
 // TestCmd_Execute_enableLogSteps tests the execution of a filter with LogSteps enabled.

--- a/plugin/someteam.example.com/v1/starlarkmixer/StarlarkMixer_test.go
+++ b/plugin/someteam.example.com/v1/starlarkmixer/StarlarkMixer_test.go
@@ -44,8 +44,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    config.kubernetes.io/path: configmap_some-cm.yaml
-    internal.config.kubernetes.io/path: configmap_some-cm.yaml
     modified-by: mixer-instance
   name: some-cm
 ---
@@ -54,17 +52,11 @@ data:
   foo: bar
 kind: ConfigMap
 metadata:
-  annotations:
-    config.kubernetes.io/path: configmap_some-cm-copy.yaml
-    internal.config.kubernetes.io/path: configmap_some-cm-copy.yaml
   name: some-cm-copy
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    config.kubernetes.io/path: configmap_net-new.yaml
-    internal.config.kubernetes.io/path: configmap_net-new.yaml
   name: net-new
 `)
 }


### PR DESCRIPTION
## Overview

Fixed bugs in `validators:`
This PR is also relevant to #5036 
As @bluebrown reported, we cannot run custom validators by setting them to `validators:`  in kustomization file.

### Details
To reproduce this, I prepared following files which are almost the same as the [validator example](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/validatorPlugin.md).

kustomization.yaml

```yaml
resources:
- configmap.yaml
validators:
- validator.yaml
```

configmap.yaml

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cm
data:
  foo: bar
```

validator.yaml

```yaml
apiVersion: someteam.example.com/v1
kind: Validator
metadata:
  name: notImportantHere
  annotations:
    config.kubernetes.io/function: |
      exec:
        path: ./validator.sh
```

validator.sh

```bash
#!/bin/bash

# Do whatever you want here. In this example we
# just print out the input

cat

```

`kustomize build` fails as follows.

```
$ kustomize build --enable-alpha-plugins --enable-exec .
Error: validator shouldn't modify the resource map: nodes unequal:
 -- {"apiVersion":"v1","data":{"foo":"bar"},"kind":"ConfigMap","metadata":{"name":"cm"}},
 -- {"apiVersion":"v1","data":{"foo":"bar"},"kind":"ConfigMap","metadata":{"annotations":{"config.kubernetes.io/path":"configmap_cm.yaml","internal.config.kubernetes.io/path":"configmap_cm.yaml"},"name":"cm"}}

--
&resource.Resource{RNode:yaml.RNode{fieldPath:[]string(nil), value:(*yaml.Node)(0xc001ff9f40), Match:[]string(nil)}, refVarNames:[]string(nil)}
------
&resource.Resource{RNode:yaml.RNode{fieldPath:[]string(nil), value:(*yaml.Node)(0xc0020779a0), Match:[]string(nil)}, refVarNames:[]string(nil)}
```

This error is caused by `runValidators` in [kusttarget.go](https://github.com/kubernetes-sigs/kustomize/blob/master/api/internal/target/kusttarget.go#L385).
We can see that two annotations (`PathAnnotation` and `LegacyPathAnnotation`) are added to the resource and I understood that these annotations are added in `FunctionFilter.Filter` in [runtimeutil.go](https://github.com/kubernetes-sigs/kustomize/blob/master/kyaml/fn/runtime/runtimeutil/runtimeutil.go#L197).

In my approach, these annotations are set in`ClearAnnotations` field of `kio.ByteWriter` in `runfn.go` https://github.com/kubernetes-sigs/kustomize/pull/5114/commits/e4e5d4ae90b09af110101e00f19eb2ee044eb3a4 
Therefore, they will be cleared at the end of pipeline execution.
This approach enables the example to work and output the expected result as follows.

```yaml
apiVersion: v1
data:
  foo: bar
kind: ConfigMap
metadata:
  name: cm
```

### Another example

I also confirmed [@bluebrown 's example](https://github.com/bluebrown/kustomize-validator-issue) works with this branch.

### Current master branch

```bash
Error: validator shouldn't modify the resource map: nodes unequal:
 -- {"apiVersion":"v1","data":{"key":1},"kind":"ConfigMap","metadata":{"name":"myapp"}},
 -- {"apiVersion":"v1","data":{"key":1},"kind":"ConfigMap","metadata":{"annotations":{"config.kubernetes.io/path":"configmap_myapp.yaml","internal.config.kubernetes.io/path":"configmap_myapp.yaml"},"name":"myapp"}}

--
&resource.Resource{RNode:yaml.RNode{fieldPath:[]string(nil), value:(*yaml.Node)(0xc001f8c000), Match:[]string(nil)}, refVarNames:[]string(nil)}
------
&resource.Resource{RNode:yaml.RNode{fieldPath:[]string(nil), value:(*yaml.Node)(0xc0020766e0), Match:[]string(nil)}, refVarNames:[]string(nil)}
```

### This PR

```yaml
apiVersion: v1
data:
  key: 1
kind: ConfigMap
metadata:
  name: myapp
```