### PR TITLE
fix add checksum create step in release scripts

### DIFF
--- a/releasing/create-release.sh
+++ b/releasing/create-release.sh
@@ -68,12 +68,12 @@ function build_kustomize_binary {
   done
 
   # create checksums.txt
-  cd "${release_dir}"
+  pushd "${release_dir}"
   for release in *; do
     echo "generate checksum: $release"
     sha256sum "$release" >> checksums.txt
   done
-  cd ../
+  popd
 
   rmdir output
 }

--- a/releasing/create-release.sh
+++ b/releasing/create-release.sh
@@ -65,8 +65,17 @@ function build_kustomize_binary {
       fi
       rm output/kustomize
     done
-    rmdir output
   done
+
+  # create checksums.txt
+  cd "${release_dir}"
+  for release in *; do
+    echo "generate checksum: $release"
+    sha256sum "$release" >> checksums.txt
+  done
+  cd ../
+
+  rmdir output
 }
 
 function create_release {


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/kustomize/issues/5403

---
Tests in my computer.

```sh
$ cat checksums.txt 
e0619f2d18d0ab64ee94cea282bd94e6872da172da54958a527c2bfc1b16a073  kustomize_v5.2.1_darwin_amd64.tar.gz
46b6a5f50ddabcbb71fb06b0ebf5ce36a145342fbe094697dd733f4efb5f2a7a  kustomize_v5.2.1_darwin_arm64.tar.gz
703cf115462143b6850377e2ea129bbf0dbd072b0a50baac8c1c7903f2294d67  kustomize_v5.2.1_linux_amd64.tar.gz
6142179474bc1d05c2e30140b4be9fc8eb48c639b479f808b88d2a05de647f8d  kustomize_v5.2.1_linux_arm64.tar.gz
f253b1ab099d34a9a04edb81c636c21d562da35a6797fdace876d573e688c4db  kustomize_v5.2.1_linux_ppc64le.tar.gz
2e11982d90ba7a71da05851e468212e2582968d4a0723647bbd263816c30a1d7  kustomize_v5.2.1_linux_s390x.tar.gz
e0f5f46c9e6731f31e2dbab757ba110539a24eb8ba33a20dbef2906b7603b6cc  kustomize_v5.2.1_windows_amd64.zip
ed59c0d295db24c93320a049b06033739e1010094809e476833066539599baf9  kustomize_v5.2.1_windows_arm64.zip

$ sha256sum kustomize_v5.2.1_linux_amd64.tar.gz 
703cf115462143b6850377e2ea129bbf0dbd072b0a50baac8c1c7903f2294d67  kustomize_v5.2.1_linux_amd64.tar.gz
$ sha256sum kustomize_v5.2.1_darwin_arm64.tar.gz 
46b6a5f50ddabcbb71fb06b0ebf5ce36a145342fbe094697dd733f4efb5f2a7a  kustomize_v5.2.1_darwin_arm64.tar.gz
```
