### PR TITLE
feat: `emitStringData` boolean for secretGenerator

### DIFF
--- a/api/internal/generators/secret.go
+++ b/api/internal/generators/secret.go
@@ -4,6 +4,8 @@
 package generators
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/api/ifc"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -11,20 +13,26 @@ import (
 
 // MakeSecret makes a kubernetes Secret.
 //
-// Secret: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#secret-v1-core
+// Secret: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/
 //
 // ConfigMaps and Secrets are similar.
 //
 // Like a ConfigMap, a Secret has a `data` field, but unlike a ConfigMap it has
-// no `binaryData` field.
+// no `binaryData` field. Secret also provides a `stringData` field.
 //
-// All of a Secret's data is assumed to be opaque in nature, and assumed to be
+// A Secret's `data` is assumed to be opaque in nature, and assumed to be
 // base64 encoded from its original representation, regardless of whether the
 // original data was UTF-8 text or binary.
 //
 // This encoding provides no secrecy. It's just a neutral, common means to
 // represent opaque text and binary data.  Beneath the base64 encoding
 // is presumably further encoding under control of the Secret's consumer.
+//
+// A Secret's `stringData` field is similar to ConfigMap's `data` field.
+// `stringData` allows specifying non-binary, UTF-8 secret data in string form.
+// It is provided as a write-only input field for convenience.
+// All keys and values are merged into the data field on write, overwriting any
+// existing values. The stringData field is never output when reading from the API.
 //
 // A Secret has string field `type` which holds an identifier, used by the
 // client, to choose the algorithm to interpret the `data` field.  Kubernetes
