### PR TITLE
Fix null YAML values being replaced by `"null"`

### DIFF
--- a/kyaml/yaml/merge2/merge2.go
+++ b/kyaml/yaml/merge2/merge2.go
@@ -66,8 +66,7 @@ func (m Merger) VisitMap(nodes walk.Sources, s *openapi.ResourceSchema) (*yaml.R
 
 		// If Origin is missing, preserve explicitly set null in Dest ("null", "~", etc)
 		if nodes.Origin().IsNil() && !nodes.Dest().IsNil() && len(nodes.Dest().YNode().Value) > 0 {
-			// Return a new node so that it won't have a "!!null" tag and therefore won't be cleared.
-			return yaml.NewScalarRNode(nodes.Dest().YNode().Value), nil
+			return yaml.MakePersistentNullNode(nodes.Dest().YNode().Value), nil
 		}
 
 		return nodes.Origin(), nil

--- a/kyaml/yaml/merge2/scalar_test.go
+++ b/kyaml/yaml/merge2/scalar_test.go
@@ -202,6 +202,22 @@ field: null
 			ListIncreaseDirection: yaml.MergeOptionsListAppend,
 		},
 	},
+	{description: `keep scalar -- missing in src, null in dest, preserves null marker`,
+		source: `
+kind: Deployment
+`,
+		dest: `
+kind: Deployment
+field: ~
+`,
+		expected: `
+kind: Deployment
+field: ~
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
 
 	//
 	// Test Case

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -24,6 +24,20 @@ func MakeNullNode() *RNode {
 	return NewRNode(&Node{Tag: NodeTagNull})
 }
 
+// MakePersistentNullNode returns an RNode that should be persisted,
+// even when merging
+func MakePersistentNullNode(value string) *RNode {
+	n := NewRNode(
+		&Node{
+			Tag:   NodeTagNull,
+			Value: value,
+			Kind:  yaml.ScalarNode,
+		},
+	)
+	n.ShouldKeep = true
+	return n
+}
+
 // IsMissingOrNull is true if the RNode is nil or explicitly tagged null.
 // TODO: make this a method on RNode.
 func IsMissingOrNull(node *RNode) bool {
@@ -213,6 +227,9 @@ type RNode struct {
 	// list entry: list entry value
 	// object root: object root
 	value *yaml.Node
+
+	// Whether we should keep this node, even if otherwise we would clear it
+	ShouldKeep bool
 
 	Match []string
 }


### PR DESCRIPTION
Related issues:

* https://github.com/kubernetes-sigs/kustomize/issues/5031
* https://github.com/kubernetes-sigs/kustomize/issues/5171

After noting this behaviour was not present in
d89b448c745937f0cf1936162f26a5aac688f840 a `git bisect` pointed to the
change 1b7db20504ba8cb0ae4fa00037fe1676585b31a9. The issue with that
change is that upon seeing a `null` node it would replace it with a node
whose value was equivalent but without a `!!null` tag. This meant that
one application of a patch would have the desired approach: the result
would be `null` in the output, but on a second application of a similar
patch the field would be rendered as `"null"`.

To avoid this, define a new attribute on `RNode`s that is checked before
clearing any node we should keep. The added
`TestApplySmPatch_Idempotency` test verifies this behaviour.

See also https://github.com/kubernetes-sigs/kustomize/pull/5365 for an
alternative approach