### PR TITLE
Fix typo in merge2

### DIFF
--- a/kyaml/yaml/merge2/merge2.go
+++ b/kyaml/yaml/merge2/merge2.go
@@ -45,9 +45,9 @@ func MergeStrings(srcStr, destStr string, infer bool, mergeOptions yaml.MergeOpt
 }
 
 type Merger struct {
-	// for forwards compatibility when new functions are added to the interface
 }
 
+// for forwards compatibility when new functions are added to the interface
 var _ walk.Visitor = Merger{}
 
 func (m Merger) VisitMap(nodes walk.Sources, s *openapi.ResourceSchema) (*yaml.RNode, error) {


### PR DESCRIPTION
The moved comment obviously is associated with the code that enshures `Merger` implements `Visitor` 