### PR TITLE
Update site/Dockerfile to use pinned hugo version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .github
 docs
 examples
-site
 travis
 *.md

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -13,13 +13,11 @@ RUN apk add --no-cache \
     build-base \
     libc6-compat
 
-ARG HUGO_VERSION
-
-RUN mkdir $HOME/src && \
-    cd $HOME/src && \
-    curl -L https://github.com/gohugoio/hugo/archive/refs/tags/v${HUGO_VERSION}.tar.gz | tar -xz && \
-    cd "hugo-${HUGO_VERSION}" && \
-    go install --tags extended
+RUN mkdir -p /go/src/sigs.k8s.io/kustomize/hack
+WORKDIR /go/src/sigs.k8s.io/kustomize/hack
+COPY hack/go.mod ./
+COPY hack/go.sum ./
+RUN go install --tags extended github.com/gohugoio/hugo
 
 FROM docker.io/library/golang:1.21-alpine
 
@@ -32,8 +30,8 @@ RUN apk add --no-cache \
 
 RUN mkdir -p /usr/local/node_packages
 WORKDIR /usr/local/node_packages
-COPY package.json ./
-COPY package-lock.json ./
+COPY site/package.json ./
+COPY site/package-lock.json ./
 RUN npm install -D autoprefixer postcss-cli
 ENV PATH="/usr/local/node_packages/node_modules/.bin:${PATH}"
 

--- a/site/Makefile
+++ b/site/Makefile
@@ -43,13 +43,23 @@ build-preview: module-check ## Build site with drafts and future posts enabled
 serve: module-check ## Boot the development server.
 	hugo server --buildFuture --environment development
 
+## Update the hugo version in ../hack/go.mod to match HUGO_VERSION in netlify.toml
+.PHONY: tools
+tools: netlify.toml
+	@echo "Hugo: v$(HUGO_VERSION)"
+	@set -euo pipefail && cd ../hack && \
+		sed -e "/github.com\/gohugoio\/hugo/ s/v[0-9]\+\.[0-9]\+\.[0-9]\+/v$(HUGO_VERSION)/" go.mod > go.mod.next && \
+		mv go.mod.next go.mod && \
+		echo "Updated ../hack/go.mod"
+	cd ../hack && go mod tidy
+
 ## Build a container image for the preview of the website
 .PHONY: container-image
-container-image: netlify.toml Dockerfile hugo.toml
-	$(CONTAINER_ENGINE) build . \
+container-image: tools Dockerfile hugo.toml
+	cd .. && $(CONTAINER_ENGINE) build . \
+		--file site/Dockerfile \
 		--network=host \
-		--tag $(CONTAINER_IMAGE) \
-		--build-arg HUGO_VERSION=$(HUGO_VERSION)
+		--tag $(CONTAINER_IMAGE)
 
 # no build lock to allow for read-only mounts
 ## Boot the development server using container.

--- a/site/README.md
+++ b/site/README.md
@@ -60,6 +60,8 @@ If you see errors, it probably means that the hugo container did not have enough
 
 Open up your browser to <http://localhost:1313> to view the website. As you make changes to the source files, Hugo updates the website and forces a browser refresh.
 
+If you need to update the `HUGO_VERSION`, edit it in the [`netlify.toml`](netlify.toml#L7) file and then run `make tools` to update the pinned version of Hugo in [hack/go.mod](/hack/go.mod#L9).
+
 ## Running the website locally using Hugo
 
 Make sure to install the Hugo extended version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L7) file.

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -4,7 +4,7 @@ command = "git submodule update --init --recursive --depth 1 && hugo"
 publish = "publishedSite/"
 
 [build.environment]
-HUGO_VERSION = "0.120.3"
+HUGO_VERSION = "0.120.4"
 NODE_ENV = "development"
 NETLIFY_BUILD_DEBUG = "true"
 


### PR DESCRIPTION
- Version pinned in hack/go.mod.
- Use `make tools` to update the pinned version to match netlify.toml