### PR TITLE
helm: add support for kube-version and add cli args for both kube-version and api-versions

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -53,6 +53,15 @@ func (p *HelmChartInflationGeneratorPlugin) Config(
 	if h.GeneralConfig().HelmConfig.Command == "" {
 		return fmt.Errorf("must specify --helm-command")
 	}
+
+	// CLI args takes precedence
+	if h.GeneralConfig().HelmConfig.KubeVersion != "" {
+		p.HelmChart.KubeVersion = h.GeneralConfig().HelmConfig.KubeVersion
+	}
+	if len(h.GeneralConfig().HelmConfig.ApiVersions) != 0 {
+		p.HelmChart.ApiVersions = h.GeneralConfig().HelmConfig.ApiVersions
+	}
+
 	p.h = h
 	if err = yaml.Unmarshal(config, p); err != nil {
 		return

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -88,6 +88,9 @@ type HelmChart struct {
 	// ApiVersions is the kubernetes apiversions used for Capabilities.APIVersions
 	ApiVersions []string `json:"apiVersions,omitempty" yaml:"apiVersions,omitempty"`
 
+	// KubeVersion is the kubernetes version used by Helm for Capabilities.KubeVersion"
+	KubeVersion string `json:"kubeVersion,omitempty" yaml:"kubeVersion,omitempty"`
+
 	// NameTemplate is for specifying the name template used to name the release.
 	NameTemplate string `json:"nameTemplate,omitempty" yaml:"nameTemplate,omitempty"`
 
@@ -172,6 +175,10 @@ func (h HelmChart) AsHelmArgs(absChartHome string) []string {
 	for _, apiVer := range h.ApiVersions {
 		args = append(args, "--api-versions", apiVer)
 	}
+	if h.KubeVersion != "" {
+		args = append(args, "--kube-version", h.KubeVersion)
+	}
+
 	if h.IncludeCRDs {
 		args = append(args, "--include-crds")
 	}

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -17,6 +17,7 @@ func TestAsHelmArgs(t *testing.T) {
 			Version:               "1.0.0",
 			Repo:                  "https://helm.releases.hashicorp.com",
 			ApiVersions:           []string{"foo", "bar"},
+			KubeVersion:           "1.27",
 			NameTemplate:          "template",
 			SkipTests:             true,
 			IncludeCRDs:           true,
@@ -33,6 +34,7 @@ func TestAsHelmArgs(t *testing.T) {
 				"-f", "values",
 				"-f", "values1", "-f", "values2",
 				"--api-versions", "foo", "--api-versions", "bar",
+				"--kube-version", "1.27",
 				"--include-crds",
 				"--skip-tests",
 				"--no-hooks"})

--- a/api/types/pluginconfig.go
+++ b/api/types/pluginconfig.go
@@ -4,8 +4,10 @@
 package types
 
 type HelmConfig struct {
-	Enabled bool
-	Command string
+	Enabled     bool
+	Command     string
+	ApiVersions []string
+	KubeVersion string
 }
 
 // PluginConfig holds plugin configuration.

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -27,10 +27,12 @@ var theFlags struct {
 		managedByLabel bool
 		helm           bool
 	}
-	helmCommand    string
-	loadRestrictor string
-	reorderOutput  string
-	fnOptions      types.FnPluginLoadingOptions
+	helmCommand     string
+	helmApiVersions []string
+	helmKubeVersion string
+	loadRestrictor  string
+	reorderOutput   string
+	fnOptions       types.FnPluginLoadingOptions
 }
 
 type Help struct {
@@ -153,6 +155,8 @@ func HonorKustomizeFlags(kOpts *krusty.Options, flags *flag.FlagSet) *krusty.Opt
 		kOpts.PluginConfig.HelmConfig.Enabled = theFlags.enable.helm
 	}
 	kOpts.PluginConfig.HelmConfig.Command = theFlags.helmCommand
+	kOpts.PluginConfig.HelmConfig.ApiVersions = theFlags.helmApiVersions
+	kOpts.PluginConfig.HelmConfig.KubeVersion = theFlags.helmKubeVersion
 	kOpts.AddManagedbyLabel = isManagedByLabelEnabled()
 	return kOpts
 }

--- a/kustomize/commands/build/flagenablehelm.go
+++ b/kustomize/commands/build/flagenablehelm.go
@@ -21,4 +21,14 @@ func AddFlagEnableHelm(set *pflag.FlagSet) {
 		"helm-command",
 		"helm", // default
 		"helm command (path to executable)")
+	set.StringArrayVar(
+		&theFlags.helmApiVersions,
+		"helm-api-versions",
+		[]string{}, // default
+		"Kubernetes api versions used by Helm for Capabilities.APIVersions")
+	set.StringVar(
+		&theFlags.helmKubeVersion,
+		"helm-kube-version",
+		"", // default
+		"Kubernetes version used by Helm for Capabilities.KubeVersion")
 }

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -59,6 +59,15 @@ func (p *plugin) Config(
 	if h.GeneralConfig().HelmConfig.Command == "" {
 		return fmt.Errorf("must specify --helm-command")
 	}
+
+	// CLI args takes precedence
+	if h.GeneralConfig().HelmConfig.KubeVersion != "" {
+		p.HelmChart.KubeVersion = h.GeneralConfig().HelmConfig.KubeVersion
+	}
+	if len(h.GeneralConfig().HelmConfig.ApiVersions) != 0 {
+		p.HelmChart.ApiVersions = h.GeneralConfig().HelmConfig.ApiVersions
+	}
+
 	p.h = h
 	if err = yaml.Unmarshal(config, p); err != nil {
 		return


### PR DESCRIPTION
Add basic --kube-version flag support and test and add Kustomize CLI args for both api-versions and kube-version

CLI args are useful since you could use one single kustomization file/helm chart for multiple clusters (which have different versions). Also it's easier to have those on the CLI if the user has some kind of tooling that will end up calling kustomize and that could pass those to Helm in the end (i.e.: ArgoCD is doing that for Helm so it could do that for Kustomize as well that will end up calling Helm).

Fixes #5112 