### PR TITLE
version: error on invalid --output

### DIFF
--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -57,8 +57,16 @@ func (o *Options) Validate(_ []string) error {
 		if o.Output != "" {
 			return fmt.Errorf("--short and --output are mutually exclusive")
 		}
+		return nil
 	}
-	return nil
+
+	switch o.Output {
+	case "", "yaml", "json":
+		return nil
+	default:
+		// Match kubectl's error phrasing for familiarity.
+		return fmt.Errorf("--output must be 'yaml' or 'json'")
+	}
 }
 
 func (o *Options) Run() error {

--- a/kustomize/commands/version/version_test.go
+++ b/kustomize/commands/version/version_test.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionRejectsInvalidOutput(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := NewCmdVersion(&buf)
+	cmd.SetArgs([]string{"--output=yml"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error, got nil (output=%q)", buf.String())
+	}
+	if got, want := err.Error(), "--output must be 'yaml' or 'json'"; !strings.Contains(got, want) {
+		t.Fatalf("expected error to contain %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
Fixes #6032.

Currently, `kustomize version --output=yml` (or any unsupported value) exits 0 and prints nothing, because the invalid value falls through the switch in Options.Run().

This change validates --output in Options.Validate() and returns an error matching kubectl's phrasing.

Includes a unit test for the invalid output case.