### PR TITLE
fix(namereference): add configuration for new admission API

### DIFF
--- a/api/internal/konfig/builtinpluginconsts/namereference.go
+++ b/api/internal/konfig/builtinpluginconsts/namereference.go
@@ -421,6 +421,13 @@ nameReference:
   fieldSpecs:
   - path: spec/ingressClassName
     kind: Ingress
+
+- kind: ValidatingAdmissionPolicy
+  group: admissionregistration.k8s.io
+  fieldSpecs:
+  - path: spec/policyName
+    kind: ValidatingAdmissionPolicyBinding
+    group: admissionregistration.k8s.io
 `
 )
 


### PR DESCRIPTION
Include configuration for the new `ValidatingAdmissionPolicy` and `ValidationAdmissionPolicyBinding` APIs so that Kustomize can natively configure the `policyName` field in `ValidatingAdmissionPolicyBinding` with the transformed name of `ValidatingAdmissionPolicy`.

Fixes #5674