### PR TITLE
Add --load-restrictor completion

### DIFF
--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -105,9 +105,11 @@ func NewCmdBuild(
 	AddFlagOutputPath(cmd.Flags())
 	AddFunctionBasicsFlags(cmd.Flags())
 	AddFlagLoadRestrictor(cmd.Flags())
+	AddFlagLoadRestrictorCompletion(cmd)
 	AddFlagEnablePlugins(cmd.Flags())
 	AddFlagReorderOutput(cmd.Flags())
 	AddFlagEnableManagedbyLabel(cmd.Flags())
+
 	msg := "Error marking flag '%s' as deprecated: %v"
 	err := cmd.Flags().MarkDeprecated(flagReorderOutputName,
 		"use the new 'sortOptions' field in kustomization.yaml instead.")

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -102,13 +102,17 @@ func NewCmdBuild(
 			return err
 		},
 	}
+
 	AddFlagOutputPath(cmd.Flags())
 	AddFunctionBasicsFlags(cmd.Flags())
 	AddFlagLoadRestrictor(cmd.Flags())
-	AddFlagLoadRestrictorCompletion(cmd)
 	AddFlagEnablePlugins(cmd.Flags())
 	AddFlagReorderOutput(cmd.Flags())
 	AddFlagEnableManagedbyLabel(cmd.Flags())
+
+	if err := AddFlagLoadRestrictorCompletion(cmd); err != nil {
+		log.Fatalf("Error adding completion for flag '--%s': %v", flagLoadRestrictorName, err)
+	}
 
 	msg := "Error marking flag '%s' as deprecated: %v"
 	err := cmd.Flags().MarkDeprecated(flagReorderOutputName,

--- a/kustomize/commands/build/flagloadrestrictor.go
+++ b/kustomize/commands/build/flagloadrestrictor.go
@@ -6,6 +6,7 @@ package build
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kustomize/api/types"
 )
@@ -21,6 +22,15 @@ func AddFlagLoadRestrictor(set *pflag.FlagSet) {
 			"', local kustomizations may load files from outside their root. "+
 			"This does, however, break the "+
 			"relocatability of the kustomization.")
+}
+
+func AddFlagLoadRestrictorCompletion(cmd *cobra.Command) {
+	cmd.RegisterFlagCompletionFunc(flagLoadRestrictorName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			types.LoadRestrictionsNone.String(),
+			types.LoadRestrictionsRootOnly.String(),
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 func validateFlagLoadRestrictor() error {

--- a/kustomize/commands/build/flagloadrestrictor.go
+++ b/kustomize/commands/build/flagloadrestrictor.go
@@ -24,13 +24,19 @@ func AddFlagLoadRestrictor(set *pflag.FlagSet) {
 			"relocatability of the kustomization.")
 }
 
-func AddFlagLoadRestrictorCompletion(cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc(flagLoadRestrictorName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func AddFlagLoadRestrictorCompletion(cmd *cobra.Command) error {
+	err := cmd.RegisterFlagCompletionFunc(flagLoadRestrictorName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			types.LoadRestrictionsNone.String(),
 			types.LoadRestrictionsRootOnly.String(),
 		}, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	if err != nil {
+		return fmt.Errorf("unable to add completion for --%s flag: %w", flagLoadRestrictorName, err)
+	}
+
+	return nil
 }
 
 func validateFlagLoadRestrictor() error {


### PR DESCRIPTION
Everytime I use kustomize I need to lookup the string for the none restrictor.

Setting up completion for this flag to not lose time any more.