### PR TITLE
Fix install_kustomize.sh

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -7,7 +7,7 @@
 # kustomize binary to your current working directory.
 # (e.g. 'install_kustomize.sh')
 #
-# If one argument is given -> 
+# If one argument is given ->
 # If that argument is in the format of #.#.#, downloads the specified
 # version of the kustomize binary to your current working directory.
 # If that argument is something else, downloads the most recently released
@@ -79,7 +79,7 @@ function find_release_url() {
   local arch=$3
 
   echo "${releases}" |\
-    grep "browser_download.*${opsys}_${arch}" |\
+    grep -o "\"browser_download_url\":[[:space:]]*\"[^\"]\+${opsys}_${arch}[^\"]\+" |\
     cut -d '"' -f 4 |\
     sort -V | tail -n 1
 }


### PR DESCRIPTION
Github recently changed their API to sometimes remove whitespace from JSON responses.  This commit updates the `find_release_url` bash function to use grep's `--only-matching option` to return just the `browser_download_url` keys and values regardless of whitespace.

I was able to test the regex against old and new by passing the JSON document through `jq` first:

```
$ curl -s --header "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes-sigs/kustomize/releases | grep -o '"browser_download_url":[[:space:]]*"[^" ]\+linux_amd64
[^" ]\+' | cut -d '"' -f 4 | sort -V
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.4/kustomize_v4.5.4_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.5/kustomize_v4.5.5_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.6/kustomize_v4.5.6_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.7/kustomize_v4.5.7_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.0/kustomize_v5.0.0_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.1/kustomize_v5.0.1_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.2/kustomize_v5.0.2_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.3/kustomize_v5.0.3_linux_amd64.tar.gz

$ curl -s --header "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/kubernetes-sigs/kustomize/releases | jq . | grep -o '"browser_download_url":[[:space:]]*"[^" ]\+linu
x_amd64[^" ]\+' | cut -d '"' -f 4 | sort -V
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.4/kustomize_v4.5.4_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.5/kustomize_v4.5.5_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.6/kustomize_v4.5.6_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.7/kustomize_v4.5.7_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.0/kustomize_v5.0.0_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.1/kustomize_v5.0.1_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.2/kustomize_v5.0.2_linux_amd64.tar.gz
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.0.3/kustomize_v5.0.3_linux_amd64.tar.gz
```

closes #4769