### PR TITLE
fix: use `fmt.Errorf` instead of non-existing `errors.New`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,24 +123,8 @@ license: $(MYGOBIN)/addlicense
 check-license: $(MYGOBIN)/addlicense
 	./hack/add-license.sh check
 
-## lint-api-static runs the linter on the API module 
-## with build-tag kustomize_disable_go_plugin_support
-## this aims to catch any issues with the API module
-## that would prevent the API module from being used
-## when the go plugin support is disabled.
-export KUSTOMIZE_ROOT ?= $(shell pwd | sed -E 's|(.*\/kustomize)/(.*)|\1|')
-.PHONY: lint-api-static
-lint-api-static: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins)
-	cd api && \
-	$(MYGOBIN)/golangci-lint \
-	  -c $$KUSTOMIZE_ROOT/.golangci.yml \
-	  --build-tags kustomize_disable_go_plugin_support \
-	  -D exhaustive \
-	  --path-prefix api \
-	  run ./...
-
 .PHONY: lint
-lint: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins) lint-api-static
+lint: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins)
 	./hack/for-each-module.sh "make lint"
 
 .PHONY: apidiff

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,24 @@ license: $(MYGOBIN)/addlicense
 check-license: $(MYGOBIN)/addlicense
 	./hack/add-license.sh check
 
+## lint-api-static runs the linter on the API module 
+## with build-tag kustomize_disable_go_plugin_support
+## this aims to catch any issues with the API module
+## that would prevent the API module from being used
+## when the go plugin support is disabled.
+export KUSTOMIZE_ROOT ?= $(shell pwd | sed -E 's|(.*\/kustomize)/(.*)|\1|')
+.PHONY: lint-api-static
+lint-api-static: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins)
+	cd api && \
+	$(MYGOBIN)/golangci-lint \
+	  -c $$KUSTOMIZE_ROOT/.golangci.yml \
+	  --build-tags kustomize_disable_go_plugin_support \
+	  -D exhaustive \
+	  --path-prefix api \
+	  run ./...
+
 .PHONY: lint
-lint: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins)
+lint: $(MYGOBIN)/golangci-lint $(MYGOBIN)/goimports $(builtinplugins) lint-api-static
 	./hack/for-each-module.sh "make lint"
 
 .PHONY: apidiff

--- a/api/Makefile
+++ b/api/Makefile
@@ -11,3 +11,18 @@ build:
 
 generate: $(MYGOBIN)/k8scopy $(MYGOBIN)/stringer
 	go generate ./...
+
+lint: lint-api-static
+
+## lint-api-static runs the linter on the API module
+## with build-tag kustomize_disable_go_plugin_support
+## this aims to catch any issues with the API module
+## that would prevent the API module from being used
+## when the go plugin support is disabled.
+lint-api-static:
+	$(MYGOBIN)/golangci-lint \
+	  -c $$KUSTOMIZE_ROOT/.golangci.yml \
+	  --build-tags kustomize_disable_go_plugin_support \
+	  -D exhaustive \
+	  --path-prefix api \
+	  run ./...

--- a/api/Makefile
+++ b/api/Makefile
@@ -20,9 +20,9 @@ lint: lint-api-static
 ## that would prevent the API module from being used
 ## when the go plugin support is disabled.
 lint-api-static:
+	$(MYGOBIN)/golangci-lint cache clean # Workaround for https://github.com/golangci/golangci-lint/issues/3228
 	$(MYGOBIN)/golangci-lint \
 	  -c $$KUSTOMIZE_ROOT/.golangci.yml \
 	  --build-tags kustomize_disable_go_plugin_support \
-	  -D exhaustive \
 	  --path-prefix api \
 	  run ./...

--- a/api/internal/plugins/loader/load_go_plugin_disabled.go
+++ b/api/internal/plugins/loader/load_go_plugin_disabled.go
@@ -14,11 +14,12 @@
 package loader
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/api/resmap"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 )
 
 func (l *Loader) loadGoPlugin(_ resid.ResId, _ string) (resmap.Configurable, error) {
-	return nil, errors.New("plugin load is disabled")
+	return nil, fmt.Errorf("plugin load is disabled")
 }


### PR DESCRIPTION
When https://github.com/kubernetes-sigs/kustomize/pull/5525 merged, it referenced `errors.New` function but that function doesn't exist. This PR replaces the call with simple `fmt.Errorf`.


