### PR TITLE
add license for api/pkg/util/image.go

### DIFF
--- a/api/pkg/util/image.go
+++ b/api/pkg/util/image.go
@@ -1,3 +1,6 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (


### PR DESCRIPTION
The CI status of the master branch is down.
https://github.com/kubernetes-sigs/kustomize/commit/26165a86b778b0401a6096fb49a761b646a3a98d

I'm fixing one lint failure on this PR.