### PR TITLE
Fix nil pointer dereferencing when converting `vars` to `replacements `

### DIFF
--- a/kustomize/commands/edit/fix/convert.go
+++ b/kustomize/commands/edit/fix/convert.go
@@ -10,12 +10,13 @@ import (
 	"strconv"
 	"strings"
 
+	"sigs.k8s.io/yaml"
+
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
-	"sigs.k8s.io/yaml"
 )
 
 func ConvertVarsToReplacements(fSys filesys.FileSystem, k *types.Kustomization) error {
@@ -134,7 +135,7 @@ func getNodesFromFile(fileName string, fSys filesys.FileSystem) ([]*kyaml.RNode,
 	}
 	out := &bytes.Buffer{}
 	r := kio.ByteReadWriter{
-		Reader:                bytes.NewBufferString(string(b)),
+		Reader:                bytes.NewReader(b),
 		Writer:                out,
 		KeepReaderAnnotations: true,
 		OmitReaderAnnotations: true,
@@ -284,7 +285,11 @@ func constructTargets(file string, node *kyaml.RNode, fieldPaths []string,
 func writePatchTargets(patch types.Patch, node *kyaml.RNode, fieldPaths []string,
 	options []*types.FieldOptions) ([]*types.TargetSelector, error) {
 	var result []*types.TargetSelector
-	selector := patch.Target.Copy()
+
+	selector := types.Selector{}
+	if patch.Target != nil {
+		selector = patch.Target.Copy()
+	}
 
 	for i := range fieldPaths {
 		target := &types.TargetSelector{

--- a/kustomize/commands/edit/fix/convert.go
+++ b/kustomize/commands/edit/fix/convert.go
@@ -10,13 +10,12 @@ import (
 	"strconv"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func ConvertVarsToReplacements(fSys filesys.FileSystem, k *types.Kustomization) error {
@@ -135,7 +134,7 @@ func getNodesFromFile(fileName string, fSys filesys.FileSystem) ([]*kyaml.RNode,
 	}
 	out := &bytes.Buffer{}
 	r := kio.ByteReadWriter{
-		Reader:                bytes.NewReader(b),
+		Reader:                bytes.NewBuffer(b),
 		Writer:                out,
 		KeepReaderAnnotations: true,
 		OmitReaderAnnotations: true,

--- a/kustomize/commands/edit/fix/convert_test.go
+++ b/kustomize/commands/edit/fix/convert_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )

--- a/kustomize/commands/edit/fix/convert_test.go
+++ b/kustomize/commands/edit/fix/convert_test.go
@@ -414,7 +414,7 @@ spec:
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
 	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
-	var cmd = NewCmdFix(fSys, os.Stdout)
+	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
 	content, err := testutils_test.ReadTestKustomization(fSys)

--- a/kustomize/commands/edit/fix/convert_test.go
+++ b/kustomize/commands/edit/fix/convert_test.go
@@ -44,7 +44,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -120,7 +120,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -198,7 +198,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -277,7 +277,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -356,7 +356,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	err := cmd.RunE(cmd, nil)
@@ -534,8 +534,8 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
-	fSys.WriteFile("patch.yaml", patch)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -658,8 +658,8 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
-	fSys.WriteFile("patch.yaml", patch)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -781,8 +781,8 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
-	fSys.WriteFile("patch.yaml", patch)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -911,8 +911,8 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
-	fSys.WriteFile("patch.yaml", patch)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -1024,8 +1024,8 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomizationOverlay)
-	fSys.WriteFile("base/pod.yaml", pod)
-	fSys.WriteFile("base/kustomization.yaml", kustomizationBase)
+	assert.NoError(t, fSys.WriteFile("base/pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("base/kustomization.yaml", kustomizationBase))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -1105,7 +1105,7 @@ metadata:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
@@ -1176,7 +1176,7 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("patch.yaml", patch)
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
 	cmd := NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))

--- a/kustomize/commands/edit/fix/convert_test.go
+++ b/kustomize/commands/edit/fix/convert_test.go
@@ -413,9 +413,9 @@ spec:
 
 	fSys := filesys.MakeFsInMemory()
 	testutils_test.WriteTestKustomizationWith(fSys, kustomization)
-	fSys.WriteFile("pod.yaml", pod)
-	fSys.WriteFile("patch.yaml", patch)
-	cmd := NewCmdFix(fSys, os.Stdout)
+	assert.NoError(t, fSys.WriteFile("pod.yaml", pod))
+	assert.NoError(t, fSys.WriteFile("patch.yaml", patch))
+	var cmd = NewCmdFix(fSys, os.Stdout)
 	assert.NoError(t, cmd.Flags().Set("vars", "true"))
 	assert.NoError(t, cmd.RunE(cmd, nil))
 	content, err := testutils_test.ReadTestKustomization(fSys)

--- a/kustomize/commands/edit/fix/convert_test.go
+++ b/kustomize/commands/edit/fix/convert_test.go
@@ -1161,7 +1161,6 @@ vars:
 `)
 	patch := []byte(`
 apiVersion: apps/v1
-kapiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
@@ -1204,7 +1203,6 @@ replacements:
 	assert.NoError(t, err)
 	assert.Equal(t, `
 apiVersion: apps/v1
-kapiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager


### PR DESCRIPTION
Fix `patch.Target` is nil in `writePatchTargets`

https://github.com/kubernetes-sigs/kustomize/blob/9e42f8d57e285d1113d608895a2015cea9ad2b21/kustomize/commands/edit/fix/convert.go#L284-L287

When converting a kustomization file that contains `Patch` with only `Path` field, using `--vars` might cause kustomize to panic for dereferencing nil pointer.

Example for the bug:
```yaml
#kustomization.yaml
patchesStrategicMerge:
  - patch.yaml

vars:
  - name: CERTIFICATE_NAMESPACE
    objref:
      name: system
    fieldref:
      fieldpath: metadata.namespace
```

```yaml
#patch.yaml
apiVersion: apps/v1
kapiVersion: apps/v1
kind: Deployment
metadata:
  name: controller-manager
  namespace: system
spec:
  template:
    spec:
      containers:
        - name: $(CERTIFICATE_NAMESPACE)
```
Then run `kustomise edit fix --vars` under this folder.