### PR TITLE
Fix a bug in Generator options

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -291,6 +291,8 @@ resources:
 configMapGenerator:
   - name: project
     behavior: merge
+    options:
+      disableNameSuffixHash: true
     literals:
     - ANOTHER_ENV_VARIABLE="bar"
 `)

--- a/api/krusty/generatorplugin_test.go
+++ b/api/krusty/generatorplugin_test.go
@@ -1,0 +1,132 @@
+package krusty_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestGeneratorHashSuffixWithMergeBehavior(t *testing.T) {
+	fSys := filesys.MakeFsOnDisk()
+	generatorFilename := "generateWithHashRequest.sh"
+
+	th := kusttest_test.MakeHarnessWithFs(t, fSys)
+	o := th.MakeOptionsPluginsEnabled()
+	o.PluginConfig.FnpLoadingOptions.EnableExec = true
+
+	tmpDir, err := filesys.NewTmpConfirmedDir()
+	assert.NoError(t, err)
+	th.WriteK(tmpDir.String(), `
+resources: 
+- configmap.yaml
+generators:
+- |-
+  kind: Executable
+  metadata:
+    name: demo
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: ./`+generatorFilename+`
+`)
+
+	th.WriteF(filepath.Join(tmpDir.String(), "configmap.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmap
+data:
+  a: b
+`)
+	th.WriteF(filepath.Join(tmpDir.String(), generatorFilename), `#!/bin/sh
+
+cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmap
+  annotations:
+    kustomize.config.k8s.io/needs-hash: "true"
+    kustomize.config.k8s.io/behavior: "merge"
+data:
+  c: d
+EOF
+`)
+	assert.NoError(t, os.Chmod(filepath.Join(tmpDir.String(), generatorFilename), 0777))
+	m := th.Run(tmpDir.String(), o)
+	assert.NoError(t, err)
+	yml, err := m.AsYaml()
+	assert.NoError(t, err)
+	assert.Equal(t, `apiVersion: v1
+data:
+  a: b
+  c: d
+kind: ConfigMap
+metadata:
+  name: cmap-fh478f99mk
+`, string(yml))
+}
+
+func TestGeneratorHashSuffixWithReplaceBehavior(t *testing.T) {
+	fSys := filesys.MakeFsOnDisk()
+	generatorFilename := "generateWithHashRequest.sh"
+
+	th := kusttest_test.MakeHarnessWithFs(t, fSys)
+	o := th.MakeOptionsPluginsEnabled()
+	o.PluginConfig.FnpLoadingOptions.EnableExec = true
+
+	tmpDir, err := filesys.NewTmpConfirmedDir()
+	assert.NoError(t, err)
+	th.WriteK(tmpDir.String(), `
+resources: 
+- configmap.yaml
+generators:
+- |-
+  kind: Executable
+  metadata:
+    name: demo
+    annotations:
+      config.kubernetes.io/function: |
+        exec:
+          path: ./`+generatorFilename+`
+`)
+
+	th.WriteF(filepath.Join(tmpDir.String(), "configmap.yaml"), `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmap
+data:
+  a: b
+`)
+	th.WriteF(filepath.Join(tmpDir.String(), generatorFilename), `#!/bin/sh
+
+cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmap
+  annotations:
+    kustomize.config.k8s.io/needs-hash: "true"
+    kustomize.config.k8s.io/behavior: "replace"
+data:
+  c: d
+EOF
+`)
+	assert.NoError(t, os.Chmod(filepath.Join(tmpDir.String(), generatorFilename), 0777))
+	m := th.Run(tmpDir.String(), o)
+	assert.NoError(t, err)
+	yml, err := m.AsYaml()
+	assert.NoError(t, err)
+	assert.Equal(t, `apiVersion: v1
+data:
+  c: d
+kind: ConfigMap
+metadata:
+  name: cmap-gbdtcf54mt
+`, string(yml))
+}

