### PR TITLE
perf: eliminate unnecessary RNode creation

### DIFF
--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -450,15 +450,13 @@ func (rn *RNode) getMetaData() *yaml.Node {
 	if IsMissingOrNull(rn) {
 		return nil
 	}
-	var n *RNode
+	content := rn.Content()
 	if rn.YNode().Kind == DocumentNode {
 		// get the content if this is the document node
-		n = NewRNode(rn.Content()[0])
-	} else {
-		n = rn
+		content = content[0].Content
 	}
 	var mf *yaml.Node
-	visitMappingNodeFields(n.Content(), func(key, value *yaml.Node) {
+	visitMappingNodeFields(content, func(key, value *yaml.Node) {
 		if !IsYNodeNilOrEmpty(value) {
 			mf = value
 		}


### PR DESCRIPTION
Eliminate an unnecessary RNode creation in RNode.getMetaData.

This PR addresses [a deferred review comment](https://github.com/kubernetes-sigs/kustomize/pull/4944/files/a0e94c16427cf986dd1f9944f9a42f7c8f66b5ba#r1088266597) from @KnVerey under #4944.