### PR TITLE
test(generators): add regression tests for deterministic ConfigMap key ordering

### DIFF
--- a/api/internal/generators/configmap_test.go
+++ b/api/internal/generators/configmap_test.go
@@ -42,6 +42,94 @@ func TestMakeConfigMap(t *testing.T) {
 		args types.ConfigMapArgs
 		exp  expected
 	}{
+		// Regression tests for https://github.com/kubernetes-sigs/kustomize/issues/4292
+		// ConfigMap data keys must be emitted in sorted (deterministic) order regardless
+		// of the order they are defined in the source.
+		"literal sources in non-alphabetical order produce sorted output": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "sortedLiterals",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{
+							"zebra=z",
+							"mango=m",
+							"apple=a",
+							"banana=b",
+							"kiwi=k",
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sortedLiterals
+data:
+  apple: a
+  banana: b
+  kiwi: k
+  mango: m
+  zebra: z
+`,
+			},
+		},
+		"env file with non-alphabetical keys produces sorted output": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "sortedEnv",
+					KvPairSources: types.KvPairSources{
+						EnvSources: []string{
+							filepath.Join("configmap", "unsorted.env"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sortedEnv
+data:
+  APPLE: a
+  BANANA: b
+  KIWI: k
+  MANGO: m
+  ZEBRA: z
+`,
+			},
+		},
+		"mixed literal and env sources produce sorted output": {
+			args: types.ConfigMapArgs{
+				GeneratorArgs: types.GeneratorArgs{
+					Name: "sortedMixed",
+					KvPairSources: types.KvPairSources{
+						LiteralSources: []string{
+							"zebra=z",
+							"apple=a",
+						},
+						EnvSources: []string{
+							filepath.Join("configmap", "unsorted.env"),
+						},
+					},
+				},
+			},
+			exp: expected{
+				out: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sortedMixed
+data:
+  APPLE: a
+  BANANA: b
+  KIWI: k
+  MANGO: m
+  ZEBRA: z
+  apple: a
+  zebra: z
+`,
+			},
+		},
 		"construct config map from env": {
 			args: types.ConfigMapArgs{
 				GeneratorArgs: types.GeneratorArgs{
@@ -199,6 +287,10 @@ immutable: true
 	fSys.WriteFile(
 		filesys.RootedPath("configmap", "app.bin"),
 		manyHellos(30))
+	// unsorted.env is used by regression tests for issue #4292 (non-deterministic ordering)
+	fSys.WriteFile(
+		filesys.RootedPath("configmap", "unsorted.env"),
+		[]byte("ZEBRA=z\nMANGO=m\nAPPLE=a\nBANANA=b\nKIWI=k\n"))
 	kvLdr := kv.NewLoader(
 		loader.NewFileLoaderAtRoot(fSys),
 		valtest_test.MakeFakeValidator())

--- a/api/internal/generators/configmap_test.go
+++ b/api/internal/generators/configmap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	. "sigs.k8s.io/kustomize/api/internal/generators"
 	"sigs.k8s.io/kustomize/api/kv"
 	"sigs.k8s.io/kustomize/api/pkg/loader"
@@ -278,19 +279,19 @@ immutable: true
 		},
 	}
 	fSys := filesys.MakeFsInMemory()
-	fSys.WriteFile(
+	require.NoError(t, fSys.WriteFile(
 		filesys.RootedPath("configmap", "app.env"),
-		[]byte("DB_USERNAME=admin\nDB_PASSWORD=qwerty\n"))
-	fSys.WriteFile(
+		[]byte("DB_USERNAME=admin\nDB_PASSWORD=qwerty\n")))
+	require.NoError(t, fSys.WriteFile(
 		filesys.RootedPath("configmap", "app-init.ini"),
-		[]byte("FOO=bar\nBAR=baz\n"))
-	fSys.WriteFile(
+		[]byte("FOO=bar\nBAR=baz\n")))
+	require.NoError(t, fSys.WriteFile(
 		filesys.RootedPath("configmap", "app.bin"),
-		manyHellos(30))
+		manyHellos(30)))
 	// unsorted.env is used by regression tests for issue #4292 (non-deterministic ordering)
-	fSys.WriteFile(
+	require.NoError(t, fSys.WriteFile(
 		filesys.RootedPath("configmap", "unsorted.env"),
-		[]byte("ZEBRA=z\nMANGO=m\nAPPLE=a\nBANANA=b\nKIWI=k\n"))
+		[]byte("ZEBRA=z\nMANGO=m\nAPPLE=a\nBANANA=b\nKIWI=k\n")))
 	kvLdr := kv.NewLoader(
 		loader.NewFileLoaderAtRoot(fSys),
 		valtest_test.MakeFakeValidator())


### PR DESCRIPTION
## What this does

Adds explicit regression tests verifying that `ConfigMap` data keys are always emitted in **sorted (alphabetical) order** regardless of the order they are defined in the source.

Closes #4292

## Background

Issue #4292 reported that `kustomize build` could produce ConfigMap items in a non-deterministic order. A previous fix attempt (#6025) was closed because it lacked sufficient test coverage — the reviewer explicitly asked for tests before anything else would be reviewed.

This PR addresses that feedback directly by adding three new test cases to `TestMakeConfigMap`:

- **Literals in non-alphabetical order** — keys defined as `zebra, mango, apple, banana, kiwi` must output as `apple, banana, kiwi, mango, zebra`
- **Env file with non-alphabetical keys** — same guarantee for env file sources
- **Mixed literal + env sources** — ordering is deterministic across source types

The behavior under test is already implemented via `SortedMapKeys` in `kyaml/yaml/datamap.go`. These tests lock it in against future regressions.

## Testing

```
go test ./api/internal/generators/... -run TestMakeConfigMap -v
```

All 8 test cases pass (3 new + 5 existing).

## Note on pre-existing failures

`TestAddManagedbyLabel` in `api/krusty` and a test in `api/provenance` fail due to a version string mismatch (`kustomize-(devel)` vs `kustomize-(test)`) that is pre-existing on `master` and unrelated to this change.