### PR TITLE
feat: preserve initial document separator with kyaml

### DIFF
--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -37,6 +37,9 @@ type ByteReadWriter struct {
 	// the Resources, otherwise they will be cleared.
 	KeepReaderAnnotations bool
 
+	// PreserveInitialDocSep if true adds kioutil.InitialDocSepAnnotation to the first resource
+	PreserveInitialDocSep bool
+
 	// PreserveSeqIndent if true adds kioutil.SeqIndentAnnotation to each resource
 	PreserveSeqIndent bool
 
@@ -63,6 +66,7 @@ func (rw *ByteReadWriter) Read() ([]*yaml.RNode, error) {
 	b := &ByteReader{
 		Reader:                rw.Reader,
 		OmitReaderAnnotations: rw.OmitReaderAnnotations,
+		PreserveInitialDocSep: rw.PreserveInitialDocSep,
 		PreserveSeqIndent:     rw.PreserveSeqIndent,
 		WrapBareSeqNode:       rw.WrapBareSeqNode,
 	}

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -322,23 +322,9 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 		r.SetAnnotations = map[string]string{}
 	}
 	if !r.OmitReaderAnnotations {
-		err := kioutil.CopyLegacyAnnotations(n)
+		err := r.setResourceAnnotations(n, index, originalYAML)
 		if err != nil {
 			return nil, err
-		}
-		r.SetAnnotations[kioutil.IndexAnnotation] = fmt.Sprintf("%d", index)
-		r.SetAnnotations[kioutil.LegacyIndexAnnotation] = fmt.Sprintf("%d", index)
-
-		if r.PreserveSeqIndent {
-			// derive and add the seqindent annotation
-			seqIndentStyle := yaml.DeriveSeqIndentStyle(originalYAML)
-			if seqIndentStyle != "" {
-				r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
-			}
-		}
-
-		if index == 0 && r.PreserveInitialDocSep && node.Kind == yaml.DocumentNode {
-			r.SetAnnotations[kioutil.InitialDocSepAnnotation] = "true"
 		}
 	}
 	var keys []string
@@ -353,4 +339,22 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 		}
 	}
 	return n, nil
+}
+
+func (r *ByteReader) setResourceAnnotations(n *yaml.RNode, index int, originalYAML string) error {
+	err := kioutil.CopyLegacyAnnotations(n)
+	if err != nil {
+		return err
+	}
+	r.SetAnnotations[kioutil.IndexAnnotation] = fmt.Sprintf("%d", index)
+	r.SetAnnotations[kioutil.LegacyIndexAnnotation] = fmt.Sprintf("%d", index)
+
+	if r.PreserveSeqIndent {
+		// derive and add the seqindent annotation
+		seqIndentStyle := yaml.DeriveSeqIndentStyle(originalYAML)
+		if seqIndentStyle != "" {
+			r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
+		}
+	}
+	return nil
 }

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -160,6 +160,9 @@ type ByteReader struct {
 	// AnchorsAweigh set to true attempts to replace all YAML anchor aliases
 	// with their definitions (anchor values) immediately after the read.
 	AnchorsAweigh bool
+
+	// PreserveInitialDocSep if true adds the kioutil.PreserveInitialDocSep annotation to the first resource
+	PreserveInitialDocSep bool
 }
 
 var _ Reader = &ByteReader{}
@@ -332,6 +335,10 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 			if seqIndentStyle != "" {
 				r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
 			}
+		}
+
+		if index == 0 && r.PreserveInitialDocSep && node.Kind == yaml.DocumentNode {
+			r.SetAnnotations[kioutil.InitialDocSepAnnotation] = "true"
 		}
 	}
 	var keys []string

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -356,7 +356,6 @@ func (r *ByteReader) setResourceAnnotations(n *yaml.RNode, index int, originalYA
 			r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
 		}
 	}
