### PR TITLE
Fix typo in help for the create subcommand

### DIFF
--- a/kustomize/commands/create/create.go
+++ b/kustomize/commands/create/create.go
@@ -61,7 +61,7 @@ func NewCmdCreate(fSys filesys.FileSystem, rf *resource.Factory) *cobra.Command 
 		&opts.namespace,
 		"namespace",
 		"",
-		"Set the value of the namespace field in the customization file.")
+		"Set the value of the namespace field in the kustomization file.")
 	c.Flags().StringVar(
 		&opts.annotations,
 		"annotations",


### PR DESCRIPTION
This is inconsistent with the help for the rest of the arguments here.