### PR TITLE
add write permission to run release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  contents: write # Allow actions to update dependabot PRs
+
 on:
   push:
     tags:


### PR DESCRIPTION
It looks like the GitHub action started to require a new parameter that is related to permission.
https://github.com/kubernetes-sigs/kustomize/actions/runs/11055955792/job/30717021189

<img width="1465" alt="Screenshot 2024-09-27 at 3 01 38" src="https://github.com/user-attachments/assets/3c45399c-4be2-49f3-b7b4-0526171848e5">

ref: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5106/files
