### PR TITLE
Add a test case under api/krusty for #5878

### DIFF
--- a/api/krusty/testdata/customschema.json
+++ b/api/krusty/testdata/customschema.json
@@ -15,12 +15,15 @@
           "properties": {
             "template": {
               "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
+            },
+            "custom": {
+              "$ref": "#/definitions/com.example.v1alpha1.CustomSpec"
             }
           },
           "type": "object"
         },
         "status": {
-           "properties": {
+          "properties": {
             "success": {
               "type": "boolean"
             }
@@ -89,7 +92,7 @@
           "type": "string"
         },
         "ports": {
-         "items": {
+          "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
           },
           "type": "array",
@@ -105,7 +108,7 @@
       "type": "object"
     },
     "io.k8s.api.core.v1.ContainerPort": {
-     "properties": {
+      "properties": {
         "containerPort": {
           "format": "int32",
           "type": "integer"
@@ -118,6 +121,27 @@
         }
       },
       "type": "object"
+    },
+    "com.example.v1alpha1.CustomSpec": {
+      "properties": {
+        "objects": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      }
     }
   }
 }

--- a/api/krusty/testdata/customschema.yaml
+++ b/api/krusty/testdata/customschema.yaml
@@ -11,6 +11,8 @@ definitions:
         properties:
           template:
             "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
+          custom:
+            "$ref": "#/definitions/com.example.v1alpha1.CustomSpec"
         type: object
       status:
         properties:
@@ -70,9 +72,23 @@ definitions:
   io.k8s.api.core.v1.ContainerPort:
     properties:
       containerPort:
+        format: int32
         type: integer
       name:
         type: string
       protocol:
         type: string
     type: object
+  com.example.v1alpha1.CustomSpec:
+    properties:
+      objects:
+        items:
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+        type: array
+        x-kubernetes-list-map-keys:
+          - name
+        x-kubernetes-list-type: map


### PR DESCRIPTION
Add a test case under api/krusty, as following https://kubectl.docs.kubernetes.io/contributing/kustomize/bugs/

This PR is to add a custom schema (in the existing CRD) which doesn't have `x-kubernetes-patch-*` extension, then, testing merge of list items only with `x-kubernetes-list-*` extensions.

As a side effect of this PR, `customschema.json` is re-generated by

```sh
yq -P -o json customschema.yaml > customschema.json
```

to have the same contents.