### PR TITLE
fix 'golang.org/x/exp/slices' dependencies

### DIFF
--- a/kustomize/commands/edit/set/setconfigmap.go
+++ b/kustomize/commands/edit/set/setconfigmap.go
@@ -9,8 +9,9 @@ import (
 
 	"sigs.k8s.io/kustomize/api/konfig"
 
+	"slices"
+
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
@@ -34,7 +35,7 @@ When namespace is omitted, the default namespace is used. Conversely, when an en
 in the %[1]s file, it can be updated by either omitting the namespace on the kustomize edit set configmap invocation or by
 specifying --namespace=default.`, konfig.DefaultKustomizationFileName()),
 		Example: fmt.Sprintf(`
-	# Edits an existing ConfigMap in the %[1]s file, changing value of key1 to 2, and namespace is implicitly defined as "default" 
+	# Edits an existing ConfigMap in the %[1]s file, changing value of key1 to 2, and namespace is implicitly defined as "default"
 	kustomize edit set configmap my-configmap --from-literal=key1=2
 
 	# Edits an existing ConfigMap in the %[1]s file, changing value of key1 to 2, and explicitly define namespace as "default"

--- a/kustomize/commands/edit/set/setsecret.go
+++ b/kustomize/commands/edit/set/setsecret.go
@@ -7,8 +7,9 @@ package set
 import (
 	"fmt"
 
+	"slices"
+
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/resource"

--- a/kustomize/go.mod
+++ b/kustomize/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/text v0.13.0
 	sigs.k8s.io/kustomize/api v0.16.0
 	sigs.k8s.io/kustomize/cmd/config v0.13.0

--- a/kustomize/go.sum
+++ b/kustomize/go.sum
@@ -75,8 +75,6 @@ go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 h1:+FNtrFTmVw0YZGpBGX56XDee33
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
`golang.org/x/exp` module was added in [unwanted-dependencies](https://github.com/kubernetes/kubernetes/blob/d3d06c3c7e07c7c79ff46c0fc3b9f081ce6b0226/hack/unwanted-dependencies.json#L62) in k/k.
https://github.com/kubernetes/kubernetes/pull/118339/files#diff-09f70f26cff6c34dc0063a45ca43cf5025d653058b06f7966fc8e6f3b9cecd3eR64