@@ -50,8 +58,14 @@ func MakeSecret(
 	if err != nil {
 		return nil, err
 	}
-	if err = rn.LoadMapIntoSecretData(m); err != nil {
-		return nil, err
+	if args.EmitStringData {
+		if err = rn.LoadMapIntoSecretStringData(m); err != nil {
+			return nil, fmt.Errorf("Failed to load map into Secret stringData: %w", err)
+		}
+	} else {
+		if err = rn.LoadMapIntoSecretData(m); err != nil {
+			return nil, fmt.Errorf("Failed to load map into Secret data: %w", err)
+		}
 	}
 	copyLabelsAndAnnotations(rn, args.Options)
 	setImmutable(rn, args.Options)

--- a/api/internal/generators/secret_test.go
+++ b/api/internal/generators/secret_test.go
@@ -196,6 +196,82 @@ immutable: true
 `,
 			},
 		},
+		"construct secret from text file as stringData": {
+			args: types.SecretArgs{
+				EmitStringData: true,
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileSecret1",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("secret", "app-init.ini"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: fileSecret1
+type: Opaque
+stringData:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+`,
+			},
+		},
+		"construct secret from text and binary file with stringData and data": {
+			args: types.SecretArgs{
+				EmitStringData: true,
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileSecret2",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("secret", "app-init.ini"),
+							filepath.Join("secret", "app.bin"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: fileSecret2
+type: Opaque
+stringData:
+  app-init.ini: |
+    FOO=bar
+    BAR=baz
+data:
+  app.bin: //0=
+`,
+			},
+		},
+		"construct secret from a binary file and fallback to data from stringData": {
+			args: types.SecretArgs{
+				EmitStringData: true,
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "fileSecret2",
+					KvPairSources: types.KvPairSources{
+						FileSources: []string{
+							filepath.Join("secret", "app.bin"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: Secret
+metadata:
+  name: fileSecret2
+type: Opaque
+data:
+  app.bin: //0=
+`,
+			},
+		},
 	}
 	fSys := filesys.MakeFsInMemory()
 	fSys.WriteFile(

--- a/api/krusty/secrets_test.go
+++ b/api/krusty/secrets_test.go
@@ -1,0 +1,687 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// Numbers and booleans are quoted
+func TestSecretGeneratorIntVsStringNoMerge(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- service.yaml
+secretGenerator:
+- name: bob
+  literals:
+  - fruit=Mango
+  - year=2025
+  - crisis=true
+`)
+	th.WriteF("service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+spec:
+  clusterIP: None
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo
+spec:
+  clusterIP: None
+---
+apiVersion: v1
+data:
+  crisis: dHJ1ZQ==
+  fruit: TWFuZ28=
+  year: MjAyNQ==
+kind: Secret
+metadata:
+  name: bob-9kb2bk8b2g
+type: Opaque
+`)
+}
+
+func TestSecretGeneratorIntVsStringWithMerge(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+secretGenerator:
+- name: bob
+  literals:
+  - fruit=Mango
+  - year=2025
+  - crisis=true
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+secretGenerator:
+- name: bob
+  behavior: merge
+  literals:
+  - month=12
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+data:
+  crisis: dHJ1ZQ==
+  fruit: TWFuZ28=
+  month: MTI=
+  year: MjAyNQ==
+kind: Secret
+metadata:
+  name: bob-mf6f2t4b62
+type: Opaque
+`)
+}
+
+func TestSecretGeneratorFromProperties(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+secretGenerator:
+  - name: test-secret
+    behavior: create
+    envs:
+    - properties
+`)
+	th.WriteF("base/properties", `
+VAR1=100
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+secretGenerator:
+- name: test-secret
+  behavior: "merge"
+  envs:
+  - properties
+`)
+	th.WriteF("overlay/properties", `
+VAR2=200
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  VAR1: MTAw
+  VAR2: MjAw
+kind: Secret
+metadata:
+  name: test-secret-c8c6d984gb
+type: Opaque
+`)
+}
+
+// TODO: This should be an error instead. However, we can't strict unmarshal until we have a yaml
+// lib that support case-insensitive keys and anchors.
+// See https://github.com/kubernetes-sigs/kustomize/issues/5061
+func TestSecretGeneratorRepeatsInKustomization(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+namePrefix: blah-
+secretGenerator:
+- name: bob
+  behavior: create
+  literals:
+  - bean=pinto
+  - star=wolf-rayet
+  literals:
+  - fruit=apple
+  - vegetable=broccoli
+  files:
+  - forces.txt
+  files:
+  - nobles=nobility.txt
+`)
+	th.WriteF("forces.txt", `
+gravitational
+electromagnetic
+strong nuclear
+weak nuclear
+`)
+	th.WriteF("nobility.txt", `
+helium
+neon
+argon
+krypton
+xenon
+radon
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  fruit: YXBwbGU=
+  nobles: CmhlbGl1bQpuZW9uCmFyZ29uCmtyeXB0b24KeGVub24KcmFkb24K
+  vegetable: YnJvY2NvbGk=
+kind: Secret
+metadata:
+  name: blah-bob-7dffd4g7cf
+type: Opaque
+`)
+}
+
+func TestSecretIssue3393(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- cm.yaml
+secretGenerator:
+  - name: project
+    behavior: merge
+    literals:
+    - ANOTHER_ENV_VARIABLE="bar"
+`)
+	th.WriteF("cm.yaml", `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: project
+type: Opaque
+data:
+  A_FIRST_ENV_VARIABLE: "foo"
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  A_FIRST_ENV_VARIABLE: foo
+  ANOTHER_ENV_VARIABLE: YmFy
+kind: Secret
+metadata:
+  name: project
+type: Opaque
+`)
+}
+
+func TestSecretGeneratorSimpleOverlay(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+namePrefix: p-
+secretGenerator:
+- name: cm
+  behavior: create
+  literals:
+  - fruit=apple
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+secretGenerator:
+- name: cm
+  behavior: merge
+  literals:
+  - veggie=broccoli
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  fruit: YXBwbGU=
+  veggie: YnJvY2NvbGk=
+kind: Secret
+metadata:
+  name: p-cm-5fg9k7g895
+type: Opaque
+`)
+}
+
+var binaryHunter2 = []byte{
+	0xff, // non-utf8
+	0x68, // h
+	0x75, // u
+	0x6e, // n
+	0x74, // t
+	0x65, // e
+	0x72, // r
+	0x32, // 2
+}
+
+func manyHunter2s(count int) (result []byte) {
+	for i := 0; i < count; i++ {
+		result = append(result, binaryHunter2...)
+	}
+	return
+}
+
+func TestSecretGeneratorOverlaysBinaryData(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("base/data.bin", string(manyHunter2s(30)))
+	th.WriteK("base", `
+namePrefix: p1-
+secretGenerator:
+- name: com1
+  behavior: create
+  files:
+  - data.bin
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+secretGenerator:
+- name: com1
+  behavior: merge
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  data.bin: |
+    /2h1bnRlcjL/aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/aHVudGVyMv9odW50ZXIy/2h1bn
+    RlcjL/aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/
+    aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/aHVudG
+    VyMv9odW50ZXIy/2h1bnRlcjL/aHVudGVyMv9odW50ZXIy/2h1bnRlcjL/aHVudGVyMv9o
+    dW50ZXIy/2h1bnRlcjL/aHVudGVyMv9odW50ZXIy
+kind: Secret
+metadata:
+  name: p1-com1-4k9fgt2gct
+type: Opaque
+`)
+}
+
+func TestSecretGeneratorOverlays(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base1", `
+namePrefix: p1-
+secretGenerator:
+- name: com1
+  behavior: create
+  literals:
+  - from=base
+`)
+	th.WriteK("base2", `
+namePrefix: p2-
+secretGenerator:
+- name: com2
+  behavior: create
+  literals:
+  - from=base
+`)
+	th.WriteK("overlay/o1", `
+resources:
+- ../../base1
+secretGenerator:
+- name: com1
+  behavior: merge
+  literals:
+  - from=overlay
+`)
+	th.WriteK("overlay/o2", `
+resources:
+- ../../base2
+secretGenerator:
+- name: com2
+  behavior: merge
+  literals:
+  - from=overlay
+`)
+	th.WriteK("overlay", `
+resources:
+- o1
+- o2
+secretGenerator:
+- name: com1
+  behavior: merge
+  literals:
+  - foo=bar
+  - baz=qux
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  baz: cXV4
+  foo: YmFy
+  from: b3ZlcmxheQ==
+kind: Secret
+metadata:
+  name: p1-com1-9tg2879fh2
+type: Opaque
+---
+apiVersion: v1
+data:
+  from: b3ZlcmxheQ==
+kind: Secret
+metadata:
+  name: p2-com2-b4g8g6529g
+type: Opaque
+`)
+}
+
+func secretGeneratorMergeNamePrefix(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("base", `
+secretGenerator:
+- name: cm
+  behavior: create
+  literals:
+  - foo=bar
+`)
+	th.WriteK("o1", `
+resources:
+- ../base
+namePrefix: o1-
+`)
+	th.WriteK("o2", `
+resources:
+- ../base
+nameSuffix: -o2
+`)
+	th.WriteK(".", `
+resources:
+- o1
+- o2
+secretGenerator:
+- name: o1-cm
+  behavior: merge
+  literals:
+  - big=bang
+- name: cm-o2
+  behavior: merge
+  literals:
+  - big=crunch
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  big: bang
+  foo: bar
+kind: Secret
+metadata:
+  name: o1-cm-ft9mmdc8c6
+type: Opaque
+---
+apiVersion: v1
+data:
+  big: crunch
+  foo: bar
+kind: Secret
+metadata:
+  name: cm-o2-5k95kd76ft
+type: Opaque
+`)
+}
+
+func secretGeneratorLiteralNewline(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+generators:
+- secrets.yaml
+`)
+	th.WriteF("secrets.yaml", `
+apiVersion: builtin
+kind: SecretGenerator
+metadata:
+  name: testing
+type: Opaque
+literals:
+  - |
+    initial.txt=greetings
+    everyone
+  - |
+    final.txt=different
+    behavior
+---
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `
+apiVersion: v1
+data:
+  final.txt: |
+    different
+    behavior
+  initial.txt: |
+    greetings
+    everyone
+kind: Secret
+metadata:
+  name: testing-tt4769fb52
+type: Opaque
+`)
+}
+
+// regression test for https://github.com/kubernetes-sigs/kustomize/issues/4233
+func TestSecretDataEndsWithQuotes(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+secretGenerator:
+  - name: test
+    literals:
+      - TEST=this is a 'test'
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `
+apiVersion: v1
+data:
+  TEST: dGhpcyBpcyBhICd0ZXN0Jw==
+kind: Secret
+metadata:
+  name: test-tg88t27545
+type: Opaque
+`)
+}
+
+func TestSecretDataIsSingleQuote(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+secretGenerator:
+  - name: test
+    literals:
+      - TEST='
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(
+		m, `
+apiVersion: v1
+data:
+  TEST: Jw==
+kind: Secret
+metadata:
+  name: test-7dthck49k5
+type: Opaque
+`)
+}
+
+// Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
+func TestSecretPrefixSuffix(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("kustomization.yaml", `
+resources:
+- a
+- b
+`)
+
+	th.WriteF("a/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: a
+`)
+
+	th.WriteF("b/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: b
+`)
+
+	th.WriteF("common/kustomization.yaml", `
+resources:
+- service
+
+secretGenerator:
+- name: "-example-secret"
+`)
+
+	th.WriteF("common/service/deployment.yaml", `
+kind: Deployment
+apiVersion: apps/v1
+
+metadata:
+  name: "-"
+
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - secretRef:
+            name: "-example-secret"
+`)
+
+	th.WriteF("common/service/kustomization.yaml", `
+resources:
+- deployment.yaml
+
+nameSuffix: api
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a-api
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: a-example-secret-46f8b28mk5
+        name: app
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  name: a-example-secret-46f8b28mk5
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b-api
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: b-example-secret-46f8b28mk5
+        name: app
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  name: b-example-secret-46f8b28mk5
+type: Opaque
+`)
+}
+
+// Regression test for https://github.com/kubernetes-sigs/kustomize/issues/5047
+func TestSecretPrefixSuffix2(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("kustomization.yaml", `
+resources:
+- a
+- b
+`)
+
+	th.WriteF("a/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: a
+`)
+
+	th.WriteF("b/kustomization.yaml", `
+resources:
+- ../common
+
+namePrefix: b
+`)
+
+	th.WriteF("common/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "-example"
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        envFrom:
+        - secretRef:
+            name: "-example-secret"
+`)
+
+	th.WriteF("common/kustomization.yaml", `
+resources:
+- deployment.yaml
+
+secretGenerator:
+- name: "-example-secret"
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a-example
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: a-example-secret-46f8b28mk5
+        name: app
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  name: a-example-secret-46f8b28mk5
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b-example
+spec:
+  template:
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: b-example-secret-46f8b28mk5
+        name: app
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  name: b-example-secret-46f8b28mk5
+type: Opaque
+`)
+}

--- a/api/krusty/secrets_test.go
+++ b/api/krusty/secrets_test.go
@@ -236,18 +236,18 @@ type: Opaque
 `)
 }
 
