### PR TITLE
chore: move removetest.go to the internal package

### DIFF
--- a/kustomize/commands/edit/remove/removeresource_test.go
+++ b/kustomize/commands/edit/remove/removeresource_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestRemoveResources(t *testing.T) {
-	testCases := []testutils_test.Case{
+	testCases := []testutils_test.RemoveTestCase{
 		{
 			Description: "remove resources",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -22,7 +22,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"resource1.yaml"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -34,7 +34,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "remove resource with pattern",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"foo/resource1.yaml",
 					"foo/resource2.yaml",
@@ -43,7 +43,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/resource*.yaml"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -56,7 +56,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -64,7 +64,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -74,14 +74,14 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       testutils_test.Given{},
-			Expected: testutils_test.Expected{
+			Given:       testutils_test.RemoveTestGivenValues{},
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Err: errors.New("must specify a resource file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -94,7 +94,7 @@ func TestRemoveResources(t *testing.T) {
 					"res*.yaml",
 				},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},

--- a/kustomize/commands/edit/remove/removeresource_test.go
+++ b/kustomize/commands/edit/remove/removeresource_test.go
@@ -7,14 +7,14 @@ import (
 	"errors"
 	"testing"
 
-	"sigs.k8s.io/kustomize/kustomize/v5/commands/edit/remove_test"
+	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/remove"
 )
 
 func TestRemoveResources(t *testing.T) {
-	testCases := []remove_test.Case{
+	testCases := []remove.Case{
 		{
 			Description: "remove resources",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -22,7 +22,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"resource1.yaml"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -34,7 +34,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "remove resource with pattern",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"foo/resource1.yaml",
 					"foo/resource2.yaml",
@@ -43,7 +43,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/resource*.yaml"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -56,7 +56,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -64,7 +64,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -74,14 +74,14 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       remove_test.Given{},
-			Expected: remove_test.Expected{
+			Given:       remove.Given{},
+			Expected: remove.Expected{
 				Err: errors.New("must specify a resource file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -94,7 +94,7 @@ func TestRemoveResources(t *testing.T) {
 					"res*.yaml",
 				},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -107,5 +107,5 @@ func TestRemoveResources(t *testing.T) {
 		},
 	}
 
-	remove_test.ExecuteTestCases(t, testCases, "resources", newCmdRemoveResource)
+	remove.ExecuteRemoveTestCases(t, testCases, "resources", newCmdRemoveResource)
 }

--- a/kustomize/commands/edit/remove/removeresource_test.go
+++ b/kustomize/commands/edit/remove/removeresource_test.go
@@ -7,14 +7,14 @@ import (
 	"errors"
 	"testing"
 
-	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/remove"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 )
 
 func TestRemoveResources(t *testing.T) {
-	testCases := []remove.Case{
+	testCases := []testutils_test.Case{
 		{
 			Description: "remove resources",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -22,7 +22,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"resource1.yaml"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -34,7 +34,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "remove resource with pattern",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"foo/resource1.yaml",
 					"foo/resource2.yaml",
@@ -43,7 +43,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/resource*.yaml"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -56,7 +56,7 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"resource1.yaml",
 					"resource2.yaml",
@@ -64,7 +64,7 @@ func TestRemoveResources(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"resource2.yaml",
 					"resource3.yaml",
@@ -74,14 +74,14 @@ func TestRemoveResources(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       remove.Given{},
-			Expected: remove.Expected{
+			Given:       testutils_test.Given{},
+			Expected: testutils_test.Expected{
 				Err: errors.New("must specify a resource file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -94,7 +94,7 @@ func TestRemoveResources(t *testing.T) {
 					"res*.yaml",
 				},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -107,5 +107,5 @@ func TestRemoveResources(t *testing.T) {
 		},
 	}
 
-	remove.ExecuteRemoveTestCases(t, testCases, "resources", newCmdRemoveResource)
+	testutils_test.ExecuteRemoveTestCases(t, testCases, "resources", newCmdRemoveResource)
 }

--- a/kustomize/commands/edit/remove/removetransformer_test.go
+++ b/kustomize/commands/edit/remove/removetransformer_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 
 	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
-
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 func TestRemoveTransformer(t *testing.T) {
-	testCases := []testutils_test.Case{
+	testCases := []testutils_test.RemoveTestCase{
 		{
 			Description: "remove transformers",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -23,7 +22,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"transformer1.yaml"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -35,7 +34,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "remove transformer with pattern",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"foo/transformer1.yaml",
 					"foo/transformer2.yaml",
@@ -44,7 +43,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/transformer*.yaml"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -57,7 +56,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -65,7 +64,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -75,14 +74,14 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       testutils_test.Given{},
-			Expected: testutils_test.Expected{
+			Given:       testutils_test.RemoveTestGivenValues{},
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Err: errors.Errorf("must specify a transformer file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: testutils_test.Given{
+			Given: testutils_test.RemoveTestGivenValues{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -95,7 +94,7 @@ func TestRemoveTransformer(t *testing.T) {
 					"tra*.yaml",
 				},
 			},
-			Expected: testutils_test.Expected{
+			Expected: testutils_test.RemoveTestExpectedValues{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},

--- a/kustomize/commands/edit/remove/removetransformer_test.go
+++ b/kustomize/commands/edit/remove/removetransformer_test.go
@@ -6,15 +6,15 @@ package remove
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/kustomize/v5/commands/edit/remove_test"
+	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/remove"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 func TestRemoveTransformer(t *testing.T) {
-	testCases := []remove_test.Case{
+	testCases := []remove.Case{
 		{
 			Description: "remove transformers",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -22,7 +22,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"transformer1.yaml"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -34,7 +34,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "remove transformer with pattern",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"foo/transformer1.yaml",
 					"foo/transformer2.yaml",
@@ -43,7 +43,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/transformer*.yaml"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -56,7 +56,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -64,7 +64,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -74,14 +74,14 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       remove_test.Given{},
-			Expected: remove_test.Expected{
+			Given:       remove.Given{},
+			Expected: remove.Expected{
 				Err: errors.Errorf("must specify a transformer file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: remove_test.Given{
+			Given: remove.Given{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -94,7 +94,7 @@ func TestRemoveTransformer(t *testing.T) {
 					"tra*.yaml",
 				},
 			},
-			Expected: remove_test.Expected{
+			Expected: remove.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -107,5 +107,5 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 	}
 
-	remove_test.ExecuteTestCases(t, testCases, "transformers", newCmdRemoveTransformer)
+	remove.ExecuteRemoveTestCases(t, testCases, "transformers", newCmdRemoveTransformer)
 }

--- a/kustomize/commands/edit/remove/removetransformer_test.go
+++ b/kustomize/commands/edit/remove/removetransformer_test.go
@@ -6,15 +6,16 @@ package remove
 import (
 	"testing"
 
-	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/remove"
+	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
+
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 func TestRemoveTransformer(t *testing.T) {
-	testCases := []remove.Case{
+	testCases := []testutils_test.Case{
 		{
 			Description: "remove transformers",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -22,7 +23,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"transformer1.yaml"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -34,7 +35,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "remove transformer with pattern",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"foo/transformer1.yaml",
 					"foo/transformer2.yaml",
@@ -43,7 +44,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo/transformer*.yaml"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -56,7 +57,7 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "nothing found to remove",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"transformer1.yaml",
 					"transformer2.yaml",
@@ -64,7 +65,7 @@ func TestRemoveTransformer(t *testing.T) {
 				},
 				RemoveArgs: []string{"foo"},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"transformer2.yaml",
 					"transformer3.yaml",
@@ -74,14 +75,14 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 		{
 			Description: "no arguments",
-			Given:       remove.Given{},
-			Expected: remove.Expected{
+			Given:       testutils_test.Given{},
+			Expected: testutils_test.Expected{
 				Err: errors.Errorf("must specify a transformer file"),
 			},
 		},
 		{
 			Description: "remove with multiple pattern arguments",
-			Given: remove.Given{
+			Given: testutils_test.Given{
 				Items: []string{
 					"foo/foo.yaml",
 					"bar/bar.yaml",
@@ -94,7 +95,7 @@ func TestRemoveTransformer(t *testing.T) {
 					"tra*.yaml",
 				},
 			},
-			Expected: remove.Expected{
+			Expected: testutils_test.Expected{
 				Items: []string{
 					"do/not/deleteme/please.yaml",
 				},
@@ -107,5 +108,5 @@ func TestRemoveTransformer(t *testing.T) {
 		},
 	}
 
-	remove.ExecuteRemoveTestCases(t, testCases, "transformers", newCmdRemoveTransformer)
+	testutils_test.ExecuteRemoveTestCases(t, testCases, "transformers", newCmdRemoveTransformer)
 }

--- a/kustomize/commands/internal/remove/remove_testutils.go
+++ b/kustomize/commands/internal/remove/remove_testutils.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package remove_test
+package remove
 
 import (
 	"fmt"
@@ -41,11 +41,15 @@ type Case struct {
 	Expected Expected
 }
 
-// ExecuteTestCases executes the provided test cases against the specified command
+// ExecuteRemoveTestCases executes the provided test cases against the specified command
 // for a particular collection (e.g. ) tests a command defined by the provided
 // collection Name (e.g. transformers or resources) and newRemoveCmdToTest function.
-func ExecuteTestCases(t *testing.T, testCases []Case, collectionName string,
-	newRemoveCmdToTest func(filesys.FileSystem) *cobra.Command) {
+func ExecuteRemoveTestCases(
+	t *testing.T,
+	testCases []Case,
+	collectionName string,
+	newRemoveCmdToTest func(filesys.FileSystem) *cobra.Command,
+) {
 	t.Helper()
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {

--- a/kustomize/commands/internal/testutils/remove_testutils.go
+++ b/kustomize/commands/internal/testutils/remove_testutils.go
@@ -12,17 +12,17 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
-// Given represents the provided inputs for the test case.
-type Given struct {
+// RemoveTestGivenValues represents the provided inputs for the test case.
+type RemoveTestGivenValues struct {
 	// Items is the given input items.
 	Items []string
 	// RemoveArgs are the arguments to pass to the remove command.
 	RemoveArgs []string
 }
 
-// Expected represents the expected outputs of the test case.
-type Expected struct {
-	// Expected is the collection of expected output items.
+// RemoveTestExpectedValues represents the expected outputs of the test case.
+type RemoveTestExpectedValues struct {
+	// RemoveTestExpectedValues is the collection of expected output items.
 	Items []string
 	// Deleted is the collection of expected Deleted items (if any).
 	Deleted []string
@@ -30,14 +30,14 @@ type Expected struct {
 	Err error
 }
 
-// Case represents a test case to execute.
-type Case struct {
+// RemoveTestCase represents a test case to execute.
+type RemoveTestCase struct {
 	// Description is the description of the test case.
 	Description string
 	// Given is the provided inputs for the test case.
-	Given Given
+	Given RemoveTestGivenValues
 	// Expected is the expected outputs for the test case.
-	Expected Expected
+	Expected RemoveTestExpectedValues
 }
 
 // ExecuteRemoveTestCases executes the provided test cases against the specified command
@@ -45,7 +45,7 @@ type Case struct {
 // collection Name (e.g. transformers or resources) and newRemoveCmdToTest function.
 func ExecuteRemoveTestCases(
 	t *testing.T,
-	testCases []Case,
+	testCases []RemoveTestCase,
 	collectionName string,
 	newRemoveCmdToTest func(filesys.FileSystem) *cobra.Command,
 ) {
@@ -64,7 +64,7 @@ func ExecuteRemoveTestCases(
 				t.Errorf("unexpected cmd error: %v", err)
 			} else if tc.Expected.Err != nil {
 				if err.Error() != tc.Expected.Err.Error() {
-					t.Errorf("expected error did not occurred. Expected: %v. Actual: %v",
+					t.Errorf("expected error did not occur. Expected: %v. Actual: %v",
 						tc.Expected.Err,
 						err)
 				}

--- a/kustomize/commands/internal/testutils/remove_testutils.go
+++ b/kustomize/commands/internal/testutils/remove_testutils.go
@@ -1,7 +1,7 @@
 // Copyright 2022 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package remove
+package testutils_test
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	testutils_test "sigs.k8s.io/kustomize/kustomize/v5/commands/internal/testutils"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -54,7 +53,7 @@ func ExecuteRemoveTestCases(
 	for _, tc := range testCases {
 		t.Run(tc.Description, func(t *testing.T) {
 			fSys := filesys.MakeFsInMemory()
-			testutils_test.WriteTestKustomizationWith(
+			WriteTestKustomizationWith(
 				fSys,
 				[]byte(fmt.Sprintf("%s:\n  - %s",
 					collectionName,
@@ -71,7 +70,7 @@ func ExecuteRemoveTestCases(
 				}
 				return
 			}
-			content, err := testutils_test.ReadTestKustomization(fSys)
+			content, err := ReadTestKustomization(fSys)
 			if err != nil {
 				t.Errorf("unexpected read error: %v", err)
 			}


### PR DESCRIPTION
* Move the `edit/remove_test/removetest.go` file to the internal package, as it is intended to aid testing.
* Rename the method `ExecuteTestCases` to `ExecuteRemoveTestCases`.