### PR TITLE
fix(nameref): eliminate resource interference in nameReference resolution

### DIFF
--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -5,6 +5,7 @@ package nameref
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/filters/fieldspec"
@@ -87,8 +88,22 @@ func (f Filter) set(node *yaml.RNode) error {
 			setScalarFn:  f.setScalar,
 			setMappingFn: f.setMapping,
 		}, node)
+	case yaml.AliasNode:
+		// YAML spec forbids circular aliases; go-yaml parser guarantees
+		// that Alias chains are acyclic, so recursion always terminates.
+		if node.YNode().Alias == nil {
+			return nil
+		}
+		return f.set(yaml.NewRNode(node.YNode().Alias))
 	default:
-		return fmt.Errorf("node must be a scalar, sequence or map")
+		// Skip nodes of unexpected kinds rather than failing.
+		// This can happen when different resources share the same
+		// key path but with different YAML structures.
+		log.Printf(
+			"nameReference: skipping unexpected node kind %d at path '%s' in %s"+
+				" (if this is unexpected, check your nameReference fieldSpecs)",
+			node.YNode().Kind, f.NameFieldToUpdate.Path, f.Referrer.CurId().String())
+		return nil
 	}
 }
 
@@ -107,11 +122,17 @@ func (f Filter) setMapping(node *yaml.RNode) error {
 		return errors.WrapPrefixf(err, "trying to match 'name' field")
 	}
 	if nameNode == nil {
-		// This is a _configuration_ error; the field path
-		// specified in NameFieldToUpdate.Path doesn't resolve
-		// to a map with a 'name' field, so we have no idea what
-		// field to update with a new name.
-		return fmt.Errorf("path config error; no 'name' field in node")
+		// The field path doesn't resolve to a map with a 'name'
+		// field, so we can't update a name reference here.
+		// This is expected when different resources share the same
+		// key path but with different structures (e.g. overlapping
+		// keys from different Helm charts or CRDs).
+		// Log for debugging — could also indicate a misconfigured fieldSpec.
+		log.Printf(
+			"nameReference: skipping mapping without 'name' field at path '%s' in %s"+
+				" (if this is unexpected, check your nameReference fieldSpecs)",
+			f.NameFieldToUpdate.Path, f.Referrer.CurId().String())
+		return nil
 	}
 	candidates, err := f.filterMapCandidatesByNamespace(node)
 	if err != nil {

--- a/api/filters/nameref/nameref_test.go
+++ b/api/filters/nameref/nameref_test.go
@@ -225,6 +225,290 @@ map:
 				},
 			},
 		},
