### PR TITLE
perf: Improve resmap performance with AppendAll and Transform functions

### DIFF
--- a/api/internal/accumulator/resaccumulator.go
+++ b/api/internal/accumulator/resaccumulator.go
@@ -171,15 +171,13 @@ func (ra *ResAccumulator) FixBackReferences() (err error) {
 // Intersection drops the resources which "other" does not have.
 func (ra *ResAccumulator) Intersection(other resmap.ResMap) error {
 	otherIds := other.AllIds()
+	seen := make(map[resid.ResId]struct{}, len(otherIds))
+	for _, id := range otherIds {
+		seen[id] = struct{}{}
+	}
 	for _, curId := range ra.resMap.AllIds() {
-		toDelete := true
-		for _, otherId := range otherIds {
-			if otherId == curId {
-				toDelete = false
-				break
-			}
-		}
-		if toDelete {
+		_, inOtherSet := seen[curId]
+		if !inOtherSet {
 			err := ra.resMap.Remove(curId)
 			if err != nil {
 				return err

--- a/api/internal/builtins/SortOrderTransformer.go
+++ b/api/internal/builtins/SortOrderTransformer.go
@@ -79,11 +79,9 @@ func (p *SortOrderTransformerPlugin) Transform(m resmap.ResMap) (err error) {
 
 		// Clear the map and re-add the resources in the sorted order.
 		m.Clear()
-		for _, r := range s.resources {
-			err := m.Append(r)
-			if err != nil {
-				return errors.WrapPrefixf(err, "SortOrderTransformer: Failed to append to resources")
-			}
+		err := m.AppendMany(s.resources...)
+		if err != nil {
+			return errors.WrapPrefixf(err, "SortOrderTransformer: Failed to append to resources")
 		}
 	}
 	return nil

--- a/api/internal/builtins/SortOrderTransformer.go
+++ b/api/internal/builtins/SortOrderTransformer.go
@@ -99,6 +99,7 @@ func (p *SortOrderTransformerPlugin) Transform(m resmap.ResMap) (err error) {
 type legacyIDSorter struct {
 	// resids only stores the metadata of the object. This is an optimization as
 	// it's expensive to compute these again and again during ordering.
+
 	resids []resid.ResId
 	// Initially, we sorted the metadata (ResId) of each object and then called GetByCurrentId on each to construct the final list.
 	// The problem is that GetByCurrentId is inefficient and does a linear scan in a list every time we do that.

--- a/api/resmap/factory.go
+++ b/api/resmap/factory.go
@@ -126,13 +126,8 @@ func (rmF *Factory) FromSecretArgs(
 func newResMapFromResourceSlice(
 	resources []*resource.Resource) (ResMap, error) {
 	result := New()
-	for _, res := range resources {
-		err := result.Append(res)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return result, nil
+	err := result.AppendMany(resources...)
+	return result, err
 }
 
 // NewResMapFromRNodeSlice returns a ResMap from a slice of RNodes

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -330,4 +330,6 @@ type ResMap interface {
 	// struct data members, i.e. the Resource struct is replaced by RNode
 	// and use of (slow) k8s metadata annotations inside the RNode.
 	ApplyFilter(f kio.Filter) error
+
+	Transform(func(r *resource.Resource) error) error
 }

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -133,6 +133,8 @@ type ResMap interface {
 	// in the cluster with the same Id.
 	Append(*resource.Resource) error
 
+	AppendMany(res ...*resource.Resource) error
+
 	// AppendAll appends another ResMap to self,
 	// failing on any CurId collision.
 	AppendAll(ResMap) error

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -519,6 +519,23 @@ func (m *resWrangler) RemoveOriginAnnotations() error {
 	return nil
 }
 
+// Transform implements ResMap
+func (m *resWrangler) Transform(cb func(*resource.Resource) error) error {
+	ids := make(map[resid.ResId]*resource.Resource)
+	for _, res := range m.rList {
+		if err := cb(res); err != nil {
+			return err
+		}
+		newId := res.CurId()
+		if other, found := ids[newId]; found {
+			return fmt.Errorf(
+				"transformation produces ID conflict: %+v, %+v", res, other)
+		}
+		ids[newId] = res
+	}
+	return nil
+}
+
 // AddTransformerAnnotation implements ResMap
 func (m *resWrangler) AddTransformerAnnotation(origin *resource.Origin) error {
 	for _, res := range m.rList {

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -83,6 +83,27 @@ func (m *resWrangler) Append(res *resource.Resource) error {
 	return nil
 }
 
+// Append implements ResMap.
+func (m *resWrangler) AppendMany(resources ...*resource.Resource) error {
+	ids := m.AllIds()
+	seen := make(map[resid.ResId]struct{}, len(ids)+len(resources))
+	for _, id := range ids {
+		seen[id] = struct{}{}
+	}
+
+	for _, res := range resources {
+		newId := res.CurId()
+		if _, ok := seen[newId]; ok {
+			return fmt.Errorf(
+				"may not add resource with an already registered id: %s", newId)
+		}
+		seen[newId] = struct{}{}
+		m.append(res)
+	}
+
+	return nil
+}
+
 // append appends without performing an Id check
 func (m *resWrangler) append(res *resource.Resource) {
 	m.rList = append(m.rList, res)

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -485,12 +485,7 @@ func (m *resWrangler) AppendAll(other ResMap) error {
 
 // appendAll appends all the resources, error on Id collision.
 func (m *resWrangler) appendAll(list []*resource.Resource) error {
-	for _, res := range list {
-		if err := m.Append(res); err != nil {
-			return err
-		}
-	}
-	return nil
+	return m.AppendMany(list...)
 }
 
 // AbsorbAll implements ResMap.

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -5,10 +5,9 @@
 package main
 
 import (
-	"fmt"
-
 	"sigs.k8s.io/kustomize/api/filters/namespace"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/yaml"
@@ -49,25 +48,18 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 	if len(p.Namespace) == 0 {
 		return nil
 	}
-	for _, r := range m.Resources() {
+
+	return m.Transform(func(r *resource.Resource) error {
 		if r.IsNilOrEmpty() {
 			// Don't mutate empty objects?
-			continue
+			return nil
 		}
 		r.StorePreviousId()
-		if err := r.ApplyFilter(namespace.Filter{
+		return r.ApplyFilter(namespace.Filter{
 			Namespace:              p.Namespace,
 			FsSlice:                p.FieldSpecs,
 			SetRoleBindingSubjects: p.SetRoleBindingSubjects,
 			UnsetOnly:              p.UnsetOnly,
-		}); err != nil {
-			return err
-		}
-		matches := m.GetMatchingResourcesByCurrentId(r.CurId().Equals)
-		if len(matches) != 1 {
-			return fmt.Errorf(
-				"namespace transformation produces ID conflict: %+v", matches)
-		}
-	}
-	return nil
+		})
+	})
 }

--- a/plugin/builtin/sortordertransformer/SortOrderTransformer.go
+++ b/plugin/builtin/sortordertransformer/SortOrderTransformer.go
@@ -82,11 +82,9 @@ func (p *plugin) Transform(m resmap.ResMap) (err error) {
 
 		// Clear the map and re-add the resources in the sorted order.
 		m.Clear()
-		for _, r := range s.resources {
-			err := m.Append(r)
-			if err != nil {
-				return errors.WrapPrefixf(err, "SortOrderTransformer: Failed to append to resources")
-			}
+		err := m.AppendMany(s.resources...)
+		if err != nil {
+			return errors.WrapPrefixf(err, "SortOrderTransformer: Failed to append to resources")
 		}
 	}
 	return nil
@@ -102,6 +100,7 @@ func (p *plugin) Transform(m resmap.ResMap) (err error) {
 type legacyIDSorter struct {
 	// resids only stores the metadata of the object. This is an optimization as
 	// it's expensive to compute these again and again during ordering.
+
 	resids []resid.ResId
 	// Initially, we sorted the metadata (ResId) of each object and then called GetByCurrentId on each to construct the final list.
 	// The problem is that GetByCurrentId is inefficient and does a linear scan in a list every time we do that.


### PR DESCRIPTION
Personal notes, keeping as draft :)

Rebased, since the SortOrderTransformer PR is in

With the benchmark suite, this PR reduces the runtime from 48s to 2.5s on my machine.
I think we could split it into multiple independent PRs now. I've benchmarked them on their own to see where the major effect 

###    perf: ResAccumulator: Use map for resmap intersection

standalone. 48s to 47s for the benchmark.

### Transform
    perf: NamespaceTransformer: Use Transform function for conflict detection
    perf: resmap: Add Transform function

pair of PRs, 48s to 47s for the benchmark

### AppendMany

commit f5cdc84e6b490a5235f4002efdd5d884310def39
    perf: resmap: Add AppendMany function
no effect on its own

commit e06a96957bb474bbff22ae4940934ff1e8692a47
    perf: improve applyOrdering by avoid call to GetByCurrentId
little effect on its own

commit f6ed5d59f998a8b5f75833faf1fe2e66358f54af
    perf: Improve SortOrderTransformer and use AppendMany
commit 0fe542166a28b7a404a5f4241862d228df6bcb87
    perf: Use AppendMany for SortOrderTransformer/newResMapFromResourceSlice/appendAll
should split this. Here's the major change 48s->2.5s Could split this into more pieces.