### PR TITLE
chore: add bad-credentials exception for install script

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -141,6 +141,10 @@ else
     releases=$(curl -s "$release_url" --header "Authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
+if [[ $releases == *"Bad credentials"* ]]; then
+  echo "Authentication failed: Invalid GITHUB_TOKEN. Please check or remove your token."
+  exit 1
+fi  
 if [[ $releases == *"API rate limit exceeded"* ]]; then
   echo "Github rate-limiter failed the request. Either authenticate or wait a couple of minutes."
   exit 1


### PR DESCRIPTION
closes #5755 

Improved error handling for cases where the GITHUB_TOKEN is invalid or expired. The `install_kustomize.sh` script now provides a clear message when authentication fails due to token issues. 