### PR TITLE
chore: pin dev deps in the dev container

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -28,8 +28,14 @@ RUN apk add --no-cache \
     git \
     openssh-client \
     rsync \
-    npm && \
-    npm install -D autoprefixer postcss-cli
+    npm
+
+RUN mkdir -p /usr/local/node_packages
+WORKDIR /usr/local/node_packages
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install -D autoprefixer postcss-cli
+ENV PATH="/usr/local/node_packages/node_modules/.bin:${PATH}"
 
 RUN mkdir -p /var/hugo && \
     addgroup -Sg 1000 hugo && \


### PR DESCRIPTION
Copy package.json and package-lock.json into the site dev container and use them to pin the versions and checksums for autoprefixer, postcss-cli, and their dependencies.

This should help reduce risk of importing newer dependency versions that haven't passed vulnerability checks.