### PR TITLE
helm: remove HELM_CONFIG_HOME default tmp value

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -106,14 +106,6 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 		return err
 	}
 
-	// ConfigHome is not loaded by the plugin, and can be located anywhere.
-	if p.ConfigHome == "" {
-		if err = p.establishTmpDir(); err != nil {
-			return errors.WrapPrefixf(
-				err, "unable to create tmp dir for HELM_CONFIG_HOME")
-		}
-		p.ConfigHome = filepath.Join(p.tmpDir, "helm")
-	}
 	return nil
 }
 
@@ -152,11 +144,15 @@ func (p *HelmChartInflationGeneratorPlugin) runHelmCommand(
 	cmd := exec.Command(p.h.GeneralConfig().HelmConfig.Command, args...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	env := []string{
-		fmt.Sprintf("HELM_CONFIG_HOME=%s", p.ConfigHome),
-		fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", p.ConfigHome),
-		fmt.Sprintf("HELM_DATA_HOME=%s/.data", p.ConfigHome)}
-	cmd.Env = append(os.Environ(), env...)
+	env := []string{}
+	if p.ConfigHome != "" {
+		env = []string{
+			fmt.Sprintf("HELM_CONFIG_HOME=%s", p.ConfigHome),
+			fmt.Sprintf("HELM_CACHE_HOME=%s/.cache", p.ConfigHome),
+			fmt.Sprintf("HELM_DATA_HOME=%s/.data", p.ConfigHome)}
+		cmd.Env = append(os.Environ(), env...)
+	}
+
 	err := cmd.Run()
 	if err != nil {
 		helm := p.h.GeneralConfig().HelmConfig.Command


### PR DESCRIPTION
`HELM_CONFIG_HOME` is supposed to contain two files `repositories.yaml` and `repositories.lock`. Kustomize sets by default `HELM_CONFIG_HOME` to an empty tmp dir not populated with any of the `repositories.*` files which prevent Helm from pulling private OCI repo for instance (even if this repo is not listed in `repositories.yaml`).

This commits remove the default value to a tmpdir. Kustomize will thus not populate `HELM_CONFIG_HOME`, `HELM_CACHE_HOME` and `HELM_DATA_HOME` by default anymore. User can still override this directory with `helmGlobals`. Setting `configHome` in global to the normal helm config location (`/home/MY_USER_HERE/.config/helm`) could also be used as a workaround before this commit.

Fixes #5407