### PR TITLE
Remove misleading documentation about config generation

### DIFF
--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -113,9 +113,7 @@ configuration is to
     the appropriate `configMapKeyRef` field.
 
 This latter change initiates rolling update to the pods
-in the deployment. The older ConfigMap, when no longer
-referenced by any other resource, is eventually [garbage
-collected](/../../issues/242).
+in the deployment.
 
 ### How this works with kustomize
 


### PR DESCRIPTION
/kind cleanup

Follow-up to #3146, cleaning examples as well.

(Note that this files appeart pretty high in search results when looking for "kustomize configmap generation", so I guess I'm not the first one to be confused ^)
