### PR TITLE
keep comments with the lines they are for

### DIFF
--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -120,7 +120,7 @@ type kustomizationFile struct {
 type commentedLine struct {
 	line    string
 	comment []byte
-	added  bool
+	added   bool
 }
 
 // NewKustomizationFile returns a new instance.

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -196,7 +196,7 @@ func TestPreserveCommentsWithAdjust(t *testing.T) {
 RESOURCES:
 - ../namespaces
 - pod.yaml
-  # See which field this comment goes into
+# See which field this comment goes into
 - service.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -229,10 +229,10 @@ generatorOptions:
 # Some comments
 # This is some comment we should preserve
 # don't delete it
-  # See which field this comment goes into
 resources:
 - ../namespaces
 - pod.yaml
+# See which field this comment goes into
 - service.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/4481

- Changes implementation of handling comments. Comments above known fields are kept and organized for that field. Line comments are kept with the line they originally commented. 