### PR TITLE
remove unnecesary install command from Dockerfile

### DIFF
--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -7,7 +7,6 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 RUN mkdir /build
-RUN apk add --no-cache git
 ADD . /build/
 WORKDIR /build/kustomize
 RUN CGO_ENABLED=0 GO111MODULE=on go build \


### PR DESCRIPTION
There was an error in the Dockerfile and the container image release failed.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kustomize-push-images/1844009527502966784
