### PR TITLE
feat(cmd): add local-config annotation on create

### DIFF
--- a/api/konfig/general.go
+++ b/api/konfig/general.go
@@ -3,6 +3,10 @@
 
 package konfig
 
+import (
+	"sigs.k8s.io/kustomize/api/types"
+)
+
 // RecognizedKustomizationFileNames is a list of file names
 // that kustomize recognizes.
 // To avoid ambiguity, a kustomization directory may not
@@ -17,6 +21,18 @@ func RecognizedKustomizationFileNames() []string {
 
 func DefaultKustomizationFileName() string {
 	return RecognizedKustomizationFileNames()[0]
+}
+
+// DefaultKustomizationMetadata returns the default metadata
+// for a kustomization configuration.
+func DefaultKustomizationMetadata() *types.ObjectMeta {
+	defaultMetadata := &types.ObjectMeta{
+		Annotations: map[string]string{
+			IgnoredByKustomizeAnnotation: "true",
+		},
+	}
+
+	return defaultMetadata
 }
 
 const (

--- a/kustomize/commands/create/create.go
+++ b/kustomize/commands/create/create.go
@@ -133,6 +133,7 @@ func runCreate(opts createFlags, fSys filesys.FileSystem, rf *resource.Factory) 
 	if err != nil {
 		return err
 	}
+	m.MetaData = konfig.DefaultKustomizationMetadata()
 	m.Resources = resources
 	m.Namespace = opts.namespace
 	m.NamePrefix = opts.prefix

--- a/kustomize/commands/create/create_test.go
+++ b/kustomize/commands/create/create_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
@@ -132,6 +133,21 @@ func TestCreateWithNameSuffix(t *testing.T) {
 	if m.NameSuffix != "-foo" {
 		t.Errorf("want: -foo, got: %s", m.NameSuffix)
 	}
+}
+
+func TestCreateHasDefaultMetadata(t *testing.T) {
+	fSys := filesys.MakeEmptyDirInMemory()
+	fSys.WriteFile("foo.yaml", []byte(""))
+	fSys.WriteFile("bar.yaml", []byte(""))
+	opts := createFlags{resources: "foo.yaml,bar.yaml"}
+	err := runCreate(opts, fSys, factory)
+
+	require.NoErrorf(t, err, "unexpected cmd error: %v")
+
+	m := readKustomizationFS(t, fSys)
+	expected := konfig.DefaultKustomizationMetadata()
+
+	require.Truef(t, reflect.DeepEqual(m.MetaData, expected), "expected %v but got %v", expected, m.MetaData)
 }
 
 func writeDetectContent(fSys filesys.FileSystem) {


### PR DESCRIPTION
this adds a DefaultMetadata object in konfig that can be used when creating a new kustomization yaml that conforms with the best practice recommendations in the kustomize docs.

> The `Kustomization` config in a `kustomization.yaml`
> **SHOULD** contain this annotation so that tools know it is not intended to be sent to
> the Kubernetes api server.

resolves: #5746