### PR TITLE
Revert "Disable CI Code Checks if all PR changes fall under `site/`"

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -4,8 +4,6 @@ name: APIDiff
 on:
   push:
   pull_request:
-    paths-ignore:
-      - 'site/**'
 
 jobs:
   go-apidiff:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - 'site/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
See explanation in https://github.com/kubernetes-sigs/kustomize/pull/5332#issuecomment-1741015735. 

Tests in https://github.com/kubernetes-sigs/kustomize/pull/5346 aren't triggering but are still required, essentially blocking it from merging.

/cc @annasong20  @koba1t 