### PR TITLE
Fix name in a configMapRef missing hash #5047

### DIFF
--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -284,9 +284,9 @@ func (f Filter) roleRefFilter() sieveFunc {
 	return previousIdSelectedByGvk(roleRefGvk)
 }
 
-func prefixSuffixEquals(other resource.ResCtx) sieveFunc {
+func prefixSuffixEquals(other resource.ResCtx, allowEmpty bool) sieveFunc {
 	return func(r *resource.Resource) bool {
-		return r.PrefixesSuffixesEquals(other)
+		return r.PrefixesSuffixesEquals(other, allowEmpty)
 	}
 }
 
@@ -325,7 +325,10 @@ func (f Filter) selectReferral(
 	if len(candidates) == 1 {
 		return candidates[0], nil
 	}
-	candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer))
+	candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer, true))
+	if len(candidates) > 1 {
+          candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer, false))
+	}
 	if len(candidates) == 1 {
 		return candidates[0], nil
 	}

--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -327,7 +327,7 @@ func (f Filter) selectReferral(
 	}
 	candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer, true))
 	if len(candidates) > 1 {
-          candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer, false))
+		candidates = doSieve(candidates, prefixSuffixEquals(f.Referrer, false))
 	}
 	if len(candidates) == 1 {
 		return candidates[0], nil

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -591,3 +591,186 @@ metadata:
   name: test-m8t7bmb6g2
 `)
 }
+
+// Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
+func TestPrefixSuffix(t *testing.T) {
+        th := kusttest_test.MakeHarness(t)
+	th.WriteF("kustomization.yaml", `
+resources:
+- a
+- b
+`)
+
+	th.WriteF("a/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: a
+`)
+
+	th.WriteF("b/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: b
+`)
+
+	th.WriteF("common/kustomization.yaml", `
+resources:
+- service
+
+configMapGenerator:
+- name: "-example-configmap"
+`)
+
+	th.WriteF("common/service/deployment.yaml", `
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: "-"
+
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - configMapRef:
+            name: "-example-configmap"
+`)
+
+	th.WriteF("common/service/kustomization.yaml", `
+resources:
+- deployment.yaml
+
+nameSuffix: api
+`)
+
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a-api
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: a-example-configmap-6ct58987ht
+        name: app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-example-configmap-6ct58987ht
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b-api
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: b-example-configmap-6ct58987ht
+        name: app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-example-configmap-6ct58987ht
+`)
+}
+
+// Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
+func TestPrefixSuffix2(t *testing.T) {
+        th := kusttest_test.MakeHarness(t)
+	th.WriteF("kustomization.yaml", `
+resources:
+- a
+- b
+`)
+
+	th.WriteF("a/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: a
+`)
+
+	th.WriteF("b/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: b
+`)
+
+	th.WriteF("common/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "-example"
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - configMapRef:
+            name: "-example-configmap"
+`)
+
+	th.WriteF("common/kustomization.yaml", `
+resources:
+- deployment.yaml
+
+configMapGenerator:
+- name: "-example-configmap"
+`)
+
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a-example
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: a-example-configmap-6ct58987ht
+        name: app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: a-example-configmap-6ct58987ht
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b-example
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: b-example-configmap-6ct58987ht
+        name: app
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: b-example-configmap-6ct58987ht
+`)
+}

