### PR TITLE
perf: cache Resource.CurId & PrevIds return value

### DIFF
--- a/api/internal/accumulator/refvartransformer.go
+++ b/api/internal/accumulator/refvartransformer.go
@@ -52,6 +52,7 @@ func (rv *refVarTransformer) Transform(m resmap.ResMap) error {
 				return err
 			}
 		}
+		res.InvalidateIdCaches()
 	}
 	return nil
 }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -577,6 +577,7 @@ func (m *resWrangler) appendReplaceOrMerge(res *resource.Resource) error {
 		}
 		switch res.Behavior() {
 		case types.BehaviorReplace:
+			res.InvalidateIdCaches()
 			res.CopyMergeMetaDataFieldsFrom(old)
 		case types.BehaviorMerge:
 			// ensure the origin annotation doesn't get overwritten
@@ -584,6 +585,7 @@ func (m *resWrangler) appendReplaceOrMerge(res *resource.Resource) error {
 			if err != nil {
 				return err
 			}
+			res.InvalidateIdCaches()
 			res.CopyMergeMetaDataFieldsFrom(old)
 			res.MergeDataMapFrom(old)
 			res.MergeBinaryDataMapFrom(old)


### PR DESCRIPTION
Cache the return value for both Resource.CurId and Resource.PrevIds to improve overall performance. These changes have minor effects on small kustomize runs, but can provide significant benefits for larger runs.

Edited to add: This work significantly helps https://github.com/kubernetes-sigs/kustomize/issues/5084#issuecomment-1806477953.