### PR TITLE
[WIP] feat: add option to merge file content in configmaps/secrets

### DIFF
--- a/api/ifc/ifc.go
+++ b/api/ifc/ifc.go
@@ -24,6 +24,7 @@ type Validator interface {
 type KvLoader interface {
 	Validator() Validator
 	Load(args types.KvPairSources) (all []types.Pair, err error)
+	LoadLines(lines string) (all []types.Pair, err error)
 }
 
 // Loader interface exposes methods to read bytes.

--- a/api/internal/plugins/utils/utils.go
+++ b/api/internal/plugins/utils/utils.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	idAnnotation       = "kustomize.config.k8s.io/id"
-	HashAnnotation     = "kustomize.config.k8s.io/needs-hash"
-	BehaviorAnnotation = "kustomize.config.k8s.io/behavior"
+	idAnnotation            = "kustomize.config.k8s.io/id"
+	HashAnnotation          = "kustomize.config.k8s.io/needs-hash"
+	BehaviorAnnotation      = "kustomize.config.k8s.io/behavior"
+	FileMergeModeAnnotation = "kustomize.config.k8s.io/file-merge-mode"
 )
 
 func GoBin() string {
@@ -216,6 +217,7 @@ func UpdateResourceOptions(rm resmap.ResMap) (resmap.ResMap, error) {
 		// request it for each resource.
 		annotations := r.GetAnnotations()
 		behavior := annotations[BehaviorAnnotation]
+		fileMergeMode := annotations[FileMergeModeAnnotation]
 		var needsHash bool
 		if val, ok := annotations[HashAnnotation]; ok {
 			b, err := strconv.ParseBool(val)
@@ -228,6 +230,7 @@ func UpdateResourceOptions(rm resmap.ResMap) (resmap.ResMap, error) {
 		}
 		delete(annotations, HashAnnotation)
 		delete(annotations, BehaviorAnnotation)
+		delete(annotations, FileMergeModeAnnotation)
 		if err := r.SetAnnotations(annotations); err != nil {
 			return nil, err
 		}
@@ -235,6 +238,7 @@ func UpdateResourceOptions(rm resmap.ResMap) (resmap.ResMap, error) {
 			r.EnableHashSuffix()
 		}
 		r.SetBehavior(types.NewGenerationBehavior(behavior))
+		r.SetFileMergeMode(types.NewFileMergeMode(fileMergeMode))
 	}
 	return rm, nil
 }

--- a/api/internal/utils/annotations.go
+++ b/api/internal/utils/annotations.go
@@ -15,6 +15,7 @@ const (
 	BuildAnnotationsRefBy             = konfig.ConfigAnnoDomain + "/refBy"
 	BuildAnnotationsGenBehavior       = konfig.ConfigAnnoDomain + "/generatorBehavior"
 	BuildAnnotationsGenAddHashSuffix  = konfig.ConfigAnnoDomain + "/needsHashSuffix"
+	BuildAnnotationsGenFileMergeMode  = konfig.ConfigAnnoDomain + "/fileMergeMode"
 
 	// the following are only for patches, to specify whether they can change names
 	// and kinds of their targets

--- a/api/kv/kv.go
+++ b/api/kv/kv.go
@@ -36,6 +36,10 @@ func (kvl *loader) Validator() ifc.Validator {
 	return kvl.validator
 }
 
+func (kvl *loader) LoadLines(lines string) (all []types.Pair, err error) {
+	return kvl.keyValuesFromLines([]byte(lines))
+}
+
 func (kvl *loader) Load(
 	args types.KvPairSources) (all []types.Pair, err error) {
 	pairs, err := kvl.keyValuesFromEnvFiles(args.EnvSources)

--- a/api/resmap/reswrangler.go
+++ b/api/resmap/reswrangler.go
@@ -589,7 +589,9 @@ func (m *resWrangler) appendReplaceOrMerge(res *resource.Resource) error {
 				return err
 			}
 			res.CopyMergeMetaDataFieldsFrom(old)
-			res.MergeDataMapFrom(old)
+			if err := res.MergeDataMapFrom(old); err != nil {
+				return err
+			}
 			res.MergeBinaryDataMapFrom(old)
 			if orig != nil {
 				res.SetOrigin(orig)

--- a/api/resource/factory.go
+++ b/api/resource/factory.go
@@ -83,6 +83,11 @@ func (rf *Factory) makeOne(rn *yaml.RNode, o *types.GeneratorArgs) *Resource {
 		if o.Options == nil || !o.Options.DisableNameSuffixHash {
 			resource.EnableHashSuffix()
 		}
+		var fileMergeMode = types.FileMergeModeUnspecified
+		if o.Options != nil && o.Options.FileMerge != nil {
+			fileMergeMode = o.Options.FileMerge.Mode
+		}
+		resource.SetFileMergeMode(fileMergeMode)
 		resource.SetBehavior(types.NewGenerationBehavior(o.Behavior))
 	}
 

--- a/api/resource/factory_test.go
+++ b/api/resource/factory_test.go
@@ -761,3 +761,60 @@ metadata:
 		})
 	}
 }
