### PR TITLE
fix: Allow patches with empty files with multiple newlines or comments

### DIFF
--- a/api/internal/builtins/PatchTransformer.go
+++ b/api/internal/builtins/PatchTransformer.go
@@ -56,8 +56,9 @@ func (p *PatchTransformerPlugin) Config(h *resmap.PluginHelpers, c []byte) error
 	patchesSM, errSM := h.ResmapFactory().RF().SliceFromBytes([]byte(p.patchText))
 	patchesJson, errJson := jsonPatchFromBytes([]byte(p.patchText))
 
-	if (errSM == nil && errJson == nil) ||
-		(patchesSM != nil && patchesJson != nil) {
+	if ((errSM == nil && errJson == nil) ||
+		(patchesSM != nil && patchesJson != nil)) &&
+		(len(patchesSM) > 0 && len(patchesJson) > 0) {
 		return fmt.Errorf(
 			"illegally qualifies as both an SM and JSON patch: %s",
 			p.patchSource)

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -59,8 +59,9 @@ func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 	patchesSM, errSM := h.ResmapFactory().RF().SliceFromBytes([]byte(p.patchText))
 	patchesJson, errJson := jsonPatchFromBytes([]byte(p.patchText))
 
-	if (errSM == nil && errJson == nil) ||
-		(patchesSM != nil && patchesJson != nil) {
+	if ((errSM == nil && errJson == nil) ||
+		(patchesSM != nil && patchesJson != nil)) &&
+		(len(patchesSM) > 0 && len(patchesJson) > 0) {
 		return fmt.Errorf(
 			"illegally qualifies as both an SM and JSON patch: %s",
 			p.patchSource)

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -1126,6 +1126,7 @@ path: patch.yaml
 target:
   name: myDeploy
 `, someDeploymentResources, func(t *testing.T, err error) {
+		t.Helper()
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}
@@ -1152,6 +1153,7 @@ path: patch.yaml
 target:
   name: myDeploy
 `, someDeploymentResources, func(t *testing.T, err error) {
+		t.Helper()
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -1114,7 +1114,17 @@ func TestPatchTransformerPatchEmpty(t *testing.T) {
 		PrepBuiltin("PatchTransformer")
 	defer th.Reset()
 
+	th.WriteF("patch.yaml", `
+  `)
+
 	th.RunTransformerAndCheckError(`
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: notImportantHere
+path: patch.yaml
+target:
+  name: myDeploy
 `, someDeploymentResources, func(t *testing.T, err error) {
 		if err != nil {
 			t.Fatalf("unexpected error")
@@ -1127,10 +1137,20 @@ func TestPatchTransformerPatchEmptyOnlyComments(t *testing.T) {
 		PrepBuiltin("PatchTransformer")
 	defer th.Reset()
 
-	th.RunTransformerAndCheckError(`
+	th.WriteF("patch.yaml", `
 # File with only comments
 
 # Is a virtually empty yaml
+`)
+
+	th.RunTransformerAndCheckError(`
+apiVersion: builtin
+kind: PatchTransformer
+metadata:
+  name: notImportantHere
+path: patch.yaml
+target:
+  name: myDeploy
 `, someDeploymentResources, func(t *testing.T, err error) {
 		if err != nil {
 			t.Fatalf("unexpected error")

--- a/plugin/builtin/patchtransformer/PatchTransformer_test.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer_test.go
@@ -1108,3 +1108,32 @@ spec:
         name: test-deployment
 `)
 }
+
+func TestPatchTransformerPatchEmpty(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckError(`
+`, someDeploymentResources, func(t *testing.T, err error) {
+		if err != nil {
+			t.Fatalf("unexpected error")
+		}
+	})
+}
+
+func TestPatchTransformerPatchEmptyOnlyComments(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("PatchTransformer")
+	defer th.Reset()
+
+	th.RunTransformerAndCheckError(`
+# File with only comments
+
+# Is a virtually empty yaml
+`, someDeploymentResources, func(t *testing.T, err error) {
+		if err != nil {
+			t.Fatalf("unexpected error")
+		}
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kustomize/issues/5487

Right now, when a file is empty, the patches given by the resmap (sm patches) or the jsonpatch is nil. When the file has only comments in it (virtually empty if we think about changes to be made) or multiple newlines, the result given by said functions is an empty slice.

I've changed the check for when we can't allow to have a patch that is valid for both SM and JSON, so it allows empty changes (both nil or empty slices).

Extra comments:
- I think that it'd be better to change the functions and return a nil object, instead of an empty slice, but I'm unsure on where to do those changes.
- Also, I can't make the tests to run locally as they complain for the content file to be empty, and that should not be the case as it's perfectly ok for the built binary to use empty patches.

I'll be more than happy to work on these two with some help or guidance.