### PR TITLE
add ability to change MergeOptions for Patch Strategic Merge

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge.go
@@ -4,13 +4,15 @@
 package patchstrategicmerge
 
 import (
+	"cmp"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
 )
 
 type Filter struct {
-	Patch *yaml.RNode
+	Patch        *yaml.RNode
+	MergeOptions *yaml.MergeOptions
 }
 
 var _ kio.Filter = Filter{}
@@ -18,12 +20,13 @@ var _ kio.Filter = Filter{}
 // Filter does a strategic merge patch, which can delete nodes.
 func (pf Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	var result []*yaml.RNode
+	mergeOptions := *cmp.Or(pf.MergeOptions, &yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+	})
 	for i := range nodes {
 		r, err := merge2.Merge(
 			pf.Patch, nodes[i],
-			yaml.MergeOptions{
-				ListIncreaseDirection: yaml.MergeOptionsListPrepend,
-			},
+			mergeOptions,
 		)
 		if err != nil {
 			return nil, err

--- a/api/internal/builtins/PatchStrategicMergeTransformer.go
+++ b/api/internal/builtins/PatchStrategicMergeTransformer.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -16,6 +17,7 @@ type PatchStrategicMergeTransformerPlugin struct {
 	loadedPatches []*resource.Resource
 	Paths         []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
 	Patches       string                      `json:"patches,omitempty" yaml:"patches,omitempty"`
+	MergeOptions  *kyaml.MergeOptions         `json:"mergeOptions,omitempty" yaml:"mergeOptions,omitempty"`
 }
 
 func (p *PatchStrategicMergeTransformerPlugin) Config(
@@ -44,6 +46,9 @@ func (p *PatchStrategicMergeTransformerPlugin) Config(
 	if len(p.loadedPatches) == 0 {
 		return fmt.Errorf(
 			"patch appears to be empty; files=%v, Patch=%s", p.Paths, p.Patches)
+	}
+	for i := range p.loadedPatches {
+		p.loadedPatches[i].MergeOptions = p.MergeOptions
 	}
 	return nil
 }

--- a/api/internal/builtins/PatchTransformer.go
+++ b/api/internal/builtins/PatchTransformer.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -23,11 +24,12 @@ type PatchTransformerPlugin struct {
 	// patchText is pure patch text created by Path or Patch
 	patchText string
 	// patchSource is patch source message
-	patchSource string
-	Path        string          `json:"path,omitempty"    yaml:"path,omitempty"`
-	Patch       string          `json:"patch,omitempty"   yaml:"patch,omitempty"`
-	Target      *types.Selector `json:"target,omitempty"  yaml:"target,omitempty"`
-	Options     map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
+	patchSource  string
+	Path         string              `json:"path,omitempty"    yaml:"path,omitempty"`
+	Patch        string              `json:"patch,omitempty"   yaml:"patch,omitempty"`
+	Target       *types.Selector     `json:"target,omitempty"  yaml:"target,omitempty"`
+	Options      map[string]bool     `json:"options,omitempty" yaml:"options,omitempty"`
+	MergeOptions *kyaml.MergeOptions `json:"MergeOptions,omitempty" yaml:"MergeOptions,omitempty"`
 }
 
 func (p *PatchTransformerPlugin) Config(h *resmap.PluginHelpers, c []byte) error {
@@ -75,6 +77,7 @@ func (p *PatchTransformerPlugin) Config(h *resmap.PluginHelpers, c []byte) error
 			if p.Options["allowKindChange"] {
 				loadedPatch.AllowKindChange()
 			}
+			loadedPatch.MergeOptions = p.MergeOptions
 		}
 	} else {
 		p.jsonPatches = patchesJson

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -36,6 +37,7 @@ type KustTarget struct {
 	rFactory      *resmap.Factory
 	pLdr          *loader.Loader
 	origin        *resource.Origin
+	mergeOptions  *kyaml.MergeOptions
 }
 
 // NewKustTarget returns a new instance of KustTarget.
@@ -43,12 +45,14 @@ func NewKustTarget(
 	ldr ifc.Loader,
 	validator ifc.Validator,
 	rFactory *resmap.Factory,
-	pLdr *loader.Loader) *KustTarget {
+	pLdr *loader.Loader,
+	mOpts *kyaml.MergeOptions) *KustTarget {
 	return &KustTarget{
-		ldr:       ldr,
-		validator: validator,
-		rFactory:  rFactory,
-		pLdr:      pLdr.LoaderWithWorkingDir(ldr.Root()),
+		ldr:          ldr,
+		validator:    validator,
+		rFactory:     rFactory,
+		pLdr:         pLdr.LoaderWithWorkingDir(ldr.Root()),
+		mergeOptions: mOpts,
 	}
 }
 
@@ -488,7 +492,7 @@ func (kt *KustTarget) accumulateComponents(
 func (kt *KustTarget) accumulateDirectory(
 	ra *accumulator.ResAccumulator, ldr ifc.Loader, isComponent bool) (*accumulator.ResAccumulator, error) {
 	defer ldr.Cleanup()
-	subKt := NewKustTarget(ldr, kt.validator, kt.rFactory, kt.pLdr)
+	subKt := NewKustTarget(ldr, kt.validator, kt.rFactory, kt.pLdr, kt.mergeOptions)
 	err := subKt.Load()
 	if err != nil {
 		return nil, errors.WrapPrefixf(

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -232,9 +232,11 @@ var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 			return
 		}
 		var c struct {
-			Paths []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
+			Paths        []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
+			MergeOptions *yaml.MergeOptions          `json:"mergeOptions,omitempty" yaml:"mergeOptions,omitempty"`
 		}
 		c.Paths = kt.kustomization.PatchesStrategicMerge
+		c.MergeOptions = kt.mergeOptions
 		p := f()
 		err = kt.configureBuiltinPlugin(p, c, bpt)
 		if err != nil {
@@ -250,16 +252,18 @@ var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 			return
 		}
 		var c struct {
-			Path    string          `json:"path,omitempty" yaml:"path,omitempty"`
-			Patch   string          `json:"patch,omitempty" yaml:"patch,omitempty"`
-			Target  *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
-			Options map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
+			Path         string             `json:"path,omitempty" yaml:"path,omitempty"`
+			Patch        string             `json:"patch,omitempty" yaml:"patch,omitempty"`
+			Target       *types.Selector    `json:"target,omitempty" yaml:"target,omitempty"`
+			Options      map[string]bool    `json:"options,omitempty" yaml:"options,omitempty"`
+			MergeOptions *yaml.MergeOptions `json:"mergeOptions,omitempty" yaml:"mergeOptions,omitempty"`
 		}
 		for _, pc := range kt.kustomization.Patches {
 			c.Target = pc.Target
 			c.Patch = pc.Patch
 			c.Path = pc.Path
 			c.Options = pc.Options
+			c.MergeOptions = kt.mergeOptions
 			p := f()
 			err = kt.configureBuiltinPlugin(p, c, bpt)
 			if err != nil {

--- a/api/internal/target/maker_test.go
+++ b/api/internal/target/maker_test.go
@@ -4,6 +4,7 @@
 package target_test
 
 import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/ifc"
@@ -68,5 +69,8 @@ func makeKustTargetWithRfAndLoaderOverride(
 		ldr,
 		valtest_test.MakeFakeValidator(),
 		rf,
-		pLdr.NewLoader(pc, rf, fSys))
+		pLdr.NewLoader(pc, rf, fSys),
+		&yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		})
 }

--- a/api/krusty/baseandoverlaymedium_test.go
+++ b/api/krusty/baseandoverlaymedium_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func writeMediumBase(th kusttest_test.Harness) {
@@ -232,6 +233,202 @@ spec:
               name: test-infra-app-env-8h5mh7f7ch
         - name: foo
           value: bar
+        image: nginx:1.8.0
+        name: nginx
+        ports:
+        - containerPort: 80
+      - envFrom:
+        - configMapRef:
+            name: someConfigMap
+        - configMapRef:
+            name: test-infra-app-env-8h5mh7f7ch
+        image: busybox
+        name: busybox
+        volumeMounts:
+        - mountPath: /tmp/env
+          name: app-env
+      volumes:
+      - configMap:
+          name: test-infra-app-env-8h5mh7f7ch
+        name: app-env
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    baseAnno: This is a base annotation
+    note: This is a test annotation
+  labels:
+    app: mungebot
+    foo: bar
+    org: kubernetes
+    repo: test-infra
+  name: test-infra-baseprefix-mungebot-service
+spec:
+  ports:
+  - port: 7002
+  selector:
+    app: mungebot
+    foo: bar
+    org: kubernetes
+    repo: test-infra
+---
+apiVersion: v1
+data:
+  DB_PASSWORD: somepw
+  DB_USERNAME: admin
+  ENERGY: electronvolt
+  FRUIT: banana
+  LEGUME: chickpea
+  LENGTH: kilometer
+kind: ConfigMap
+metadata:
+  annotations:
+    note: This is a test annotation
+  labels:
+    app: mungebot
+    org: kubernetes
+    repo: test-infra
+  name: test-infra-app-env-8h5mh7f7ch
+---
+apiVersion: v1
+data:
+  nonsense: "Lorem ipsum dolor sit amet, consectetur\nadipiscing elit, sed do eiusmod
+    tempor\nincididunt ut labore et dolore magna aliqua. \n"
+kind: ConfigMap
+metadata:
+  annotations:
+    note: This is a test annotation
+  labels:
+    app: mungebot
+    org: kubernetes
+    repo: test-infra
+  name: test-infra-app-config-49d6f5h7b5
+`)
+}
+
+func TestMediumOverlayMergeOptionsListAppend(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	writeMediumBase(th)
+	th.WriteK("overlay", `
+namePrefix: test-infra-
+commonLabels:
+  app: mungebot
+  org: kubernetes
+  repo: test-infra
+commonAnnotations:
+  note: This is a test annotation
+resources:
+- ../base
+patchesStrategicMerge:
+- deployment/deployment.yaml
+configMapGenerator:
+- name: app-env
+  envs:
+  - configmap/db.env
+  - configmap/units.ini
+  - configmap/food.ini
+- name: app-config
+  files:
+  - nonsense=configmap/dummy.txt
+images:
+- name: nginx
+  newTag: 1.8.0`)
+
+	th.WriteF("overlay/configmap/db.env", `
+DB_USERNAME=admin
+DB_PASSWORD=somepw
+`)
+	th.WriteF("overlay/configmap/units.ini", `
+LENGTH=kilometer
+ENERGY=electronvolt
+`)
+	th.WriteF("overlay/configmap/food.ini", `
+FRUIT=banana
+LEGUME=chickpea
+`)
+	th.WriteF("overlay/configmap/dummy.txt",
+		`Lorem ipsum dolor sit amet, consectetur
+adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. 
+`)
+	th.WriteF("overlay/deployment/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mungebot
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        env:
+        - name: FOO
+          valueFrom:
+            configMapKeyRef:
+              name: app-env
+              key: somekey
+      - name: busybox
+        image: busybox
+        envFrom:
+        - configMapRef:
+            name: someConfigMap
+        - configMapRef:
+            name: app-env
+        volumeMounts:
+        - mountPath: /tmp/env
+          name: app-env
+      volumes:
+      - configMap:
+          name: app-env
+        name: app-env
+`)
+	options := th.MakeDefaultOptions()
+	options.MergeOptions.ListIncreaseDirection = yaml.MergeOptionsListAppend
+	m := th.Run("overlay", options)
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    baseAnno: This is a base annotation
+    note: This is a test annotation
+  labels:
+    app: mungebot
+    foo: bar
+    org: kubernetes
+    repo: test-infra
+  name: test-infra-baseprefix-mungebot
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: mungebot
+      foo: bar
+      org: kubernetes
+      repo: test-infra
+  template:
+    metadata:
+      annotations:
+        baseAnno: This is a base annotation
+        note: This is a test annotation
+      labels:
+        app: mungebot
+        foo: bar
+        org: kubernetes
+        repo: test-infra
+    spec:
+      containers:
+      - env:
+        - name: foo
+          value: bar
+        - name: FOO
+          valueFrom:
+            configMapKeyRef:
+              key: somekey
+              name: test-infra-app-env-8h5mh7f7ch
         image: nginx:1.8.0
         name: nginx
         ports:

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -70,6 +70,7 @@ func (b *Kustomizer) Run(
 		resmapFactory,
 		// The plugin configs are always located on disk, regardless of the fSys passed in
 		pLdr.NewLoader(b.options.PluginConfig, resmapFactory, filesys.MakeFsOnDisk()),
+		b.options.MergeOptions,
 	)
 	err = kt.Load()
 	if err != nil {

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -6,6 +6,7 @@ package krusty
 import (
 	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 type ReorderOption string
@@ -34,6 +35,9 @@ type Options struct {
 	//   select the appropriate default.
 	Reorder ReorderOption
 
+	// MergeOptions is a struct which contains the options for merge
+	MergeOptions *yaml.MergeOptions
+
 	// When true, a label
 	//     app.kubernetes.io/managed-by: kustomize-<version>
 	// is added to all the resources in the build out.
@@ -52,8 +56,11 @@ func MakeDefaultOptions() *Options {
 	return &Options{
 		Reorder:           ReorderOptionNone,
 		AddManagedbyLabel: false,
-		LoadRestrictions:  types.LoadRestrictionsRootOnly,
-		PluginConfig:      types.DisabledPluginConfig(),
+		MergeOptions: &yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+		LoadRestrictions: types.LoadRestrictionsRootOnly,
+		PluginConfig:     types.DisabledPluginConfig(),
 	}
 }
 

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -23,7 +23,8 @@ import (
 // paired with metadata used by kustomize.
 type Resource struct {
 	kyaml.RNode
-	refVarNames []string
+	refVarNames  []string
+	MergeOptions *kyaml.MergeOptions
 }
 
 var BuildAnnotations = []string{
@@ -147,7 +148,8 @@ type ResCtxMatcher func(ResCtx) bool
 // DeepCopy returns a new copy of resource
 func (r *Resource) DeepCopy() *Resource {
 	rc := &Resource{
-		RNode: *r.Copy(),
+		RNode:        *r.Copy(),
+		MergeOptions: r.MergeOptions,
 	}
 	rc.copyKustomizeSpecificFields(r)
 	return rc
@@ -495,7 +497,8 @@ func (r *Resource) ApplySmPatch(patch *Resource) error {
 		r.StorePreviousId()
 	}
 	if err := r.ApplyFilter(patchstrategicmerge.Filter{
-		Patch: &patch.RNode,
+		Patch:        &patch.RNode,
+		MergeOptions: patch.MergeOptions,
 	}); err != nil {
 		return err
 	}

--- a/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
+++ b/plugin/builtin/patchstrategicmergetransformer/PatchStrategicMergeTransformer.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -17,6 +18,7 @@ type plugin struct {
 	loadedPatches []*resource.Resource
 	Paths         []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
 	Patches       string                      `json:"patches,omitempty" yaml:"patches,omitempty"`
+	MergeOptions  *kyaml.MergeOptions         `json:"mergeOptions,omitempty" yaml:"mergeOptions,omitempty"`
 }
 
 var KustomizePlugin plugin //nolint:gochecknoglobals
@@ -47,6 +49,9 @@ func (p *plugin) Config(
 	if len(p.loadedPatches) == 0 {
 		return fmt.Errorf(
 			"patch appears to be empty; files=%v, Patch=%s", p.Paths, p.Patches)
+	}
+	for i := range p.loadedPatches {
+		p.loadedPatches[i].MergeOptions = p.MergeOptions
 	}
 	return nil
 }

--- a/plugin/builtin/patchtransformer/PatchTransformer.go
+++ b/plugin/builtin/patchtransformer/PatchTransformer.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -24,11 +25,12 @@ type plugin struct {
 	// patchText is pure patch text created by Path or Patch
 	patchText string
 	// patchSource is patch source message
-	patchSource string
-	Path        string          `json:"path,omitempty"    yaml:"path,omitempty"`
-	Patch       string          `json:"patch,omitempty"   yaml:"patch,omitempty"`
-	Target      *types.Selector `json:"target,omitempty"  yaml:"target,omitempty"`
-	Options     map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
+	patchSource  string
+	Path         string              `json:"path,omitempty"    yaml:"path,omitempty"`
+	Patch        string              `json:"patch,omitempty"   yaml:"patch,omitempty"`
+	Target       *types.Selector     `json:"target,omitempty"  yaml:"target,omitempty"`
+	Options      map[string]bool     `json:"options,omitempty" yaml:"options,omitempty"`
+	MergeOptions *kyaml.MergeOptions `json:"MergeOptions,omitempty" yaml:"MergeOptions,omitempty"`
 }
 
 var KustomizePlugin plugin //nolint:gochecknoglobals
@@ -78,6 +80,7 @@ func (p *plugin) Config(h *resmap.PluginHelpers, c []byte) error {
 			if p.Options["allowKindChange"] {
 				loadedPatch.AllowKindChange()
 			}
+			loadedPatch.MergeOptions = p.MergeOptions
 		}
 	} else {
 		p.jsonPatches = patchesJson


### PR DESCRIPTION
At the moment, we have the option to append/prepend elements in the Merge function (as seen in https://github.com/kubernetes-sigs/kustomize/pull/3048). However, Patch Strategic Merge currently lacks an alternative for prepending elements in a list. This pull request will add the option for Patch Strategic Merge to append elements while merging, and it will forward this option up to `krusty`.