### PR TITLE
Fix: Replace deprecated commonLabels with labels in examples directory.

### DIFF
--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -129,8 +129,10 @@ Now, create `kustomization.yaml` add all your resources.
 <!-- @createKustomizationYaml @testE2EAgainstLatestRelease-->
 ```
 cat <<EOF >$BASE/kustomization.yaml
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 
 resources:
 - deployment.yaml

--- a/examples/breakfast.md
+++ b/examples/breakfast.md
@@ -69,8 +69,10 @@ likes her coffee hot:
 mkdir -p $DEMO_HOME/breakfast/overlays/alice
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/alice/kustomization.yaml
-commonLabels:
-  who: alice
+labels:
+- includeSelectors: true
+  pairs:
+    who: alice
 resources:
 - ../../base
 patches:
@@ -92,8 +94,10 @@ And likewise a [variant] for Bob, who wants _five_ pancakes, with strawberries:
 mkdir -p $DEMO_HOME/breakfast/overlays/bob
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/bob/kustomization.yaml
-commonLabels:
-  who: bob
+labels:
+- includeSelectors: true
+  pairs:
+    who: bob
 resources:
 - ../../base
 patches:

--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -41,8 +41,10 @@ curl -s -o "$BASE/#1.yaml" "https://raw.githubusercontent.com\
 /{deployment,service}.yaml"
 
 cat <<'EOF' >$BASE/kustomization.yaml
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 resources:
 - deployment.yaml
 - service.yaml
@@ -65,9 +67,11 @@ mkdir -p $OVERLAYS/staging
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
 nameSuffix: -v1
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:

--- a/examples/configureBuiltinPlugin.md
+++ b/examples/configureBuiltinPlugin.md
@@ -54,7 +54,7 @@ Define a place to work:
 DEMO_HOME=$(mktemp -d)
 ```
 
-### Using the `commonLabels` and `commonAnnotations` fields
+### Using the `labels` and `commonAnnotations` fields
  
 In this simple example, we'll use just two resources: a deployment and a service.
 
@@ -100,8 +100,10 @@ to be read and transformed:
 ```
 cat <<'EOF' >$DEMO_HOME/kustomization.yaml
 namePrefix: hello-
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 commonAnnotations:
   area: "51"
   greeting: Take me to your leader

--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -143,9 +143,11 @@ defining a new name prefix, and some different labels.
 ```
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:
@@ -184,9 +186,11 @@ with a different name prefix and labels.
 ```
 cat <<EOF >$OVERLAYS/production/kustomization.yaml
 namePrefix: production-
-commonLabels:
-  variant: production
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: production
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
 resources:

--- a/examples/helloWorld/kustomization.yaml
+++ b/examples/helloWorld/kustomization.yaml
@@ -5,8 +5,10 @@ metadata:
 
 # Example configuration for the webserver
 # at https://github.com/monopole/hello
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 
 resources:
 - deployment.yaml

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -183,8 +183,10 @@ add a label, but one can always edit
 <!-- @customizeLabels @testAgainstLatestRelease -->
 ```
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
-commonLabels:
-  env: prod
+labels:
+- includeSelectors: true
+  pairs:
+    env: prod
 EOF
 ```
 

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -80,9 +80,11 @@ The labels transformer adds labels to the `metadata/labels` field for all resour
 Example:
 
 ```yaml
-commonLabels:
-- path: metadata/labels
-  create: true
+labels:
+- includeSelectors: true
+  pairs:
+    path: metadata/labels
+    create: true
 
 - path: spec/selector
   create: true
@@ -97,10 +99,12 @@ commonLabels:
 Example kustomization.yaml:
 
 ```yaml
-commonLabels:
-  someName: someValue
-  owner: alice
-  app: bingo
+labels:
+- includeSelectors: true
+  pairs:
+    someName: someValue
+    owner: alice
+    app: bingo
 ```
 
 ## Annotations transformer

--- a/examples/transformerconfigs/crd/README.md
+++ b/examples/transformerconfigs/crd/README.md
@@ -22,10 +22,12 @@ Add the following file to configure the transformers for the above fields
 mkdir $DEMO_HOME/kustomizeconfig
 cat > $DEMO_HOME/kustomizeconfig/mykind.yaml << EOF
 
