### PR TITLE
fix: include label in templates when adding by cli

### DIFF
--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -116,6 +116,9 @@ func (o *addMetadataOptions) validateAndParse(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("must specify %s", o.kind)
 	}
+	if !o.labelsWithoutSelector && o.includeTemplates {
+		return fmt.Errorf("--without-selector flag must be specified for --include-templates to work")
+	}
 	m, err := util.ConvertSliceToMap(args, o.kind.String())
 	if err != nil {
 		return err

--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -39,6 +39,7 @@ type addMetadataOptions struct {
 	mapValidator          func(map[string]string) error
 	kind                  kindOfAdd
 	labelsWithoutSelector bool
+	includeTemplates      bool
 }
 
 // newCmdAddAnnotation adds one or more commonAnnotations to the kustomization file.
@@ -82,6 +83,9 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	)
 	cmd.Flags().BoolVar(&o.labelsWithoutSelector, "without-selector", false,
 		"using add labels without selector option",
+	)
+	cmd.Flags().BoolVar(&o.includeTemplates, "include-templates", false,
+		"include labels in templates (requires --without-selector)",
 	)
 	return cmd
 }
@@ -132,7 +136,11 @@ func (o *addMetadataOptions) addAnnotations(m *types.Kustomization) error {
 
 func (o *addMetadataOptions) addLabels(m *types.Kustomization) error {
 	if o.labelsWithoutSelector {
-		m.Labels = append(m.Labels, types.Label{Pairs: make(map[string]string), IncludeSelectors: false})
+		m.Labels = append(m.Labels, types.Label{
+			Pairs:            make(map[string]string),
+			IncludeSelectors: false,
+			IncludeTemplates: o.includeTemplates,
+		})
 		return o.writeToMap(m.Labels[len(m.Labels)-1].Pairs, label)
 	}
 	if m.CommonLabels == nil {

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -294,6 +294,19 @@ func TestAddLabelWithoutSelectorIncludeTemplates(t *testing.T) {
 	assert.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"new": "label"}, IncludeTemplates: true})
 }
 
+func TestAddLabelIncludeTemplatesWithoutRequiredFlag(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	v := valtest_test.MakeHappyMapValidator(t)
+	cmd := newCmdAddLabel(fSys, v.Validator)
+	args := []string{"new:label"}
+	_ = cmd.Flag("include-templates").Value.Set("true")
+	_ = cmd.Flag("without-selector").Value.Set("false")
+	err := cmd.RunE(cmd, args)
+	v.VerifyNoCall()
+	require.Error(t, err)
+	require.Containsf(t, err.Error(), "--without-selector flag must be specified for --include-templates to work", "incorrect error: %s", err.Error())
+}
+
 func TestAddLabelWithoutSelectorAddLabel(t *testing.T) {
 	var o addMetadataOptions
 	o.metadata = map[string]string{"owls": "cute", "otters": "adorable"}

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -284,6 +284,16 @@ func TestAddLabelWithoutSelector(t *testing.T) {
 	assert.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"new": "label"}})
 }
 
+func TestAddLabelWithoutSelectorIncludeTemplates(t *testing.T) {
+	var o addMetadataOptions
+	o.labelsWithoutSelector = true
+	m := makeKustomization(t)
+	o.metadata = map[string]string{"new": "label"}
+	o.includeTemplates = true
+	require.NoError(t, o.addLabels(m))
+	assert.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"new": "label"}, IncludeTemplates: true})
+}
+
 func TestAddLabelWithoutSelectorAddLabel(t *testing.T) {
 	var o addMetadataOptions
 	o.metadata = map[string]string{"owls": "cute", "otters": "adorable"}


### PR DESCRIPTION
Related to this comment: https://github.com/kubernetes-sigs/kustomize/issues/1009#issuecomment-1607147158

added `--include-templates` to add labels to templates when using `kustomize edit add label`