### PR TITLE
Test accumulateResources errors for repos

### DIFF
--- a/api/krusty/accumulation_test.go
+++ b/api/krusty/accumulation_test.go
@@ -283,6 +283,37 @@ resources:
 			// know resource is file.
 			errDir: `new root '%s' cannot be absolute`,
 		},
+		{
+			name: "non-http scheme repo does not exist",
+		},
+		{
+			name: "scp-like repo does not exist locally",
+		},
+		{
+			name: "scp-like repo also localized",
+		},
+		{
+			name:     "http repo path does not exist",
+			resource: "https://github.com/kubernetes-sigs/kustomize//non-existent/path?submodules=0&ref=kustomize%2Fv4.5.7&timeout=300",
+		},
+		{
+			name:     "repo missing kustomization.yaml",
+			resource: "file://",
+		},
+		{
+			name:     "http repo root has README.md",
+			resource: "https://github.com/kubernetes-sigs/kustomize?submodules=0&ref=kustomize%2Fv4.5.7&timeout=300",
+		},
+		{
+			name:     "repo cycle",
+			resource: "file://",
+		},
+		{
+			name:     "non-http repo resource error",
+			resource: "file://",
+		},
+		// TODO(annasong): Add http repo resource error test
+		// after merging testdata/error
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			// Should use real file system to indicate that we are creating
@@ -304,7 +335,6 @@ resources:
 		})
 	}
 	// TODO(annasong): add tests that check accumulateResources errors for
-	// - repos
 	// - local directories
 	// - files that yield malformed yaml errors
 }

--- a/api/krusty/testdata/remoteload/error/deployment.yaml
+++ b/api/krusty/testdata/remoteload/error/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-repetitive-deployment
+  labels:
+    app: repetitive-deployment
+spec:
+  selector:
+    matchLabels:
+      app: repeat
+  template:
+    metadata:
+      labels:
+        app: repeat
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.16
+        ports:
+        - containerPort: 8080

--- a/api/krusty/testdata/remoteload/error/kustomization.yaml
+++ b/api/krusty/testdata/remoteload/error/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: repeat-error
+resources:
+- deployment.yaml
+- deployment.yaml


### PR DESCRIPTION
The PR continues to make progress towards #4807; it adds test coverage for the `accumulateResources` method when the resource is a remote root.

In addition to test cases, this PR adds a bad kustomization that yields a `kustomize build` error to `testdata` in the repository. This way, a future PR can analyze the `accumulateResources` error message for a resource that is both considered a remote root and a remote file.