### PR TITLE
Pin kustomize image in cockroachdb example

### DIFF
--- a/functions/examples/template-heredoc-cockroachdb/Makefile
+++ b/functions/examples/template-heredoc-cockroachdb/Makefile
@@ -1,11 +1,27 @@
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: image
+# This example uses a pinned version of the kustomize image, as an example of
+# what users should do downstream, to ensure supply chain security.
+#
+# Whenever KUSTOMIZE_IMAGE_TAG & KUSTOMIZE_IMAGE_SHA are updated,
+# EXAMPLE_IMAGE_TAG should also be updated to a new patch version.
+# For reference, see
+# https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-kustomize/images.yaml
+EXAMPLE_IMAGE_TAG=v0.1.1
+KUSTOMIZE_IMAGE_TAG=v5.4.1
+KUSTOMIZE_IMAGE_SHA=sha256:7492c35d6fbe64e05100009915167a37b285ca7391067fa0c7bec9a7d1856882
 
 all:
 	true
 
-image:
-	docker build image -t gcr.io/kustomize-functions/example-cockroachdb:v0.1.0
-	docker push gcr.io/kustomize-functions/example-cockroachdb:v0.1.0
+.PHONY: image-build
+image-build:
+	docker build image \
+		--build-arg "KUSTOMIZE_IMAGE_TAG=$(KUSTOMIZE_IMAGE_TAG)" \
+		--build-arg "KUSTOMIZE_IMAGE_SHA=$(KUSTOMIZE_IMAGE_SHA)" \
+		-t gcr.io/kustomize-functions/example-cockroachdb:$(EXAMPLE_IMAGE_TAG)
+
+.PHONY: image
+image: image-build
+	docker push gcr.io/kustomize-functions/example-cockroachdb:$(EXAMPLE_IMAGE_TAG)

--- a/functions/examples/template-heredoc-cockroachdb/image/Dockerfile
+++ b/functions/examples/template-heredoc-cockroachdb/image/Dockerfile
@@ -1,12 +1,10 @@
 # Copyright 2019 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.21-bullseye
-ENV CGO_ENABLED=0
-RUN go get -v sigs.k8s.io/kustomize/kustomize
+ARG KUSTOMIZE_IMAGE_TAG
+ARG KUSTOMIZE_IMAGE_SHA
 
-FROM alpine:latest
+FROM registry.k8s.io/kustomize/kustomize:${KUSTOMIZE_IMAGE_TAG}@${KUSTOMIZE_IMAGE_SHA}
 RUN apk add --no-cache bash
-COPY --from=0 /go/bin/kustomize /usr/local/bin
 COPY cockroachdb-template.sh /usr/local/bin/config-function
 CMD ["config-function"]


### PR DESCRIPTION
- Pin to v5.4.1 with sha256 as example of how to ensure supply-chain security. Pulling the latest kustomize image or source is insecure without checksum validation.
- Bump example image tag to v0.1.1

This PR supersedes https://github.com/kubernetes-sigs/kustomize/pull/5534