### PR TITLE
configmap with alphabetical order

### DIFF
--- a/kyaml/yaml/datamap.go
+++ b/kyaml/yaml/datamap.go
@@ -13,11 +13,9 @@ import (
 // SortedMapKeys returns a sorted slice of keys to the given map.
 // Writing this function never gets old.
 func SortedMapKeys(m map[string]string) []string {
-	keys := make([]string, len(m))
-	i := 0
+	keys := make([]string, 0, len(m))
 	for k := range m {
-		keys[i] = k
-		i++
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	return keys


### PR DESCRIPTION
this PR tend to resolve #4292  by using alphabetical way. as I currently can't figure out a better way to move #5308 on.

I used to have a scenes that need to sort keys order in a map, and I've done it like here. IMHO, the configmap key is getting sort here and then get load.