### PR TITLE
fix: allow patches to override namespace, fixing evaluation order

### DIFF
--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -71,12 +71,12 @@ func (kt *KustTarget) configureBuiltinTransformers(
 	result []*resmap.TransformerWithProperties, err error) {
 	for _, bpt := range []builtinhelpers.BuiltinPluginType{
 		builtinhelpers.PatchStrategicMergeTransformer,
-		builtinhelpers.PatchTransformer,
 		builtinhelpers.NamespaceTransformer,
 		builtinhelpers.PrefixTransformer,
 		builtinhelpers.SuffixTransformer,
 		builtinhelpers.LabelTransformer,
 		builtinhelpers.AnnotationsTransformer,
+		builtinhelpers.PatchTransformer,
 		builtinhelpers.PatchJson6902Transformer,
 		builtinhelpers.ReplicaCountTransformer,
 		builtinhelpers.ImageTagTransformer,

--- a/api/resmap/resmap.go
+++ b/api/resmap/resmap.go
@@ -101,7 +101,7 @@ type TransformerPlugin interface {
 // transformations to a common base.  When looking for a
 // resource to transform, try the OrgId first, and if this
 // fails or finds too many, it might make sense to then try
-// the CurrId.  Depends on the situation.
+// the CurId.  Depends on the situation.
 //
 // TODO: get rid of this interface (use bare resWrangler).
 // There aren't multiple implementations any more.

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -30,7 +30,6 @@ type resWrangler struct {
 
 func newOne() *resWrangler {
 	result := &resWrangler{}
-	result.Clear()
 	return result
 }
 

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -157,7 +157,9 @@ func (r *Resource) DeepCopy() *Resource {
 // the resource.
 // TODO: move to RNode, use GetMeta to improve performance.
 // TODO: make a version of mergeStringMaps that is build-annotation aware
-//   to avoid repeatedly setting refby and genargs annotations
+//
+//	to avoid repeatedly setting refby and genargs annotations
+//
 // Must remove the kustomize bit at the end.
 func (r *Resource) CopyMergeMetaDataFieldsFrom(other *Resource) error {
 	if err := r.SetLabels(
@@ -490,7 +492,7 @@ func (r *Resource) AppendRefVarName(variable types.Var) {
 
 // ApplySmPatch applies the provided strategic merge patch.
 func (r *Resource) ApplySmPatch(patch *Resource) error {
-	n, ns, k := r.GetName(), r.GetNamespace(), r.GetKind()
+	n, k := r.GetName(), r.GetKind()
 	if patch.NameChangeAllowed() || patch.KindChangeAllowed() {
 		r.StorePreviousId()
 	}
@@ -508,7 +510,6 @@ func (r *Resource) ApplySmPatch(patch *Resource) error {
 	if !patch.NameChangeAllowed() {
 		r.SetName(n)
 	}
-	r.SetNamespace(ns)
 	return nil
 }
 

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -173,6 +173,7 @@ metadata:
     app: mungebot
     foo: bar
   name: bingo
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -198,6 +199,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: baseprefix-mungebot
+  namespace: patched
 spec:
   template:
     spec:
@@ -221,6 +223,7 @@ metadata:
     app: mungebot
     foo: bar
   name: bingo
+  namespace: patched
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Fixes #5626

Previously, when a `namespace` was specified in the kustomization.yaml, `patches` attempting to override `metadata.namespace` were ignored. This fix ensures that `patches` can override the `namespace` as expected, even when a default `namespace` is set via the `NamespaceTransformer`.