### PR TITLE
feat(helm): allow the use of devel alias for helmcharts

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -337,6 +337,9 @@ func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
 	if p.Version != "" {
 		args = append(args, "--version", p.Version)
 	}
+	if p.Devel {
+		args = append(args, "--devel")
+	}
 	return args
 }
 

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -99,6 +99,9 @@ type HelmChart struct {
 
 	// debug enables debug output from the Helm chart inflator generator.
 	Debug bool `json:"debug,omitempty" yaml:"debug,omitempty"`
+
+	// allow for devel release to be used.
+	Devel bool `json:"devel,omitempty" yaml:"devel,omitempty"`
 }
 
 // HelmChartArgs contains arguments to helm.
@@ -193,6 +196,9 @@ func (h HelmChart) AsHelmArgs(absChartHome string) []string {
 	}
 	if h.Debug {
 		args = append(args, "--debug")
+	}
+	if h.Devel {
+		args = append(args, "--devel")
 	}
 	return args
 }

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -77,4 +77,28 @@ func TestAsHelmArgs(t *testing.T) {
 				"-f", "values2",
 				"--debug"})
 	})
+
+	t.Run("use helm-devel", func(t *testing.T) {
+		// We first test that the devel flag is only appended when specified
+		p := types.HelmChart{
+			Name:                  "chart-name",
+			Version:               "1.0.0",
+			Repo:                  "https://helm.releases.hashicorp.com",
+			ValuesFile:            "values",
+			AdditionalValuesFiles: []string{"values1", "values2"},
+		}
+		require.Equal(t, p.AsHelmArgs("/home/charts"),
+			[]string{"template", "--generate-name", "/home/charts/chart-name",
+				"-f", "values",
+				"-f", "values1",
+				"-f", "values2"})
+
+		p.Devel = true
+		require.Equal(t, p.AsHelmArgs("/home/charts"),
+			[]string{"template", "--generate-name", "/home/charts/chart-name",
+				"-f", "values",
+				"-f", "values1",
+				"-f", "values2",
+				"--devel"})
+	})
 }

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -343,6 +343,9 @@ func (p *plugin) pullCommand() []string {
 	if p.Version != "" {
 		args = append(args, "--version", p.Version)
 	}
+	if p.Devel {
+		args = append(args, "--devel")
+	}
 	return args
 }
 

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -1007,22 +1007,23 @@ func TestHelmChartInflationGeneratorWithDevel(t *testing.T) {
 apiVersion: builtin
 kind: HelmChartInflationGenerator
 metadata:
-  name: test-chart
-name: test-chart
+  name: sm-operator
+name:  sm-operator
 version: 0.1.0-Beta
 repo: https://charts.bitwarden.com/
 releaseName: sm-operator
+chartHome: ./charts
 devel: true
 `)
 	cm, err := rm.Resources()[0].GetFieldValue("metadata.name")
 	require.NoError(t, err)
-	assert.Equal(t, "bar", cm)
+	assert.Equal(t, "sm-operator-controller-manager", cm)
 
-	chartDir := filepath.Join(th.GetRoot(), "charts/test-chart")
+	chartDir := filepath.Join(th.GetRoot(), "charts/sm-operator-0.1.0-Beta/sm-operator")
 	assert.True(t, th.GetFSys().Exists(chartDir))
 
 	chartYamlContent, err := th.GetFSys().ReadFile(filepath.Join(chartDir, "Chart.yaml"))
 	require.NoError(t, err)
-	assert.Contains(t, string(chartYamlContent), "name: test-chart")
+	assert.Contains(t, string(chartYamlContent), "name: sm-operator")
 	assert.Contains(t, string(chartYamlContent), "version: 0.1.0-Beta")
 }

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -993,3 +993,36 @@ debug: true
 	assert.Contains(t, string(chartYamlContent), "name: test-chart")
 	assert.Contains(t, string(chartYamlContent), "version: 1.0.0")
 }
+
+func TestHelmChartInflationGeneratorWithDevel(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+	copyTestChartsIntoHarness(t, th)
+
+	rm := th.LoadAndRunGenerator(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: test-chart
+name: test-chart
+version: 0.1.0-Beta
+repo: https://charts.bitwarden.com/
+releaseName: sm-operator
+devel: true
+`)
+	cm, err := rm.Resources()[0].GetFieldValue("metadata.name")
+	require.NoError(t, err)
+	assert.Equal(t, "bar", cm)
+
+	chartDir := filepath.Join(th.GetRoot(), "charts/test-chart")
+	assert.True(t, th.GetFSys().Exists(chartDir))
+
+	chartYamlContent, err := th.GetFSys().ReadFile(filepath.Join(chartDir, "Chart.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(chartYamlContent), "name: test-chart")
+	assert.Contains(t, string(chartYamlContent), "version: 0.1.0-Beta")
+}


### PR DESCRIPTION
Hello,
This pull request adds support for an explicit devel option in helmCharts definitions within `kustomization.yaml`. This allows users to enable Helm's --devel flag directly, facilitating the use of development releases without relying on implicit version constraints.

Previously, one had to work around this limitation by specifying a version constraint like ">0.0.0-0", which was functionally equivalent to --devel. For example:
```yaml
helmCharts:
- name: sm-operator
  releaseName: sm-operator
  namespace: bitwarden
  repo: https://charts.bitwarden.com/
  valuesFile: bitwarden-sm-op-values.yaml
  version: ">0.0.0-0" # equivalent for "--devel"
 ```
With this PR, users can explicitly enable development releases using the devel field:
```yaml
helmCharts:
- name: sm-operator
  releaseName: sm-operator
  namespace: bitwarden
  repo: https://charts.bitwarden.com/
  valuesFile: bitwarden-sm-op-values.yaml
  version: "0.1.0-Beta"
  devel: true
  ```
 
 