### PR TITLE
fix release binary archive contains unnecessary dir

### DIFF
--- a/releasing/create-release.sh
+++ b/releasing/create-release.sh
@@ -59,9 +59,9 @@ function build_kustomize_binary {
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=$build_date"\
         kustomize/main.go
       if [ "$os" == "windows" ]; then
-        zip "${release_dir}/kustomize_${version}_${os}_${arch}.zip" output/kustomize
+        zip -j "${release_dir}/kustomize_${version}_${os}_${arch}.zip" output/kustomize
       else
-        tar cvfz "${release_dir}/kustomize_${version}_${os}_${arch}.tar.gz" output/kustomize
+        tar cvfz "${release_dir}/kustomize_${version}_${os}_${arch}.tar.gz" -C output kustomize
       fi
       rm output/kustomize
     done


### PR DESCRIPTION
I think the current binary release script contains a problem that contains an unnecessary directory name for the archive file.


```
kob@Yugos-MacBook-Air tmp % curl -ssLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.2.0/kustomize_v5.2.0_linux_amd64.tar.gz"
kob@Yugos-MacBook-Air tmp % curl -ssLO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.1.0/kustomize_v5.1.0_linux_amd64.tar.gz"
kob@Yugos-MacBook-Air tmp % tar xvf kustomize_v5.2.0_linux_amd64.tar.gz
x output/kustomize
kob@Yugos-MacBook-Air tmp % tar xvf kustomize_v5.1.0_linux_amd64.tar.gz
x kustomize
```