### PR TITLE
Add test for issue #5131

### DIFF
--- a/api/krusty/testdata/remoteload/with-submodule/README.md
+++ b/api/krusty/testdata/remoteload/with-submodule/README.md
@@ -1,0 +1,10 @@
+# submodule
+
+This repo demonstrates kustomize's ability to download git repos 
+with submodules. The following branches contain
+* main: submodule via absolute path
+* relative-submodule: submodule via relative path
+
+For the submodule accessed via a relative path, we include a random hash in the
+submodule name to avoid accessing an unintended directory in the case kustomize
+contains loader bugs (issue #5131).


### PR DESCRIPTION
This PR adds a regression test for issue #5131 - relative path to submodules need `origin`. This PR demonstrates the issue so that we can be confident #5183 fixes it.