-	//
 	if index == 0 && r.PreserveInitialDocSep &&
 		strings.HasPrefix(originalYAML, "---") {
 		r.SetAnnotations[kioutil.InitialDocSepAnnotation] = "true"

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -199,8 +199,8 @@ func splitDocuments(s string) ([]string, error) {
 }
 
 func (r *ByteReader) Read() ([]*yaml.RNode, error) {
-	if r.PreserveSeqIndent && r.OmitReaderAnnotations {
-		return nil, errors.Errorf(`"PreserveSeqIndent" option adds a reader annotation, please set "OmitReaderAnnotations" to false`)
+	if (r.PreserveSeqIndent || r.PreserveInitialDocSep) && r.OmitReaderAnnotations {
+		return nil, errors.Errorf(`"PreserveSeqIndent" and "PreserveInitialDocSep" options add a reader annotation, please set "OmitReaderAnnotations" to false`)
 	}
 
 	output := ResourceNodeSlice{}
@@ -356,6 +356,7 @@ func (r *ByteReader) setResourceAnnotations(n *yaml.RNode, index int, originalYA
 			r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
 		}
 	}
+	//
 	if index == 0 && r.PreserveInitialDocSep &&
 		strings.HasPrefix(originalYAML, "---") {
 		r.SetAnnotations[kioutil.InitialDocSepAnnotation] = "true"

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -356,5 +356,11 @@ func (r *ByteReader) setResourceAnnotations(n *yaml.RNode, index int, originalYA
 			r.SetAnnotations[kioutil.SeqIndentAnnotation] = seqIndentStyle
 		}
 	}
+	if index == 0 && r.PreserveInitialDocSep &&
+		strings.HasPrefix(originalYAML, "---") {
+		r.SetAnnotations[kioutil.InitialDocSepAnnotation] = "true"
+	} else {
+		delete(r.SetAnnotations, kioutil.InitialDocSepAnnotation)
+	}
 	return nil
 }

--- a/kyaml/kio/byteio_reader.go
+++ b/kyaml/kio/byteio_reader.go
@@ -348,7 +348,7 @@ func (r *ByteReader) decode(originalYAML string, index int, decoder *yaml.Decode
 func (r *ByteReader) setResourceAnnotations(n *yaml.RNode, index int, originalYAML string) error {
 	err := kioutil.CopyLegacyAnnotations(n)
 	if err != nil {
-		return err
+		return fmt.Errorf("copying legacy annotations failed: %w", err)
 	}
 	r.SetAnnotations[kioutil.IndexAnnotation] = fmt.Sprintf("%d", index)
 	r.SetAnnotations[kioutil.LegacyIndexAnnotation] = fmt.Sprintf("%d", index)

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -1080,7 +1080,7 @@ env:
   - bar
 `,
 			OmitReaderAnnotations: true,
-			err:                   `"PreserveSeqIndent" option adds a reader annotation, please set "OmitReaderAnnotations" to false`,
+			err:                   `"PreserveSeqIndent" and "PreserveInitialDocSep" options add a reader annotation, please set "OmitReaderAnnotations" to false`,
 		},
 	}
 
@@ -1152,6 +1152,21 @@ spec:
   - baz
 `,
 			expectedAnnoValue: "",
+		},
+		{
+			name: "error if conflicting options",
+			input: `apiVersion: apps/v1
+		kind: Deployment
+		spec:
+		- foo
+		- bar
+		- baz
+		env:
+		  - foo
+		  - bar
+		`,
+			OmitReaderAnnotations: true,
+			err:                   `"PreserveSeqIndent" and "PreserveInitialDocSep" options add a reader annotation, please set "OmitReaderAnnotations" to false`,
 		},
 	}
 

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -1103,3 +1103,74 @@ env:
 		})
 	}
 }
