### PR TITLE
fix:kustomize cfg grep with no arguments causes panic

### DIFF
--- a/cmd/config/internal/commands/grep.go
+++ b/cmd/config/internal/commands/grep.go
@@ -54,6 +54,9 @@ type GrepRunner struct {
 }
 
 func (r *GrepRunner) preRunE(c *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing required argument: QUERY")
+	}
 	r.GrepFilter.Compare = func(a, b string) (int, error) {
 		qa, err := resource.ParseQuantity(a)
 		if err != nil {

--- a/cmd/config/internal/commands/grep_test.go
+++ b/cmd/config/internal/commands/grep_test.go
@@ -421,3 +421,17 @@ spec:
 		})
 	}
 }
+
+// TestGrepCmd_noQuery verifies the grep command errors when QUERY argument is missing
+func TestGrepCmd_noQuery(t *testing.T) {
+	b := &bytes.Buffer{}
+	r := commands.GetGrepRunner("")
+	// No QUERY argument
+	r.Command.SetArgs([]string{})
+	r.Command.SetOut(b)
+
+	err := r.Command.Execute()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "missing required argument: QUERY")
+	}
+}


### PR DESCRIPTION
- Before the Fix

```
➜  ✗ kustomize cfg grep                                
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
sigs.k8s.io/kustomize/cmd/config/internal/commands.(*GrepRunner).preRunE(0x104cf5ad0?, 0x0?, {0x105ac5f68?, 0x104cf0f8c?, 0x1400018bd00?})
          /Users/denniszh/kustomize/cmd/config/internal/commands/grep.go:69 +0x3bc
github.com/spf13/cobra.(*Command).execute(0x14000287b08, {0x105ac5f68, 0x0, 0x0})
        /Users/denniszh/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:968 +0x7e8
github.com/spf13/cobra.(*Command).ExecuteC(0x140001e2608)
         /Users/denniszh/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(0x1059bbfa8?)
        /Users/denniszh/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
main.main()
       /Users/denniszh/kustomize/kustomize/main.go:14 +0x20
```

- After the Fix
 ```
➜ ✗ kustomize cfg grep
Error: missing required argument: QUERY
Usage:
  kustomize cfg grep QUERY [DIR] [flags]

Examples:

    # find Deployment Resources
    kustomize cfg grep "kind=Deployment" my-dir/

    # find Resources named nginx
    kustomize cfg grep "metadata.name=nginx" my-dir/

    # use tree to display matching Resources
    kustomize cfg grep "metadata.name=nginx" my-dir/ | kustomize cfg tree

    # look for Resources matching a specific container image
    kustomize cfg grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" my-dir/ | kustomize cfg tree

Flags:
      --annotate              annotate resources with their file origins. (default true)
  -h, --help                  help for grep
      --invert-match          Selected Resources are those not matching any of the specified patterns..
  -R, --recurse-subpackages   also print resources recursively in all the nested subpackages (default true)

Global Flags:
      --stack-trace   print a stack-trace on error
```

Fixes: #5701 