### PR TITLE
fix version subcommand is not working after release build

### DIFF
--- a/api/provenance/provenance.go
+++ b/api/provenance/provenance.go
@@ -67,14 +67,22 @@ func GetProvenance() Provenance {
 
 	for _, dep := range info.Deps {
 		if dep != nil && dep.Path == "sigs.k8s.io/kustomize/kustomize/v5" {
-			p.Version = GetMostRecentTag(*dep)
+			if dep.Version != "devel" {
+				continue
+			}
+			v, err := GetMostRecentTag(*dep)
+			if err != nil {
+				fmt.Printf("failed to get most recent tag for %s: %v\n", dep.Path, err)
+				continue
+			}
+			p.Version = v
 		}
 	}
 
 	return p
 }
 
-func GetMostRecentTag(m debug.Module) string {
+func GetMostRecentTag(m debug.Module) (string, error) {
 	for m.Replace != nil {
 		m = *m.Replace
 	}
@@ -83,13 +91,13 @@ func GetMostRecentTag(m debug.Module) string {
 	sv, err := semver.Parse(strings.TrimPrefix(split[0], "v"))
 
 	if err != nil {
-		return "unknown"
+		return "", fmt.Errorf("failed to parse version %s: %w", m.Version, err)
 	}
 
 	if len(split) > 1 && sv.Patch > 0 {
 		sv.Patch -= 1
 	}
-	return fmt.Sprintf("v%s", sv.FinalizeVersion())
+	return fmt.Sprintf("v%s", sv.FinalizeVersion()), nil
 }
 
 // Short returns the shortened provenance stamp.

--- a/api/provenance/provenance_test.go
+++ b/api/provenance/provenance_test.go
@@ -59,6 +59,7 @@ func TestGetMostRecentTag(t *testing.T) {
 	tests := []struct {
 		name        string
 		module      debug.Module
+		isError     bool
 		expectedTag string
 	}{
 		{
@@ -72,9 +73,9 @@ func TestGetMostRecentTag(t *testing.T) {
 			expectedTag: "v0.0.0",
 		},
 		{
-			name:        "Invalid semver string",
-			module:      mockModule("invalid-version"),
-			expectedTag: "unknown",
+			name:    "Invalid semver string",
+			module:  mockModule("invalid-version"),
+			isError: true,
 		},
 		{
 			name:        "Valid semver with patch increment and pre-release info",
@@ -90,8 +91,14 @@ func TestGetMostRecentTag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tag := provenance.GetMostRecentTag(tt.module)
-			assert.Equal(t, tt.expectedTag, tag)
+			tag, err := provenance.GetMostRecentTag(tt.module)
+			if err != nil {
+				if !tt.isError {
+					assert.NoError(t, err)
+				}
+			} else {
+				assert.Equal(t, tt.expectedTag, tag)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fix the version output problem in the release: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.4.0
related: https://github.com/kubernetes-sigs/kustomize/pull/5463


```
kob@Yugos-MacBook-Air kustomize % go build -o output/kustomize -ldflags="-X sigs.k8s.io/kustomize/api/provenance.version=v5.5.5" kustomize/main.go
kob@Yugos-MacBook-Air kustomize % ./output/kustomize version
v5.5.5
kob@Yugos-MacBook-Air kustomize % ./output/kustomize version -o yaml
version: v5.5.5
gitCommit: unknown
buildDate: unknown
goOs: darwin
goArch: arm64
goVersion: go1.22.2
```