### PR TITLE
feat: add Windows support by handling empty path case in PathSplit function

### DIFF
--- a/kyaml/filesys/util.go
+++ b/kyaml/filesys/util.go
@@ -52,6 +52,12 @@ func PathSplit(incoming string) []string {
 	if dir == "" {
 		return []string{path}
 	}
+	if dir == incoming {
+		// No progress can be made in the recursion. This happens on Windows
+		// with volume names (e.g. "C:") where filepath.Split returns the
+		// volume as dir with no trailing separator to trim.
+		return []string{dir}
+	}
 	return append(PathSplit(dir), path)
 }
 

--- a/kyaml/filesys/util_windows_test.go
+++ b/kyaml/filesys/util_windows_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package filesys
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Confirm behavior of filepath.Split on Windows.
+// On Windows, filepath.Split treats volume names (e.g. "C:") specially:
+// filepath.Split("C:") returns dir="C:", path="" because "C:" is a volume name
+// with no trailing separator. This is relevant to the PathSplit recursion bug.
+func TestFilePathSplitWindows(t *testing.T) {
+	cases := []struct {
+		full string
+		dir  string
+		file string
+	}{
+		{
+			full: "",
+			dir:  "",
+			file: "",
+		},
+		{
+			full: SelfDir,
+			dir:  "",
+			file: SelfDir,
+		},
+		{
+			full: "rabbit.jpg",
+			dir:  "",
+			file: "rabbit.jpg",
+		},
+		{
+			full: `\`,
+			dir:  `\`,
+			file: "",
+		},
+		{
+			full: `\beans`,
+			dir:  `\`,
+			file: "beans",
+		},
+		{
+			full: `C:\`,
+			dir:  `C:\`,
+			file: "",
+		},
+		{
+			full: `C:`,
+			dir:  `C:`,
+			file: "",
+		},
+		{
+			full: `C:\Users`,
+			dir:  `C:\`,
+			file: "Users",
+		},
+		{
+			full: `C:\Users\foo\bar`,
+			dir:  `C:\Users\foo\`,
+			file: "bar",
+		},
+		{
+			full: `C:\Users\foo\`,
+			dir:  `C:\Users\foo\`,
+			file: "",
+		},
+	}
+	for _, p := range cases {
+		dir, file := filepath.Split(p.full)
+		if dir != p.dir || file != p.file {
+			t.Fatalf(
+				"in '%s',\ngot dir='%s' (expected '%s'),\n got file='%s' (expected '%s').",
+				p.full, dir, p.dir, file, p.file)
+		}
+	}
+}
+
+// TestPathSplitAndJoinWindows tests PathSplit and PathJoin with
+// relative and backslash-absolute paths on Windows.
+func TestPathSplitAndJoinWindows(t *testing.T) {
+	cases := map[string]struct {
+		original string
+		expected []string
+	}{
+		"Empty": {
+			original: "",
+			expected: []string{},
+		},
+		"One": {
+			original: "hello",
+			expected: []string{"hello"},
+		},
+		"Two": {
+			original: `hello\there`,
+			expected: []string{"hello", "there"},
+		},
+		"Three": {
+			original: `hello\my\friend`,
+			expected: []string{"hello", "my", "friend"},
+		},
+	}
+	for n, c := range cases {
+		f := func(t *testing.T, original string, expected []string) {
+			t.Helper()
+			actual := PathSplit(original)
+			if len(actual) != len(expected) {
+				t.Fatalf(
+					"expected len %d, got len %d (%v)",
+					len(expected), len(actual), actual)
+			}
+			for i := range expected {
+				if expected[i] != actual[i] {
+					t.Fatalf(
+						"at i=%d, expected '%s', got '%s'",
+						i, expected[i], actual[i])
+				}
+			}
+			joined := PathJoin(actual)
+			if joined != original {
+				t.Fatalf(
+					"when rejoining, expected '%s', got '%s'",
+					original, joined)
+			}
+		}
+		t.Run("relative"+n, func(t *testing.T) {
+			f(t, c.original, c.expected)
+		})
+		t.Run("absolute"+n, func(t *testing.T) {
+			f(t,
+				string(os.PathSeparator)+c.original,
+				append([]string{""}, c.expected...))
+		})
+	}
+}
+
+// TestPathSplitWindowsVolumePaths tests PathSplit with Windows
+// volume paths (drive letters, UNC). Without the fix, these paths
+// cause infinite recursion (stack overflow) because filepath.Split
+// returns the volume name as dir with no trailing separator to trim,
+// creating a fixed-point in the recursion.
+func TestPathSplitWindowsVolumePaths(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected []string
+	}{
+		"DriveLetterOnly": {
+			input:    `C:`,
+			expected: []string{"C:"},
+		},
+		"DriveRoot": {
+			input:    `C:\`,
+			expected: []string{"C:", ""},
+		},
+		"DriveRootOneDir": {
+			input:    `C:\Users`,
+			expected: []string{"C:", "Users"},
+		},
+		"DriveRootTwoDirs": {
+			input:    `C:\Users\foo`,
+			expected: []string{"C:", "Users", "foo"},
+		},
+		"DriveRootThreeDirs": {
+			input:    `C:\Users\foo\bar`,
+			expected: []string{"C:", "Users", "foo", "bar"},
+		},
+		"DriveRootTrailingBackslash": {
+			input:    `C:\foo\`,
+			expected: []string{"C:", "foo", ""},
+		},
+		"RelativeDrivePath": {
+			input:    `C:foo`,
+			expected: []string{"C:", "foo"},
+		},
+		"UNCShareOnly": {
+			input:    `\\server\share`,
+			expected: []string{`\\server\share`},
+		},
+		"UNCShareWithDir": {
+			input:    `\\server\share\foo`,
+			expected: []string{`\\server\share`, "foo"},
+		},
+		"UNCShareWithNestedDirs": {
+			input:    `\\server\share\foo\bar`,
+			expected: []string{`\\server\share`, "foo", "bar"},
+		},
+	}
+	for n, c := range cases {
+		t.Run(n, func(t *testing.T) {
+			actual := PathSplit(c.input)
+			if len(actual) != len(c.expected) {
+				t.Fatalf(
+					"expected len %d, got len %d (%v)",
+					len(c.expected), len(actual), actual)
+			}
+			for i := range c.expected {
+				if c.expected[i] != actual[i] {
+					t.Fatalf(
+						"at i=%d, expected '%s', got '%s'",
+						i, c.expected[i], actual[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Goal: Fix `PathSplit` function to handle empty path case for `Windows` support

Context: This PR fixes an issue I was having when adding `Windows` support for some of my utilities by updating the function to handle the case when is empty.

# The issue
When running on `Windows`, I was getting errors because the function wasn't handling empty paths correctly. The problem occurs because `Windows` uses backslashes (`\`) as path separators, so when resolves to `\`, the path splitting logic behaves differently than on Unix systems.
For example, I was seeing errors like this locally:

```shell
C:\Users\<user>\AppData\Local\Temp\<my_local_git>@<local_ref>
```

Causing a `stack overflow`:

<details>

<summary><i>click here to see the stack trace... ❗️</i></summary>

```shell
fatal error: stack overflow

runtime stack:
runtime.throw({0x7ff62c817a83?, 0x7ff62a2ef630?})
        C:/Program Files/Go/src/runtime/panic.go:1101 +0x38 fp=0x26bffffd60 sp=0x26bffffd30 pc=0x7ff62a331418
runtime.newstack()
        C:/Program Files/Go/src/runtime/stack.go:1107 +0x464 fp=0x26bffffea0 sp=0x26bffffd60 pc=0x7ff62a318094
runtime.morestack()
        C:/Program Files/Go/src/runtime/asm_arm64.s:342 +0x70 fp=0x26bffffea0 sp=0x26bffffea0 pc=0x7ff62a336d60

goroutine 52 gp=0x400072a700 m=10 mp=0x4000742008 [running]:
internal/filepathlite.1({0x40020ea7b0, 0x7})
        C:/Program Files/Go/src/internal/filepathlite/path_windows.go:204 +0x2b8 fp=0x4022d67380 sp=0x4022d67380 pc=0x7ff62a382af8
internal/filepathlite.VolumeName({0x40020ea7b0, 0x7})
        C:/Program Files/Go/src/internal/filepathlite/path.go:267 +0x24 fp=0x4022d673b0 sp=0x4022d67380 pc=0x7ff62a381e24
internal/filepathlite.Split({0x40020ea7b0, 0x7})
        C:/Program Files/Go/src/internal/filepathlite/path.go:206 +0x24 fp=0x4022d673d0 sp=0x4022d673b0 pc=0x7ff62a381b04
path/filepath.Split(...)
        C:/Program Files/Go/src/path/filepath/path.go:120
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:44 +0x28 fp=0x4022d67450 sp=0x4022d673d0 pc=0x7ff62b8c2968
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d674d0 sp=0x4022d67450 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d67550 sp=0x4022d674d0 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d675d0 sp=0x4022d67550 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d67650 sp=0x4022d675d0 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d676d0 sp=0x4022d67650 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d67750 sp=0x4022d676d0 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d677d0 sp=0x4022d67750 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d67850 sp=0x4022d677d0 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
        C:/Users/my_user/go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.20.0/filesys/util.go:55 +0x168 fp=0x4022d678d0 sp=0x4022d67850 pc=0x7ff62b8c2aa8
sigs.k8s.io/kustomize/kyaml/filesys.PathSplit({0x40020ea7b0?, 0x7?})
...
```

</details>

_Note: `go version go1.24.5 windows/arm64`_

## My proposal
I added a simple check to the existing condition in . This prevents issues when working with `Windows` systems.

```diff
@@ -49,7 +49,7 @@ func PathSplit(incoming string) []string {
                return []string{"", path}
        }
        dir = strings.TrimSuffix(dir, string(os.PathSeparator))
-       if dir == "" {
+       if dir == "" || path == "" {
                return []string{path}
        }
        return append(PathSplit(dir), path)
```

## Why this works
The existing tests already pass with this change, which confirms this change does not impact existing unix support. It is aimed at ensuring consistent behaviour across operating systems without requiring more invasive changes.

## Testing notes
The existing tests exclude `Windows` intentionally, and I wasn't sure if adapting them would be straightforward since proper testing needs to be done on a `Windows` host where resolves to the `Windows`-specific rune.

Any form of feedback is greatly appreciated.