### PR TITLE
Support `edit set generatoroptions`

### DIFF
--- a/kustomize/commands/edit/set/all.go
+++ b/kustomize/commands/edit/set/all.go
@@ -26,6 +26,7 @@ func NewCmdSet(fSys filesys.FileSystem, ldr ifc.KvLoader, v ifc.Validator) *cobr
 	}
 
 	c.AddCommand(
+		newCmdSetGeneratorOptions(fSys),
 		newCmdSetNamePrefix(fSys),
 		newCmdSetNameSuffix(fSys),
 		newCmdSetNamespace(fSys, v),

--- a/kustomize/commands/edit/set/setgeneratoroptions.go
+++ b/kustomize/commands/edit/set/setgeneratoroptions.go
@@ -1,0 +1,101 @@
+package set
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
+	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/util"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type setGeneratorOptions struct {
+	GeneratorOptions types.GeneratorOptions
+	Labels           []string
+	Annotations      []string
+}
+
+func newCmdSetGeneratorOptions(fSys filesys.FileSystem) *cobra.Command {
+	var o setGeneratorOptions
+	cmd := &cobra.Command{
+		Use:   "generatoroptions",
+		Short: "Set a generatoroptions to the kustomization file",
+		Long:  "",
+		Example: `
+	# Set a generatoroptions with a "immutable = true" to the kustomization file.
+	kustomize edit set generatoroptions --immutable
+
+	# Set a generatoroptions with a "disableNameSuffixHash = true" to the kustomization file.
+	kustomize edit set generatoroptions --disableNameSuffixHash
+
+	# Set generatoroptions with labels to the kustomization file.
+	kustomize edit set generatoroptions --labels=app:hazelcast --labels=env:prod
+
+	# Set generatoroptions with annotations to the kustomization file.
+	kustomize edit set generatoroptions --annotations=app:hazelcast --annotations=env:prod
+`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			err := o.Validate()
+			if err != nil {
+				return err
+			}
+			o.GeneratorOptions.Labels, err = util.ConvertSliceToMap(o.Labels, "label")
+			if err != nil {
+				return err
+			}
+			o.GeneratorOptions.Annotations, err = util.ConvertSliceToMap(o.Annotations, "annotation")
+			if err != nil {
+				return err
+			}
+			return o.RunSetGeneratorOptions(fSys)
+		},
+	}
+	cmd.Flags().BoolVar(
+		&o.GeneratorOptions.Immutable,
+		"immutable",
+		false,
+		"Enable immutable of the generatorOptions.")
+	cmd.Flags().BoolVar(
+		&o.GeneratorOptions.DisableNameSuffixHash,
+		"disableNameSuffixHash",
+		false,
+		"Disable the name suffix of the generatorOptions.")
+	cmd.Flags().StringArrayVar(
+		&o.Labels,
+		"labels",
+		[]string{},
+		"Specify labels to be added to the generatorOptions.")
+	cmd.Flags().StringArrayVar(
+		&o.Annotations,
+		"annotations",
+		[]string{},
+		"Specify annotations to be added to the generatorOptions.")
+
+	return cmd
+}
+
+func (o *setGeneratorOptions) Validate() error {
+	if !o.GeneratorOptions.Immutable &&
+		!o.GeneratorOptions.DisableNameSuffixHash &&
+		len(o.Labels) == 0 &&
+		len(o.Annotations) == 0 {
+		return errors.New("at least immutable, or disableNameSuffixHash or labels or annotations must be set.")
+	}
+	return nil
+}
+
+func (o *setGeneratorOptions) RunSetGeneratorOptions(fSys filesys.FileSystem) error {
+	mf, err := kustfile.NewKustomizationFile(fSys)
+	if err != nil {
+		return err
+	}
+
+	m, err := mf.Read()
+	if err != nil {
+		return err
+	}
+
+	m.GeneratorOptions = types.MergeGlobalOptionsIntoLocal(&o.GeneratorOptions, m.GeneratorOptions)
+	return mf.Write(m)
+}

