### PR TITLE
fix: Don't panic on multiple $patch: delete strategic merge patches in a single patch file

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -181,6 +181,10 @@ func (m *resWrangler) GetMatchingResourcesByAnyId(
 	matches IdMatcher) []*resource.Resource {
 	var result []*resource.Resource
 	for _, r := range m.rList {
+		if r.RNode.IsNilOrEmpty() {
+			continue
+		}
+
 		for _, id := range append(r.PrevIds(), r.CurId()) {
 			if matches(id) {
 				result = append(result, r)


### PR DESCRIPTION
Fixes #5552.

Removing a resource entirely with a `$patch: delete` patch internally yields a resource that has no content (and hence no GVKNN), so calls to `(*resource.Resource).CurId()` would panic.