-commonLabels:
-- path: spec/selectors
-  create: true
-  kind: MyKind
+labels:
+- includeSelectors: true
+  pairs:
+    path: spec/selectors
+    create: true
+    kind: MyKind
 
 nameReference:
 - kind: Bee
@@ -96,8 +98,10 @@ resources:
 
 namePrefix: test-
 
-commonLabels:
-  foo: bar
+labels:
+- includeSelectors: true
+  pairs:
+    foo: bar
 
 vars:
 - name: BEE_ACTION

--- a/examples/transformerconfigs/crd/kustomization.yaml
+++ b/examples/transformerconfigs/crd/kustomization.yaml
@@ -3,8 +3,10 @@ resources:
 
 namePrefix: test-
 
-commonLabels:
-  foo: bar
+labels:
+- includeSelectors: true
+  pairs:
+    foo: bar
 
 vars:
 - name: BEE_ACTION

--- a/examples/zh/breakfast.md
+++ b/examples/zh/breakfast.md
@@ -63,8 +63,10 @@ EOF
 mkdir -p $DEMO_HOME/breakfast/overlays/alice
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/alice/kustomization.yaml
-commonLabels:
-  who: alice
+labels:
+- includeSelectors: true
+  pairs:
+    who: alice
 resources:
 - ../../base
 patches:
@@ -86,8 +88,10 @@ EOF
 mkdir -p $DEMO_HOME/breakfast/overlays/bob
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/bob/kustomization.yaml
-commonLabels:
-  who: bob
+labels:
+- includeSelectors: true
+  pairs:
+    who: bob
 resources:
 - ../../base
 patches:

--- a/examples/zh/configGeneration.md
+++ b/examples/zh/configGeneration.md
@@ -46,8 +46,10 @@ curl -s -o "$BASE/#1.yaml" "https://raw.githubusercontent.com\
 /{deployment,service}.yaml"
 
 cat <<'EOF' >$BASE/kustomization.yaml
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 resources:
 - deployment.yaml
 - service.yaml
@@ -70,9 +72,11 @@ mkdir -p $OVERLAYS/staging
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
 nameSuffix: -v1
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:

--- a/examples/zh/helloWorld.md
+++ b/examples/zh/helloWorld.md
@@ -131,9 +131,11 @@ mkdir -p $OVERLAYS/production
 ```
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:
@@ -170,9 +172,11 @@ EOF
 ```
 cat <<EOF >$OVERLAYS/production/kustomization.yaml
 namePrefix: production-
-commonLabels:
-  variant: production
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: production
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
 resources:

--- a/examples/zh/springboot.md
+++ b/examples/zh/springboot.md
@@ -163,8 +163,10 @@ kustomize build $DEMO_HOME | grep prod-
 <!-- @customizeLabels @testAgainstLatestRelease -->
 ```
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
-commonLabels:
-  env: prod
+labels:
+- includeSelectors: true
+  pairs:
+    env: prod
 EOF
 ```
 

--- a/examples/zh/transformerconfigs.md
+++ b/examples/zh/transformerconfigs.md
@@ -73,9 +73,11 @@ labels transformer 将 labels 添加到所有资源的 `metadata/labels` 字段�
 示例：
 
 ```yaml
-commonLabels:
-- path: metadata/labels
-  create: true
+labels:
+- includeSelectors: true
+  pairs:
+    path: metadata/labels
+    create: true
 
 - path: spec/selector
   create: true
@@ -90,10 +92,12 @@ commonLabels:
 kustomization.yaml 示例:
 
 ```yaml
-commonLabels:
-  someName: someValue
-  owner: alice
-  app: bingo
+labels:
+- includeSelectors: true
+  pairs:
+    someName: someValue
+    owner: alice
+    app: bingo
 ```
 
 ## Annotations transformer


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/kustomize/issues/5653. 
Replace `commonLables` inside example directory with `lables` to avoid deprecated message.