### PR TITLE
Add ignoredGvks to namespaceTransformer built-in plugin

### DIFF
--- a/api/filters/namespace/namespace.go
+++ b/api/filters/namespace/namespace.go
@@ -30,6 +30,8 @@ type Filter struct {
 	// - none: all subjects will be skipped.
 	SetRoleBindingSubjects RoleBindingSubjectMode `json:"setRoleBindingSubjects" yaml:"setRoleBindingSubjects"`
 
+	IgnoredGvks []string
+
 	trackableSetter filtersutil.TrackableSetter
 }
 
@@ -94,6 +96,9 @@ func (ns Filter) metaNamespaceHack(obj *yaml.RNode, gvk resid.Gvk) error {
 	if gvk.IsClusterScoped() {
 		return nil
 	}
+	if ns.ignoreGvk(gvk) {
+		return nil
+	}
 	f := fsslice.Filter{
 		FsSlice: []types.FieldSpec{
 			{Path: types.MetadataNamespacePath, CreateIfNotPresent: true},
@@ -103,6 +108,15 @@ func (ns Filter) metaNamespaceHack(obj *yaml.RNode, gvk resid.Gvk) error {
 	}
 	_, err := f.Filter(obj)
 	return err
+}
+
+func (ns Filter) ignoreGvk(gvk resid.Gvk) bool {
+	for _, ignoredGvk := range ns.IgnoredGvks {
+		if gvk.String() == ignoredGvk {
+			return true
+		}
+	}
+	return false
 }
 
 // roleBindingHack is a hack for implementing the transformer's SetRoleBindingSubjects option
@@ -119,10 +133,10 @@ func (ns Filter) metaNamespaceHack(obj *yaml.RNode, gvk resid.Gvk) error {
 //
 // kind: RoleBinding
 // subjects:
-// - name: "default" # this will have the namespace set
-//   ...
-// - name: "something-else" # this will not have the namespace set
-//   ...
+//   - name: "default" # this will have the namespace set
+//     ...
+//   - name: "something-else" # this will not have the namespace set
+//     ...
 func (ns Filter) roleBindingHack(obj *yaml.RNode) error {
 	var visitor filtersutil.SetFn
 	switch ns.SetRoleBindingSubjects {

--- a/api/internal/builtins/NamespaceTransformer.go
+++ b/api/internal/builtins/NamespaceTransformer.go
@@ -19,6 +19,7 @@ type NamespaceTransformerPlugin struct {
 	FieldSpecs             []types.FieldSpec                `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 	UnsetOnly              bool                             `json:"unsetOnly" yaml:"unsetOnly"`
 	SetRoleBindingSubjects namespace.RoleBindingSubjectMode `json:"setRoleBindingSubjects" yaml:"setRoleBindingSubjects"`
+	IgnoredGvks            []string                         `json:"ignoredGvks" yaml:"ignoredGvks"`
 }
 
 func (p *NamespaceTransformerPlugin) Config(
@@ -57,6 +58,7 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 			FsSlice:                p.FieldSpecs,
 			SetRoleBindingSubjects: p.SetRoleBindingSubjects,
 			UnsetOnly:              p.UnsetOnly,
+			IgnoredGvks:            p.IgnoredGvks,
 		}); err != nil {
 			return err
 		}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -20,6 +20,7 @@ type plugin struct {
 	FieldSpecs             []types.FieldSpec                `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 	UnsetOnly              bool                             `json:"unsetOnly" yaml:"unsetOnly"`
 	SetRoleBindingSubjects namespace.RoleBindingSubjectMode `json:"setRoleBindingSubjects" yaml:"setRoleBindingSubjects"`
+	IgnoredGvks            []string                         `json:"ignoredGvks" yaml:"ignoredGvks"`
 }
 
 var KustomizePlugin plugin //nolint:gochecknoglobals
@@ -60,6 +61,7 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			FsSlice:                p.FieldSpecs,
 			SetRoleBindingSubjects: p.SetRoleBindingSubjects,
 			UnsetOnly:              p.UnsetOnly,
+			IgnoredGvks:            p.IgnoredGvks,
 		}); err != nil {
 			return err
 		}

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -762,3 +762,40 @@ subjects:
 `)
 		})
 }
+
+func TestNamespaceTransformer_ingoreGvks(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
+	th.RunTransformerAndCheckResult(`
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: notImportantHere
+  namespace: test
+ignoredGvks:
+- ClusterKind.v1.test.io
+`,
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+---
+apiVersion: test.io/v1
+kind: ClusterKind
+metadata:
+  name: cm
+`, `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: test
+---
+apiVersion: test.io/v1
+kind: ClusterKind
+metadata:
+  name: cm
+`)
+}


### PR DESCRIPTION
fix #552 
add a ignoredGvks field to namespace transformer.
A IgnoredGvk's metadata.namespace won't be set. 