### PR TITLE
Add default case to handle invalid `--output` flag in version command

### DIFF
--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -81,6 +81,8 @@ func (o *Options) Run() error {
 			return errors.WrapPrefixf(err, "marshalling provenance to json")
 		}
 		fmt.Fprintln(o.Writer, string(marshalled))
+	default:
+		return fmt.Errorf("--output must be 'yaml' or 'json'")
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Add default case for invalid `--output` flag in version command

When users specify an invalid value for the `--output` flag (e.g., `--output=yml`),
the command fails silently with no error message or output.

This PR adds a default case to the switch statement that returns a clear error message, 
matching the error handling pattern used in kubectl version.

### Output after adding default block
```bash
$ kustomize version --output=yml
Error: --output must be 'yaml' or 'json'
Usage:
  kustomize version [flags]

Examples:
kustomize version

Flags:
  -h, --help            help for version
  -o, --output string   One of 'yaml' or 'json'.

Global Flags:
      --stack-trace   print a stack-trace on error

exit status 1
```

Fixes #6032 

## Additional context

This is my first contribution to the kustomize codebase.
Please let me know if there's anything I should adjust to better align with the project's conventions.