--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -594,7 +594,7 @@ metadata:
 
 // Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
 func TestPrefixSuffix(t *testing.T) {
-        th := kusttest_test.MakeHarness(t)
+	th := kusttest_test.MakeHarness(t)
 	th.WriteF("kustomization.yaml", `
 resources:
 - a
@@ -647,7 +647,6 @@ resources:
 nameSuffix: api
 `)
 
-
 	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
 apiVersion: apps/v1
@@ -690,7 +689,7 @@ metadata:
 
 // Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
 func TestPrefixSuffix2(t *testing.T) {
-        th := kusttest_test.MakeHarness(t)
+	th := kusttest_test.MakeHarness(t)
 	th.WriteF("kustomization.yaml", `
 resources:
 - a
@@ -733,7 +732,6 @@ resources:
 configMapGenerator:
 - name: "-example-configmap"
 `)
-
 
 	m := th.Run(".", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -157,9 +157,7 @@ func (r *Resource) DeepCopy() *Resource {
 // the resource.
 // TODO: move to RNode, use GetMeta to improve performance.
 // TODO: make a version of mergeStringMaps that is build-annotation aware
-//
-//	to avoid repeatedly setting refby and genargs annotations
-//
+//   to avoid repeatedly setting refby and genargs annotations
 // Must remove the kustomize bit at the end.
 func (r *Resource) CopyMergeMetaDataFieldsFrom(other *Resource) error {
 	if err := r.SetLabels(

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -157,7 +157,9 @@ func (r *Resource) DeepCopy() *Resource {
 // the resource.
 // TODO: move to RNode, use GetMeta to improve performance.
 // TODO: make a version of mergeStringMaps that is build-annotation aware
-//   to avoid repeatedly setting refby and genargs annotations
+//
+//	to avoid repeatedly setting refby and genargs annotations
+//
 // Must remove the kustomize bit at the end.
 func (r *Resource) CopyMergeMetaDataFieldsFrom(other *Resource) error {
 	if err := r.SetLabels(

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -302,7 +302,6 @@ func (r *Resource) PrefixesSuffixesEquals(o ResCtx, allowEmpty bool) bool {
 	} else {
 		return utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes()) &&
 			utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes())
-
 	}
 }
 

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -287,9 +287,14 @@ func (r *Resource) getCsvAnnotation(name string) []string {
 	return strings.Split(annotations[name], ",")
 }
 
-// PrefixesSuffixesEquals is conceptually doing the same task
-// as OutermostPrefixSuffix but performs a deeper comparison
-// of the suffix and prefix slices.
+// PrefixesSuffixesEquals is conceptually doing the same task as
+// OutermostPrefixSuffix but performs a deeper comparison of the suffix and
+// prefix slices.
+// The allowEmpty flag determines whether an empty prefix/suffix
+// should be considered a match on anything.
+// This is used when filtering, starting with a coarser pass allowing empty
+// matches, before requiring exact matches if there are multiple
+// remaining candidates.
 func (r *Resource) PrefixesSuffixesEquals(o ResCtx, allowEmpty bool) bool {
 	if allowEmpty {
 		eitherPrefixEmpty := len(r.GetNamePrefixes()) == 0 || len(o.GetNamePrefixes()) == 0

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -290,12 +290,18 @@ func (r *Resource) getCsvAnnotation(name string) []string {
 // PrefixesSuffixesEquals is conceptually doing the same task
 // as OutermostPrefixSuffix but performs a deeper comparison
 // of the suffix and prefix slices.
-func (r *Resource) PrefixesSuffixesEquals(o ResCtx) bool {
-	eitherPrefixEmpty := len(r.GetNamePrefixes()) == 0 || len(o.GetNamePrefixes()) == 0
-	eitherSuffixEmpty := len(r.GetNameSuffixes()) == 0 || len(o.GetNameSuffixes()) == 0
+func (r *Resource) PrefixesSuffixesEquals(o ResCtx, allowEmpty bool) bool {
+	if allowEmpty {
+		eitherPrefixEmpty := len(r.GetNamePrefixes()) == 0 || len(o.GetNamePrefixes()) == 0
+		eitherSuffixEmpty := len(r.GetNameSuffixes()) == 0 || len(o.GetNameSuffixes()) == 0
 
-	return (eitherPrefixEmpty || utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes())) &&
-		(eitherSuffixEmpty || utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes()))
+		return (eitherPrefixEmpty || utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes())) &&
+			(eitherSuffixEmpty || utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes()))
+	} else {
+		return utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes()) &&
+			utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes())
+
+	}
 }
 
 // RemoveBuildAnnotations removes annotations created by the build process.

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -291,8 +291,11 @@ func (r *Resource) getCsvAnnotation(name string) []string {
 // as OutermostPrefixSuffix but performs a deeper comparison
 // of the suffix and prefix slices.
 func (r *Resource) PrefixesSuffixesEquals(o ResCtx) bool {
-	return utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes()) &&
-		utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes())
+	eitherPrefixEmpty := len(r.GetNamePrefixes()) == 0 || len(o.GetNamePrefixes()) == 0
+	eitherSuffixEmpty := len(r.GetNameSuffixes()) == 0 || len(o.GetNameSuffixes()) == 0
+
+	return (eitherPrefixEmpty || utils.SameEndingSubSlice(r.GetNamePrefixes(), o.GetNamePrefixes())) &&
+		(eitherSuffixEmpty || utils.SameEndingSubSlice(r.GetNameSuffixes(), o.GetNameSuffixes()))
 }
 
 // RemoveBuildAnnotations removes annotations created by the build process.


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/5047.

Until https://github.com/kubernetes-sigs/kustomize/pull/3529, an empty prefix/suffix was considered to have the same `SameEndingSubSlice` (previously named `SameEndingSubarray`) as a one element prefix/suffix.

This allowed the example in https://github.com/kubernetes-sigs/kustomize/issues/5047 (added as a test case in this PR), which has no longer worked since v3.9.3.

This PR adds back support for this behaviour, by making two passes in `selectReferral`:

1. If a prefix/suffix is empty, then it vacuously matches anything (i.e `allowEmpty = true`).
Unlike before it also doesn't matter how many elements are in the non-empty prefix/suffix.

If there is still more than one candidate, then

2. Fall back to the current behaviour, requiring an exact match of the prefix and suffix (i.e. `allowEmpty = false`).