+		"no name in mapping is skipped": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  notName: oldName
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  notName: oldName
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "ref"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"no name in mapping is skipped with multiple candidates": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  notName: oldName
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+---
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName2
+`,
+			originalNames: []string{"oldName", "oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  notName: oldName
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "ref"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		// Regression test: a scalar value that doesn't match any candidate's
+		// previous name is left unchanged by selectReferral (returns nil, nil).
+		// This verifies existing behavior is preserved after the skip changes.
+		"scalar value not matching any candidate is unchanged": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  config: true
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  config: true
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "spec/config"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"yaml anchor alias via anchor field": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  name: &anchor oldName
+  alias: *anchor
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  name: newName
+  alias: *anchor
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "ref/name"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"yaml anchor alias via alias field": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  name: &anchor oldName
+  alias: *anchor
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			// Resolving the alias dereferences to the anchor node,
+			// so updating through the alias also updates the anchor.
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+ref:
+  name: newName
+  alias: *anchor
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "ref/alias"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"sequence element mapping without name field is skipped": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- nested:
+    deep: value
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- nested:
+    deep: value
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "seq"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"sequence with nested sequence element is skipped": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- - nestedItem1
+  - nestedItem2
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- - nestedItem1
+  - nestedItem2
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "seq"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"sequence with alias element resolves through anchor": {
+			referrerOriginal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- &anchor oldName
+- *anchor
+`,
+			candidates: `
+apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: newName
+`,
+			originalNames: []string{"oldName"},
+			referrerFinal: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+seq:
+- newName
+- *anchor
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{Path: "seq"},
+				ReferralTarget: resid.Gvk{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {
@@ -288,37 +572,6 @@ metadata:
 			referrerFinal: "",
 			filter: Filter{
 				NameFieldToUpdate: types.FieldSpec{Path: "ref/name"},
-				ReferralTarget: resid.Gvk{
-					Group:   "apps",
-					Version: "v1",
-					Kind:    "Secret",
-				},
-			},
-		},
-		"no name": {
-			referrerOriginal: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: dep
-ref:
-  notName: oldName
-`,
-			candidates: `
-apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName
----
-apiVersion: apps/v1
-kind: Secret
-metadata:
-  name: newName2
-`,
-			originalNames: []string{"oldName", "oldName"},
-			referrerFinal: "",
-			filter: Filter{
-				NameFieldToUpdate: types.FieldSpec{Path: "ref"},
 				ReferralTarget: resid.Gvk{
 					Group:   "apps",
 					Version: "v1",

--- a/api/filters/nameref/seqfilter.go
+++ b/api/filters/nameref/seqfilter.go
@@ -5,6 +5,7 @@ package nameref
 
 import (
 	"fmt"
+	"log"
 
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -36,9 +37,19 @@ func (sf seqFilter) Filter(node *yaml.RNode) (*yaml.RNode, error) {
 		// string field containing the name
 		err := sf.setMappingFn(node)
 		return node, err
+	case yaml.AliasNode:
+		// YAML spec forbids circular aliases; go-yaml parser guarantees
+		// that Alias chains are acyclic, so recursion always terminates.
+		if node.YNode().Alias == nil {
+			return node, nil
+		}
+		return sf.Filter(yaml.NewRNode(node.YNode().Alias))
 	default:
-		return node, fmt.Errorf(
-			"%#v is expected to be either a string or a map of string", node)
+		// Skip nodes of unexpected kinds rather than failing.
+		log.Printf("nameReference: skipping unexpected node kind %d in sequence element"+
+			" (if this is unexpected, check your nameReference fieldSpecs)",
+			node.YNode().Kind)
+		return node, nil
 	}
 }
 

--- a/api/internal/accumulator/namereferencetransformer_test.go
+++ b/api/internal/accumulator/namereferencetransformer_test.go
@@ -477,54 +477,67 @@ func TestNameReferenceHappyRun(t *testing.T) {
 	}
 }
 
+// TestNameReferenceUnexpectedStructureIsSkipped verifies that resources with
+// unexpected YAML structures (e.g. a nested sequence or a mapping without a
+// 'name' field) in a nameReference path are gracefully skipped rather than
+// causing errors.
+func TestNameReferenceUnexpectedStructureIsSkipped(t *testing.T) {
+	tests := []resmap.ResMap{
+		// resourceNames contains a nested empty list — the sequence
+		// element is a SequenceNode, which is skipped.
+		resmaptest_test.NewRmBuilderDefault(t).Add(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"metadata": map[string]interface{}{
+					"name": "cr",
+				},
+				"rules": []interface{}{
+					map[string]interface{}{
+						"resources": []interface{}{
+							"secrets",
+						},
+						"resourceNames": []interface{}{
+							[]interface{}{},
+						},
+					},
+				},
+			}).ResMap(),
+		// resourceNames is a mapping without a 'name' field — skipped.
+		resmaptest_test.NewRmBuilderDefault(t).Add(
+			map[string]interface{}{
+				"apiVersion": "rbac.authorization.k8s.io/v1",
+				"kind":       "ClusterRole",
+				"metadata": map[string]interface{}{
+					"name": "cr",
+				},
+				"rules": []interface{}{
+					map[string]interface{}{
+						"resources": []interface{}{
+							"secrets",
+						},
+						"resourceNames": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			}).ResMap(),
+	}
+
+	nrt := newNameReferenceTransformer(builtinconfig.MakeDefaultConfig().NameReference)
+	for i, resMap := range tests {
+		err := nrt.Transform(resMap)
+		if err != nil {
+			t.Fatalf("test %d: unexpected error: %v", i, err)
+		}
+	}
+}
+
 func TestNameReferenceUnhappyRun(t *testing.T) {
 	tests := []struct {
 		resMap      resmap.ResMap
 		expectedErr string
 	}{
-		{
-			resMap: resmaptest_test.NewRmBuilderDefault(t).Add(
-				map[string]interface{}{
-					"apiVersion": "rbac.authorization.k8s.io/v1",
-					"kind":       "ClusterRole",
-					"metadata": map[string]interface{}{
-						"name": "cr",
-					},
-					"rules": []interface{}{
-						map[string]interface{}{
-							"resources": []interface{}{
-								"secrets",
-							},
-							"resourceNames": []interface{}{
-								[]interface{}{},
-							},
-						},
-					},
-				}).ResMap(),
-			expectedErr: "is expected to be"},
-		{
-			resMap: resmaptest_test.NewRmBuilderDefault(t).Add(
-				map[string]interface{}{
-					"apiVersion": "rbac.authorization.k8s.io/v1",
-					"kind":       "ClusterRole",
-					"metadata": map[string]interface{}{
-						"name": "cr",
-					},
-					"rules": []interface{}{
-						map[string]interface{}{
-							"resources": []interface{}{
-								"secrets",
-							},
-							"resourceNames": map[string]interface{}{
-								"foo": "bar",
-							},
-						},
-					},
-				}).ResMap(),
-			expectedErr: `updating name reference in 'rules/resourceNames' field of 'ClusterRole.v1.rbac.authorization.k8s.io/cr.[noNs]': ` +
-				`considering field 'rules/resourceNames' of object ClusterRole.v1.rbac.authorization.k8s.io/cr.[noNs]: visit traversal on ` +
-				`path: [resourceNames]: path config error; no 'name' field in node`,
-		},
 		{
 			// When targeting a map reference, we need to update both name and namespace, so multiple
 			// possible referral targets with different namespaces should not be considered identical.

--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -787,6 +787,102 @@ spec:
 `)
 }
 