--- a/kustomize/commands/edit/set/setgeneratoroptions_test.go
+++ b/kustomize/commands/edit/set/setgeneratoroptions_test.go
@@ -1,0 +1,338 @@
+package set
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+func TestNewSetGeneratorOptionsIsNotNil(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	assert.NotNil(t, newCmdSetGeneratorOptions(fSys), nil)
+}
+
+func TestRunSetGeneratorOptionsValidate(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	cmd := newCmdSetGeneratorOptions(fSys)
+	testutils_test.WriteTestKustomization(fSys)
+	args := []string{}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Equal(t, "at least immutable, or disableNameSuffixHash or labels or annotations must be set.", err.Error())
+}
+
+func TestRunSetGeneratorOptionsWithImmutable(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	cmd := newCmdSetGeneratorOptions(fSys)
+	testutils_test.WriteTestKustomization(fSys)
+	args := []string{"--immutable"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	assert.NoError(t, err)
+	expectedStr := strings.Join([]string{
+		"generatorOptions:",
+		"  immutable: true",
+	}, "\n")
+	assert.Contains(t, string(content), expectedStr)
+}
+
+func TestRunSetGeneratorOptionsWithDisableNameSuffixHash(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	cmd := newCmdSetGeneratorOptions(fSys)
+	testutils_test.WriteTestKustomization(fSys)
+	args := []string{"--disableNameSuffixHash"}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	assert.NoError(t, err)
+	expectedStr := strings.Join([]string{
+		"generatorOptions:",
+		"  disableNameSuffixHash: true",
+	}, "\n")
+	assert.Contains(t, string(content), expectedStr)
+}
+
+func TestRunSetGeneratorOptionsWithLabels(t *testing.T) {
+	type given struct {
+		args []string
+	}
+	type expected struct {
+		fileOutput []string
+		errMessage string
+	}
+	testCases := []struct {
+		description string
+		given       given
+		expected    expected
+	}{
+		{
+			description: "One pair",
+			given: given{
+				args: []string{
+					"--labels=a:b",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  labels:",
+					"    a: b",
+				},
+			},
+		},
+		{
+			description: "Two pairs",
+			given: given{
+				args: []string{
+					"--labels=a:b",
+					"--labels=c:d",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  labels:",
+					"    a: b",
+					"    c: d",
+				},
+			},
+		},
+		{
+			description: "There are three colons",
+			given: given{
+				args: []string{
+					"--labels=a:b:c",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  labels:",
+					"    a: b:c",
+				},
+			},
+		},
+		{
+			description: "Empty value",
+			given: given{
+				args: []string{
+					"--labels=a: ",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  labels:",
+					"    a:",
+				},
+			},
+		},
+		{
+			description: "No colon",
+			given: given{
+				args: []string{
+					"--labels=x,y",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  labels:",
+					"    x,y:",
+				},
+			},
+		},
+		{
+			description: "Empty key",
+			given: given{
+				args: []string{
+					"--labels=:y",
+				},
+			},
+			expected: expected{
+				errMessage: "invalid label: ':y' (need k:v pair where v may be quoted)",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s%v", tc.description, tc.given.args), func(t *testing.T) {
+			fSys := filesys.MakeFsInMemory()
+			cmd := newCmdSetGeneratorOptions(fSys)
+			testutils_test.WriteTestKustomization(fSys)
+			cmd.SetArgs(tc.given.args)
+
+			err := cmd.Execute()
+
+			errMessage := ""
+			if err != nil {
+				errMessage = err.Error()
+			}
+
+			if errMessage != tc.expected.errMessage {
+				t.Errorf("Unexpected error from set generatoroptions command. Actual: %s\nExpected: %s", errMessage, tc.expected.errMessage)
+				t.FailNow()
+			}
+
+			content, err := testutils_test.ReadTestKustomization(fSys)
+			if err != nil {
+				t.Errorf("unexpected read error: %v", err)
+				t.FailNow()
+			}
+
+			expectedStr := strings.Join(tc.expected.fileOutput, "\n")
+			if !strings.Contains(string(content), expectedStr) {
+				t.Errorf("unexpected image in kustomization file. \nActual:\n%s\nExpected:\n%s", content, expectedStr)
+			}
+		})
+	}
+}
+
+func TestRunSetGeneratorOptionsWithAnnotations(t *testing.T) {
+	type given struct {
+		args []string
+	}
+	type expected struct {
+		fileOutput []string
+		errMessage string
+	}
+	testCases := []struct {
+		description string
+		given       given
+		expected    expected
+	}{
+		{
+			description: "One pair",
+			given: given{
+				args: []string{
+					"--annotations=a:b",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  annotations:",
+					"    a: b",
+				},
+			},
+		},
+		{
+			description: "Two pairs",
+			given: given{
+				args: []string{
+					"--annotations=a:b",
+					"--annotations=c:d",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  annotations:",
+					"    a: b",
+					"    c: d",
+				},
+			},
+		},
+		{
+			description: "There are three colons",
+			given: given{
+				args: []string{
+					"--annotations=a:b:c",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  annotations:",
+					"    a: b:c",
+				},
+			},
+		},
+		{
+			description: "Empty value",
+			given: given{
+				args: []string{
+					"--annotations=a: ",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  annotations:",
+					"    a:",
+				},
+			},
+		},
+		{
+			description: "No colon",
+			given: given{
+				args: []string{
+					"--annotations=x,y",
+				},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"generatorOptions:",
+					"  annotations:",
+					"    x,y:",
+				},
+			},
+		},
+		{
+			description: "Empty key",
+			given: given{
+				args: []string{
+					"--annotations=:y",
+				},
+			},
+			expected: expected{
+				errMessage: "invalid annotation: ':y' (need k:v pair where v may be quoted)",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s%v", tc.description, tc.given.args), func(t *testing.T) {
+			fSys := filesys.MakeFsInMemory()
+			cmd := newCmdSetGeneratorOptions(fSys)
+			testutils_test.WriteTestKustomization(fSys)
+			cmd.SetArgs(tc.given.args)
+
+			err := cmd.Execute()
+
+			errMessage := ""
+			if err != nil {
+				errMessage = err.Error()
+			}
+
+			if errMessage != tc.expected.errMessage {
+				t.Errorf("Unexpected error from set generatoroptions command. Actual: %s\nExpected: %s", errMessage, tc.expected.errMessage)
+				t.FailNow()
+			}
+
+			content, err := testutils_test.ReadTestKustomization(fSys)
+			if err != nil {
+				t.Errorf("unexpected read error: %v", err)
+				t.FailNow()
+			}
+
+			expectedStr := strings.Join(tc.expected.fileOutput, "\n")
+			if !strings.Contains(string(content), expectedStr) {
+				t.Errorf("unexpected image in kustomization file. \nActual:\n%s\nExpected:\n%s", content, expectedStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented `edit set generatoroptions` as requested in https://github.com/kubernetes-sigs/kustomize/issues/5168.
