### PR TITLE
fix: make AbsorbAll conflict error more verbose

### DIFF
--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -597,7 +597,7 @@ func (m *resWrangler) appendReplaceOrMerge(res *resource.Resource) error {
 
 		default:
 			return fmt.Errorf(
-				"id %#v exists; behavior must be merge or replace", id)
+				"id %#v exists; can not use behavior: '%s', behavior must be merge or replace", id, res.Behavior())
 		}
 		i, err := m.Replace(res)
 		if err != nil {


### PR DESCRIPTION
As a response to #5924.
Accumulation errors in case of a conflict, in the case a resource's ID exists in history and an attempt to, for example, generate a resource with the same ID, with a resource's behavior `create` or `unspecified` could be even more clarified by stating the behavior inside the error itself.