### PR TITLE
fix edit set image to parse both tag and digest

### DIFF
--- a/api/pkg/util/image.go
+++ b/api/pkg/util/image.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"sigs.k8s.io/kustomize/api/internal/image"
+)
+
+// Splits image string name into name, tag and digest
+func SplitImageName(imageName string) (name string, tag string, digest string) {
+	return image.Split(imageName)
+}

--- a/kustomize/commands/edit/set/setimage_test.go
+++ b/kustomize/commands/edit/set/setimage_test.go
@@ -97,6 +97,31 @@ func TestSetImage(t *testing.T) {
 				}},
 		},
 		{
+			given: given{
+				args: []string{"my-image1:my-tag@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- digest: sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3",
+					"  name: my-image1",
+					"  newTag: my-tag",
+				}},
+		},
+		{
+			given: given{
+				args: []string{"image1=my-image1:my-tag@sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3"},
+			},
+			expected: expected{
+				fileOutput: []string{
+					"images:",
+					"- digest: sha256:24a0c4b4a4c0eb97a1aabb8e29f18e917d05abfe1b7a7c07857230879ce7d3d3",
+					"  name: image1",
+					"  newName: my-image1",
+					"  newTag: my-tag",
+				}},
+		},
+		{
 			description: "<image>=<image>",
 			given: given{
 				args: []string{"ngnix=localhost:5000/my-project/ngnix"},


### PR DESCRIPTION
Ref. #4713

Add support to pass both tag and digest to `edit set image command`

```
kustomize edit set image org/repo:tag@sha256:digest
kustomize edit set image myimage=org/repo:tag@sha256:digest
```
