### PR TITLE
feat: add support to set labels without selector

### DIFF
--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -70,7 +70,7 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	o.mapValidator = v
 	cmd := &cobra.Command{
 		Use: "label",
-		Short: "Adds one or more commonLabels to " +
+		Short: "Adds one or more commonLabels or labels to " +
 			konfig.DefaultKustomizationFileName(),
 		Example: `
 		add label {labelKey1:labelValue1} {labelKey2:labelValue2}`,

--- a/kustomize/commands/edit/set/setlabel.go
+++ b/kustomize/commands/edit/set/setlabel.go
@@ -85,9 +85,8 @@ func (o *setLabelOptions) validateAndParse(args []string) error {
 }
 
 func (o *setLabelOptions) setLabels(m *types.Kustomization) error {
+	o.removeDuplicateLabels(m)
 	if o.labelsWithoutSelector {
-		o.removeDuplicateLabels(m)
-
 		var labelPairs *types.Label
 		for _, label := range m.Labels {
 			if !label.IncludeSelectors && label.IncludeTemplates == o.includeTemplates {
@@ -131,12 +130,8 @@ func (o *setLabelOptions) removeDuplicateLabels(m *types.Kustomization) {
 		// delete duplicate label from deprecated common labels
 		delete(m.CommonLabels, k)
 		for idx, label := range m.Labels {
-			// delete label if it's already present in labels with mismatched includeTemplates value
-			if label.IncludeTemplates != o.includeTemplates {
-				m.Labels = deleteLabel(k, label, m.Labels, idx)
-			}
-			if label.IncludeSelectors {
-				// delete label if it's already present in labels and includes selectors
+			// delete label if it's already present in labels
+			if _, found := label.Pairs[k]; found {
 				m.Labels = deleteLabel(k, label, m.Labels, idx)
 			}
 		}

--- a/kustomize/commands/edit/set/setlabel.go
+++ b/kustomize/commands/edit/set/setlabel.go
@@ -15,8 +15,10 @@ import (
 )
 
 type setLabelOptions struct {
-	metadata     map[string]string
-	mapValidator func(map[string]string) error
+	metadata              map[string]string
+	mapValidator          func(map[string]string) error
+	labelsWithoutSelector bool
+	includeTemplates      bool
 }
 
 // newCmdSetLabel sets one or more commonLabels to the kustomization file.
@@ -25,7 +27,7 @@ func newCmdSetLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	o.mapValidator = v
 	cmd := &cobra.Command{
 		Use: "label",
-		Short: "Sets one or more commonLabels in " +
+		Short: "Sets one or more commonLabels or labels in " +
 			konfig.DefaultKustomizationFileName(),
 		Example: `
 		set label {labelKey1:labelValue1} {labelKey2:labelValue2}`,
@@ -33,6 +35,12 @@ func newCmdSetLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 			return o.runE(args, fSys, o.setLabels)
 		},
 	}
+	cmd.Flags().BoolVar(&o.labelsWithoutSelector, "without-selector", false,
+		"using set labels without selector option",
+	)
+	cmd.Flags().BoolVar(&o.includeTemplates, "include-templates", false,
+		"include labels in templates (requires --without-selector)",
+	)
 	return cmd
 }
 
@@ -62,6 +70,9 @@ func (o *setLabelOptions) validateAndParse(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("must specify label")
 	}
+	if !o.labelsWithoutSelector && o.includeTemplates {
+		return fmt.Errorf("--without-selector flag must be specified for --include-templates to work")
+	}
 	m, err := util.ConvertSliceToMap(args, "label")
 	if err != nil {
 		return err
@@ -74,9 +85,36 @@ func (o *setLabelOptions) validateAndParse(args []string) error {
 }
 
 func (o *setLabelOptions) setLabels(m *types.Kustomization) error {
+	if o.labelsWithoutSelector {
+		o.removeDuplicateLabels(m)
+
+		var labelPairs *types.Label
+		for _, label := range m.Labels {
+			if !label.IncludeSelectors && label.IncludeTemplates == o.includeTemplates {
+				labelPairs = &label
+				break
+			}
+		}
+
+		if labelPairs != nil {
+			if labelPairs.Pairs == nil {
+				labelPairs.Pairs = make(map[string]string)
+			}
+			return o.writeToMap(labelPairs.Pairs)
+		}
+
+		m.Labels = append(m.Labels, types.Label{
+			Pairs:            make(map[string]string),
+			IncludeSelectors: false,
+			IncludeTemplates: o.includeTemplates,
+		})
+		return o.writeToMap(m.Labels[len(m.Labels)-1].Pairs)
+	}
+
 	if m.CommonLabels == nil {
 		m.CommonLabels = make(map[string]string)
 	}
+
 	return o.writeToMap(m.CommonLabels)
 }
 
@@ -85,4 +123,32 @@ func (o *setLabelOptions) writeToMap(m map[string]string) error {
 		m[k] = v
 	}
 	return nil
+}
+
+// removeDuplicateLabels removes duplicate labels from commonLabels or labels
+func (o *setLabelOptions) removeDuplicateLabels(m *types.Kustomization) {
+	for k := range o.metadata {
+		// delete duplicate label from deprecated common labels
+		delete(m.CommonLabels, k)
+		for idx, label := range m.Labels {
+			// delete label if it's already present in labels with mismatched includeTemplates value
+			if label.IncludeTemplates != o.includeTemplates {
+				m.Labels = deleteLabel(k, label, m.Labels, idx)
+			}
+			if label.IncludeSelectors {
+				// delete label if it's already present in labels and includes selectors
+				m.Labels = deleteLabel(k, label, m.Labels, idx)
+			}
+		}
+	}
+}
+
+// deleteLabel deletes label from types.Label
+func deleteLabel(key string, label types.Label, labels []types.Label, idx int) []types.Label {
+	delete(label.Pairs, key)
+	if len(label.Pairs) == 0 {
+		// remove empty map label.Pairs from labels
+		labels = append(labels[:idx], labels[idx+1:]...)
+	}
+	return labels
 }

--- a/kustomize/commands/edit/set/setlabel_test.go
+++ b/kustomize/commands/edit/set/setlabel_test.go
@@ -210,3 +210,20 @@ func TestSetLabelWithoutSelectorWithCommonLabel(t *testing.T) {
 	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld", "key1": "foo"})
 	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key2": "bar"}})
 }
+
+func TestSetLabelCommonLabelWithWithoutSelector(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+
+	m := makeKustomization(t)
+	o.labelsWithoutSelector = true
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar"}})
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld"})
+
+	o.metadata = map[string]string{"key2": "bar2"}
+	o.labelsWithoutSelector = false
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo"}})
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld", "key2": "bar2"})
+}


### PR DESCRIPTION
Tries to solve issue: https://github.com/kubernetes-sigs/kustomize/issues/3866

Based on existing feature merged in https://github.com/kubernetes-sigs/kustomize/pull/4486, uses same command flags with `edit set label`
Set label removes existing duplicate labels from commonLabels, and labels where includeTemplates value does not match.

Duplicate of https://github.com/kubernetes-sigs/kustomize/pull/4478, added modifications to command flags and test
