### PR TITLE
perf: Add an option to skip OpenAPI schema initialization

### DIFF
--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -76,15 +76,18 @@ func (b *Kustomizer) Run(
 		return nil, err
 	}
 	var bytes []byte
-	if openApiPath, exists := kt.Kustomization().OpenAPI["path"]; exists {
+	kustomization := kt.Kustomization()
+	if openApiPath, exists := kustomization.OpenAPI["path"]; exists {
 		bytes, err = ldr.Load(openApiPath)
 		if err != nil {
 			return nil, err
 		}
 	}
-	err = openapi.SetSchema(kt.Kustomization().OpenAPI, bytes, true)
-	if err != nil {
-		return nil, err
+	if _, skip := kustomization.OpenAPI["skip"]; !skip {
+		err = openapi.SetSchema(kustomization.OpenAPI, bytes, true)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var m resmap.ResMap
 	m, err = kt.MakeCustomizedResMap()


### PR DESCRIPTION
This PR introduces a new `skip` field to the `openapi` map in the kustomization file.

### Problem

When using Kustomize as a library, `Kustomizer.Run` calls `openapi.SetSchema` on every execution. In high-frequency scenarios where the same schema is used repeatedly, this leads to a significant performance bottleneck due to redundant schema compilation.

In our use case, we call `Kustomizer.Run` thousands of times. Flame graph analysis showed that schema compilation was a major contributor to the overall execution time.

### Solution

By setting `openapi.skip` to `true`, users can now bypass the call to `openapi.SetSchema` inside `Kustomizer.Run`. This allows library consumers to initialize the schema once at application startup and reuse it for all subsequent runs.

**Example workflow:**

1. Initialize the schema manually once when your application starts: `openapi.SetSchema(...)`.
2. In your `kustomization.yaml`, add the `skip` field:
  ```yaml
  openapi:
    skip: true
  ```
3. Call `kustomizer.Run()` as usual.

### Result

This change dramatically improves performance in our scenario, reducing the total processing time **from 30 minutes to 9 minutes**.

### Next Steps and Design Alternatives

I've submitted this patch as a minimal implementation to start a discussion and validate the approach. I'm keen to hear your feedback and I'm ready to make adjustments.

Here are a few alternatives I've considered:

1.  Instead of modifying the public `kustomization.yaml` format, we could add a new field directly to the `Kustomizer` struct (e.g., `Kustomizer.SkipOpenAPISchema`). This would make the feature available only when Kustomize is used as a library, which is the primary use case for this optimization. I'm happy to implement it this way if you prefer.
2.  The field name `skip` is a placeholder. A more descriptive name like `usePreconfiguredSchema` or `built-in` might be better. I don't have a strong preference and am open to suggestions.

My main goal is to get early feedback on whether this direction for performance improvement is welcome before investing more time.