### PR TITLE
Fix bug with merge2 with null values

### DIFF
--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -725,7 +725,7 @@ func (s FieldSetter) Filter(rn *RNode) (*RNode, error) {
 	}
 
 	// Clear the field if it is empty, or explicitly null
-	if s.Value == nil || s.Value.IsTaggedNull() {
+	if s.Value == nil {
 		return rn.Pipe(Clear(s.Name))
 	}
 


### PR DESCRIPTION
## Related issues
Fixes https://github.com/kubernetes-sigs/kustomize/issues/5031

## Problem
https://github.com/kubernetes-sigs/kustomize/pull/4890 originally introduced the problem. [The change removes the null tag from the target node](https://github.com/brianpursley/kustomize/blob/1b7db20504ba8cb0ae4fa00037fe1676585b31a9/kyaml/yaml/merge2/merge2.go#L67-L71)to preserve the null value, and it works fine if users only merge the files once. However, a problem occurs if users try to merge another file to the output since the node, which used to be tagged as null, does not have any tags attached and looks like a plain ScalarRNode from kyaml's perspective. As a result, [the FieldSetter adds DoubleQuotedStyle to the node that used to be tagged as null
](https://github.com/kubernetes-sigs/kustomize/blob/779f1530719c61df642e69675c7c47c87e4a1267/kyaml/yaml/fns.go#L704-L708), and that leads to https://github.com/kubernetes-sigs/kustomize/issues/5031.

I've added a test case called TestMerge_null to demonstrate the problem, so please take a look at it as well.

## Proposed changes

The original problem was that we could not return null nodes from the Merger#VisitMap since then [the FieldSetter#Filter removed them](https://github.com/kubernetes-sigs/kustomize/blob/779f1530719c61df642e69675c7c47c87e4a1267/kyaml/yaml/fns.go#L728-L730). In this PR, I've changed the FieldSetter#Filter and stopped deleting null nodes. Instead, when we want to remove the nodes, we can simply return walk.ClearNode.

