### PR TITLE
chore: add deprecation comment to commonLabels

### DIFF
--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -55,6 +55,7 @@ type Kustomization struct {
 	// Namespace to add to all objects.
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
+	// Deprecated: Use the Labels field instead, which provides a superset of the functionality of CommonLabels.
 	// CommonLabels to add to all objects and selectors.
 	CommonLabels map[string]string `json:"commonLabels,omitempty" yaml:"commonLabels,omitempty"`
 


### PR DESCRIPTION
`commonLabels` is deprecated, but the field did not have a deprecation comment, like other fields do. Add the deprecation comment, as some IDEs use that as a guideline to show a strikethrough in the field names (and to follow the pattern of other deprecated fields).

/kind documentation