--- a/api/krusty/generatorplugin_test.go
+++ b/api/krusty/generatorplugin_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package krusty_test
 
 import (

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/filters/labels"
+	"sigs.k8s.io/kustomize/api/internal/utils"
 	"sigs.k8s.io/kustomize/api/provider"
 	. "sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
@@ -895,6 +896,16 @@ func TestAbsorbAll(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(
 		t, strings.Contains(err.Error(), "behavior must be merge or replace"))
+
+	// Assure BuildAnnotationsGenAddHashSuffix is not deleted after AbsorbAll
+	w = makeMap1()
+	w.RemoveBuildAnnotations()
+	w2 = makeMap2(types.BehaviorReplace)
+	assert.NoError(t, w.AbsorbAll(w2))
+	expected = makeMap2(types.BehaviorUnspecified)
+	expected.RemoveBuildAnnotations()
+	expected.AnnotateAll(utils.BuildAnnotationsGenAddHashSuffix, "enabled")
+	assert.NoError(t, w.ErrorIfNotEqualLists(expected))
 }
 
 func TestToRNodeSlice(t *testing.T) {

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -904,7 +904,7 @@ func TestAbsorbAll(t *testing.T) {
 	assert.NoError(t, w.AbsorbAll(w2))
 	expected = makeMap2(types.BehaviorUnspecified)
 	expected.RemoveBuildAnnotations()
-	expected.AnnotateAll(utils.BuildAnnotationsGenAddHashSuffix, "enabled")
+	assert.NoError(t, expected.AnnotateAll(utils.BuildAnnotationsGenAddHashSuffix, "enabled"))
 	assert.NoError(t, w.ErrorIfNotEqualLists(expected))
 }
 

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -523,6 +523,9 @@ func mergeStringMapsWithBuildAnnotations(maps ...map[string]string) map[string]s
 	result := mergeStringMaps(maps...)
 	for i := range BuildAnnotations {
 		if len(maps) > 0 {
+			if BuildAnnotations[i] == utils.BuildAnnotationsGenAddHashSuffix {
+				continue
+			}
 			if v, ok := maps[0][BuildAnnotations[i]]; ok {
 				result[BuildAnnotations[i]] = v
 				continue

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -523,7 +523,7 @@ func mergeStringMapsWithBuildAnnotations(maps ...map[string]string) map[string]s
 	result := mergeStringMaps(maps...)
 	for i := range BuildAnnotations {
 		if len(maps) > 0 {
-                        // not delete BuildAnnotationsGenAddHashSuffix to work with kustomize.config.k8s.io/needs-hash annotation in generator options
+			// not delete BuildAnnotationsGenAddHashSuffix to work with kustomize.config.k8s.io/needs-hash annotation in generator options
 			if BuildAnnotations[i] == utils.BuildAnnotationsGenAddHashSuffix {
 				continue
 			}

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -523,6 +523,7 @@ func mergeStringMapsWithBuildAnnotations(maps ...map[string]string) map[string]s
 	result := mergeStringMaps(maps...)
 	for i := range BuildAnnotations {
 		if len(maps) > 0 {
+                        // not delete BuildAnnotationsGenAddHashSuffix to work with kustomize.config.k8s.io/needs-hash annotation in generator options
 			if BuildAnnotations[i] == utils.BuildAnnotationsGenAddHashSuffix {
 				continue
 			}


### PR DESCRIPTION
As mentioned by @KnVerey  in [this comment](https://github.com/kubernetes-sigs/kustomize/issues/4833#issuecomment-1341770498), using both `kustomize.config.k8s.io/behavior` and `kustomize.config.k8s.io/needs-hash` as generator options can cause a bug where the hash is not added to the `metadata.name` of the generated resource.

I reproduced this issue with current master branch as follows.

kustomization.yaml

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- configmap.yaml
generators:
- |-
  kind: Executable
  metadata:
    name: demo
    annotations:
      config.kubernetes.io/function: |
        exec:
          path: ./generator.sh
```

configmap.yaml

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cmap
data:
  a: b

```

generator.sh

```sh
#!/bin/sh
cat <<EOF
apiVersion: v1
kind: ConfigMap
metadata:
  name: cmap2
  annotations:
    kustomize.config.k8s.io/behavior: merge
    kustomize.config.k8s.io/needs-hash: true
data:
  c: d
EOF
```

result of kustomize build

```sh
$ chmod +x generator.sh
$ kustomize build --enable-alpha-plugins --enable-exec .
apiVersion: v1
data:
  a: b
  c: d
kind: ConfigMap
metadata:
  name: cmap # hash isn't added here
```

If we set `kustomize.config.k8s.io/needs-hash` as a generator option, [`UpdateResourceOptions`](https://github.com/natasha41575/kustomize/blob/master/api/internal/plugins/utils/utils.go#L213) is called from [`Generate` 
](https://github.com/natasha41575/kustomize/blob/master/api/internal/target/kusttarget.go#L260) in `api/internal/target/kusttarget.go`. `UpdateResourceOptions` sets a build annotation `internal.config.kubernetes.io/needsHashSuffix` to the resource generated by a generator.

However, I found out this annotation is removed when `kustomize.config.k8s.io/behavior` option is set. 
We can confirm this In [kustomize/blob/master/api/resmap/reswrangler.go](https://github.com/natasha41575/kustomize/blob/master/api/resmap/reswrangler.go#L509), where `CopyMergeMetaDataFieldsFrom` is called.  I believe this method copies the metadata of the origin resource to the one of the generated resource. In merge process, all build annotations, including `internal.config.kubernetes.io/needsHashSuffix`  are removed (see https://github.com/natasha41575/kustomize/blob/master/api/resource/resource.go#L465). My approach is to not delete `internal.config.kubernetes.io/needsHashSuffix` annotation here.

Here is output of this branch

```sh
$ ./kustomize build --enable-alpha-plugins --enable-exec .
apiVersion: v1
data:
  a: b
  c: d
kind: ConfigMap
metadata:
  name: cmap-fh478f99mk
```

Reference: https://kubectl.docs.kubernetes.io/guides/extending_kustomize/#generator-options