### PR TITLE
small fixes

### DIFF
--- a/hack/krmFunctionBenchmark/benchmark.sh
+++ b/hack/krmFunctionBenchmark/benchmark.sh
@@ -6,7 +6,7 @@
 set -e
 
 KUSTOMIZE_EXEC=kustomize
-KUSTOMIZE_FLAGS="build --enable_alpha_plugins --enable-exec"
+KUSTOMIZE_FLAGS="build --enable-exec --enable-alpha-plugins"
 
 function build_label_namespace_exec {
     cd label_namespace/execfn

--- a/hack/krmFunctionBenchmark/label_namespace/execfn/Dockerfile
+++ b/hack/krmFunctionBenchmark/label_namespace/execfn/Dockerfile
@@ -5,7 +5,8 @@ FROM alpine:latest
 
 ENV BUILD_HOME=/usr/local/build
 RUN apk update && apk add --no-cache git nodejs npm
-RUN npm install -g typescript
+COPY ["./package.json", "./package-lock.json", "./"]
+RUN npm install -g
 
 RUN mkdir -p $BUILD_HOME
 

--- a/hack/krmFunctionBenchmark/label_namespace/execfn/package-lock.json
+++ b/hack/krmFunctionBenchmark/label_namespace/execfn/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "help": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/help/-/help-3.0.2.tgz",
+      "integrity": "sha512-jDd0MU+9xzvOQRC6CIzdjvb+agCvpzQY/Fp11quDnugDO4QQzh134EsLkRQMvFIJBleFkvnXagHFm4MTefkkpA=="
+    },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+    }
+  }
+}

--- a/hack/krmFunctionBenchmark/label_namespace/execfn/package.json
+++ b/hack/krmFunctionBenchmark/label_namespace/execfn/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "execfn",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
move the typescript dependency in the benchmark test into its own package-lock.json file