### PR TITLE
Add regex support for Replacement selectors

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
-	"sigs.k8s.io/kustomize/kyaml/resid"
 	kyaml_utils "sigs.k8s.io/kustomize/kyaml/utils"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -110,6 +109,10 @@ func applyReplacement(nodes []*yaml.RNode, value *yaml.RNode, targetSelectors []
 		if len(selector.FieldPaths) == 0 {
 			selector.FieldPaths = []string{types.DefaultReplacementFieldPath}
 		}
+		tsr, err := types.NewTargetSelectorRegex(selector)
+		if err != nil {
+			return nil, err
+		}
 		for _, possibleTarget := range nodes {
 			ids, err := utils.MakeResIds(possibleTarget)
 			if err != nil {
@@ -127,7 +130,7 @@ func applyReplacement(nodes []*yaml.RNode, value *yaml.RNode, targetSelectors []
 
 			// filter targets by matching resource IDs
 			for _, id := range ids {
-				if id.IsSelectedBy(selector.Select.ResId) && !containsRejectId(selector.Reject, ids) {
+				if tsr.Selects(id) && !tsr.RejectsAny(ids) {
 					err := copyValueToTarget(possibleTarget, value, selector)
 					if err != nil {
 						return nil, err
@@ -166,20 +169,6 @@ func matchesAnnoAndLabelSelector(n *yaml.RNode, selector *types.Selector) (bool,
 		return false, err
 	}
 	return annoMatch && labelMatch, nil
-}
-
-func containsRejectId(rejects []*types.Selector, ids []resid.ResId) bool {
-	for _, r := range rejects {
-		if r.ResId.IsEmpty() {
-			continue
-		}
-		for _, id := range ids {
-			if id.IsSelectedBy(r.ResId) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func copyValueToTarget(target *yaml.RNode, value *yaml.RNode, selector *types.TargetSelector) error {

--- a/api/types/replacement.go
+++ b/api/types/replacement.go
@@ -63,6 +63,53 @@ type TargetSelector struct {
 	Options *FieldOptions `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
+type TargetSelectorRegex struct {
+	targetSelector *TargetSelector
+	selectRegex    *SelectorRegex
+	rejectRegex    []*SelectorRegex
+}
+
+func NewTargetSelectorRegex(ts *TargetSelector) (*TargetSelectorRegex, error) {
+	tsr := new(TargetSelectorRegex)
+	tsr.targetSelector = ts
+	var err error
+
+	tsr.selectRegex, err = NewSelectorRegex(ts.Select)
+	if err != nil {
+		return nil, err
+	}
+
+	rej := []*SelectorRegex{}
+	for _, r := range ts.Reject {
+		rr, err := NewSelectorRegex(r)
+		if err != nil {
+			return nil, err
+		}
+		rej = append(rej, rr)
+	}
+	tsr.rejectRegex = rej
+
+	return tsr, nil
+}
+
+func (tsr *TargetSelectorRegex) Selects(id resid.ResId) bool {
+	return tsr.selectRegex.MatchGvk(id.Gvk) && tsr.selectRegex.MatchName(id.Name) && tsr.selectRegex.MatchNamespace(id.Namespace)
+}
+
+func (tsr *TargetSelectorRegex) RejectsAny(ids []resid.ResId) bool {
+	for _, r := range tsr.rejectRegex {
+		if r.selector.ResId.IsEmpty() {
+			continue
+		}
+		for _, id := range ids {
+			if r.MatchGvk(id.Gvk) && r.MatchName(id.Name) && r.MatchNamespace(id.Namespace) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // FieldOptions refine the interpretation of FieldPaths.
 type FieldOptions struct {
 	// Used to split/join the field.


### PR DESCRIPTION
- re-implement replacement target selector with regex support, in the patch selector spirit
- isolate select and reject functions to a new specialized struct
- related issue https://github.com/kubernetes-sigs/kustomize/issues/5862