### PR TITLE
feat: add support to set labels without selector

### DIFF
--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -70,7 +70,7 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 	o.mapValidator = v
 	cmd := &cobra.Command{
 		Use: "label",
-		Short: "Adds one or more commonLabels to " +
+		Short: "Adds one or more commonLabels or labels to " +
 			konfig.DefaultKustomizationFileName(),
 		Example: `
 		add label {labelKey1:labelValue1} {labelKey2:labelValue2}`,

--- a/kustomize/commands/edit/set/setlabel_test.go
+++ b/kustomize/commands/edit/set/setlabel_test.go
@@ -6,6 +6,7 @@ package set
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
@@ -151,4 +152,82 @@ func TestSetLabelExisting(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err.Error())
 	}
+}
+
+func TestSetLabelWithoutSelector(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+	o.labelsWithoutSelector = true
+
+	m := makeKustomization(t)
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar"}})
+}
+
+func TestSetLabelWithoutSelectorWithExistingLabels(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+	o.labelsWithoutSelector = true
+
+	m := makeKustomization(t)
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar"}})
+
+	o.metadata = map[string]string{"key3": "foobar"}
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar", "key3": "foobar"}})
+}
+
+func TestSetLabelWithoutSelectorWithDuplicateLabel(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+	o.labelsWithoutSelector = true
+	o.includeTemplates = true
+
+	m := makeKustomization(t)
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar"}, IncludeTemplates: true})
+
+	o.metadata = map[string]string{"key2": "bar"}
+	o.includeTemplates = false
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo"}, IncludeTemplates: true})
+	require.Equal(t, m.Labels[1], types.Label{Pairs: map[string]string{"key2": "bar"}})
+}
+
+func TestSetLabelWithoutSelectorWithCommonLabel(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+
+	m := makeKustomization(t)
+	require.NoError(t, o.setLabels(m))
+	require.Empty(t, m.Labels)
+	//nolint:staticcheck
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld", "key1": "foo", "key2": "bar"})
+
+	o.metadata = map[string]string{"key2": "bar"}
+	o.labelsWithoutSelector = true
+	require.NoError(t, o.setLabels(m))
+	//nolint:staticcheck
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld", "key1": "foo"})
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key2": "bar"}})
+}
+
+func TestSetLabelCommonLabelWithWithoutSelector(t *testing.T) {
+	var o setLabelOptions
+	o.metadata = map[string]string{"key1": "foo", "key2": "bar"}
+
+	m := makeKustomization(t)
+	o.labelsWithoutSelector = true
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo", "key2": "bar"}})
+	//nolint:staticcheck
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld"})
+
+	o.metadata = map[string]string{"key2": "bar2"}
+	o.labelsWithoutSelector = false
+	require.NoError(t, o.setLabels(m))
+	require.Equal(t, m.Labels[0], types.Label{Pairs: map[string]string{"key1": "foo"}})
+	//nolint:staticcheck
+	require.Equal(t, m.CommonLabels, map[string]string{"app": "helloworld", "key2": "bar2"})
 }


### PR DESCRIPTION
Tries to solve issue: https://github.com/kubernetes-sigs/kustomize/issues/3866

Based on existing feature merged in https://github.com/kubernetes-sigs/kustomize/pull/4486, uses same command flags with `edit set label`
Set label removes existing duplicate labels from commonLabels, and labels where includeTemplates value does not match.

Duplicate of https://github.com/kubernetes-sigs/kustomize/pull/4478, added modifications to command flags and test

Reopened https://github.com/kubernetes-sigs/kustomize/pull/5741 after rebasing default branch