### PR TITLE
Improve framework documentation

### DIFF
--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -73,7 +73,8 @@
 //        # run the function by creating this container and providing this
 //        # Example as the functionConfig
 //        config.kubernetes.io/function: |
-//          image: image/containing/function:impl
+//          container:
+//            image: image/containing/function:impl
 //    spec:
 //      value: foo
 //

--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -63,7 +63,7 @@
 //
 // The functionConfig may be specified declaratively and run with
 //
-//  kustomize fn run DIR/
+//	kustomize fn run DIR/
 //
 // Declarative function declaration:
 //
@@ -82,7 +82,7 @@
 // Generated ResourceList.functionConfig -- ConfigMaps
 // Functions may also be specified imperatively and run using:
 //
-//   kustomize fn run DIR/ --image image/containing/function:impl -- value=foo
+//	kustomize fn run DIR/ --image image/containing/function:impl -- value=foo
 //
 // When run imperatively, a ConfigMap is generated for the functionConfig, and the command
 // arguments are set as ConfigMap data entries.

--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -24,7 +24,7 @@
 //		functionConfig := &Example{}
 //
 //		fn := func(items []*yaml.RNode) ([]*yaml.RNode, error) {
-//			for i := range rl.Items {
+//			for i := range items {
 //				// modify the items...
 //			}
 //			return items, nil

--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -75,7 +75,7 @@
 // Generated ResourceList.functionConfig -- ConfigMaps
 // Functions may also be specified imperatively and run using:
 //
-//   kpt fn run DIR/ --image image/containing/function:impl -- value=foo
+//   kustomize fn run DIR/ --image image/containing/function:impl -- value=foo
 //
 // When run imperatively, a ConfigMap is generated for the functionConfig, and the command
 // arguments are set as ConfigMap data entries.

--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -13,6 +13,13 @@
 //
 // Example function implementation using framework.SimpleProcessor with a struct input
 //
+//	import (
+//		"sigs.k8s.io/kustomize/kyaml/errors"
+//		"sigs.k8s.io/kustomize/kyaml/fn/framework"
+//		"sigs.k8s.io/kustomize/kyaml/kio"
+//		"sigs.k8s.io/kustomize/kyaml/yaml"
+//	)
+//
 //	type Spec struct {
 //		Value string `yaml:"value,omitempty"`
 //	}

--- a/kyaml/fn/framework/doc.go
+++ b/kyaml/fn/framework/doc.go
@@ -63,7 +63,7 @@
 //
 // The functionConfig may be specified declaratively and run with
 //
-//  config run DIR/
+//  kustomize fn run DIR/
 //
 // Declarative function declaration:
 //


### PR DESCRIPTION
This PR makes several minor improvements to the documentation on https://pkg.go.dev/sigs.k8s.io/kustomize/kyaml/fn/framework:

- Fixes undefined variable in example code
- Adds import statements to help new users get up-and-running quicker
- Fixes the two commands needed to `run` the functions