### PR TITLE
Support for selector and rejects in replacements source

### DIFF
--- a/api/types/replacement.go
+++ b/api/types/replacement.go
@@ -27,6 +27,12 @@ type SourceSelector struct {
 	// A specific object to read it from.
 	resid.ResId `json:",inline,omitempty" yaml:",inline,omitempty"`
 
+	// Reads an object from a given label or annotation.
+	Select *Selector `json:"select,omitempty" yaml:"select,omitempty"`
+
+	// From the allowed set, remove objects that match this.
+	Reject []*Selector `json:"reject,omitempty" yaml:"reject,omitempty"`
+
 	// Structured field path expected in the allowed object.
 	FieldPath string `json:"fieldPath,omitempty" yaml:"fieldPath,omitempty"`
 


### PR DESCRIPTION
Support for selector and rejects in replacements source.
Related issue: https://github.com/kubernetes-sigs/kustomize/issues/4763

# Example
In this example, Replace the pod's `configMapRef.name` with the Secret's `metadata.name` selected in the label.

resource.yaml

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: test1
  labels:
    name: test1
    type: secret
---
apiVersion: v1
kind: Secret
metadata:
  name: test2
  labels:
    name: test2
    type: secret
---
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
    - name: nginx
      image: nginx
      envFrom:
        - configMapRef:
            name: TO_BE_REPLACED
```

kustomization.yaml
```yaml
resources:
  - resource.yaml

replacements:
  - source:
      select:
        labelSelector: "type=secret"
      reject:
        - labelSelector: "name=test1"
      fieldPath: metadata.name
    targets:
      - select:
          version: v1
          kind: Pod
          name: test
        fieldPaths:
          - spec.containers.0.envFrom.0.configMapRef.name
```

output:
```yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    name: test1
    type: secret
  name: test1
---
apiVersion: v1
kind: Secret
metadata:
  labels:
    name: test2
    type: secret
  name: test2
---
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  containers:
  - envFrom:
    - configMapRef:
        name: test2
    image: nginx
    name: nginx
```