### PR TITLE
Fix a failing test

### DIFF
--- a/api/internal/loader/fileloader_test.go
+++ b/api/internal/loader/fileloader_test.go
@@ -686,5 +686,5 @@ func TestLoaderHTTPMalformedURL(t *testing.T) {
 		RestrictionRootOnly, MakeFakeFs([]testData{}), filesys.Separator)
 	_, err := l1.Load(malformedURL)
 	require.Error(err)
-	require.Equal("HTTP Error: status code 500 (Internal Server Error)", err.Error())
+	require.Equal("HTTP Error: status code 400 (Bad Request)", err.Error())
 }


### PR DESCRIPTION
While I'm executing tests, I've got an error like:
```
=== RUN   TestLoaderHTTPMalformedURL
    fileloader_test.go:689: 
        	Error Trace:	/home/runner/work/kustomize/kustomize/api/internal/loader/fileloader_test.go:689
        	Error:      	Not equal: 
        	            	expected: "HTTP Error: status code 500 (Internal Server Error)"
        	            	actual  : "HTTP Error: status code 400 (Bad Request)"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-HTTP Error: status code 500 (Internal Server Error)
        	            	+HTTP Error: status code 400 (Bad Request)
        	Test:       	TestLoaderHTTPMalformedURL
```

I'm not sure why is's caused, but it would be due to example.com-side changes.