### PR TITLE
docs: update remove configmap comment

### DIFF
--- a/kustomize/commands/edit/remove/removeconfigmap.go
+++ b/kustomize/commands/edit/remove/removeconfigmap.go
@@ -20,7 +20,7 @@ type removeConfigMapOptions struct {
 	configMapNamesToRemove []string
 }
 
-// newCmdRemoveResource remove the name of a file containing a resource to the kustomization file.
+// newCmdRemoveConfigMap removes configMapGenerator(s) with the specified name(s).
 func newCmdRemoveConfigMap(fSys filesys.FileSystem) *cobra.Command {
 	var o removeConfigMapOptions
 


### PR DESCRIPTION
Update the comment for the `newCmdRemoveConfigMap` function to explain what this function really does. The previous comment was referring to a different function.