### PR TITLE
fix: add namespace option to 'edit add configmap' command

### DIFF
--- a/api/types/generatorargs.go
+++ b/api/types/generatorargs.go
@@ -5,7 +5,7 @@ package types
 
 // GeneratorArgs contains arguments common to ConfigMap and Secret generators.
 type GeneratorArgs struct {
-	// Namespace for the configmap, optional
+	// Namespace for the resource, optional
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	// Name - actually the partial name - of the generated resource.

--- a/kustomize/commands/edit/add/configmap.go
+++ b/kustomize/commands/edit/add/configmap.go
@@ -38,8 +38,8 @@ func newCmdAddConfigMap(
 	# Adds a configmap from env-file with behavior merge
 	kustomize edit add configmap my-configmap --behavior=merge --from-env-file=env/path.env
 
-    # Adds a configmap to the kustomization file with a specific namespace
-    kustomize edit add configmap my-configmap --namespace test-ns --from-literal=my-key=my-value
+	# Adds a configmap to the kustomization file with a specific namespace
+	kustomize edit add configmap my-configmap --namespace test-ns --from-literal=my-key=my-value
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runEditAddConfigMap(flags, fSys, args, ldr, rf)

--- a/kustomize/commands/edit/add/configmapSecretFlagsAndArgs.go
+++ b/kustomize/commands/edit/add/configmapSecretFlagsAndArgs.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/types"
-
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/util"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -17,8 +16,9 @@ const (
 	fromFileFlag              = "from-file"
 	fromLiteralFlag           = "from-literal"
 	fromEnvFileFlag           = "from-env-file"
-	flagDisableNameSuffixHash = "disableNameSuffixHash"
-	flagBehavior              = "behavior"
+	disableNameSuffixHashFlag = "disableNameSuffixHash"
+	behaviorFlag              = "behavior"
+	namespaceFlag             = "namespace"
 	flagFormat                = "--%s=%s"
 )
 

--- a/kustomize/commands/edit/add/configmap_test.go
+++ b/kustomize/commands/edit/add/configmap_test.go
@@ -306,7 +306,6 @@ func TestEditAddConfigMapWithFileSource(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			fSys := filesys.MakeEmptyDirInMemory()
 			testutils_test.WriteTestKustomization(fSys)
 

--- a/kustomize/commands/edit/add/secret.go
+++ b/kustomize/commands/edit/add/secret.go
@@ -64,12 +64,12 @@ func newCmdAddSecret(
 		"Specify the secret type this can be 'Opaque' (default), or 'kubernetes.io/tls'")
 	cmd.Flags().StringVar(
 		&flags.Namespace,
-		"namespace",
+		namespaceFlag,
 		"",
 		"Specify the namespace of the secret")
 	cmd.Flags().BoolVar(
 		&flags.DisableNameSuffixHash,
-		flagDisableNameSuffixHash,
+		disableNameSuffixHashFlag,
 		false,
 		"Disable the name suffix for the secret")
 
@@ -125,7 +125,9 @@ func runEditAddSecret(
 func addSecret(
 	ldr ifc.KvLoader,
 	k *types.Kustomization,
-	flags configmapSecretFlagsAndArgs, rf *resource.Factory) error {
+	flags configmapSecretFlagsAndArgs,
+	rf *resource.Factory,
+) error {
 	args := findOrMakeSecretArgs(k, flags.Name, flags.Namespace, flags.Type)
 	mergeFlagsIntoGeneratorArgs(&args.GeneratorArgs, flags)
 	// Validate by trying to create corev1.secret.


### PR DESCRIPTION
* Add option to include a namespace when adding a ConfigMap via `kustomize edit add configmap` command.
* Refactor the constants for flag names to keep a standard between them.
* Update comment for `GeneratorArgs` to reflect the usage of the `Namespace` field.

Fixes #5366