### PR TITLE
chore: disable testpackage linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - golint
     - maintidx
     - nosnakecase
+    - testpackage # it's better to keep tests in the same package for now because kustomize does open box testing
 
 linters-settings:
   dupl:


### PR DESCRIPTION
Disable the `testpackage` linter as per https://github.com/kubernetes-sigs/kustomize/pull/5430#discussion_r1392946396, for a few reasons:
* It is currently only enforcing changes in new files, causing a drift between the pattern of existing test packages vs. the pattern of newly added test packages.
* It's preferrable to have tests sit in the same package as the code the tests touch, since Kustomize does open-box testing for the time being.