### PR TITLE
Move inactive contributors to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 # See https://github.com/kubernetes/community/blob/master/community-membership.md
 approvers:
   - kustomize-approvers
-
 reviewers:
   - kustomize-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,19 +13,12 @@ aliases:
     - yuwenma
     - annasong20
     - koba1t
-
-  kyaml-approvers:
-    - mengqiy
-    - mortent
-    - phanimarupaka
-  kyaml-reviewers:
-    - mengqiy
-    - mortent
-    - phanimarupaka
-
-  emeritus-approvers:
-    - liujingfang1
-    - Shell32-Natsu
-    - justinsb
-    - monopole
-    - pwittrock
+  #  emeritus:
+  #    - liujingfang1
+  #    - Shell32-Natsu
+  #    - justinsb
+  #    - monopole
+  #    - pwittrock
+  #    - mengqiy
+  #    - mortent
+  #    - phanimarupaka

--- a/cmd/config/OWNERS
+++ b/cmd/config/OWNERS
@@ -1,6 +1,0 @@
-# See https://github.com/kubernetes/community/blob/master/community-membership.md
-approvers:
-  - kyaml-approvers
-
-reviewers:
-  - kyaml-reviewers

--- a/kyaml/OWNERS
+++ b/kyaml/OWNERS
@@ -1,6 +1,0 @@
-# See https://github.com/kubernetes/community/blob/master/community-membership.md
-approvers:
-  - kyaml-approvers
-
-reviewers:
-  - kyaml-reviewers


### PR DESCRIPTION
I used https://github.com/kubernetes-sigs/maintainers for this.

```bash
 maintainers prune --repository-github=kubernetes-sigs/kustomize --repository-devstats=kubernetes-sigs/kustomize --dryrun=false
```

If any of these folks become active again, we would of course be delighted and will add them back! But for now, this more accurately reflects the state of the project.

Since none of the separate kyaml / cmd/config maintainers are active anymore, I've removed those separate owners files.

/cc @natasha41575