### PR TITLE
Add --not-in-schema Flag to Helm

### DIFF
--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -102,6 +102,9 @@ type HelmChart struct {
 
 	// allow for devel release to be used.
 	Devel bool `json:"devel,omitempty" yaml:"devel,omitempty"`
+
+	// SkipSchemaValidation disables JSON schema validation
+	SkipSchemaValidation bool `json:"skipSchemaValidation,omitempty" yaml:"skipSchemaValidation,omitempty"`
 }
 
 // HelmChartArgs contains arguments to helm.
@@ -199,6 +202,10 @@ func (h HelmChart) AsHelmArgs(absChartHome string) []string {
 	}
 	if h.Devel {
 		args = append(args, "--devel")
+	}
+	
+	if h.SkipSchemaValidation {
+		args = append(args, "--skip-schema-validation")
 	}
 	return args
 }

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -101,4 +101,21 @@ func TestAsHelmArgs(t *testing.T) {
 				"-f", "values2",
 				"--devel"})
 	})
+
+	t.Run("use skip-schema-validation", func(t *testing.T) {
+		p := types.HelmChart{
+			Name:                  "chart-name",
+			Version:               "1.0.0",
+			Repo:                  "https://helm.releases.hashicorp.com",
+			ValuesFile:            "values",
+			AdditionalValuesFiles: []string{"values1", "values2"},
+			SkipSchemaValidation:  true,
+		}
+		require.Equal(t, p.AsHelmArgs("/home/charts"),
+			[]string{"template", "--generate-name", "/home/charts/chart-name",
+				"-f", "values",
+				"-f", "values1",
+				"-f", "values2",
+				"--skip-schema-validation"})
+	})
 }


### PR DESCRIPTION
This pull request introduces the new --not-in-schema flag for Helm, addressing the request in issue #5813. When enabled, this flag will cause Helm to ignore the .schema.json file, if present, in a chart. 

from issue
> helm enforces schema validation for the values passed to a chart if the chart defines a schema for the expected values. While this feature might be practical in some use-cases it is a problem when using a helm-chart as dependency when the passed values contain properties for other dependencies or the main chart.

Key Changes:
+ Added the --not-in-schema flag to the Helm command-line options.
+ Updated tests to cover scenarios with and without the flag enabled, ensuring backward compatibility.

This enhancement offers greater flexibility for users facing issues with schema validation, streamlining deployments in environments where strict schema adherence is not required.