### PR TITLE
use Strict unmarshal when read TransformerConfig

### DIFF
--- a/api/internal/plugins/builtinconfig/loaddefaultconfig.go
+++ b/api/internal/plugins/builtinconfig/loaddefaultconfig.go
@@ -33,7 +33,7 @@ func loadDefaultConfig(
 // makeTransformerConfigFromBytes returns a TransformerConfig object from bytes
 func makeTransformerConfigFromBytes(data []byte) (*TransformerConfig, error) {
 	var t TransformerConfig
-	err := yaml.Unmarshal(data, &t)
+	err := yaml.UnmarshalStrict(data, &t)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/plugins/builtinconfig/loaddefaultconfig_test.go
+++ b/api/internal/plugins/builtinconfig/loaddefaultconfig_test.go
@@ -5,6 +5,7 @@ package builtinconfig
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/internal/loader"
@@ -42,5 +43,57 @@ namePrefix:
 	}
 	if !reflect.DeepEqual(tCfg, expected) {
 		t.Fatalf("expected %v\n but go6t %v\n", expected, tCfg)
+	}
+}
+
+func TestLoadDefaultConfigsFromFilesWithMissingFields(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	filePathContainsTypo := "config_contains_typo.yaml"
+	if err := fSys.WriteFile(filePathContainsTypo, []byte(`
+namoPrefix:
+- path: nameprefix/path
+  kind: SomeKind
+`)); err != nil {
+		t.Fatal(err)
+	}
+	ldr, err := loader.NewLoader(
+		loader.RestrictionRootOnly, filesys.Separator, fSys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errMsg := "error unmarshaling JSON: while decoding JSON: json: unknown field"
+	_, err = loadDefaultConfig(ldr, []string{filePathContainsTypo})
+	if err == nil {
+		t.Fatalf("expected to fail unmarshal yaml, but got nil %s", filePathContainsTypo)
+	}
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Fatalf("expected error %s, but got %s", errMsg, err)
+	}
+}
+
+// please remove this failing test after implements the labels support
+func TestLoadDefaultConfigsFromFilesWithMissingFieldsLabels(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	filePathContainsTypo := "config_contains_typo.yaml"
+	if err := fSys.WriteFile(filePathContainsTypo, []byte(`
+labels:
+  - path: spec/podTemplate/metadata/labels
+    create: true
+    kind: FlinkDeployment
+`)); err != nil {
+		t.Fatal(err)
+	}
+	ldr, err := loader.NewLoader(
+		loader.RestrictionRootOnly, filesys.Separator, fSys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errMsg := "error unmarshaling JSON: while decoding JSON: json: unknown field"
+	_, err = loadDefaultConfig(ldr, []string{filePathContainsTypo})
+	if err == nil {
+		t.Fatalf("expected to fail unmarshal yaml, but got nil %s", filePathContainsTypo)
+	}
+	if !strings.Contains(err.Error(), errMsg) {
+		t.Fatalf("expected error %s, but got %s", errMsg, err)
 	}
 }

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -313,19 +313,21 @@ configurations:
 	th.WriteF("/merge-config/name-prefix-rules.yaml", `
 namePrefix:
 - path: metadata/name
-  apiVersion: v1
+  group: apps
+  version: v1
   kind: Deployment
 - path: metadata/name
-  apiVersion: v1
+  version: v1
   kind: Secret
 `)
 	th.WriteF("/merge-config/name-suffix-rules.yaml", `
 nameSuffix:
 - path: metadata/name
-  apiVersion: v1
+  version: v1
   kind: ConfigMap
 - path: metadata/name
-  apiVersion: v1
+  group: apps
+  version: v1
   kind: Deployment
 `)
 	th.WriteF("/merge-config/deployment.yaml", `

--- a/api/krusty/customconfig_test.go
+++ b/api/krusty/customconfig_test.go
@@ -17,12 +17,16 @@ commonLabels:
 vars:
 - name: APRIL_DIET
   objref:
+    group: foo
+    version: v1
     kind: Giraffe
     name: april
   fieldref:
     fieldpath: spec.diet
 - name: KOKO_DIET
   objref:
+    group: foo
+    version: v1
     kind: Gorilla
     name: koko
   fieldref:
@@ -36,6 +40,7 @@ configurations:
 - config/custom.yaml
 `)
 	th.WriteF("base/giraffes.yaml", `
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   name: april
@@ -43,6 +48,7 @@ spec:
   diet: mimosa
   location: NE
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   name: may
@@ -51,6 +57,7 @@ spec:
   location: SE
 `)
 	th.WriteF("base/gorilla.yaml", `
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   name: koko
@@ -59,7 +66,7 @@ spec:
   location: SW
 `)
 	th.WriteF("base/animalPark.yaml", `
-apiVersion: foo
+apiVersion: foo/v1
 kind: AnimalPark
 metadata:
   name: sandiego
@@ -94,7 +101,7 @@ varReference:
 `)
 	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
-apiVersion: foo
+apiVersion: foo/v1
 kind: AnimalPark
 metadata:
   labels:
@@ -109,6 +116,7 @@ spec:
   gorillaRef:
     name: x-koko
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -118,6 +126,7 @@ spec:
   diet: mimosa
   location: NE
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -127,6 +136,7 @@ spec:
   diet: acacia
   location: SE
 ---
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   labels:
@@ -163,7 +173,7 @@ varReference:
 `)
 	m := th.Run("base", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
-apiVersion: foo
+apiVersion: foo/v1
 kind: AnimalPark
 metadata:
   labels:
@@ -178,6 +188,7 @@ spec:
   gorillaRef:
     name: x-koko
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -187,6 +198,7 @@ spec:
   diet: mimosa
   location: NE
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -196,6 +208,7 @@ spec:
   diet: acacia
   location: SE
 ---
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   labels:
@@ -215,17 +228,20 @@ func TestFixedBug605_BaseCustomizationAvailableInOverlay(t *testing.T) {
 nameReference:
 - kind: Gorilla
   fieldSpecs:
-  - apiVersion: foo
+  - group: foo
+    version: v1
     kind: AnimalPark
     path: spec/gorillaRef/name
 - kind: Giraffe
   fieldSpecs:
-  - apiVersion: foo
+  - group: foo
+    version: v1
     kind: AnimalPark
     path: spec/giraffeRef/name
 varReference:
 - path: spec/food
-  apiVersion: foo
+  group: foo
+  version: v1
   kind: AnimalPark
 `)
 	th.WriteK("overlay", `
@@ -239,6 +255,7 @@ resources:
 - ursus.yaml
 `)
 	th.WriteF("overlay/ursus.yaml", `
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   name: ursus
@@ -248,7 +265,7 @@ spec:
 `)
 	// The following replaces the gorillaRef in the AnimalPark.
 	th.WriteF("overlay/animalPark.yaml", `
-apiVersion: foo
+apiVersion: foo/v1
 kind: AnimalPark
 metadata:
   name: sandiego
@@ -258,7 +275,7 @@ spec:
 `)
 	m := th.Run("overlay", th.MakeDefaultOptions())
 	th.AssertActualEqualsExpected(m, `
-apiVersion: foo
+apiVersion: foo/v1
 kind: AnimalPark
 metadata:
   labels:
@@ -274,6 +291,7 @@ spec:
   gorillaRef:
     name: o-ursus
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -284,6 +302,7 @@ spec:
   diet: mimosa
   location: NE
 ---
+apiVersion: foo/v1
 kind: Giraffe
 metadata:
   labels:
@@ -294,6 +313,7 @@ spec:
   diet: acacia
   location: SE
 ---
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   labels:
@@ -304,6 +324,7 @@ spec:
   diet: bambooshoots
   location: SW
 ---
+apiVersion: foo/v1
 kind: Gorilla
 metadata:
   labels:

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -377,7 +377,8 @@ spec:
 	th.WriteF("base/config/knative.yaml", `
 images:
 - path: spec/runLatest/configuration/revisionTemplate/spec/container/image
-  apiVersion: serving.knative.dev/v1alpha1
+  group: serving.knative.dev
+  version: v1alpha1
   kind: Service
 `)
 }

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -460,7 +460,7 @@ vars:
   objref: &config-map-ref
     kind: ConfigMap
     name: kustomize-vars
-    apiVersion: v1
+    version: v1
   fieldref:
     fieldpath: data.DBT_TARGET
 - name: SUSPENDED
@@ -500,10 +500,12 @@ nameReference:
 varReference:
   - path: spec/workflowSpec/arguments/parameters/value
     kind: CronWorkflow
-    apiVersion: argoproj.io/v1alpha1
+    group: argoproj.io
+    version: v1alpha1
   - path: spec
     kind: CronWorkflow
-    apiVersion: argoproj.io/v1alpha1
+    group: argoproj.io
+    version: v1alpha1
 `)
 	th.WriteF("vars.env", `
 DBT_TARGET=development


### PR DESCRIPTION
We can't get an appropriate error if we have a misconfiguration in TransformerConfig.
related: https://github.com/kubernetes-sigs/kustomize/issues/5527

This PR started to use strict unmarshal when reading the TransformerConfig file, which detects the above misconfiguration and shows the right error message to the user.

/cc @stormqueen1990 