### PR TITLE
Add deprecation warning message to commonLabels

### DIFF
--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -197,6 +197,9 @@ func (k *Kustomization) CheckDeprecatedFields() *[]string {
 	if k.Bases != nil {
 		warningMessages = append(warningMessages, deprecatedBaseWarningMessage)
 	}
+	if k.CommonLabels != nil {
+		warningMessages = append(warningMessages, deprecatedCommonLabelsWarningMessage)
+	}
 	if k.ImageTags != nil {
 		warningMessages = append(warningMessages, deprecatedImageTagsWarningMessage)
 	}
@@ -208,9 +211,6 @@ func (k *Kustomization) CheckDeprecatedFields() *[]string {
 	}
 	if k.Vars != nil {
 		warningMessages = append(warningMessages, deprecatedVarsMessage)
-	}
-	if k.CommonLabels != nil {
-		warningMessages = append(warningMessages, deprecatedCommonLabelsWarningMessage)
 	}
 	return &warningMessages
 }

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -188,6 +188,7 @@ const (
 	deprecatedPatchesJson6902Message           = "# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead." + " " + deprecatedWarningToRunEditFix
 	deprecatedPatchesStrategicMergeMessage     = "# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead." + " " + deprecatedWarningToRunEditFix
 	deprecatedVarsMessage                      = "# Warning: 'vars' is deprecated. Please use 'replacements' instead." + " " + deprecatedWarningToRunEditFixExperimential
+	deprecatedCommonLabelsWarningMessage       = "# Warning: 'commonLabels' is deprecated. Please use 'labels' instead."
 )
 
 // CheckDeprecatedFields check deprecated field is used or not.
@@ -207,6 +208,9 @@ func (k *Kustomization) CheckDeprecatedFields() *[]string {
 	}
 	if k.Vars != nil {
 		warningMessages = append(warningMessages, deprecatedVarsMessage)
+	}
+	if k.CommonLabels != nil {
+		warningMessages = append(warningMessages, deprecatedCommonLabelsWarningMessage)
 	}
 	return &warningMessages
 }

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -188,7 +188,7 @@ const (
 	deprecatedPatchesJson6902Message           = "# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead." + " " + deprecatedWarningToRunEditFix
 	deprecatedPatchesStrategicMergeMessage     = "# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead." + " " + deprecatedWarningToRunEditFix
 	deprecatedVarsMessage                      = "# Warning: 'vars' is deprecated. Please use 'replacements' instead." + " " + deprecatedWarningToRunEditFixExperimential
-	deprecatedCommonLabelsWarningMessage       = "# Warning: 'commonLabels' is deprecated. Please use 'labels' instead."
+	deprecatedCommonLabelsWarningMessage       = "# Warning: 'commonLabels' is deprecated. Please use 'labels' instead." + " " + deprecatedWarningToRunEditFix
 )
 
 // CheckDeprecatedFields check deprecated field is used or not.

--- a/api/types/kustomization_test.go
+++ b/api/types/kustomization_test.go
@@ -30,6 +30,13 @@ func TestKustomization_CheckDeprecatedFields(t *testing.T) {
 			want: &[]string{deprecatedBaseWarningMessage},
 		},
 		{
+			name: "using_CommonLabels",
+			k: Kustomization{
+				CommonLabels: map[string]string{},
+			},
+			want: &[]string{deprecatedCommonLabelsWarningMessage},
+		},
+		{
 			name: "using_ImageTags",
 			k: Kustomization{
 				ImageTags: []Image{},
@@ -61,6 +68,7 @@ func TestKustomization_CheckDeprecatedFields(t *testing.T) {
 			name: "usingAll",
 			k: Kustomization{
 				Bases:                 []string{"base"},
+				CommonLabels:          map[string]string{},
 				ImageTags:             []Image{},
 				PatchesJson6902:       []Patch{},
 				PatchesStrategicMerge: []PatchStrategicMerge{},
@@ -68,6 +76,7 @@ func TestKustomization_CheckDeprecatedFields(t *testing.T) {
 			},
 			want: &[]string{
 				deprecatedBaseWarningMessage,
+				deprecatedCommonLabelsWarningMessage,
 				deprecatedImageTagsWarningMessage,
 				deprecatedPatchesJson6902Message,
 				deprecatedPatchesStrategicMergeMessage,


### PR DESCRIPTION
`commonLabels` and `labels` with `includeSelectors` enabled produce the same output. It would beneficial to remove duplicate behavior where possible. The `commonLabels` field can be deprecated in kustomization v1. 

This change adds a deprecation warning message to the `commonLabels` field.

Related issue: https://github.com/kubernetes-sigs/kustomize/issues/5436

Sample output:
```bash
~/go/bin/kustomize build
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead.
```