### PR TITLE
merge2: fix duplicate test case

### DIFF
--- a/kyaml/yaml/merge2/scalar_test.go
+++ b/kyaml/yaml/merge2/scalar_test.go
@@ -110,7 +110,7 @@ kind: Deployment
 	{description: `remove scalar -- empty in src`,
 		source: `
 kind: Deployment
-field: null
+field:
 `,
 		dest: `
 kind: Deployment


### PR DESCRIPTION
The `remove scalar -- empty in src` test case was identical to the `remove scalar -- null in src` case.