### PR TITLE
feat: extend `TemplateStrings` and `TemplateFiles` function by introducing custom template function

### DIFF
--- a/kyaml/fn/framework/parser/func_testdata/cm3.template.yaml
+++ b/kyaml/fn/framework/parser/func_testdata/cm3.template.yaml
@@ -1,0 +1,11 @@
+# Copyright 2021 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appconfig
+  labels:
+    app: {{ .Name }}
+data:
+  app: {{ .Name | toUpper }} 

--- a/kyaml/fn/framework/parser/func_testdata/cm4.template.yaml
+++ b/kyaml/fn/framework/parser/func_testdata/cm4.template.yaml
@@ -1,0 +1,11 @@
+# Copyright 2021 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env
+  labels:
+    app: {{ .Name | toUpper }}
+data:
+  env: production

--- a/kyaml/fn/framework/parser/func_testdata/ignore.yaml
+++ b/kyaml/fn/framework/parser/func_testdata/ignore.yaml
@@ -1,0 +1,4 @@
+# Copyright 2021 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+not: a_resource

--- a/kyaml/fn/framework/parser/template.go
+++ b/kyaml/fn/framework/parser/template.go
@@ -22,19 +22,19 @@ const (
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
 //
-//	 processor := framework.TemplateProcessor{
+//	processor := framework.TemplateProcessor{
 //		ResourceTemplates: []framework.ResourceTemplate{{
 //			Templates: parser.TemplateStrings(`
 //				apiVersion: apps/v1
 //				kind: Deployment
 //				metadata:
-//				 name: foo
-//				 namespace: default
-//				 annotations:
-//				   {{ .Key }}: {{ .Value }}
+//					name: foo
+//					namespace: default
+//					annotations:
+//						{{ .Key }}: {{ .Value }}
 //				`)
 //		}},
-//	 }
+//	}
 func TemplateStrings(data ...string) framework.TemplateParser {
 	return TemplateFuncStrings(nil, data...)
 }
@@ -42,33 +42,34 @@ func TemplateStrings(data ...string) framework.TemplateParser {
 // TemplateFuncStrings is similar to TemplateStrings but allows you to specify custom template functions.
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
-//    funcMap := template.FuncMap{
-//      "toUpper": strings.ToUpper,
-//    }
-//	 processor := framework.TemplateProcessor{
-//		ResourceTemplates: []framework.ResourceTemplate{{
-//			Templates: parser.TemplateFuncStrings(funcMap, `apiVersion: apps/v1
-//				kind: Deployment
-//				metadata:
-//				 name: foo
-//				 namespace: default
-//				 annotations:
-//				   {{ .Key }}: {{ .Value | toUpper }}
-//				`)
-//		}},
-//	 }
+//
+//	funcMap := template.FuncMap{
+//		"toUpper": strings.ToUpper,
+//	}
+//	processor := framework.TemplateProcessor{
+//			ResourceTemplates: []framework.ResourceTemplate{{
+//				Templates: parser.TemplateFuncStrings(funcMap, `apiVersion: apps/v1
+//						kind: Deployment
+//						metadata:
+//							name: foo
+//							namespace: default
+//							annotations:
+//								{{ .Key }}: {{ .Value | toUpper }}
+//						`)
+//				}},
+//	}
 func TemplateFuncStrings(funcs template.FuncMap, data ...string) framework.TemplateParser {
-    return framework.TemplateParserFunc(func() ([]*template.Template, error) {
-        var templates []*template.Template
-        for i := range data {
-            t, err := template.New(fmt.Sprintf("inline%d", i)).Funcs(funcs).Parse(data[i])
-            if err != nil {
-                return nil, err
-            }
-            templates = append(templates, t)
-        }
-        return templates, nil
-    })
+	return framework.TemplateParserFunc(func() ([]*template.Template, error) {
+		var templates []*template.Template
+		for i := range data {
+			t, err := template.New(fmt.Sprintf("inline%d", i)).Funcs(funcs).Parse(data[i])
+			if err != nil {
+				return nil, err
+			}
+			templates = append(templates, t)
+		}
+		return templates, nil
+	})
 }
 
 // TemplateFiles returns a TemplateParser that will parse the templates from the given files or directories.
@@ -77,11 +78,11 @@ func TemplateFuncStrings(funcs template.FuncMap, data ...string) framework.Templ
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
 //
-// 	 processor := framework.TemplateProcessor{
-//		ResourceTemplates: []framework.ResourceTemplate{{
+//	processor := framework.TemplateProcessor{
+//			ResourceTemplates: []framework.ResourceTemplate{{
 //			Templates: parser.TemplateFiles("path/to/templates", "path/to/special.template.yaml")
 //		}},
-//   }
+//	}
 func TemplateFiles(paths ...string) TemplateParser {
 	return TemplateFuncFiles(nil, paths...)
 }
@@ -89,15 +90,16 @@ func TemplateFiles(paths ...string) TemplateParser {
 // TemplateFuncFiles is similar to TemplateFiles but allows you to specify custom template functions.
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
-
-//   funcMap := template.FuncMap{
-//     "toUpper": strings.ToUpper,
-//   }
-// 	 processor := framework.TemplateProcessor{
+//
+//	funcMap := template.FuncMap{
+//		"toUpper": strings.ToUpper,
+//	}
+//
+//	processor := framework.TemplateProcessor{
 //		ResourceTemplates: []framework.ResourceTemplate{{
 //			Templates: parser.TemplateFuncFiles(funcMap, "path/to/templates", "path/to/special.template.yaml")
 //		}},
-//   }
+//	}
 func TemplateFuncFiles(funcs template.FuncMap, paths ...string) TemplateParser {
 	return TemplateParser{parser{paths: paths, extensions: []string{TemplateExtension}}, funcs}
 }

--- a/kyaml/fn/framework/parser/template.go
+++ b/kyaml/fn/framework/parser/template.go
@@ -42,12 +42,9 @@ func TemplateStrings(data ...string) framework.TemplateParser {
 // TemplateFuncStrings is similar to TemplateStrings but allows you to specify custom template functions.
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
-//    func ToUpper(s string) string {
-//      return strings.ToUpper(s)
-//    }
 //    funcMap := template.FuncMap{
-//      "toUpper": ToUpper,
-//    } 
+//      "toUpper": strings.ToUpper,
+//    }
 //	 processor := framework.TemplateProcessor{
 //		ResourceTemplates: []framework.ResourceTemplate{{
 //			Templates: parser.TemplateFuncStrings(funcMap, `apiVersion: apps/v1
@@ -93,12 +90,9 @@ func TemplateFiles(paths ...string) TemplateParser {
 //
 // This is a helper for use with framework.TemplateProcessor's template subfields. Example:
 
-//   func ToUpper(s string) string {
-//     return strings.ToUpper(s)
-//   }
 //   funcMap := template.FuncMap{
-//     "toUpper": ToUpper,
-//   } 
+//     "toUpper": strings.ToUpper,
+//   }
 // 	 processor := framework.TemplateProcessor{
 //		ResourceTemplates: []framework.ResourceTemplate{{
 //			Templates: parser.TemplateFuncFiles(funcMap, "path/to/templates", "path/to/special.template.yaml")


### PR DESCRIPTION
Hi, I would like to extend the template for both `TemplateStrings` and `TemplateFiles`.
By introducing the customized template function, any user could generate their desired template in the ResourceTemplates.
I try to keep backward compatibility as much as possible. 

P.S. This is a real need from my company, and I am trying to backport the change here.
