### PR TITLE
fix: Propagate Namespace correctly to Helm

### DIFF
--- a/api/internal/builtins/NamespaceTransformer.go
+++ b/api/internal/builtins/NamespaceTransformer.go
@@ -53,6 +53,12 @@ func (p *NamespaceTransformerPlugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
+		if origin, err := r.GetOrigin(); err == nil && origin != nil {
+			if origin.ConfiguredBy.Kind == "HelmChartInflationGenerator" {
+				// Don't apply namespace on Helm generated manifest. Helm should take care of it.
+				continue
+			}
+		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
 			Namespace:              p.Namespace,

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -496,6 +496,11 @@ func (kt *KustTarget) accumulateDirectory(
 	}
 	subKt.kustomization.BuildMetadata = kt.kustomization.BuildMetadata
 	subKt.origin = kt.origin
+	// Propagate namespace to child kustomization if child doesn't have one
+	// This ensures Helm charts in base kustomizations inherit namespace from overlays
+	if subKt.kustomization.Namespace == "" && kt.kustomization.Namespace != "" {
+		subKt.kustomization.Namespace = kt.kustomization.Namespace
+	}
 	var bytes []byte
 	if openApiPath, exists := subKt.Kustomization().OpenAPI["path"]; exists {
 		bytes, err = ldr.Load(openApiPath)

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -127,11 +127,11 @@ func (kt *KustTarget) MakeCustomizedResMap() (resmap.ResMap, error) {
 }
 
 func (kt *KustTarget) makeCustomizedResMap() (resmap.ResMap, error) {
-	var origin *resource.Origin
-	if len(kt.kustomization.BuildMetadata) != 0 {
-		origin = &resource.Origin{}
-	}
-	kt.origin = origin
+	// Track origin for all resources so builtins can make decisions
+	// based on where resources originated from.
+	// Origin annotations will be stripped from the output if not
+	// requested via build metadata options.
+	kt.origin = &resource.Origin{}
 	ra, err := kt.AccumulateTarget()
 	if err != nil {
 		return nil, err

--- a/api/internal/target/kusttarget_configplugin.go
+++ b/api/internal/target/kusttarget_configplugin.go
@@ -166,6 +166,11 @@ var generatorConfigurators = map[builtinhelpers.BuiltinPluginType]func(
 		for _, chart := range kt.kustomization.HelmCharts {
 			c.HelmGlobals = globals
 			c.HelmChart = chart
+			// Pass kustomize namespace to helm
+			// Fixes https://github.com/kubernetes-sigs/kustomize/issues/5566
+			if c.HelmChart.Namespace == "" && kt.kustomization.Namespace != "" {
+				c.HelmChart.Namespace = kt.kustomization.Namespace
+			}
 			p := f()
 			if err = kt.configureBuiltinPlugin(p, c, bpt); err != nil {
 				return nil, err

--- a/api/internal/target/kusttarget_test.go
+++ b/api/internal/target/kusttarget_test.go
@@ -300,6 +300,8 @@ metadata:
 		require.NoError(t, expected.Append(r), "failed to append resource: %v")
 	}
 	expected.RemoveBuildAnnotations()
+	require.NoError(t, expected.RemoveTransformerAnnotations())
+	require.NoError(t, expected.RemoveOriginAnnotations())
 	expYaml, err := expected.AsYaml()
 	require.NoError(t, err)
 
@@ -308,6 +310,8 @@ metadata:
 	actual, err := kt.MakeCustomizedResMap()
 	require.NoError(t, err)
 	actual.RemoveBuildAnnotations()
+	require.NoError(t, actual.RemoveTransformerAnnotations())
+	require.NoError(t, actual.RemoveOriginAnnotations())
 	actYaml, err := actual.AsYaml()
 	require.NoError(t, err)
 	assert.Equal(t, string(expYaml), string(actYaml))
@@ -411,6 +415,8 @@ metadata:
 		require.NoError(t, err)
 	}
 	expected.RemoveBuildAnnotations()
+	require.NoError(t, expected.RemoveTransformerAnnotations())
+	require.NoError(t, expected.RemoveOriginAnnotations())
 	expYaml, err := expected.AsYaml()
 	require.NoError(t, err)
 
@@ -419,6 +425,8 @@ metadata:
 	actual, err := kt.MakeCustomizedResMap()
 	require.NoError(t, err)
 	actual.RemoveBuildAnnotations()
+	require.NoError(t, actual.RemoveTransformerAnnotations())
+	require.NoError(t, actual.RemoveOriginAnnotations())
 	actYaml, err := actual.AsYaml()
 	require.NoError(t, err)
 	require.Equal(t, string(expYaml), string(actYaml))

--- a/api/krusty/helmchartinflationgenerator_test.go
+++ b/api/krusty/helmchartinflationgenerator_test.go
@@ -21,10 +21,31 @@ kind: Secret
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
-  name: test-minecraft
+  name: test-minecraft-rcon
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-minecraft
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test
+  name: test-minecraft-curseforge
+  namespace: default
 type: Opaque
 ---
 apiVersion: v1
@@ -32,10 +53,14 @@ kind: Service
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft
+  namespace: default
 spec:
   ports:
   - name: minecraft
@@ -150,7 +175,7 @@ func TestHelmChartInflationGeneratorOld(t *testing.T) {
 helmChartInflationGenerator:
 - chartName: minecraft
   chartRepoUrl: https://itzg.github.io/minecraft-server-charts
-  chartVersion: 3.1.3
+  chartVersion: 4.26.4
   releaseName: test
 `)
 
@@ -217,7 +242,7 @@ func TestHelmChartInflationGenerator(t *testing.T) {
 helmCharts:
 - name: minecraft
   repo: https://itzg.github.io/minecraft-server-charts
-  version: 3.1.3
+  version: 4.26.4
   releaseName: test
 `)
 
@@ -300,7 +325,7 @@ func TestHelmChartProdVsDev(t *testing.T) {
 helmCharts:
 - name: minecraft
   repo: https://itzg.github.io/minecraft-server-charts
-  version: 3.1.3
+  version: 4.26.4
   releaseName: test
 `)
 	th.WriteK(dirProd, `
@@ -335,10 +360,30 @@ kind: Secret
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
-  name: myProd-test-minecraft
+  name: myProd-test-minecraft-rcon
+  namespace: prod
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-minecraft
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test
+  name: myProd-test-minecraft-curseforge
   namespace: prod
 type: Opaque
 ---
@@ -347,7 +392,10 @@ kind: Service
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: myProd-test-minecraft
@@ -373,10 +421,30 @@ kind: Secret
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
-  name: myDev-test-minecraft
+  name: myDev-test-minecraft-rcon
+  namespace: dev
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-minecraft
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test
+  name: myDev-test-minecraft-curseforge
   namespace: dev
 type: Opaque
 ---
@@ -385,7 +453,10 @@ kind: Service
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: myDev-test-minecraft
@@ -407,10 +478,30 @@ kind: Secret
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
-  name: myProd-test-minecraft
+  name: myProd-test-minecraft-rcon
+  namespace: prod
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-minecraft
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test
+  name: myProd-test-minecraft-curseforge
   namespace: prod
 type: Opaque
 ---
@@ -419,7 +510,10 @@ kind: Service
 metadata:
   labels:
     app: test-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: myProd-test-minecraft
@@ -634,11 +728,11 @@ helmCharts:
     skipTests: true
   - name: minecraft
     repo: https://itzg.github.io/minecraft-server-charts
-    version: 3.1.3
+    version: 4.26.4
     releaseName: test-1
   - name: minecraft
     repo: https://itzg.github.io/minecraft-server-charts
-    version: 3.1.4
+    version: 4.26.4
     releaseName: test-2
 `)
 
@@ -669,10 +763,30 @@ kind: Secret
 metadata:
   labels:
     app: test-1-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-1-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test-1
-  name: test-1-minecraft
+  name: test-1-minecraft-rcon
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-1-minecraft
+    app.kubernetes.io/instance: test-1-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test-1
+  name: test-1-minecraft-curseforge
   namespace: default
 type: Opaque
 ---
@@ -681,7 +795,10 @@ kind: Service
 metadata:
   labels:
     app: test-1-minecraft
-    chart: minecraft-3.1.3
+    app.kubernetes.io/instance: test-1-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test-1
   name: test-1-minecraft
@@ -703,10 +820,30 @@ kind: Secret
 metadata:
   labels:
     app: test-2-minecraft
-    chart: minecraft-3.1.4
+    app.kubernetes.io/instance: test-2-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test-2
-  name: test-2-minecraft
+  name: test-2-minecraft-rcon
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  cf-api-key: Q0hBTkdFTUUh
+kind: Secret
+metadata:
+  labels:
+    app: test-2-minecraft
+    app.kubernetes.io/instance: test-2-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
+    heritage: Helm
+    release: test-2
+  name: test-2-minecraft-curseforge
   namespace: default
 type: Opaque
 ---
@@ -715,7 +852,10 @@ kind: Service
 metadata:
   labels:
     app: test-2-minecraft
-    chart: minecraft-3.1.4
+    app.kubernetes.io/instance: test-2-minecraft
+    app.kubernetes.io/name: minecraft
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test-2
   name: test-2-minecraft
@@ -746,7 +886,7 @@ namespace: default
 helmCharts:
   - name: minecraft
     repo: https://itzg.github.io/minecraft-server-charts
-    version: 4.11.0
+    version: 4.26.4
     releaseName: test
     kubeVersion: "1.16"
     valuesInline:
@@ -772,8 +912,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-rcon
@@ -789,8 +929,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-curseforge
@@ -804,8 +944,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft
@@ -827,8 +967,8 @@ metadata:
     app: test-minecraft-map
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-map
@@ -842,7 +982,7 @@ namespace: default
 helmCharts:
   - name: minecraft
     repo: https://itzg.github.io/minecraft-server-charts
-    version: 4.11.0
+    version: 4.26.4
     releaseName: test
     kubeVersion: "1.27"
     valuesInline:
@@ -868,8 +1008,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-rcon
@@ -885,8 +1025,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-curseforge
@@ -900,8 +1040,8 @@ metadata:
     app: test-minecraft
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft
@@ -923,14 +1063,167 @@ metadata:
     app: test-minecraft-map
     app.kubernetes.io/instance: test-minecraft
     app.kubernetes.io/name: minecraft
-    app.kubernetes.io/version: 4.11.0
-    chart: minecraft-4.11.0
+    app.kubernetes.io/version: 4.26.4
+    chart: minecraft-4.26.4
     heritage: Helm
     release: test
   name: test-minecraft-map
   namespace: default
 spec:
   rules: null
+`)
+}
+
+func TestHelmChartNamespacePropagationViaResources(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	// Create base directory with helm chart
+	baseDir := th.MkDir("base")
+	chartDir := filepath.Join(baseDir, "charts", "service")
+	require.NoError(t, th.GetFSys().MkdirAll(filepath.Join(chartDir, "templates")))
+	th.WriteF(filepath.Join(chartDir, "Chart.yaml"), `
+apiVersion: v2
+name: service
+type: application
+version: 1.0.0
+`)
+	th.WriteF(filepath.Join(chartDir, "values.yaml"), ``)
+	th.WriteF(filepath.Join(chartDir, "templates", "service.yaml"), `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    deployed-in-namespace: {{ .Release.Namespace }}
+`)
+
+	// Base kustomization with helmCharts
+	th.WriteK(baseDir, `
+helmGlobals:
+  chartHome: ./charts
+helmCharts:
+  - name: service
+    releaseName: service
+`)
+
+	// Overlay that references base via resources and sets namespace
+	overlayDir := th.MkDir("overlay")
+	th.WriteK(overlayDir, `
+namespace: production
+resources:
+  - ../base
+`)
+
+	m := th.Run(overlayDir, th.MakeOptionsPluginsEnabled())
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    deployed-in-namespace: production
+  name: test-service
+  namespace: production
+`)
+}
+
+func TestHelmChartDifferentNamespaces(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	chartDir := filepath.Join(th.GetRoot(), "charts", "service")
+	require.NoError(t, th.GetFSys().MkdirAll(filepath.Join(chartDir, "templates")))
+	th.WriteF(filepath.Join(chartDir, "Chart.yaml"), `
+apiVersion: v2
+name: service
+type: application
+version: 1.0.0
+`)
+	th.WriteF(filepath.Join(chartDir, "values.yaml"), ``)
+	th.WriteF(filepath.Join(chartDir, "templates", "service.yaml"), `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm-namespace: {{ .Release.Namespace }}
+`)
+
+	// Test with different namespaces in transformer vs helmCharts.namespace
+	th.WriteK(th.GetRoot(), `
+helmGlobals:
+  chartHome: ./charts
+namespace: transformer-ns
+helmCharts:
+  - name: service
+    releaseName: service
+    namespace: helm-ns
+`)
+
+	m := th.Run(th.GetRoot(), th.MakeOptionsPluginsEnabled())
+	// helmCharts.namespace should take precedence
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    helm-namespace: helm-ns
+  name: test-service
+  namespace: helm-ns
+`)
+}
+
+func TestHelmChartSameNamespace(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	chartDir := filepath.Join(th.GetRoot(), "charts", "service")
+	require.NoError(t, th.GetFSys().MkdirAll(filepath.Join(chartDir, "templates")))
+	th.WriteF(filepath.Join(chartDir, "Chart.yaml"), `
+apiVersion: v2
+name: service
+type: application
+version: 1.0.0
+`)
+	th.WriteF(filepath.Join(chartDir, "values.yaml"), ``)
+	th.WriteF(filepath.Join(chartDir, "templates", "service.yaml"), `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    deployed-namespace: {{ .Release.Namespace }}
+`)
+
+	// Test with same namespace in both places
+	th.WriteK(th.GetRoot(), `
+helmGlobals:
+  chartHome: ./charts
+namespace: shared-namespace
+helmCharts:
+  - name: service
+    releaseName: service
+    namespace: shared-namespace
+`)
+
+	m := th.Run(th.GetRoot(), th.MakeOptionsPluginsEnabled())
+	th.AssertActualEqualsExpected(m, `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    deployed-namespace: shared-namespace
+  name: test-service
+  namespace: shared-namespace
 `)
 }
 

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer.go
@@ -56,6 +56,12 @@ func (p *plugin) Transform(m resmap.ResMap) error {
 			// Don't mutate empty objects?
 			continue
 		}
+		if origin, err := r.GetOrigin(); err == nil && origin != nil {
+			if origin.ConfiguredBy.Kind == "HelmChartInflationGenerator" {
+				// Don't apply namespace on Helm generated manifest. Helm should take care of it.
+				continue
+			}
+		}
 		r.StorePreviousId()
 		if err := r.ApplyFilter(namespace.Filter{
 			Namespace:              p.Namespace,

--- a/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
+++ b/plugin/builtin/namespacetransformer/NamespaceTransformer_test.go
@@ -8,7 +8,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 const defaultFieldSpecs = `
@@ -761,4 +766,42 @@ subjects:
   namespace: random
 `)
 		})
+}
+
+func TestNamespaceTransformer_SkipHelmOrigin(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t).
+		PrepBuiltin("NamespaceTransformer")
+	defer th.Reset()
+
+	rmF := resmap.NewFactory(provider.NewDefaultDepProvider().GetResourceFactory())
+	rm, err := rmF.NewResMapFromBytes([]byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: helm-ns
+`))
+	require.NoError(t, err)
+	r := rm.Resources()[0]
+	origin := &resource.Origin{
+		ConfiguredBy: kyaml.ResourceIdentifier{
+			TypeMeta: kyaml.TypeMeta{APIVersion: "builtin", Kind: "HelmChartInflationGenerator"},
+		},
+	}
+	require.NoError(t, r.SetOrigin(origin))
+
+	rm, err = th.RunTransformerFromResMap(`
+apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: notImportantHere
+  namespace: test
+`+defaultFieldSpecs, rm)
+	require.NoError(t, err)
+	require.NoError(t, rm.RemoveOriginAnnotations())
+	th.AssertActualEqualsExpectedNoIdAnnotations(rm, `apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: helm-ns
+`)
 }


### PR DESCRIPTION
### Summary

This PR introduces a bugfix for [issue #5566](https://github.com/kubernetes-sigs/kustomize/issues/5566), which is currently the 6th most upvoted issue in the Kustomize repository.

### Bugfix Details

The fix modifies how `namespace` values are handled within `kustomization.yaml` when using `helmCharts`:

- If a `namespace` is set at the top level of the `kustomization.yaml`, it will always be propagated to the Helm CLI command.
- However, if a `helmCharts` entry specifies its own `namespace`, that value takes precedence and overrides the top-level one.

### NamespaceTransformer Behavior

Additionally, the `NamespaceTransformer` will now **skip all manifests generated by Helm charts**. This aligns with the principle that Helm charts should manage their own namespaces internally.

This change also enables charts to deploy resources across multiple namespaces—an essential capability for many popular charts such as the `cert-manager` Helm chart, which installs RBAC resources into the `kube-system` namespace.

----

### TL;DR

If you use Kustomize with Helm charts, ensure that your Helm templates explicitly set the namespace, for example:

```yaml
metadata:
  namespace: {{ .Release.Namespace }}
```

If your charts already handle namespaces this way, this change should not introduce any breaking behavior.
