### PR TITLE
Fix helm valuesInline merge failure when types differ

### DIFF
--- a/kyaml/yaml/merge2/merge2_test.go
+++ b/kyaml/yaml/merge2/merge2_test.go
@@ -51,3 +51,178 @@ type testCase struct {
 	infer        bool
 	mergeOptions yaml.MergeOptions
 }
+
+// TestMergeWithKindChange tests the AllowKindChange option which allows
+// merging nodes of different kinds (e.g., map to list, map to scalar).
+// This is needed for Helm values merging where charts may have placeholder
+// types that don't match what users want to provide.
+// Reference: https://github.com/kubernetes-sigs/kustomize/issues/5766
+// Reference: https://github.com/actions/actions-runner-controller/issues/3819
+func TestMergeWithKindChange(t *testing.T) {
+	testCases := []struct {
+		name            string
+		source          string
+		dest            string
+		expected        string
+		allowKindChange bool
+		expectError     bool
+	}{
+		{
+			// Issue #5766: Chart has empty map {}, user wants to provide a list
+			name: "map to list with AllowKindChange=true (issue #5766)",
+			source: `
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+`,
+			dest: `
+topologySpreadConstraints: {}
+`,
+			expected: `
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+`,
+			allowKindChange: true,
+			expectError:     false,
+		},
+		{
+			name: "map to list without AllowKindChange should fail",
+			source: `
+topologySpreadConstraints:
+- maxSkew: 1
+`,
+			dest: `
+topologySpreadConstraints: {}
+`,
+			allowKindChange: false,
+			expectError:     true,
+		},
+		{
+			// Issue #3819: Chart has map structure, user wants to provide a scalar string
+			name: "map to scalar with AllowKindChange=true (issue #3819)",
+			source: `
+githubConfigSecret: my-custom-secret
+`,
+			dest: `
+githubConfigSecret:
+  github_token: ""
+`,
+			expected: `
+githubConfigSecret: my-custom-secret
+`,
+			allowKindChange: true,
+			expectError:     false,
+		},
+		{
+			name: "map to scalar without AllowKindChange should fail",
+			source: `
+githubConfigSecret: my-custom-secret
+`,
+			dest: `
+githubConfigSecret:
+  github_token: ""
+`,
+			allowKindChange: false,
+			expectError:     true,
+		},
+		{
+			// Reverse case: list to map
+			name: "list to map with AllowKindChange=true",
+			source: `
+tls:
+  termination: edge
+  insecureEdgeTerminationPolicy: Redirect
+`,
+			dest: `
+tls: []
+`,
+			expected: `
+tls:
+  termination: edge
+  insecureEdgeTerminationPolicy: Redirect
+`,
+			allowKindChange: true,
+			expectError:     false,
+		},
+		{
+			// Scalar to map
+			name: "scalar to map with AllowKindChange=true",
+			source: `
+config:
+  enabled: true
+  value: 42
+`,
+			dest: `
+config: "default"
+`,
+			expected: `
+config:
+  enabled: true
+  value: 42
+`,
+			allowKindChange: true,
+			expectError:     false,
+		},
+		{
+			// Nested kind change
+			name: "nested kind change with AllowKindChange=true",
+			source: `
+route:
+  tls:
+    termination: edge
+`,
+			dest: `
+route:
+  tls: []
+`,
+			expected: `
+route:
+  tls:
+    termination: edge
+`,
+			allowKindChange: true,
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mergeOpts := yaml.MergeOptions{AllowKindChange: tc.allowKindChange}
+			actual, err := MergeStrings(tc.source, tc.dest, false, mergeOpts)
+
+			if tc.expectError {
+				assert.Error(t, err, "expected error but got none")
+				return
+			}
+
+			if !assert.NoError(t, err, tc.name) {
+				t.FailNow()
+			}
+
+			// Parse and format both expected and actual for comparison
+			src, err := yaml.Parse(tc.source)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			srcMap, err := src.Map()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			act, err := yaml.Parse(actual)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			actMap, err := act.Map()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			// The source values should be present in the result
+			for key := range srcMap {
+				assert.Contains(t, actMap, key, "result should contain key from source: %s", key)
+			}
+		})
+	}
+}

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -246,6 +246,14 @@ type MergeOptions struct {
 	// ListIncreaseDirection indicates should merge function prepend the items from
 	// source list to destination or append.
 	ListIncreaseDirection MergeOptionsListIncreaseDirection
+
+	// AllowKindChange if set to true will allow the merge to replace a field with
+	// a different type. For example, if the destination has a map and the source
+	// has a list (or scalar), the source will replace the destination instead of
+	// returning an error. This is useful for merging Helm values where the chart's
+	// values.yaml may have a placeholder type that needs to be overridden.
+	// See https://github.com/kubernetes-sigs/kustomize/issues/5766
+	AllowKindChange bool
 }
 
 // Since ObjectMeta and TypeMeta are stable, we manually create DeepCopy funcs for ResourceMeta and ObjectMeta.


### PR DESCRIPTION
> [!WARNING]
> All the code was generated by Opus 4.5 - but it's remarkably good!

When using valuesInline with helm charts, kustomize would fail with "wrong node kind" errors when the chart's values.yaml had a different type than what the user provided. For example:
- Chart has `topologySpreadConstraints: {}` but user provides a list
- Chart has `githubConfigSecret: {github_token: ""}` but user provides a string

This adds an AllowKindChange option to MergeOptions that allows the source value to completely replace the destination when their YAML node kinds differ (e.g., map vs list, map vs scalar).

The HelmChartInflationGenerator now enables this option when merging values, fixing the regression introduced in kustomize 5.4.0.

Fixes https://github.com/kubernetes-sigs/kustomize/issues/5766 and https://github.com/actions/actions-runner-controller/issues/3819