### PR TITLE
Extend HelmChart to support helm --set-file

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -101,6 +101,14 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 		// the additional values filepaths must be relative to the kust root
 		p.AdditionalValuesFiles[i] = filepath.Join(p.h.Loader().Root(), file)
 	}
+	for key, file := range p.SetFile {
+		// use Load() to enforce root restrictions
+		if _, err := p.h.Loader().Load(file); err != nil {
+			return errors.WrapPrefixf(err, "could not load file '%s' specified in SetFile", file)
+		}
+		// the filepaths must be relative to the kust root
+		p.SetFile[key] = filepath.Join(p.h.Loader().Root(), file)
+	}
 
 	if err = p.errIfIllegalValuesMerge(); err != nil {
 		return err

--- a/api/krusty/testdata/helmcharts/test-chart/templates/configmap.yaml
+++ b/api/krusty/testdata/helmcharts/test-chart/templates/configmap.yaml
@@ -1,8 +1,9 @@
+---
+{{- if .Values.config }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.foo }}
-{{- if .Values.config }}
+  name: game-demo
 data:
   # file-like keys
   game.properties: {{ .Values.config.game | toYaml | indent 2 }}

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -63,6 +63,11 @@ type HelmChart struct {
 	// addition to either the default values file or the values specified in ValuesFile.
 	AdditionalValuesFiles []string `json:"additionalValuesFiles,omitempty" yaml:"additionalValuesFiles,omitempty"`
 
+	// SetFile holds value mappings where the value is specified in a file.
+	// This allows setting values from respective files. The file's content
+	// will become the value's content.
+	SetFile map[string]string `json:"setFile,omitempty" yaml:"setFile,omitempty"`
+
 	// ValuesFile is a local file path to a values file to use _instead of_
 	// the default values that accompanied the chart.
 	// The default values are in '{ChartHome}/{Name}/values.yaml'.
@@ -167,6 +172,9 @@ func (h HelmChart) AsHelmArgs(absChartHome string) []string {
 	}
 	for _, valuesFile := range h.AdditionalValuesFiles {
 		args = append(args, "-f", valuesFile)
+	}
+	for key, file := range h.SetFile {
+		args = append(args, "--set-file", key+"="+file)
 	}
 
 	for _, apiVer := range h.ApiVersions {

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -107,6 +107,14 @@ func (p *plugin) validateArgs() (err error) {
 		// the additional values filepaths must be relative to the kust root
 		p.AdditionalValuesFiles[i] = filepath.Join(p.h.Loader().Root(), file)
 	}
+	for key, file := range p.SetFile {
+		// use Load() to enforce root restrictions
+		if _, err := p.h.Loader().Load(file); err != nil {
+			return errors.WrapPrefixf(err, "could not load file '%s' specified in SetFile", file)
+		}
+		// the filepaths must be relative to the kust root
+		p.SetFile[key] = filepath.Join(p.h.Loader().Root(), file)
+	}
 
 	if err = p.errIfIllegalValuesMerge(); err != nil {
 		return err

--- a/plugin/builtin/helmchartinflationgenerator/testdata/charts/test-chart/README.md
+++ b/plugin/builtin/helmchartinflationgenerator/testdata/charts/test-chart/README.md
@@ -1,0 +1,1 @@
+This is a simple test chart.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

The PR adds a new field `setFile` to `helmCharts` to support `--set-file key=filepath` helm arg. This allows setting values from respective files. 

E.g. instead of inlining multi-line strings like this:
```yaml
# values.yaml
runners:
  config: |
    [[runners]]
      [runners.kubernetes]
        image = "ubuntu:22.04"
```

one can set the value in a file and reference that file:
```yaml
# kustomization.yaml
helmCharts:
- name: gitlab-runner
  namespace: gitlab-runner
  releasename: gitlab-runner
  repo: https://charts.gitlab.io
  version:  0.57.1
  setFile:
    runners.config: config.toml # runners.config will be set to content of config.toml
```

```toml
# config.toml
[[runners]]
  [runners.kubernetes]
    image = "ubuntu:22.04"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new field `setFile` is added to `helmCharts` to support `--set-file key=filepath` helm arg
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