-var binaryHunter2 = []byte{
-	0xff, // non-utf8
-	0x68, // h
-	0x75, // u
-	0x6e, // n
-	0x74, // t
-	0x65, // e
-	0x72, // r
-	0x32, // 2
-}
-
 func manyHunter2s(count int) (result []byte) {
+	binaryHunter2 := []byte{
+		0xff, // non-utf8
+		0x68, // h
+		0x75, // u
+		0x6e, // n
+		0x74, // t
+		0x65, // e
+		0x72, // r
+		0x32, // 2
+	}
+
 	for i := 0; i < count; i++ {
 		result = append(result, binaryHunter2...)
 	}
@@ -354,100 +354,6 @@ data:
 kind: Secret
 metadata:
   name: p2-com2-b4g8g6529g
-type: Opaque
-`)
-}
-
-func secretGeneratorMergeNamePrefix(t *testing.T) {
-	th := kusttest_test.MakeHarness(t)
-	th.WriteK("base", `
-secretGenerator:
-- name: cm
-  behavior: create
-  literals:
-  - foo=bar
-`)
-	th.WriteK("o1", `
-resources:
-- ../base
-namePrefix: o1-
-`)
-	th.WriteK("o2", `
-resources:
-- ../base
-nameSuffix: -o2
-`)
-	th.WriteK(".", `
-resources:
-- o1
-- o2
-secretGenerator:
-- name: o1-cm
-  behavior: merge
-  literals:
-  - big=bang
-- name: cm-o2
-  behavior: merge
-  literals:
-  - big=crunch
-`)
-	m := th.Run(".", th.MakeDefaultOptions())
-	th.AssertActualEqualsExpected(m, `
-apiVersion: v1
-data:
-  big: bang
-  foo: bar
-kind: Secret
-metadata:
-  name: o1-cm-ft9mmdc8c6
-type: Opaque
----
-apiVersion: v1
-data:
-  big: crunch
-  foo: bar
-kind: Secret
-metadata:
-  name: cm-o2-5k95kd76ft
-type: Opaque
-`)
-}
-
-func secretGeneratorLiteralNewline(t *testing.T) {
-	th := kusttest_test.MakeHarness(t)
-	th.WriteK(".", `
-generators:
-- secrets.yaml
-`)
-	th.WriteF("secrets.yaml", `
-apiVersion: builtin
-kind: SecretGenerator
-metadata:
-  name: testing
-type: Opaque
-literals:
-  - |
-    initial.txt=greetings
-    everyone
-  - |
-    final.txt=different
-    behavior
----
-`)
-	m := th.Run(".", th.MakeDefaultOptions())
-	th.AssertActualEqualsExpected(
-		m, `
-apiVersion: v1
-data:
-  final.txt: |
-    different
-    behavior
-  initial.txt: |
-    greetings
-    everyone
-kind: Secret
-metadata:
-  name: testing-tt4769fb52
 type: Opaque
 `)
 }

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -591,6 +591,7 @@ func (m *resWrangler) appendReplaceOrMerge(res *resource.Resource) error {
 			res.CopyMergeMetaDataFieldsFrom(old)
 			res.MergeDataMapFrom(old)
 			res.MergeBinaryDataMapFrom(old)
+			res.MergeStringDataMapFrom(old)
 			if orig != nil {
 				res.SetOrigin(orig)
 			}

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -157,7 +157,7 @@ func (r *Resource) DeepCopy() *Resource {
 // the resource.
 // TODO: move to RNode, use GetMeta to improve performance.
 // TODO: make a version of mergeStringMaps that is build-annotation aware
-//   to avoid repeatedly setting refby and genargs annotations
+// to avoid repeatedly setting refby and genargs annotations
 // Must remove the kustomize bit at the end.
 func (r *Resource) CopyMergeMetaDataFieldsFrom(other *Resource) error {
 	if err := r.SetLabels(
@@ -195,6 +195,10 @@ func (r *Resource) MergeDataMapFrom(o *Resource) {
 
 func (r *Resource) MergeBinaryDataMapFrom(o *Resource) {
 	r.SetBinaryDataMap(mergeStringMaps(o.GetBinaryDataMap(), r.GetBinaryDataMap()))
+}
+
+func (r *Resource) MergeStringDataMapFrom(o *Resource) {
+	r.SetStringDataMap(mergeStringMaps(o.GetStringDataMap(), r.GetStringDataMap()))
 }
 
 func (r *Resource) ErrIfNotEquals(o *Resource) error {

--- a/api/types/secretargs.go
+++ b/api/types/secretargs.go
@@ -16,4 +16,10 @@ type SecretArgs struct {
 	// If type is "kubernetes.io/tls", then "literals" or "files" must have exactly two
 	// keys: "tls.key" and "tls.crt"
 	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+
+	// EmitStringData if true generates a v1/Secret with plain-text stringData fields
+	// instead of base64-encoded data fields. If a generating field does not have a
+	// UTF-8 value, it falls back to being stored as a base64-encoded data field. This
+	// is similar to the default binaryData fallback of a ConfigMapGenerator.
+	EmitStringData bool `json:"emitStringData,omitempty" yaml:"emitStringData,omitempty"`
 }

--- a/kyaml/yaml/const.go
+++ b/kyaml/yaml/const.go
@@ -24,6 +24,7 @@ const (
 	MetadataField    = "metadata"
 	DataField        = "data"
 	BinaryDataField  = "binaryData"
+	StringDataField  = "stringData"
 	NameField        = "name"
 	NamespaceField   = "namespace"
 	LabelsField      = "labels"

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -632,6 +632,19 @@ func (rn *RNode) GetBinaryDataMap() map[string]string {
 	return result
 }
 
+func (rn *RNode) GetStringDataMap() map[string]string {
+	n, err := rn.Pipe(Lookup(StringDataField))
+	if err != nil {
+		return nil
+	}
+	result := map[string]string{}
+	_ = n.VisitFields(func(node *MapNode) error {
+		result[GetValue(node.Key)] = GetValue(node.Value)
+		return nil
+	})
+	return result
+}
+
 // GetValidatedDataMap retrieves the data map and returns an error if the data
 // map contains entries which are not included in the expectedKeys set.
 func (rn *RNode) GetValidatedDataMap(expectedKeys []string) (map[string]string, error) {
@@ -684,6 +697,21 @@ func (rn *RNode) SetBinaryDataMap(m map[string]string) {
 		return
 	}
 	if err := rn.LoadMapIntoConfigMapBinaryData(m); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (rn *RNode) SetStringDataMap(m map[string]string) {
+	if rn == nil {
+		log.Fatal("cannot set stringData map on nil Rnode")
+	}
+	if err := rn.PipeE(Clear(StringDataField)); err != nil {
+		log.Fatal(err)
+	}
+	if len(m) == 0 {
+		return
+	}
+	if err := rn.LoadMapIntoSecretStringData(m); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/site/content/en/docs/Reference/API/included/secretargs.md
+++ b/site/content/en/docs/Reference/API/included/secretargs.md
@@ -16,3 +16,10 @@ _build:
 * **type** (string), optional
 
     Type of the secret. Must be `Opaque` or `kubernetes.io/tls`. Defaults to `Opaque`.
+
+* **emitStringData** (bool), optional
+
+	  emitStringData if true generates a v1/Secret with plain-text stringData fields
+	  instead of base64-encoded data fields. If a generating field does not have a
+	  UTF-8 value, it falls back to being stored as a base64-encoded data field. This
+	  is similar to the default binaryData fallback of a configMapGenerator.


### PR DESCRIPTION
This allows users to pass `emitStringData: true` to the secretGenerator, alongside the `type` option.
When enabled, UTF-8 strings are output in plainText stringData, and non-UTF strings and any binary data fallback to the default behavior of being base64 encoded in `data`.

This is very similar to the default, kyaml behavior of loading values into ConfigMap's `data` and `binaryData` fields.

This feature provides a general U/X improvement for people using kustomize interactively, and also allows Flux users to template into generated secrets.
(Flux users already can and do template into ConfigMaps, so we want to give people more secure mechanisms in kustomize-controller)

- **test: add secretGenerator testcases**
- **feat: support emitStringData in secretGenerator**
- **test: test emitStringData in secretGenerator**

resolves #5142 #1444 #1261 #793
