### PR TITLE
Add name reference support for `HTTPRoute`

### DIFF
--- a/api/internal/konfig/builtinpluginconsts/namereference.go
+++ b/api/internal/konfig/builtinpluginconsts/namereference.go
@@ -317,6 +317,8 @@ nameReference:
   - path: webhooks/clientConfig/service
     kind: MutatingWebhookConfiguration
     group: admissionregistration.k8s.io
+  - path: spec/rules/backendRefs/name
+    kind: HTTPRoute
 
 - kind: Role
   group: rbac.authorization.k8s.io


### PR DESCRIPTION
Quite new to Kustomize, but was a bit surprised that `HTTPRoute` wasn't better supported; the `backendRefs` name, pointing to a `Service`, wasn't updated when using a `nameSuffix`.

This seems to be easily solved by adding a new built in `nameReference` though.