### PR TITLE
Disable abandoned/archived linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,10 @@ linters:
     - maintidx
     - nosnakecase
     - testpackage # it's better to keep tests in the same package for now because kustomize does open box testing
+    - structcheck # abandoned by author
+    - varcheck # abandoned by author
+    - maligned # abandoned by author
+    - interfacer # archived by author
 
 linters-settings:
   dupl:


### PR DESCRIPTION
This reduces the warnings printed when running `make lint`.

This should also make the linter less fragile. There's some panics that seem to be blocking https://github.com/kubernetes-sigs/kustomize/pull/5622