### PR TITLE
Fix volume mount source incorrectly converted to absolute path

### DIFF
--- a/kyaml/fn/runtime/container/container.go
+++ b/kyaml/fn/runtime/container/container.go
@@ -189,7 +189,7 @@ func (c *Filter) getCommand() (string, []string) {
 
 	for _, storageMount := range c.StorageMounts {
 		// convert declarative relative paths to absolute (otherwise docker will throw an error)
-		if !filepath.IsAbs(storageMount.Src) {
+		if storageMount.MountType != "volume" && !filepath.IsAbs(storageMount.Src) {
 			storageMount.Src = filepath.Join(c.Exec.WorkingDir, storageMount.Src)
 		}
 		args = append(args, "--mount", storageMount.String())

--- a/kyaml/fn/runtime/container/container_test.go
+++ b/kyaml/fn/runtime/container/container_test.go
@@ -100,6 +100,32 @@ metadata:
 			UIDGID: "nobody",
 		},
 		{
+			name: "volume_mount_relative_path_not_converted",
+			functionConfig: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+`,
+			expectedArgs: []string{
+				"run",
+				"--rm",
+				"-i", "-a", "STDIN", "-a", "STDOUT", "-a", "STDERR",
+				"--network", "none",
+				"--user", "nobody",
+				"--security-opt=no-new-privileges",
+				"--mount", fmt.Sprintf("type=%s,source=%s,target=%s,readonly", "volume", "myvol", "/local/"),
+				"--mount", fmt.Sprintf("type=%s,source=%s,target=%s,readonly", "bind", getAbsFilePath("relative", "bind", "path"), "/bind/"),
+			},
+			containerSpec: runtimeutil.ContainerSpec{
+				Image: "example.com:version",
+				StorageMounts: []runtimeutil.StorageMount{
+					{MountType: "volume", Src: "myvol", DstPath: "/local/"},
+					{MountType: "bind", Src: filepath.Join("relative", "bind", "path"), DstPath: "/bind/"},
+				},
+			},
+			UIDGID: "nobody",
+		},
+		{
 			name: "as current user",
 			functionConfig: `apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
When using `kustomize build --enable-alpha-plugins` with a container transformer that specifies a Docker volume mount, the volume name (e.g. "my-volume") is incorrectly converted to an absolute host path (e.g. "/working/dir/my-volume"). This breaks the Docker --mount flag because a named volume is not a filesystem path.

Skip the relative-to-absolute path conversion for volume type mounts, as their source represents a Docker volume name, not a host path.

Follow up for commit: 9d5491c2e20c23c7a9b3d5a055d2aa24cc14bede 
Issue https://github.com/kubernetes-sigs/kustomize/issues/6072

Related: 
* https://github.com/kubernetes-sigs/kustomize/pull/6069
* https://github.com/kubernetes-sigs/kustomize/pull/5256
