### PR TITLE
Path for glossary.md corrected

### DIFF
--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -1,6 +1,6 @@
-[patch]: ../docs/glossary.md#patch
-[resource]: ../docs/glossary.md#resource
-[variant]: ../docs/glossary.md#variant
+[patch]: https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#patch
+[resource]: https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#resource
+[variant]: https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#variant
 
 ## ConfigMap generation and rolling updates
 


### PR DESCRIPTION
Fixes: #5372 
Path for glossary corrected in configGeneration.md to fix various broken links