### PR TITLE
Fix infinite loop in HTTP client by validating URLs before requests

### DIFF
--- a/api/internal/loader/fileloader.go
+++ b/api/internal/loader/fileloader.go
@@ -311,7 +311,11 @@ func (fl *FileLoader) httpClientGetContent(path string) ([]byte, error) {
 	} else {
 		hc = &http.Client{}
 	}
-	resp, err := hc.Get(path)
+	parsedURL, err := url.ParseRequestURI(path)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+	resp, err := hc.Get(parsedURL.String())
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/api/internal/loader/fileloader_test.go
+++ b/api/internal/loader/fileloader_test.go
@@ -676,3 +676,15 @@ func setupOnDisk(t *testing.T) (filesys.FileSystem, filesys.ConfirmedDir) {
 	})
 	return fSys, dir
 }
+
+// TestLoaderHTTPMalformedURL tests that malformed URLs are properly handled
+// to prevent infinite loops in http.Client.Get
+func TestLoaderHTTPMalformedURL(t *testing.T) {
+	require := require.New(t)
+	malformedURL := "https://example.com/example?ref=main - ../../example/example.yaml"
+	l1 := NewLoaderOrDie(
+		RestrictionRootOnly, MakeFakeFs([]testData{}), filesys.Separator)
+	_, err := l1.Load(malformedURL)
+	require.Error(err)
+	require.Equal("HTTP Error: status code 500 (Internal Server Error)", err.Error())
+}


### PR DESCRIPTION
close: https://github.com/kubernetes-sigs/kustomize/issues/5947