### PR TITLE
:seedling:  [WIP] remove  check and directly modify image tag

### DIFF
--- a/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
+++ b/plugin/builtin/imagetagtransformer/ImageTagTransformer.go
@@ -28,11 +28,6 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
-	if err := m.ApplyFilter(imagetag.LegacyFilter{
-		ImageTag: p.ImageTag,
-	}); err != nil {
-		return err
-	}
 	return m.ApplyFilter(imagetag.Filter{
 		ImageTag: p.ImageTag,
 		FsSlice:  p.FieldSpecs,


### PR DESCRIPTION
This is a different approach for issue #4814

In this PR we are calling filter twice , once to check validity of if tag suffix can be applied , in case of error then return the error
Else apply the tag transformation in the fieldspecs using the same filter method

This ignores the error check since we return the error anyway 