### PR TITLE
feat: Add suport for Image Volumes

### DIFF
--- a/api/filters/imagetag/imagetag_test.go
+++ b/api/filters/imagetag/imagetag_test.go
@@ -879,6 +879,84 @@ spec:
 				},
 			},
 		},
+		"update image volume in pod template": {
+			input: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: imagevolume
+spec:
+  template:
+    spec:
+      volumes:
+      - name: volume
+        image:
+          reference: nginx
+`,
+			expectedOutput: `
+group: apps
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: imagevolume
+spec:
+  template:
+    spec:
+      volumes:
+      - name: volume
+        image:
+          reference: apache@12345
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					Name:    "nginx",
+					NewName: "apache",
+					Digest:  "12345",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/template/spec/volumes[]/image/reference",
+				},
+			},
+		},
+		"update image volume in pod spec": {
+			input: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: imagevolume
+spec:
+  volumes:
+  - name: volume
+    image:
+      reference: nginx
+`,
+			expectedOutput: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: imagevolume
+spec:
+  volumes:
+  - name: volume
+    image:
+      reference: apache@12345
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					Name:    "nginx",
+					NewName: "apache",
+					Digest:  "12345",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/volumes[]/image/reference",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/internal/konfig/builtinpluginconsts/images.go
+++ b/api/internal/konfig/builtinpluginconsts/images.go
@@ -10,9 +10,13 @@ images:
   create: true
 - path: spec/initContainers[]/image
   create: true
+- path: spec/volumes[]/image/reference
+  create: true
 - path: spec/template/spec/containers[]/image
   create: true
 - path: spec/template/spec/initContainers[]/image
+  create: true
+- path: spec/template/spec/volumes[]/image/reference
   create: true
 `
 )


### PR DESCRIPTION
Kubernetes now supports [mounting container images as volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/). This adds built in support for these.