### PR TITLE
added helm template --validate --dry-run=server support for HelmChart…

### DIFF
--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -96,6 +96,10 @@ type HelmChart struct {
 
 	// SkipTests skips tests from templated output.
 	SkipTests bool `json:"skipTests,omitempty" yaml:"skipTests,omitempty"`
+
+	// ServerValidation makes api calls to the kubernetes cluster. Enables helm lookup
+	// as well as checking cluster capabilities
+	ServerValidation bool `json:"serverValidation,omitempty" yaml:"serverValidation,omitempty"`
 }
 
 // HelmChartArgs contains arguments to helm.
@@ -187,6 +191,10 @@ func (h HelmChart) AsHelmArgs(absChartHome string) []string {
 	}
 	if h.SkipHooks {
 		args = append(args, "--no-hooks")
+	}
+	if h.ServerValidation {
+		args = append(args, "--validate")
+		args = append(args, "--dry-run=server")
 	}
 	return args
 }

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -60,21 +60,17 @@ func TestAsHelmArgs(t *testing.T) {
 				"-f", "values1", "-f", "values2",
 				"--api-versions", "foo", "--api-versions", "bar"})
 	})
-}
 
-func TestAsHelmArgsServerValidation(t *testing.T) {
 	t.Run("use server-validation", func(t *testing.T) {
 		p := types.HelmChart{
 			Name:                  "chart-name",
 			Version:               "1.0.0",
 			Repo:                  "https://helm.releases.hashicorp.com",
-			ValuesFile:            "values",
 			ServerValidation:	   true,
 		}
 		require.Equal(t, p.AsHelmArgs("/home/charts"),
 			[]string{"template", "--generate-name",
 				"/home/charts/chart-name",
-				"-f", "values",
 				"--validate",
 				"--dry-run=server"})
 	})

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -22,6 +22,7 @@ func TestAsHelmArgs(t *testing.T) {
 			SkipTests:             true,
 			IncludeCRDs:           true,
 			SkipHooks:             true,
+			ServerValidation:	   true,
 			ValuesFile:            "values",
 			AdditionalValuesFiles: []string{"values1", "values2"},
 			Namespace:             "my-ns",
@@ -37,7 +38,9 @@ func TestAsHelmArgs(t *testing.T) {
 				"--kube-version", "1.27",
 				"--include-crds",
 				"--skip-tests",
-				"--no-hooks"})
+				"--no-hooks",
+				"--validate",
+				"--dry-run=server"})
 	})
 
 	t.Run("use release-name", func(t *testing.T) {

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -22,7 +22,6 @@ func TestAsHelmArgs(t *testing.T) {
 			SkipTests:             true,
 			IncludeCRDs:           true,
 			SkipHooks:             true,
-			ServerValidation:	   true,
 			ValuesFile:            "values",
 			AdditionalValuesFiles: []string{"values1", "values2"},
 			Namespace:             "my-ns",
@@ -38,9 +37,7 @@ func TestAsHelmArgs(t *testing.T) {
 				"--kube-version", "1.27",
 				"--include-crds",
 				"--skip-tests",
-				"--no-hooks",
-				"--validate",
-				"--dry-run=server"})
+				"--no-hooks"})
 	})
 
 	t.Run("use release-name", func(t *testing.T) {
@@ -62,5 +59,23 @@ func TestAsHelmArgs(t *testing.T) {
 				"-f", "values",
 				"-f", "values1", "-f", "values2",
 				"--api-versions", "foo", "--api-versions", "bar"})
+	})
+}
+
+func TestAsHelmArgsServerValidation(t *testing.T) {
+	t.Run("use server-validation", func(t *testing.T) {
+		p := types.HelmChart{
+			Name:                  "chart-name",
+			Version:               "1.0.0",
+			Repo:                  "https://helm.releases.hashicorp.com",
+			ValuesFile:            "values",
+			ServerValidation:	   true,
+		}
+		require.Equal(t, p.AsHelmArgs("/home/charts"),
+			[]string{"template", "--generate-name",
+				"/home/charts/chart-name",
+				"-f", "values",
+				"--validate",
+				"--dry-run=server"})
 	})
 }


### PR DESCRIPTION
With this helmchartinflationgenerator is able to do api Calls for checking information on the target cluster if wanted.
The field ServerValidation appends the args --validate and --dry-run=server to the helm template command.
This is needed if a chart wants to make use of the lookup command (--dry-run=server) or check cluster capabilities (--validate).

Closes https://github.com/kubernetes-sigs/kustomize/issues/5348