### PR TITLE
refactor: rename valtest_test and testutils_test imports

### DIFF
--- a/api/internal/generators/secret_test.go
+++ b/api/internal/generators/secret_test.go
@@ -11,7 +11,7 @@ import (
 	. "sigs.k8s.io/kustomize/api/internal/generators"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -209,7 +209,7 @@ immutable: true
 		[]byte{0xff, 0xfd})
 	kvLdr := kv.NewLoader(
 		loader.NewFileLoaderAtRoot(fSys),
-		valtest_test.MakeFakeValidator())
+		valtest.MakeFakeValidator())
 
 	for n := range testCases {
 		tc := testCases[n]

--- a/api/internal/plugins/loader/loader_test.go
+++ b/api/internal/plugins/loader/loader_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -73,7 +73,7 @@ func TestLoader(t *testing.T) {
 			t.Fatal("expect non-nil loader")
 		}
 		_, err = pLdr.LoadGenerators(
-			fLdr, valtest_test.MakeFakeValidator(), generatorConfigs)
+			fLdr, valtest.MakeFakeValidator(), generatorConfigs)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -11,7 +11,7 @@ import (
 	fLdr "sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -42,7 +42,7 @@ func makeKustTargetWithRf(
 	pc := types.DisabledPluginConfig()
 	return target.NewKustTarget(
 		ldr,
-		valtest_test.MakeFakeValidator(),
+		valtest.MakeFakeValidator(),
 		rf,
 		pLdr.NewLoader(pc, rf, fSys))
 }

