### PR TITLE
Docs: fix kubectl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This tool is sponsored by [sig-cli] ([KEP]).
 To find the kustomize version embedded in recent versions of kubectl, run `kubectl version`:
 
 ```sh
-> kubectl version --short --client
-Client Version: v1.26.0
-Kustomize Version: v4.5.7
+> kubectl version --client
+Client Version: v1.31.0
+Kustomize Version: v5.4.2
 ```
 
 The kustomize build flow at [v2.0.3] was added


### PR DESCRIPTION
### Description

Docs: fix the `kubectl` command shown in the homepage.

### Motivation

Ever since: https://github.com/kubernetes/kubectl/commit/e0816cbaa1cee5556e27ee148e6307c9c1224b28, the `--short` flag has been removed. Running commands with this flag now results in an error:
```sh
❯ kubectl version --client
Client Version: v1.31.0
Kustomize Version: v5.4.2
❯ kubectl version --short --client
error: unknown flag: --short
See 'kubectl version --help' for usage.
```
