### PR TITLE
Add an option in kustomize lib to suppress the deprecation warnings

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -71,7 +71,7 @@ func (kt *KustTarget) Load() error {
 	// show warning message when using deprecated fields.
 	if warningMessages := k.CheckDeprecatedFields(); warningMessages != nil {
 		for _, msg := range *warningMessages {
-			kt.logger.Warn("%v", msg)
+			kt.logger.Warn(msg)
 		}
 	}
 

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -123,7 +123,7 @@ bases:
 `,
 			k: types.Kustomization{
 				TypeMeta:  expectedTypeMeta,
-				Resources: []string{"ldap"}, //Moved to resources by FixKustomization()
+				Resources: []string{"ldap"},
 			},
 		},
 	}

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -116,6 +116,16 @@ commonLabels:
 				CommonLabels: map[string]string{"app": "nginx"},
 			},
 		},
+		"deprecated": {
+			content: `
+bases:
+ - ldap
+`,
+			k: types.Kustomization{
+				TypeMeta:  expectedTypeMeta,
+				Resources: []string{"ldap"}, //Moved to resources by FixKustomization()
+			},
+		},
 	}
 
 	kt := makeKustTargetWithRf(

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -44,9 +44,8 @@ func makeKustTargetWithRf(
 	pc := types.DisabledPluginConfig()
 
 	opts := &slog.HandlerOptions{
-		Level: slog.LevelWarn,
+		Level: slog.LevelError,
 	}
-
 	return target.NewKustTarget(
 		ldr,
 		valtest_test.MakeFakeValidator(),

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -4,8 +4,10 @@
 package target_test
 
 import (
+	"os"
 	"testing"
 
+	"golang.org/x/exp/slog"
 	fLdr "sigs.k8s.io/kustomize/api/internal/loader"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
 	"sigs.k8s.io/kustomize/api/internal/target"
@@ -40,9 +42,16 @@ func makeKustTargetWithRf(
 	}
 	rf := resmap.NewFactory(pvd.GetResourceFactory())
 	pc := types.DisabledPluginConfig()
+
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}
+
 	return target.NewKustTarget(
 		ldr,
 		valtest_test.MakeFakeValidator(),
 		rf,
-		pLdr.NewLoader(pc, rf, fSys))
+		pLdr.NewLoader(pc, rf, fSys),
+		slog.New(slog.NewTextHandler(os.Stdout, opts)),
+	)
 }

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -51,6 +51,6 @@ func makeKustTargetWithRf(
 		valtest_test.MakeFakeValidator(),
 		rf,
 		pLdr.NewLoader(pc, rf, fSys),
-		slog.New(slog.NewTextHandler(os.Stdout, opts)),
+		slog.New(slog.NewJSONHandler(os.Stdout, opts)),
 	)
 }

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -71,7 +71,7 @@ func (b *Kustomizer) Run(
 		Level: b.options.LogLevel,
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, opts))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, opts))
 
 	kt := target.NewKustTarget(
 		ldr,

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -71,7 +71,7 @@ func (b *Kustomizer) Run(
 		Level: b.options.LogLevel,
 	}
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, opts))
+	errLogger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
 
 	kt := target.NewKustTarget(
 		ldr,
@@ -79,7 +79,7 @@ func (b *Kustomizer) Run(
 		resmapFactory,
 		// The plugin configs are always located on disk, regardless of the fSys passed in
 		pLdr.NewLoader(b.options.PluginConfig, resmapFactory, filesys.MakeFsOnDisk()),
-		logger,
+		errLogger,
 	)
 	err = kt.Load()
 	if err != nil {

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -6,7 +6,9 @@ package krusty
 import (
 	"fmt"
 	"log"
+	"os"
 
+	"golang.org/x/exp/slog"
 	"sigs.k8s.io/kustomize/api/internal/builtins"
 	fLdr "sigs.k8s.io/kustomize/api/internal/loader"
 	pLdr "sigs.k8s.io/kustomize/api/internal/plugins/loader"
@@ -64,12 +66,20 @@ func (b *Kustomizer) Run(
 		return nil, err
 	}
 	defer ldr.Cleanup()
+
+	opts := &slog.HandlerOptions{
+		Level: b.options.LogLevel,
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, opts))
+
 	kt := target.NewKustTarget(
 		ldr,
 		b.depProvider.GetFieldValidator(),
 		resmapFactory,
 		// The plugin configs are always located on disk, regardless of the fSys passed in
 		pLdr.NewLoader(b.options.PluginConfig, resmapFactory, filesys.MakeFsOnDisk()),
+		logger,
 	)
 	err = kt.Load()
 	if err != nil {

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -4,6 +4,7 @@
 package krusty
 
 import (
+	"golang.org/x/exp/slog"
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/types"
 )
@@ -45,6 +46,9 @@ type Options struct {
 
 	// Options related to kustomize plugins.
 	PluginConfig *types.PluginConfig
+
+	// Flag to set slog level
+	LogLevel slog.Level
 }
 
 // MakeDefaultOptions returns a default instance of Options.
@@ -54,6 +58,7 @@ func MakeDefaultOptions() *Options {
 		AddManagedbyLabel: false,
 		LoadRestrictions:  types.LoadRestrictionsRootOnly,
 		PluginConfig:      types.DisabledPluginConfig(),
+		LogLevel:          slog.LevelWarn,
 	}
 }
 

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -58,7 +58,7 @@ func MakeDefaultOptions() *Options {
 		AddManagedbyLabel: false,
 		LoadRestrictions:  types.LoadRestrictionsRootOnly,
 		PluginConfig:      types.DisabledPluginConfig(),
-		LogLevel:          slog.LevelWarn,
+		LogLevel:          slog.LevelInfo,
 	}
 }
 


### PR DESCRIPTION
The goal of this PR is to add and Logger option to suppress warnings if user integrates kustomize in his project.
But the kustomize binary still printing warnings by default.

**Implementation**
I injected a slog.Logger in `KustTarget` this way the lib user might pass a custom logger. 

In order to configure this logger, I extended de `Options` to add a new field called `LogLevel` which is filled by default as Info (just to be compatible with the current binary version)

Fixes: https://github.com/kubernetes-sigs/kustomize/issues/5452


```
./go/bin/kustomize build kustomization-foo
{"time":"2023-11-29T21:26:25.85695+01:00","level":"WARN","msg":"# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically."}
...
```