### PR TITLE
chore: temporary dirs are created under PWD

### DIFF
--- a/kyaml/filesys/confirmeddir.go
+++ b/kyaml/filesys/confirmeddir.go
@@ -17,7 +17,8 @@ type ConfirmedDir string
 // The directory is cleaned, no symlinks, etc. so it's
 // returned as a ConfirmedDir.
 func NewTmpConfirmedDir() (ConfirmedDir, error) {
-	n, err := os.MkdirTemp("", "kustomize-")
+	currentDir, err := os.Getwd()
+	n, err := os.MkdirTemp(currentDir, ".kustomize-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Git can be configured per directory using the includeIf statement in ~/.gitconfig. This allows per-customer (if you have many clients for whom you work) ssh key.

Up to now, kustomize builds its yaml in /tmp/kustomize- prefixed directory. Per say, no .gitconfig on that directory.

This patch instructs kustomize to use $PWD/kustomize- prefixed directory.