--- a/api/kv/kv_test.go
+++ b/api/kv/kv_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	ldr "sigs.k8s.io/kustomize/api/loader"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -17,7 +17,7 @@ import (
 func makeKvLoader(fSys filesys.FileSystem) *loader {
 	return &loader{
 		ldr:       ldr.NewFileLoaderAtRoot(fSys),
-		validator: valtest_test.MakeFakeValidator()}
+		validator: valtest.MakeFakeValidator()}
 }
 
 func TestKeyValuesFromLines(t *testing.T) {

--- a/api/resmap/factory_test.go
+++ b/api/resmap/factory_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/kustomize/api/loader"
 	. "sigs.k8s.io/kustomize/api/resmap"
 	resmaptest_test "sigs.k8s.io/kustomize/api/testutils/resmaptest"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -124,7 +124,7 @@ func TestNewFromConfigMaps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	kvLdr := kv.NewLoader(ldr, valtest_test.MakeFakeValidator())
+	kvLdr := kv.NewLoader(ldr, valtest.MakeFakeValidator())
 	testCases := []testCase{
 		{
 			description: "construct config map from env",
@@ -250,7 +250,7 @@ func TestNewResMapFromSecretArgs(t *testing.T) {
 	actual, err := rmF.NewResMapFromSecretArgs(
 		kv.NewLoader(
 			loader.NewFileLoaderAtRoot(fSys),
-			valtest_test.MakeFakeValidator()), secrets)
+			valtest.MakeFakeValidator()), secrets)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -16,7 +16,7 @@ import (
 	fLdr "sigs.k8s.io/kustomize/api/loader"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -163,7 +163,7 @@ func (th *HarnessEnhanced) LoadAndRunGeneratorWithBuildAnnotations(
 		th.t.Fatalf("Err: %v", err)
 	}
 	g, err := th.pl.LoadGenerator(
-		th.ldr, valtest_test.MakeFakeValidator(), res)
+		th.ldr, valtest.MakeFakeValidator(), res)
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
@@ -220,7 +220,7 @@ func (th *HarnessEnhanced) RunTransformerFromResMap(
 		th.t.Fatalf("Err: %v", err)
 	}
 	g, err := th.pl.LoadTransformer(
-		th.ldr, valtest_test.MakeFakeValidator(), transConfig)
+		th.ldr, valtest.MakeFakeValidator(), transConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -8,17 +8,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	testutils "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 func makeKustomization(t *testing.T) *types.Kustomization {
 	t.Helper()
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
+	testutils.WriteTestKustomization(fSys)
 	kf, err := kustfile.NewKustomizationFile(fSys)
 	assert.NoError(t, err)
 	m, err := kf.Read()
@@ -42,7 +42,7 @@ func TestRunAddAnnotation(t *testing.T) {
 
 func TestAddAnnotationNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -52,19 +52,19 @@ func TestAddAnnotationNoArgs(t *testing.T) {
 
 func TestAddAnnotationInvalidFormat(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"whatever:whatever"}
 	err := cmd.RunE(cmd, args)
 	v.VerifyCall()
 	assert.Error(t, err)
-	assert.Equal(t, valtest_test.SAD, err.Error())
+	assert.Equal(t, valtest.SAD, err.Error())
 }
 
 func TestAddAnnotationManyArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"k1:v1,k2:v2,k3:v3,k4:v5"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -73,8 +73,8 @@ func TestAddAnnotationManyArgs(t *testing.T) {
 
 func TestAddAnnotationValueQuoted(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"k1:\"v1\""}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -83,8 +83,8 @@ func TestAddAnnotationValueQuoted(t *testing.T) {
 
 func TestAddAnnotationValueWithColon(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"k1:\"v1:v2\""}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -93,8 +93,8 @@ func TestAddAnnotationValueWithColon(t *testing.T) {
 
 func TestAddAnnotationValueWithComma(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	value := "{\"k1\":\"v1\",\"k2\":\"v2\"}"
 	args := []string{"test:" + value}
@@ -107,7 +107,7 @@ func TestAddAnnotationValueWithComma(t *testing.T) {
 
 func TestAddAnnotationNoKey(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{":nokey"}
 	err := cmd.RunE(cmd, args)
@@ -118,8 +118,8 @@ func TestAddAnnotationNoKey(t *testing.T) {
 
 func TestAddAnnotationTooManyColons(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"key:v1:v2"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -128,8 +128,8 @@ func TestAddAnnotationTooManyColons(t *testing.T) {
 
 func TestAddAnnotationNoValue(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"no:,value"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -138,8 +138,8 @@ func TestAddAnnotationNoValue(t *testing.T) {
 
 func TestAddAnnotationMultipleArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"this:annotation", "has:spaces"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -148,22 +148,22 @@ func TestAddAnnotationMultipleArgs(t *testing.T) {
 
 func TestAddAnnotationForce(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddAnnotation(fSys, v.Validator)
 	args := []string{"key:foo"}
 	assert.NoError(t, cmd.RunE(cmd, args))
 	v.VerifyCall()
 	// trying to add the same annotation again should not work
 	args = []string{"key:bar"}
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdAddAnnotation(fSys, v.Validator)
 	err := cmd.RunE(cmd, args)
 	v.VerifyCall()
 	assert.Error(t, err)
 	assert.Equal(t, "annotation key already in kustomization file", err.Error())
 	// but trying to add it with --force should
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdAddAnnotation(fSys, v.Validator)
 	err = cmd.Flag("force").Value.Set("true")
 	require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestRunAddLabel(t *testing.T) {
 
 func TestAddLabelNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -196,20 +196,20 @@ func TestAddLabelNoArgs(t *testing.T) {
 
 func TestAddLabelInvalidFormat(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{"exclamation!:point"}
 	err := cmd.RunE(cmd, args)
 	v.VerifyCall()
 	assert.Error(t, err)
-	if err.Error() != valtest_test.SAD {
+	if err.Error() != valtest.SAD {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }
 
 func TestAddLabelNoKey(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{":nokey"}
 	err := cmd.RunE(cmd, args)
@@ -222,8 +222,8 @@ func TestAddLabelNoKey(t *testing.T) {
 
 func TestAddLabelTooManyColons(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{"key:v1:v2"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -232,8 +232,8 @@ func TestAddLabelTooManyColons(t *testing.T) {
 
 func TestAddLabelNoValue(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{"no,value:"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -242,8 +242,8 @@ func TestAddLabelNoValue(t *testing.T) {
 
 func TestAddLabelMultipleArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{"this:input", "has:spaces"}
 	assert.NoError(t, cmd.RunE(cmd, args))
@@ -252,22 +252,22 @@ func TestAddLabelMultipleArgs(t *testing.T) {
 
 func TestAddLabelForce(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdAddLabel(fSys, v.Validator)
 	args := []string{"key:foo"}
 	assert.NoError(t, cmd.RunE(cmd, args))
 	v.VerifyCall()
 	// trying to add the same label again should not work
 	args = []string{"key:bar"}
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdAddLabel(fSys, v.Validator)
 	err := cmd.RunE(cmd, args)
 	v.VerifyCall()
 	assert.Error(t, err)
 	assert.Equal(t, "label key already in kustomization file", err.Error())
 	// but trying to add it with --force should
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdAddLabel(fSys, v.Validator)
 	err = cmd.Flag("force").Value.Set("true")
 	require.NoError(t, err)

--- a/kustomize/commands/edit/add/configmap_test.go
+++ b/kustomize/commands/edit/add/configmap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -20,7 +20,7 @@ func TestNewAddConfigMapIsNotNil(t *testing.T) {
 		fSys,
 		kv.NewLoader(
 			loader.NewFileLoaderAtCwd(fSys),
-			valtest_test.MakeFakeValidator()),
+			valtest.MakeFakeValidator()),
 		nil))
 }
 

--- a/kustomize/commands/edit/add/secret_test.go
+++ b/kustomize/commands/edit/add/secret_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/loader"
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -20,7 +20,7 @@ func TestNewCmdAddSecretIsNotNil(t *testing.T) {
 		fSys,
 		kv.NewLoader(
 			loader.NewFileLoaderAtCwd(fSys),
-			valtest_test.MakeFakeValidator()),
+			valtest.MakeFakeValidator()),
 		nil))
 }
 

--- a/kustomize/commands/edit/remove/removemetadata_test.go
+++ b/kustomize/commands/edit/remove/removemetadata_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	testutils "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -20,7 +20,7 @@ func makeKustomizationFS() filesys.FileSystem {
 	commonLabels := []string{"label1: val1", "label2: val2"}
 	commonAnnotations := []string{"annotation1: val1", "annotation2: val2"}
 
-	testutils_test.WriteTestKustomizationWith(fSys, []byte(
+	testutils.WriteTestKustomizationWith(fSys, []byte(
 		fmt.Sprintf("commonLabels:\n  %s\ncommonAnnotations:\n  %s",
 			strings.Join(commonLabels, "\n  "), strings.Join(commonAnnotations, "\n  "))))
 	return fSys
@@ -75,7 +75,7 @@ func TestRemoveAnnotation(t *testing.T) {
 func TestRemoveAnnotationIgnore(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	cmd.Flag("ignore-non-existence").Value.Set("true")
 	args := []string{"annotation3"}
@@ -89,9 +89,9 @@ func TestRemoveAnnotationIgnore(t *testing.T) {
 
 func TestRemoveAnnotationNoDefinition(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomizationWith(fSys, []byte(""))
+	testutils.WriteTestKustomizationWith(fSys, []byte(""))
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	args := []string{"annotation1,annotation2"}
 	err := cmd.RunE(cmd, args)
@@ -107,9 +107,9 @@ func TestRemoveAnnotationNoDefinition(t *testing.T) {
 
 func TestRemoveAnnotationNoDefinitionIgnore(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomizationWith(fSys, []byte(""))
+	testutils.WriteTestKustomizationWith(fSys, []byte(""))
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	cmd.Flag("ignore-non-existence").Value.Set("true")
 	args := []string{"annotation1,annotation2"}
@@ -124,7 +124,7 @@ func TestRemoveAnnotationNoDefinitionIgnore(t *testing.T) {
 func TestRemoveAnnotationNoArgs(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -140,7 +140,7 @@ func TestRemoveAnnotationNoArgs(t *testing.T) {
 func TestRemoveAnnotationInvalidFormat(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	args := []string{"nospecialchars%^=@"}
 	err := cmd.RunE(cmd, args)
@@ -149,7 +149,7 @@ func TestRemoveAnnotationInvalidFormat(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected an error")
 	}
-	if err.Error() != valtest_test.SAD {
+	if err.Error() != valtest.SAD {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }
@@ -157,7 +157,7 @@ func TestRemoveAnnotationInvalidFormat(t *testing.T) {
 func TestRemoveAnnotationMultipleArgs(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	args := []string{"annotation1,annotation2"}
 	err := cmd.RunE(cmd, args)
@@ -179,7 +179,7 @@ func TestRemoveAnnotationMultipleArgs(t *testing.T) {
 func TestRemoveAnnotationMultipleArgsInvalidFormat(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdRemoveAnnotation(fSys, v.ValidatorArray)
 	args := []string{"annotation1", "annotation2"}
 	err := cmd.RunE(cmd, args)
@@ -223,7 +223,7 @@ func TestRemoveLabel(t *testing.T) {
 func TestRemoveLabelIgnore(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	cmd.Flag("ignore-non-existence").Value.Set("true")
 	args := []string{"label3"}
@@ -237,9 +237,9 @@ func TestRemoveLabelIgnore(t *testing.T) {
 
 func TestRemoveLabelNoDefinition(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomizationWith(fSys, []byte(""))
+	testutils.WriteTestKustomizationWith(fSys, []byte(""))
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	args := []string{"label1,label2"}
 	err := cmd.RunE(cmd, args)
@@ -255,9 +255,9 @@ func TestRemoveLabelNoDefinition(t *testing.T) {
 
 func TestRemoveLabelNoDefinitionIgnore(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomizationWith(fSys, []byte(""))
+	testutils.WriteTestKustomizationWith(fSys, []byte(""))
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	cmd.Flag("ignore-non-existence").Value.Set("true")
 	args := []string{"label1,label2"}
@@ -272,7 +272,7 @@ func TestRemoveLabelNoDefinitionIgnore(t *testing.T) {
 func TestRemoveLabelNoArgs(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -288,7 +288,7 @@ func TestRemoveLabelNoArgs(t *testing.T) {
 func TestRemoveLabelInvalidFormat(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	args := []string{"exclamation!"}
 	err := cmd.RunE(cmd, args)
@@ -297,7 +297,7 @@ func TestRemoveLabelInvalidFormat(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected an error")
 	}
-	if err.Error() != valtest_test.SAD {
+	if err.Error() != valtest.SAD {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }
@@ -305,7 +305,7 @@ func TestRemoveLabelInvalidFormat(t *testing.T) {
 func TestRemoveLabelMultipleArgs(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	args := []string{"label1,label2"}
 	err := cmd.RunE(cmd, args)
@@ -327,7 +327,7 @@ func TestRemoveLabelMultipleArgs(t *testing.T) {
 func TestRemoveLabelMultipleArgsInvalidFormat(t *testing.T) {
 	fSys := makeKustomizationFS()
 
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
 	args := []string{"label1", "label2"}
 	err := cmd.RunE(cmd, args)

--- a/kustomize/commands/edit/set/setannotation_test.go
+++ b/kustomize/commands/edit/set/setannotation_test.go
@@ -6,10 +6,10 @@ package set
 import (
 	"testing"
 
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	testutils "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -19,7 +19,7 @@ const invalidAnnotationKey string = "invalid annotation key: see the syntax and 
 func makeAnnotationKustomization(t *testing.T) *types.Kustomization {
 	t.Helper()
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
+	testutils.WriteTestKustomization(fSys)
 	kf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		t.Errorf("unexpected new error %v", err)
@@ -55,7 +55,7 @@ func TestRunSetAnnotation(t *testing.T) {
 
 func TestSetAnnotationNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -70,7 +70,7 @@ func TestSetAnnotationNoArgs(t *testing.T) {
 
 func TestSetAnnotationInvalidFormat(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"exclamation!:point"}
 	err := cmd.RunE(cmd, args)
@@ -79,7 +79,7 @@ func TestSetAnnotationInvalidFormat(t *testing.T) {
 		t.Errorf("expected an error")
 		t.FailNow()
 	}
-	if err.Error() != valtest_test.SAD {
+	if err.Error() != valtest.SAD {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }
@@ -112,7 +112,7 @@ func TestSetAnnotation253Prefix63Name(t *testing.T) {
 
 func TestSetAnnotation254Prefix62Name(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi" +
 		"jklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
@@ -132,7 +132,7 @@ func TestSetAnnotation254Prefix62Name(t *testing.T) {
 
 func TestSetAnnotation252Prefix64Name(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi" +
 		"jklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
@@ -152,7 +152,7 @@ func TestSetAnnotation252Prefix64Name(t *testing.T) {
 
 func TestSetAnnotationNoKey(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{":nokey"}
 	err := cmd.RunE(cmd, args)
@@ -168,8 +168,8 @@ func TestSetAnnotationNoKey(t *testing.T) {
 
 func TestSetAnnotationTooManyColons(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"key:v1:v2"}
 	err := cmd.RunE(cmd, args)
@@ -181,8 +181,8 @@ func TestSetAnnotationTooManyColons(t *testing.T) {
 
 func TestSetAnnotationNoValue(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"no,value:"}
 	err := cmd.RunE(cmd, args)
@@ -198,8 +198,8 @@ func TestSetAnnotationNoValue(t *testing.T) {
 
 func TestSetAnnotationMultipleArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"this:input", "has:spaces"}
 	err := cmd.RunE(cmd, args)
@@ -211,8 +211,8 @@ func TestSetAnnotationMultipleArgs(t *testing.T) {
 
 func TestSetAnnotationExisting(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetAnnotation(fSys, v.Validator)
 	args := []string{"key:foo"}
 	err := cmd.RunE(cmd, args)
@@ -220,7 +220,7 @@ func TestSetAnnotationExisting(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err.Error())
 	}
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdSetAnnotation(fSys, v.Validator)
 	err = cmd.RunE(cmd, args)
 	v.VerifyCall()

--- a/kustomize/commands/edit/set/setlabel_test.go
+++ b/kustomize/commands/edit/set/setlabel_test.go
@@ -6,17 +6,17 @@ package set
 import (
 	"testing"
 
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	testutils "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 func makeKustomization(t *testing.T) *types.Kustomization {
 	t.Helper()
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
+	testutils.WriteTestKustomization(fSys)
 	kf, err := kustfile.NewKustomizationFile(fSys)
 	if err != nil {
 		t.Errorf("unexpected new error %v", err)
@@ -52,7 +52,7 @@ func TestRunSetLabel(t *testing.T) {
 
 func TestSetLabelNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	err := cmd.Execute()
 	v.VerifyNoCall()
@@ -66,7 +66,7 @@ func TestSetLabelNoArgs(t *testing.T) {
 
 func TestSetLabelInvalidFormat(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeSadMapValidator(t)
+	v := valtest.MakeSadMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{"exclamation!:point"}
 	err := cmd.RunE(cmd, args)
@@ -74,14 +74,14 @@ func TestSetLabelInvalidFormat(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected an error")
 	}
-	if err.Error() != valtest_test.SAD {
+	if err.Error() != valtest.SAD {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }
 
 func TestSetLabelNoKey(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	v := valtest_test.MakeHappyMapValidator(t)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{":nokey"}
 	err := cmd.RunE(cmd, args)
@@ -96,8 +96,8 @@ func TestSetLabelNoKey(t *testing.T) {
 
 func TestSetLabelTooManyColons(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{"key:v1:v2"}
 	err := cmd.RunE(cmd, args)
@@ -109,8 +109,8 @@ func TestSetLabelTooManyColons(t *testing.T) {
 
 func TestSetLabelNoValue(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{"no,value:"}
 	err := cmd.RunE(cmd, args)
@@ -122,8 +122,8 @@ func TestSetLabelNoValue(t *testing.T) {
 
 func TestSetLabelMultipleArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{"this:input", "has:spaces"}
 	err := cmd.RunE(cmd, args)
@@ -135,8 +135,8 @@ func TestSetLabelMultipleArgs(t *testing.T) {
 
 func TestSetLabelExisting(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
-	v := valtest_test.MakeHappyMapValidator(t)
+	testutils.WriteTestKustomization(fSys)
+	v := valtest.MakeHappyMapValidator(t)
 	cmd := newCmdSetLabel(fSys, v.Validator)
 	args := []string{"key:foo"}
 	err := cmd.RunE(cmd, args)
@@ -144,7 +144,7 @@ func TestSetLabelExisting(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err.Error())
 	}
-	v = valtest_test.MakeHappyMapValidator(t)
+	v = valtest.MakeHappyMapValidator(t)
 	cmd = newCmdSetLabel(fSys, v.Validator)
 	err = cmd.RunE(cmd, args)
 	v.VerifyCall()

--- a/kustomize/commands/edit/set/setnamespace_test.go
+++ b/kustomize/commands/edit/set/setnamespace_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+	valtest "sigs.k8s.io/kustomize/api/testutils/valtest"
+	testutils "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -19,15 +19,15 @@ const (
 
 func TestSetNamespaceHappyPath(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
+	testutils.WriteTestKustomization(fSys)
 
-	cmd := newCmdSetNamespace(fSys, valtest_test.MakeFakeValidator())
+	cmd := newCmdSetNamespace(fSys, valtest.MakeFakeValidator())
 	args := []string{goodNamespaceValue}
 	err := cmd.RunE(cmd, args)
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := testutils_test.ReadTestKustomization(fSys)
+	content, err := testutils.ReadTestKustomization(fSys)
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}
@@ -39,9 +39,9 @@ func TestSetNamespaceHappyPath(t *testing.T) {
 
 func TestSetNamespaceOverride(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
-	testutils_test.WriteTestKustomization(fSys)
+	testutils.WriteTestKustomization(fSys)
 
-	cmd := newCmdSetNamespace(fSys, valtest_test.MakeFakeValidator())
+	cmd := newCmdSetNamespace(fSys, valtest.MakeFakeValidator())
 	args := []string{goodNamespaceValue}
 	err := cmd.RunE(cmd, args)
 	if err != nil {
@@ -52,7 +52,7 @@ func TestSetNamespaceOverride(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected cmd error: %v", err)
 	}
-	content, err := testutils_test.ReadTestKustomization(fSys)
+	content, err := testutils.ReadTestKustomization(fSys)
 	if err != nil {
 		t.Errorf("unexpected read error: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestSetNamespaceOverride(t *testing.T) {
 func TestSetNamespaceNoArgs(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 
-	cmd := newCmdSetNamespace(fSys, valtest_test.MakeFakeValidator())
+	cmd := newCmdSetNamespace(fSys, valtest.MakeFakeValidator())
 	err := cmd.Execute()
 	if err == nil {
 		t.Errorf("expected error: %v", err)
@@ -78,7 +78,7 @@ func TestSetNamespaceNoArgs(t *testing.T) {
 func TestSetNamespaceInvalid(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 
-	cmd := newCmdSetNamespace(fSys, valtest_test.MakeFakeValidator())
+	cmd := newCmdSetNamespace(fSys, valtest.MakeFakeValidator())
 	args := []string{"/badnamespace/"}
 	err := cmd.RunE(cmd, args)
 	if err == nil {


### PR DESCRIPTION
Rename the usages of the `testutils` and `valtest` utilities from `testutils_test` to `testutils` and `valtest_test` to `valtest`.

There are at least two other packages I found that are being used with a similar naming pattern: `kusttest` and `resmaptest`.

This is based on feedback given in https://github.com/kubernetes-sigs/kustomize/pull/5315#discussion_r1333762476

/hold for discussion and until #5315 is merged