### PR TITLE
hotfix: return error instead of log at `FromMapAndOption`

### DIFF
--- a/api/internal/plugins/utils/utils_test.go
+++ b/api/internal/plugins/utils/utils_test.go
@@ -53,7 +53,7 @@ func makeConfigMap(rf *resource.Factory, name, behavior string, hashValue *strin
 	return r
 }
 
-func makeConfigMapOptions(rf *resource.Factory, name, behavior string, disableHash bool) *resource.Resource {
+func makeConfigMapOptions(rf *resource.Factory, name, behavior string, disableHash bool) (*resource.Resource, error) {
 	return rf.FromMapAndOption(map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
@@ -89,7 +89,8 @@ func TestUpdateResourceOptions(t *testing.T) {
 		name := fmt.Sprintf("test%d", i)
 		err := in.Append(makeConfigMap(rf, name, c.behavior, c.hashValue))
 		require.NoError(t, err)
-		err = expected.Append(makeConfigMapOptions(rf, name, c.behavior, !c.needsHash))
+		config := makeConfigMap(rf, name, c.behavior, c.hashValue)
+		err = expected.Append(config)
 		require.NoError(t, err)
 	}
 	actual, err := UpdateResourceOptions(in)

--- a/api/internal/plugins/utils/utils_test.go
+++ b/api/internal/plugins/utils/utils_test.go
@@ -91,7 +91,7 @@ func TestUpdateResourceOptions(t *testing.T) {
 		require.NoError(t, err)
 		config, err := makeConfigMapOptions(rf, name, c.behavior, !c.needsHash)
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("expected new instance with an options but got error: %v", err)
 		}
 		err = expected.Append(config)
 		require.NoError(t, err)

--- a/api/internal/plugins/utils/utils_test.go
+++ b/api/internal/plugins/utils/utils_test.go
@@ -89,7 +89,10 @@ func TestUpdateResourceOptions(t *testing.T) {
 		name := fmt.Sprintf("test%d", i)
 		err := in.Append(makeConfigMap(rf, name, c.behavior, c.hashValue))
 		require.NoError(t, err)
-		config := makeConfigMap(rf, name, c.behavior, c.hashValue)
+		config, err := makeConfigMapOptions(rf, name, c.behavior, !c.needsHash)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		err = expected.Append(config)
 		require.NoError(t, err)
 	}

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -823,6 +823,7 @@ func TestAppendAll(t *testing.T) {
 }
 
 func makeMap1(t *testing.T) ResMap {
+	t.Helper()
 	r, err := rf.FromMapAndOption(
 		map[string]interface{}{
 			"apiVersion": "apps/v1",
@@ -843,7 +844,7 @@ func makeMap1(t *testing.T) ResMap {
 	return rmF.FromResource(r)
 }
 
-func makeMap2(b types.GenerationBehavior, t *testing.T) ResMap {
+func makeMap2(t *testing.T, b types.GenerationBehavior) ResMap {
 	r, err := rf.FromMapAndOption(
 		map[string]interface{}{
 			"apiVersion": "apps/v1",

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -845,6 +845,7 @@ func makeMap1(t *testing.T) ResMap {
 }
 
 func makeMap2(t *testing.T, b types.GenerationBehavior) ResMap {
+	t.Helper()
 	r, err := rf.FromMapAndOption(
 		map[string]interface{}{
 			"apiVersion": "apps/v1",

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -903,9 +903,7 @@ func TestAbsorbAll(t *testing.T) {
 	assert.NoError(t, w.AbsorbAll(w2))
 	w2.RemoveBuildAnnotations()
 	assert.NoError(t, w2.ErrorIfNotEqualLists(w))
-	w = makeMap1(t)
-	w2 = makeMap2(t, types.BehaviorUnspecified)
-	err = w.AbsorbAll(w2)
+	err = makeMap1(t).AbsorbAll(makeMap2(t, types.BehaviorUnspecified))
 	assert.Error(t, err)
 	assert.True(
 		t, strings.Contains(err.Error(), "behavior must be merge or replace"))

--- a/api/resmap/reswrangler_test.go
+++ b/api/resmap/reswrangler_test.go
@@ -839,7 +839,7 @@ func makeMap1(t *testing.T) ResMap {
 			Behavior: "create",
 		})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected new intance with an options but got error: %v", err)
 	}
 	return rmF.FromResource(r)
 }
@@ -861,7 +861,7 @@ func makeMap2(t *testing.T, b types.GenerationBehavior) ResMap {
 			Behavior: b.String(),
 		})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected new intance with an options but got error: %v", err)
 	}
 	return rmF.FromResource(r)
 }
@@ -886,11 +886,11 @@ func TestAbsorbAll(t *testing.T) {
 			Behavior: "create",
 		})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected new intance with an options but got error: %v", err)
 	}
 	expected := rmF.FromResource(r)
 	w := makeMap1(t)
-	assert.NoError(t, w.AbsorbAll(makeMap2(types.BehaviorMerge, t)))
+	assert.NoError(t, w.AbsorbAll(makeMap2(t, types.BehaviorMerge)))
 	expected.RemoveBuildAnnotations()
 	w.RemoveBuildAnnotations()
 	assert.NoError(t, expected.ErrorIfNotEqualLists(w))
@@ -899,12 +899,12 @@ func TestAbsorbAll(t *testing.T) {
 	assert.NoError(t, w.ErrorIfNotEqualLists(makeMap1(t)))
 
 	w = makeMap1(t)
-	w2 := makeMap2(types.BehaviorReplace, t)
+	w2 := makeMap2(t, types.BehaviorReplace)
 	assert.NoError(t, w.AbsorbAll(w2))
 	w2.RemoveBuildAnnotations()
 	assert.NoError(t, w2.ErrorIfNotEqualLists(w))
 	w = makeMap1(t)
-	w2 = makeMap2(types.BehaviorUnspecified, t)
+	w2 = makeMap2(t, types.BehaviorUnspecified)
 	err = w.AbsorbAll(w2)
 	assert.Error(t, err)
 	assert.True(

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -44,6 +44,7 @@ func (rf *Factory) Hasher() ifc.KustHasher {
 func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
 	res, err := rf.FromMapAndOption(m, nil)
 	if err != nil {
+		// TODO: return err instead of log.
 		log.Fatalf("failed to create resource from map: %v", err)
 	}
 	return res
@@ -58,6 +59,7 @@ func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
 	r, err := rf.FromMapAndOption(m, nil)
 	if err != nil {
+		// TODO: return err instead of log.
 		log.Fatalf("failed to create resource from map: %v", err)
 	}
 	return r.setPreviousId(ns, n, r.GetKind())

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -41,8 +41,11 @@ func (rf *Factory) Hasher() ifc.KustHasher {
 }
 
 // FromMap returns a new instance of Resource.
-func (rf *Factory) FromMap(m map[string]interface{}) (*Resource) {
-	res, _ := rf.FromMapAndOption(m, nil)
+func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
+	res, err := rf.FromMapAndOption(m, nil)
+	if err != nil {
+		log.Fatal("Option must not be null")
+	}
 	return res
 }
 
@@ -53,7 +56,10 @@ func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource
 
 // FromMapWithNamespaceAndName returns a new instance with the given "original" namespace.
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
-	r, _ := rf.FromMapAndOption(m, nil)
+	r, err := rf.FromMapAndOption(m, nil)
+	if err != nil {
+		log.Fatal("Option must not be null")
+	}
 	return r.setPreviousId(ns, n, r.GetKind())
 }
 

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -44,7 +44,7 @@ func (rf *Factory) Hasher() ifc.KustHasher {
 func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
 	res, err := rf.FromMapAndOption(m, nil)
 	if err != nil {
-		log.Fatal("Option must not be null")
+		log.Fatalf("failed to create resource from map: %v", err)
 	}
 	return res
 }
@@ -58,7 +58,7 @@ func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
 	r, err := rf.FromMapAndOption(m, nil)
 	if err != nil {
-		log.Fatal("Option must not be null")
+		log.Fatalf("failed to create resource from map: %v", err)
 	}
 	return r.setPreviousId(ns, n, r.GetKind())
 }

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -68,7 +68,7 @@ func (rf *Factory) FromMapAndOption(
 	m map[string]interface{}, args *types.GeneratorArgs) (*Resource, error) {
 	n, err := yaml.FromMap(m)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to convert map to YAML node: %w", err)
 	}
 	return rf.makeOne(n, args), nil
 }

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -41,8 +41,9 @@ func (rf *Factory) Hasher() ifc.KustHasher {
 }
 
 // FromMap returns a new instance of Resource.
-func (rf *Factory) FromMap(m map[string]interface{}) *Resource {
-	return rf.FromMapAndOption(m, nil)
+func (rf *Factory) FromMap(m map[string]interface{}) (*Resource) {
+	res, _ := rf.FromMapAndOption(m, nil)
+	return res
 }
 
 // FromMapWithName returns a new instance with the given "original" name.
@@ -52,19 +53,18 @@ func (rf *Factory) FromMapWithName(n string, m map[string]interface{}) *Resource
 
 // FromMapWithNamespaceAndName returns a new instance with the given "original" namespace.
 func (rf *Factory) FromMapWithNamespaceAndName(ns string, n string, m map[string]interface{}) *Resource {
-	r := rf.FromMapAndOption(m, nil)
+	r, _ := rf.FromMapAndOption(m, nil)
 	return r.setPreviousId(ns, n, r.GetKind())
 }
 
 // FromMapAndOption returns a new instance of Resource with given options.
 func (rf *Factory) FromMapAndOption(
-	m map[string]interface{}, args *types.GeneratorArgs) *Resource {
+	m map[string]interface{}, args *types.GeneratorArgs) (*Resource, error) {
 	n, err := yaml.FromMap(m)
 	if err != nil {
-		// TODO: return err instead of log.
-		log.Fatal(err)
+		return nil, err
 	}
-	return rf.makeOne(n, args)
+	return rf.makeOne(n, args), nil
 }
 
 // makeOne returns a new instance of Resource.


### PR DESCRIPTION
Make [FromMapAndOption](https://github.com/kubernetes-sigs/kustomize/blob/master/api/resource/factory.go#L64-L65) to return error.