### PR TITLE
fix: preserve original YAML formatting in resource output

### DIFF
--- a/api/krusty/stringquoteblank_test.go
+++ b/api/krusty/stringquoteblank_test.go
@@ -9,11 +9,8 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-// This test is for output string style.
-// Currently all quotes will be removed if the string is valid as plain (unquoted) style.
-// If a string cannot be unquoted, it will be put into a pair of single quotes.
-// See https://yaml.org/spec/1.2/spec.html#id2788859 for more details about what kind of string
-// is invalid as plain style.
+// This test verifies that long lines are NOT wrapped in YAML output.
+// See https://github.com/kubernetes-sigs/kustomize/issues/947
 func TestLongLineBreaks(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteF("deployment.yaml", `
@@ -59,27 +56,24 @@ spec:
   template:
     spec:
       containers:
-      - env:
+      - name: mariadb
+        image: test
+        env:
         - name: SHORT_STRING
           value: short_string
         - name: SHORT_STRING_WITH_SINGLE_QUOTE
-          value: short_string
+          value: 'short_string'
         - name: SHORT_STRING_WITH_DOUBLE_QUOTE
-          value: short_string
+          value: "short_string"
         - name: SHORT_STRING_BLANK
           value: short string
         - name: LONG_STRING_BLANK
-          value: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas
-            suscipit ex non molestie varius.
+          value: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas suscipit ex non molestie varius.
         - name: LONG_STRING_BLANK_WITH_SINGLE_QUOTE
-          value: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas
-            suscipit ex non molestie varius.
+          value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas suscipit ex non molestie varius.'
         - name: LONG_STRING_BLANK_WITH_DOUBLE_QUOTE
-          value: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas
-            suscipit ex non molestie varius.
+          value: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas suscipit ex non molestie varius."
         - name: INVALID_PLAIN_STYLE_STRING
           value: ': test'
-        image: test
-        name: mariadb
 `)
 }

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -380,11 +380,10 @@ func (r *Resource) String() string {
 // AsYAML returns the resource in Yaml form.
 // Easier to read than JSON.
 func (r *Resource) AsYAML() ([]byte, error) {
-	json, err := r.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return yaml.JSONToYAML(json)
+	// Use kyaml's encoder directly to preserve original formatting
+	// and avoid line wrapping issues with sigs.k8s.io/yaml.JSONToYAML.
+	// See https://github.com/kubernetes-sigs/kustomize/issues/947
+	return []byte(r.MustString()), nil
 }
 
 // MustYaml returns YAML or panics.

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -380,10 +380,17 @@ func (r *Resource) String() string {
 // AsYAML returns the resource in Yaml form.
 // Easier to read than JSON.
 func (r *Resource) AsYAML() ([]byte, error) {
+	if _, err := r.Map(); err != nil {
+		return nil, fmt.Errorf("failed to convert resource %s to YAML: invalid resource structure: %w", r.CurId(), err)
+	}
 	// Use kyaml's encoder directly to preserve original formatting
 	// and avoid line wrapping issues with sigs.k8s.io/yaml.JSONToYAML.
 	// See https://github.com/kubernetes-sigs/kustomize/issues/947
-	return []byte(r.MustString()), nil
+	s, err := r.RNode.String()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert resource %s to YAML: serialize failed: %w", r.CurId(), err)
+	}
+	return []byte(s), nil
 }
 
 // MustYaml returns YAML or panics.

--- a/kustomize/commands/build/build_test.go
+++ b/kustomize/commands/build/build_test.go
@@ -68,48 +68,48 @@ metadata:
 const expectedContent = `apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    note: This is a test annotation
+  name: ns1
   labels:
     app: nginx
-  name: ns1
+  annotations:
+    note: This is a test annotation
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo-literalConfigMap-bar-g5f6t456f5
+  namespace: ns1
+  labels:
+    app: nginx
+  annotations:
+    note: This is a test annotation
 data:
   DB_PASSWORD: somepw
   DB_USERNAME: admin
-kind: ConfigMap
-metadata:
-  annotations:
-    note: This is a test annotation
-  labels:
-    app: nginx
-  name: foo-literalConfigMap-bar-g5f6t456f5
-  namespace: ns1
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: foo-secret-bar-82c2g5f8f6
+  namespace: ns1
+  labels:
+    app: nginx
+  annotations:
+    note: This is a test annotation
+type: Opaque
 data:
   DB_PASSWORD: c29tZXB3
   DB_USERNAME: YWRtaW4=
-kind: Secret
-metadata:
-  annotations:
-    note: This is a test annotation
-  labels:
-    app: nginx
-  name: foo-secret-bar-82c2g5f8f6
-  namespace: ns1
-type: Opaque
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    note: This is a test annotation
   labels:
     app: nginx
   name: foo-dply1-bar
   namespace: ns1
+  annotations:
+    note: This is a test annotation
 spec:
   replica: "3"
   selector:


### PR DESCRIPTION
## What this PR does

Changes `Resource.AsYAML()` to use kyaml's encoder instead of `sigs.k8s.io/yaml.JSONToYAML`.

## Why

The previous implementation had issues with:
- Long lines being wrapped (breaking shell commands, template strings)
- Inconsistent quote handling

## Breaking changes

Quote styles are now preserved instead of being normalized. For example:
- `'quoted_value'` stays as `'quoted_value'` (previously became `quoted_value`)

This is considered an improvement as it provides consistent, predictable output.

---
Related to:
- #947 
- #3969