+// Overlapping keys from different resources should not cause errors
+// when nameReference path resolves to a different YAML node kind
+// than expected. This reproduces the scenario where Helm charts
+// share key names but with different value structures.
+// The Deployment's scalar spec/config should be updated to the
+// prefixed ConfigMap name, while the CRD's mapping spec/config
+// should be left unchanged.
+func TestNameReferenceOverlappingKeysDifferentStructure(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- deployment.yaml
+- configmap.yaml
+- crd.yaml
+namePrefix: test-
+configurations:
+- nameref.yaml
+`)
+	// Custom nameReference config without kind restriction -
+	// applies globally to all resources
+	th.WriteF("nameref.yaml", `
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/config
+`)
+	// Standard Deployment where spec/config is a scalar (name of ConfigMap)
+	th.WriteF("deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  config: my-configmap
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:latest
+`)
+	// ConfigMap that is the referral target
+	th.WriteF("configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  key: value
+`)
+	// CRD where spec/config is a mapping, not a scalar.
+	// Without the fix, this would fail with
+	// "path config error; no 'name' field in node"
+	// because the nameReference filter expects a mapping with
+	// a 'name' field but finds {retries, timeout} instead.
+	th.WriteF("crd.yaml", `
+apiVersion: custom.io/v1
+kind: MyCustomResource
+metadata:
+  name: myresource
+spec:
+  config:
+    retries: 3
+    timeout: 30s
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-myapp
+spec:
+  config: test-my-configmap
+  template:
+    spec:
+      containers:
+      - image: myapp:latest
+        name: app
+---
+apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  name: test-my-configmap
+---
+apiVersion: custom.io/v1
+kind: MyCustomResource
+metadata:
+  name: test-myresource
+spec:
+  config:
+    retries: 3
+    timeout: 30s
+`)
+}
+
 func TestBackReferenceAdmissionPolicy(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK(".", `


### PR DESCRIPTION
### What would you like to have added?

Resources interfere with each other through the `nameReference` transformer: if multiple resources share the same `fieldSpec` path but have different YAML structures at that path, one resource's structure causes `kustomize build` to fail for the **entire build** — including the resources that would have been resolved correctly. Errors:

```
path config error; no 'name' field in node
```
```
is expected to be either a string or a map of string
```

The proposed change makes the filter skip non-matching resources with a diagnostic `log.Printf` message instead of failing the whole build, and adds support for YAML anchor/alias nodes (`&anchor` / `*anchor`).

### Why is this needed?

Independent resources interfere with each other through the `nameReference` transformer: a resource that has nothing to do with name references causes the **entire `kustomize build` to fail**, solely because it has a different YAML structure at the same path.

The `nameReference` filter is applied to every resource matching a `fieldSpec`. If any two resources matching the `fieldSpec` use the same path differently — one as a scalar ConfigMap name, the other as a mapping `{retries: 3, timeout: 30s}` — the build fails on the second resource, and the entire build fails.

This interference cannot be eliminated by scoping the `fieldSpec` — no combination of `kind`, `namespace`, or other restrictions can distinguish resources that differ only in YAML structure at the same path. The user may also not control all resource definitions (e.g., third-party Helm charts, shared bases).

The structural mismatch can only be detected at the YAML node level. The correct behavior is to skip the non-matching resource and eliminate the interference — exactly as `selectReferral` already does when a scalar value doesn't match any candidate's previous name (returns `nil, nil` without error). A mapping without a `name` field is semantically equivalent: it is clearly not a name reference and should not interfere with other resources.

**Reproduction:** `nameReference` for `ConfigMap` at path `spec/config` applied to two resources where `spec/config` has different structures:

```yaml
# Resource A: spec/config is a ConfigMap name (scalar) → should be updated
spec:
  config: my-configmap

# Resource B: spec/config is an arbitrary mapping → should be skipped
spec:
  config:
    retries: 3
    timeout: 30s
```

**Current result:** `kustomize build` fails on Resource B with:
```
updating name reference in 'spec/config' field of
'MyCustomResource.v1.custom.io/test-myresource.[noNs]':
path config error; no 'name' field in node
```

**Expected result:** build succeeds, Resource A is updated, Resource B is left unchanged.

### Can you accomplish the motivating task without this feature, and if so, how?

No. The interference happens between any resources matching the same `fieldSpec`, regardless of kind or namespace — there is no scoping that can distinguish them. The user would have to ensure that no two resources ever have different YAML structures at the same path, which is not practical with third-party Helm charts, shared bases, or CRDs.

There is also no workaround for YAML anchor/alias nodes — they are simply not handled by the current code.

### What other solutions have you considered?

1. **Namespace-based scoping of candidates:** Already implemented in `SubsetThatCouldBeReferencedByResource()` and `sameCurrentNamespaceAsReferrer()`. Does not help because the interference is on the **referrer** side, not the candidate side. Any two resources matching the `fieldSpec` can have different structures and still interfere with each other.

2. **Early Group/Version/Kind filtering in `determineFilters()`:** The referrer's kind is already checked via `IsSelected(&referrerSpec.Gvk)`. This filters out resources whose kind doesn't match the fieldSpec, but cannot isolate resources of the same kind with different structures at the same path from interfering with each other.

3. **Pre-validating the node structure before `setMapping`/`setScalar`:** Equivalent to the proposed approach but with an extra validation pass. Adds complexity without benefit — the type switch in `set()` already dispatches by node kind, so handling unexpected kinds there is natural.

4. **Returning errors (current behavior):** Rejected because it causes resource interference — one resource with a non-matching structure blocks name resolution for all other resources in the build. The maintainers of #4880 noted that silently ignoring is bad, but hard-failing is also bad when the resource genuinely doesn't contain a name reference. The proposed `log.Printf` diagnostic is a middle ground, consistent with existing warning patterns in the codebase (`resaccumulator.go`, `repospec.go`, `kustomizer.go`).

### Anything else we should know?

**Changes:**

1. **`nameref.go` / `set()`:** Add `yaml.AliasNode` handling (dereference through the alias to the anchor node). Replace the hard error for unknown node kinds with a `log.Printf` diagnostic and graceful skip, so that non-matching resources no longer block the entire build.

2. **`nameref.go` / `setMapping()`:** When a mapping node has no `name` field, log a diagnostic message and skip instead of returning an error that would fail the build for all resources.

3. **`seqfilter.go` / `Filter()`:** Add `yaml.AliasNode` handling for sequence elements. Replace the hard error for unexpected node kinds with a diagnostic log and skip.

**Test coverage:**

- 8 unit tests in `nameref_test.go` (skip mapping without name, alias/anchor handling, nested sequences, regression tests)
- `TestNameReferenceUnexpectedStructureIsSkipped` integration test
- `TestNameReferenceOverlappingKeysDifferentStructure` end-to-end test

**Behavioral change:** `kustomize build` no longer fails the entire build when a resource has an unexpected structure at a `nameReference` path. Resource interference is eliminated: non-matching resources are skipped with a diagnostic log to stderr, allowing other resources to be processed correctly in isolation.