### PR TITLE
Fix `reject` needing both current and previous ids

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -126,8 +126,8 @@ func applyReplacement(nodes []*yaml.RNode, value *yaml.RNode, targetSelectors []
 			}
 
 			// filter targets by matching resource IDs
-			for i, id := range ids {
-				if id.IsSelectedBy(selector.Select.ResId) && !rejectId(selector.Reject, &ids[i]) {
+			for _, id := range ids {
+				if id.IsSelectedBy(selector.Select.ResId) && !containsRejectId(selector.Reject, ids) {
 					err := copyValueToTarget(possibleTarget, value, selector)
 					if err != nil {
 						return nil, err
@@ -168,10 +168,15 @@ func matchesAnnoAndLabelSelector(n *yaml.RNode, selector *types.Selector) (bool,
 	return annoMatch && labelMatch, nil
 }
 
-func rejectId(rejects []*types.Selector, id *resid.ResId) bool {
+func containsRejectId(rejects []*types.Selector, ids []resid.ResId) bool {
 	for _, r := range rejects {
-		if !r.ResId.IsEmpty() && id.IsSelectedBy(r.ResId) {
-			return true
+		if r.ResId.IsEmpty() {
+			continue
+		}
+		for _, id := range ids {
+			if id.IsSelectedBy(r.ResId) {
+				return true
+			}
 		}
 	}
 	return false

--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -604,7 +604,7 @@ spec:
     spec:
       containers:
       - image: app1:1.0
-        name: something-else
+        name: app
 ---
 apiVersion: v1
 data:

--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -546,3 +546,71 @@ metadata:
   name: red-dc6gc5btkc
 `)
 }
+
+func TestReplacementTransformerWithSuffixTransformerAndReject(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t)
+	defer th.Reset()
+
+	th.WriteF("base/app.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: original-name
+spec:
+  template:
+    spec:
+      containers:
+        - image: app1:1.0
+          name: app
+`)
+	th.WriteK("base", `
+resources:
+  - app.yaml
+`)
+	th.WriteK("overlay", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -dev
+resources:
+  - ../base
+
+configMapGenerator:
+  - name: app-config
+    literals:
+      - name=something-else
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: app-config
+      fieldPath: data.name
+    targets:
+      - fieldPaths:
+          - spec.template.spec.containers.0.name
+        select:
+          kind: Deployment
+        reject:
+          - name: original-name
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: original-name-dev
+spec:
+  template:
+    spec:
+      containers:
+      - image: app1:1.0
+        name: something-else
+---
+apiVersion: v1
+data:
+  name: something-else
+kind: ConfigMap
+metadata:
+  name: app-config-dev-97544dk6t8
+`)
+}


### PR DESCRIPTION
fixes #5241

The bug is really well explained in the issue, so please check it to understand the context.

## Bug Explanation

1. In `applyReplacement`, we apply replacement on the selected node if it is not rejected.

2. When prefix or suffix transformer is applied on a resource, the id of the resource is changed.

Problem: We were checking **both of the ids, previous and current**, and if any of it was *not* rejected, we applied the replacement.

  - Even if previous id was rejected, current id is not.
  - Even if current id was rejected, previous id is not.
  - So we had to manually reject **both** previous and current ids, which is wierd and not scalable.

```go
func applyReplacement(nodes []*yaml.RNode, value *yaml.RNode, targetSelectors []*types.TargetSelector) ([]*yaml.RNode, error) {
	for _, selector := range targetSelectors {
		...
		for _, possibleTarget := range nodes {
		        // MakeResIds returns all of an RNode's current and previous Ids
			ids, err := utils.MakeResIds(possibleTarget)
			...
			// filter targets by matching resource IDs
			for i, id := range ids {
				if id.IsSelectedBy(selector.Select.ResId) && !rejectId(selector.Reject, &ids[i]) {
					err := copyValueToTarget(possibleTarget, value, selector)
					if err != nil {
						return nil, err
					}
					break
				}
			}
		}
	}
	return nodes, nil
}
```

## Fix

I just made it apply replacement only if *none* of the ids (previous and current) *were rejected*.

## Tests

I think we need a E2E test for this. `TestFilter` at `replacement_test.go` isn't enough for this case. 

Is there a way to test multiple Filters? 

## Another Solutions

1. To ignore the effect of other transformations, We could only check the original id of each node instead of all the ids.
2. Making sure replacement happens before other transformations could be a way, but I don't think that's a smart solution. Also, TransformerFactories