### PR TITLE
Include exec plugin `stderr` with wrapped error

### DIFF
--- a/api/internal/plugins/execplugin/execplugin.go
+++ b/api/internal/plugins/execplugin/execplugin.go
@@ -169,15 +169,16 @@ func (p *ExecPlugin) invokePlugin(input []byte) ([]byte, error) {
 		p.path, append([]string{f.Name()}, p.args...)...)
 	cmd.Env = p.getEnv()
 	cmd.Stdin = bytes.NewReader(input)
-	cmd.Stderr = os.Stderr
+	var stdErr bytes.Buffer
+	cmd.Stderr = &stdErr
 	if _, err := os.Stat(p.h.Loader().Root()); err == nil {
 		cmd.Dir = p.h.Loader().Root()
 	}
 	result, err := cmd.Output()
 	if err != nil {
 		return nil, errors.WrapPrefixf(
-			err, "failure in plugin configured via %s; %v",
-			f.Name(), err.Error())
+			fmt.Errorf("failure in plugin configured via %s; %w",
+				f.Name(), err), stdErr.String())
 	}
 	return result, os.Remove(f.Name())
 }


### PR DESCRIPTION
This allows external plugins to provide more error details aside from just `exit status 1` inside the error. This also aligns with how other internal generators do error handling, for instance:
https://github.com/kubernetes-sigs/kustomize/blob/b154361c00429dc1807328313e175e4927dc7a6b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go#L177-L184

To illustrate the difference, this error:
```
failure in plugin configured via /var/folders/mt/6766yzb50jlb9t0x6gvl0nz00000gn/T/kust-plugin-config-280379728; exit status 1
```

Would be populated with relevant details:
```
Error: error processing the PolicyGenerator file '/var/folders/mt/6766yzb50jlb9t0x6gvl0nz00000gn/T/kust-plugin-config-280379728': the PolicyGenerator configuration file is invalid: yaml: unmarshal errors:
  line 10: field consolidatManifests found but not defined in type policyDefaults - did you mean 'consolidateManifests'?
: failure in plugin configured via /var/folders/mt/6766yzb50jlb9t0x6gvl0nz00000gn/T/kust-plugin-config-280379728; exit status 1
```