### PR TITLE
Set Git messages to English for TestRemoteLoad_LocalProtocol

### DIFF
--- a/api/krusty/remoteloader_test.go
+++ b/api/krusty/remoteloader_test.go
@@ -282,6 +282,8 @@ resources:
 		},
 	}
 
+	t.Setenv("LC_ALL", "C")
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.skip {


### PR DESCRIPTION
This pull request ensures consistent error message matching by setting `LC_ALL=C` in `TestRemoteLoad_LocalProtocol`, preventing locale-based variations in Git output.


To reproduce the bug a variation of LOCALE can be set and to then run `go test`.

####  Variation

```
LC_ALL = et_EE.UTF-8
LANGUAGE = et_EE.UTF-8:fr
```

#### Test Error
```
=== RUN   TestRemoteLoad_LocalProtocol/repo_does_not_exist_
    remoteloader_test.go:301: 
        	Error Trace:	/tmp/reprotest.tT0OHI/const_build_path/const_build_path/_build/src/sigs.k8s.io/kustomize/api/krusty/remoteloader_test.go:301
        	Error:      	Expect "accumulating resources: accumulation err='accumulating resources from 'file:///not/a/real/repo': evalsymlink failure on '/tmp/kustomize-3177399597/file:/not/a/real/repo' : lstat /tmp/kustomize-3177399597/file:: no such file or directory': failed to run '/usr/bin/git fetch --depth=1 file:///not/a/real/repo HEAD': fatal : '/not/a/real/repo' does not appear to be a git repository
        	            	fatal : Impossible de lire le dépôt distant.
        	            	
        	            	Veuillez vérifier que vous avez les droits d'accès
        	            	et que le dépôt existe.
        	            	: exit status 128" to match "fatal: '/not/a/real/repo' does not appear to be a git repository"
        	Test:       	TestRemoteLoad_LocalProtocol/repo_does_not_exist_
```

Since git command is has internalization support it will print the git error messages in french.
