### PR TITLE
:seedling:  Fix bug to duplicate tagsuffix in kustomization generated resources

### DIFF
--- a/api/filters/imagetag/imagetag_test.go
+++ b/api/filters/imagetag/imagetag_test.go
@@ -879,6 +879,45 @@ spec:
 				},
 			},
 		},
+		"updateimagesuffixnoaddition": {
+			input: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploysuffix
+spec:
+  template:
+    spec:
+      containers:
+      - image: redis:6.2.6-alpine
+        name: redis
+`,
+			expectedOutput: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: deploysuffix
+spec:
+  template:
+    spec:
+      containers:
+      - image: redis:6.2.6-alpine
+        name: redis
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					Name:      "redis",
+					TagSuffix: "-alpine",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/template/spec/containers[]/image",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -4,6 +4,8 @@
 package imagetag
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/api/filters/filtersutil"
 
 	"sigs.k8s.io/kustomize/api/image"
@@ -48,8 +50,10 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		tag = ""
 		digest = u.ImageTag.Digest
 	case u.ImageTag.TagSuffix != "":
-		tag += u.ImageTag.TagSuffix
+		fmt.Println(tag, u.ImageTag.TagSuffix)
+		tag = fmt.Sprintf("%s%s", tag, u.ImageTag.TagSuffix)
 		digest = ""
+		u.ImageTag.TagSuffix = ""
 	}
 
 	// build final image name
@@ -60,10 +64,14 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		name += "@" + digest
 	}
 
+	fmt.Println(tag, digest, "final")
+	fmt.Println(rn)
+
 	return u.trackableSetter.SetScalar(name)(rn)
 }
 
 func (u imageTagUpdater) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	fmt.Println("call filter", u)
 	if err := u.SetImageValue(rn); err != nil {
 		return nil, err
 	}

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -4,7 +4,7 @@
 package imagetag
 
 import (
-	"fmt"
+	"strings"
 
 	"sigs.k8s.io/kustomize/api/filters/filtersutil"
 
@@ -50,9 +50,12 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		tag = ""
 		digest = u.ImageTag.Digest
 	case u.ImageTag.TagSuffix != "":
-		tag = fmt.Sprintf("%s%s", tag, u.ImageTag.TagSuffix)
+		// this is a temporary fix and should be removed
+		// when legacyFilter is deprecated
+		if !strings.Contains(tag, u.ImageTag.TagSuffix) {
+			tag += u.ImageTag.TagSuffix
+		}
 		digest = ""
-		u.ImageTag.TagSuffix = ""
 	}
 
 	// build final image name

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -50,7 +50,6 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		tag = ""
 		digest = u.ImageTag.Digest
 	case u.ImageTag.TagSuffix != "":
-		fmt.Println(tag, u.ImageTag.TagSuffix)
 		tag = fmt.Sprintf("%s%s", tag, u.ImageTag.TagSuffix)
 		digest = ""
 		u.ImageTag.TagSuffix = ""
@@ -64,14 +63,10 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 		name += "@" + digest
 	}
 
-	fmt.Println(tag, digest, "final")
-	fmt.Println(rn)
-
 	return u.trackableSetter.SetScalar(name)(rn)
 }
 
 func (u imageTagUpdater) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
-	fmt.Println("call filter", u)
 	if err := u.SetImageValue(rn); err != nil {
 		return nil, err
 	}

--- a/api/filters/imagetag/updater.go
+++ b/api/filters/imagetag/updater.go
@@ -52,7 +52,7 @@ func (u imageTagUpdater) SetImageValue(rn *yaml.RNode) error {
 	case u.ImageTag.TagSuffix != "":
 		// this is a temporary fix and should be removed
 		// when legacyFilter is deprecated
-		if !strings.Contains(tag, u.ImageTag.TagSuffix) {
+		if !strings.HasSuffix(tag, u.ImageTag.TagSuffix) {
 			tag += u.ImageTag.TagSuffix
 		}
 		digest = ""

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"fmt"
-
 	"sigs.k8s.io/kustomize/api/filters/imagetag"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
@@ -30,15 +28,11 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
-	fmt.Println("Call TransForm")
-	fmt.Println(p.ImageTag, p.ImageTag.Name, p.ImageTag.TagSuffix)
 	if err := m.ApplyFilter(imagetag.LegacyFilter{
 		ImageTag: p.ImageTag,
 	}); err != nil {
 		return err
 	}
-	fmt.Println(p.ImageTag, p.ImageTag.Name, p.ImageTag.TagSuffix)
-	fmt.Println("fields", p.FieldSpecs, p.ImageTag)
 	if p.ImageTag.TagSuffix != "" {
 		p.ImageTag.TagSuffix = ""
 	}

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -33,9 +33,6 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	}); err != nil {
 		return err
 	}
-	if p.ImageTag.TagSuffix != "" {
-		p.ImageTag.TagSuffix = ""
-	}
 	return m.ApplyFilter(imagetag.Filter{
 		ImageTag: p.ImageTag,
 		FsSlice:  p.FieldSpecs,

--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/api/filters/imagetag"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
@@ -28,10 +30,17 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	fmt.Println("Call TransForm")
+	fmt.Println(p.ImageTag, p.ImageTag.Name, p.ImageTag.TagSuffix)
 	if err := m.ApplyFilter(imagetag.LegacyFilter{
 		ImageTag: p.ImageTag,
 	}); err != nil {
 		return err
+	}
+	fmt.Println(p.ImageTag, p.ImageTag.Name, p.ImageTag.TagSuffix)
+	fmt.Println("fields", p.FieldSpecs, p.ImageTag)
+	if p.ImageTag.TagSuffix != "" {
+		p.ImageTag.TagSuffix = ""
 	}
 	return m.ApplyFilter(imagetag.Filter{
 		ImageTag: p.ImageTag,


### PR DESCRIPTION
Links issue #4814 

Since tagsuffix is the only tag parameter which adds a value in a tag instead of wholly replacing them , so it is best to invalidate addition of tagsuffix instead in second addition.

Pending: addition of tests for ImageTagTransformer