+
+// TestByteReader_AddPreserveInitialDocSepAnnotation tests if the internal.config.kubernetes.io/initial-doc-sep
+// annotation is added to resources appropriately
+func TestByteReader_AddPreserveInitialDocSepAnnotation(t *testing.T) {
+	type testCase struct {
+		name                  string
+		err                   string
+		input                 string
+		expectedAnnoValue     string
+		OmitReaderAnnotations bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "read with initial document separator",
+			input: `---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+`,
+			expectedAnnoValue: "true",
+		},
+		{
+			name: "read with initial document separator after commments",
+			input: `#a comment
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+`,
+			expectedAnnoValue: "",
+		},
+		{
+			name: "read without initial document separator",
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  - foo
+  - bar
+  - baz
+`,
+			expectedAnnoValue: "",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			rNodes, err := (&ByteReader{
+				OmitReaderAnnotations: tc.OmitReaderAnnotations,
+				PreserveInitialDocSep: true,
+				Reader:                bytes.NewBuffer([]byte(tc.input)),
+			}).Read()
+			if tc.err != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.err, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			actual := rNodes[0].GetAnnotations()[kioutil.InitialDocSepAnnotation]
+			assert.Equal(t, tc.expectedAnnoValue, actual)
+		})
+	}
+}

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -4,7 +4,6 @@
 package kio_test
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
@@ -443,7 +442,7 @@ c: d
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			r := tc.instance
-			r.Reader = bytes.NewBufferString(tc.input)
+			r.Reader = strings.NewReader(tc.input)
 			nodes, err := r.Read()
 			if tc.err != "" {
 				if !assert.EqualError(t, err, tc.err) {
@@ -885,7 +884,7 @@ data:
 		rNodes, err := (&ByteReader{
 			OmitReaderAnnotations: true,
 			AnchorsAweigh:         false,
-			Reader:                bytes.NewBuffer([]byte(input)),
+			Reader:                strings.NewReader(input),
 		}).Read()
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rNodes))
@@ -947,7 +946,7 @@ data:
 		rNodes, err := (&ByteReader{
 			OmitReaderAnnotations: true,
 			AnchorsAweigh:         true,
-			Reader:                bytes.NewBuffer([]byte(input)),
+			Reader:                strings.NewReader(input),
 		}).Read()
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rNodes))
@@ -1090,7 +1089,7 @@ env:
 			rNodes, err := (&ByteReader{
 				OmitReaderAnnotations: tc.OmitReaderAnnotations,
 				PreserveSeqIndent:     true,
-				Reader:                bytes.NewBuffer([]byte(tc.input)),
+				Reader:                strings.NewReader(tc.input),
 			}).Read()
 			if tc.err != "" {
 				require.Error(t, err)
@@ -1176,7 +1175,7 @@ spec:
 			rNodes, err := (&ByteReader{
 				OmitReaderAnnotations: tc.OmitReaderAnnotations,
 				PreserveInitialDocSep: true,
-				Reader:                bytes.NewBuffer([]byte(tc.input)),
+				Reader:                strings.NewReader(tc.input),
 			}).Read()
 			if tc.err != "" {
 				require.Error(t, err)

--- a/kyaml/kio/byteio_reader_test.go
+++ b/kyaml/kio/byteio_reader_test.go
@@ -1129,7 +1129,7 @@ spec:
 			expectedAnnoValue: "true",
 		},
 		{
-			name: "read with initial document separator after commments",
+			name: "read with initial document separator after comments",
 			input: `#a comment
 ---
 apiVersion: apps/v1

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -424,7 +424,7 @@ metadata:
   annotations:
     internal.config.kubernetes.io/index: 0
     internal.config.kubernetes.io/path: "a/b/b_test.yaml"
-    internal.config.kubernetes.io/inital-doc-sep: "true"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
 `,
 			},
 

--- a/kyaml/kio/byteio_writer_test.go
+++ b/kyaml/kio/byteio_writer_test.go
@@ -384,6 +384,71 @@ metadata:
 		// Test Case
 		//
 		{
+			name:     "add_initial_doc_sep",
+			instance: ByteWriter{KeepReaderAnnotations: true},
+			items: []string{
+				`a: b
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
+`,
+			},
+
+			expectedOutput: `---
+a: b
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
+`,
+		},
+		//
+		// Test Case
+		//
+		{
+			name:     "multiple_nodes_with_initial_doc_sep_annotations",
+			instance: ByteWriter{KeepReaderAnnotations: true},
+			items: []string{
+				`a: b
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
+`,
+				`c: d
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/b_test.yaml"
+    internal.config.kubernetes.io/inital-doc-sep: "true"
+`,
+			},
+
+			expectedOutput: `---
+a: b
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/a_test.yaml"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
+---
+c: d
+metadata:
+  annotations:
+    internal.config.kubernetes.io/index: 0
+    internal.config.kubernetes.io/path: "a/b/b_test.yaml"
+    internal.config.kubernetes.io/initial-doc-sep: "true"
+`,
+		},
+
+		//
+		// Test Case
+		//
+		{
 			name: "encode_valid_json",
 			items: []string{
 				`{

--- a/kyaml/kio/kioutil/kioutil.go
+++ b/kyaml/kio/kioutil/kioutil.go
@@ -30,6 +30,9 @@ const (
 	// SeqIndentAnnotation records the sequence nodes indentation of the input resource
 	SeqIndentAnnotation AnnotationKey = internalPrefix + "seqindent"
 
+	// InitialDocSepAnnotation indicates that the initial document separator should be kept
+	InitialDocSepAnnotation AnnotationKey = internalPrefix + "initial-doc-sep"
+
 	// IdAnnotation records the id of the resource to map inputs to outputs
 	IdAnnotation AnnotationKey = internalPrefix + "id"
 

--- a/kyaml/kio/pkgio_reader.go
+++ b/kyaml/kio/pkgio_reader.go
@@ -41,6 +41,9 @@ type LocalPackageReadWriter struct {
 
 	KeepReaderAnnotations bool `yaml:"keepReaderAnnotations,omitempty"`
 
+	// PreserveInitialDocSep if true adds kioutil.InitialDocSepAnnotation to the first resource
+	PreserveInitialDocSep bool
+
 	// PreserveSeqIndent if true adds kioutil.SeqIndentAnnotation to each resource
 	PreserveSeqIndent bool
 
@@ -93,16 +96,17 @@ type LocalPackageReadWriter struct {
 
 func (r *LocalPackageReadWriter) Read() ([]*yaml.RNode, error) {
 	nodes, err := LocalPackageReader{
-		PackagePath:         r.PackagePath,
-		MatchFilesGlob:      r.MatchFilesGlob,
-		IncludeSubpackages:  r.IncludeSubpackages,
-		ErrorIfNonResources: r.ErrorIfNonResources,
-		SetAnnotations:      r.SetAnnotations,
-		PackageFileName:     r.PackageFileName,
-		FileSkipFunc:        r.FileSkipFunc,
-		PreserveSeqIndent:   r.PreserveSeqIndent,
-		FileSystem:          r.FileSystem,
-		WrapBareSeqNode:     r.WrapBareSeqNode,
+		PackagePath:           r.PackagePath,
+		MatchFilesGlob:        r.MatchFilesGlob,
+		IncludeSubpackages:    r.IncludeSubpackages,
+		ErrorIfNonResources:   r.ErrorIfNonResources,
+		SetAnnotations:        r.SetAnnotations,
+		PackageFileName:       r.PackageFileName,
+		FileSkipFunc:          r.FileSkipFunc,
+		PreserveInitialDocSep: r.PreserveInitialDocSep,
+		PreserveSeqIndent:     r.PreserveSeqIndent,
+		FileSystem:            r.FileSystem,
+		WrapBareSeqNode:       r.WrapBareSeqNode,
 	}.Read()
 	if err != nil {
 		return nil, errors.Wrap(err)
@@ -195,6 +199,9 @@ type LocalPackageReader struct {
 	// FileSkipFunc is a function which returns true if reader should ignore
 	// the file
 	FileSkipFunc LocalPackageSkipFileFunc
+
+	// PreserveInitialDocSep if true adds kioutil.InitialDocSepAnnotation to the first resource
+	PreserveInitialDocSep bool
 
 	// PreserveSeqIndent if true adds kioutil.SeqIndentAnnotation to each resource
 	PreserveSeqIndent bool
@@ -301,6 +308,7 @@ func (r *LocalPackageReader) readFile(path string, _ os.FileInfo) ([]*yaml.RNode
 		Reader:                f,
 		OmitReaderAnnotations: r.OmitReaderAnnotations,
 		SetAnnotations:        r.SetAnnotations,
+		PreserveInitialDocSep: r.PreserveInitialDocSep,
 		PreserveSeqIndent:     r.PreserveSeqIndent,
 		WrapBareSeqNode:       r.WrapBareSeqNode,
 	}


### PR DESCRIPTION
# Context

This PR aims to implement a feature requested in #5850 . The `kyaml` package shall optionally be able to retain a leading document separator. As suggested by the author of the before mentioned issue the implementation is similar to the sequence indentation handling.

# Content

- adding new field to configure behavior for document separator retention in `ByteReadWriter` + `ByteReader`
- checking for leading document separator
- adding metadata annotation for leading RNode in `ByteReader.Read()`
- append `---` to the start of the `io.Writer` in case of annotation being present

# Note
The check for a leading document separator is kept simple to avoid adding a complex regex or importing additional packages in byteio_reader.go