### PR TITLE
chore: remove unused build arg and address warnings

### DIFF
--- a/kustomize.Dockerfile
+++ b/kustomize.Dockerfile
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # build
-FROM public.ecr.aws/docker/library/golang:1.22.7-bullseye as builder
+FROM public.ecr.aws/docker/library/golang:1.22.7-bullseye AS builder
 ARG VERSION
-ARG COMMIT
 ARG DATE
 RUN mkdir /build
 ADD . /build/
@@ -14,10 +13,10 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build \
     -X sigs.k8s.io/kustomize/api/provenance.buildDate=${DATE}"
 
 # only copy binary
-FROM alpine
+FROM public.ecr.aws/docker/library/alpine
 # install dependencies
 RUN apk add --no-cache git openssh
 COPY --from=builder /build/kustomize/kustomize /app/
 WORKDIR /app
-ENV PATH "$PATH:/app"
+ENV PATH="$PATH:/app"
 ENTRYPOINT ["/app/kustomize"]

--- a/releasing/cloudbuild_kustomize_image.yaml
+++ b/releasing/cloudbuild_kustomize_image.yaml
@@ -26,8 +26,6 @@ steps:
         --build-arg
         VERSION=${_PULL_BASE_REF}
         --build-arg
-        COMMIT=$(git rev-parse HEAD)
-        --build-arg
         DATE=$(date -u +%FT%TZ)
         .
 


### PR DESCRIPTION
The pull request makes some small changes to kustomize main dockerfile:

- addresses 2 warnings when building the docker image: FromAsCasing and LegacyKeyValueFormat
- COMMIT container build argument is not used anymore
- use same container registry for both images for consistency