+
+func TestFromMapAndOption_FileMergeMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		options      *types.GeneratorOptions
+		expectedMode types.FileMergeMode
+	}{
+		{
+			name: "with FileMerge content mode",
+			options: &types.GeneratorOptions{
+				FileMerge: &types.FileMergeOptions{
+					Mode: types.FileMergeModeFileContent,
+				},
+			},
+			expectedMode: types.FileMergeModeFileContent,
+		},
+		{
+			name: "with FileMerge files mode",
+			options: &types.GeneratorOptions{
+				FileMerge: &types.FileMergeOptions{
+					Mode: types.FileMergeModeFiles,
+				},
+			},
+			expectedMode: types.FileMergeModeFiles,
+		},
+		{
+			name:         "with nil FileMerge",
+			options:      &types.GeneratorOptions{},
+			expectedMode: types.FileMergeModeUnspecified,
+		},
+		{
+			name:         "with nil options",
+			options:      nil,
+			expectedMode: types.FileMergeModeUnspecified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, err := factory.FromMapAndOption(
+				map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]interface{}{"name": "test"},
+				},
+				&types.GeneratorArgs{
+					Options: tc.options,
+				},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, resource)
+
+			actualMode := resource.FileMergeMode()
+			require.Equal(t, tc.expectedMode, actualMode)
+		})
+	}
+}

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -66,14 +66,8 @@ func IsYNodeString(n *yaml.Node) bool {
 
 // IsYNodeZero is true if all the public fields in the Node are empty.
 // Which means it's not initialized and should be omitted when marshal.
-// The Node itself has a method IsZero but it is not released
-// in yaml.v3. https://pkg.go.dev/gopkg.in/yaml.v3#Node.IsZero
 func IsYNodeZero(n *yaml.Node) bool {
-	// TODO: Change this to use IsZero when it's avaialable.
-	return n != nil && n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" &&
-		n.Anchor == "" && n.Alias == nil && n.Content == nil &&
-		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" &&
-		n.Line == 0 && n.Column == 0
+	return n != nil && n.IsZero()
 }
 
 // Parser parses values into configuration.


### PR DESCRIPTION
## Problem

When using `behavior: merge` with ConfigMap/Secret generators, files with the same key are completely overridden rather than merged. The `behavior: merge` only works at the resource level (merging keys), not at the file content level.

This issue was originally reported in https://github.com/kubernetes-sigs/kustomize/issues/370 and was kind of popular judging by the comments [here](https://github.com/kubernetes-sigs/kustomize/issues/370#issuecomment-474597641) and [here](https://github.com/kubernetes-sigs/kustomize/issues/370#issuecomment-497655793)

## Proposed Solution

Added `fileMerge.mode` option to `generatorOptions` to enable content-level merging:

- `files` (default): Existing behavior - files with same key override completely
- `content`: Merges file contents when the same key appears across layers

**Merge strategies:**
- `.yaml`/`.yml` files: Strategic merge of YAML structures, uses the same logic as when merging `Resources` (so f.e. specifying schema in a comment works etc)
- all other files: Key-value merge, uses the logic from `kv` package, similar to `envs` but keeps the content in the file after merge

**Example:**
```yaml
generatorOptions:
  fileMerge:
    mode: content

configMapGenerator:
- name: app-config
  behavior: merge
  files:
  - config.properties
```

Base properties are merged with overlay properties - overlay overrides specific keys while preserving all other base keys. This only works on the `data` field, binary data is ignored.

## Concerns

### Secrets handling

While it makes sense to me that this behaviour should also work for Secrets, due to secret file content encoding we have to decode before merging, and recode again. Even though I tried to implement it in the most careful way possible it still feels off to do that.

### `generatorOptions` are global

This is a major issue because lets say I have a file which is a `.json` config. Since we assume that any non `.yaml` is a KV config file - we completely corrupt it. 

If the user would like to fix that by separating the files into different configmaps - he can't, because generator options apply to all.

## Alternative Solutions

* add a field *next to* `behavior` for file merge mode?
* add another option to `behavior` like `merge-file-content`
* add another KVSource next to `files` like `file-content` or whatever

None of these solutions struck me as perfect, so I would love some input from the experts on this project. 

I hope you are open to this functionality, and lmk your thoughts on the current implementation, suggestions etc are very welcome. Thanks!