### PR TITLE
feat: add mergeKeys field for ad-hoc CRD list merge keys

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge.go
@@ -11,6 +11,11 @@ import (
 
 type Filter struct {
 	Patch *yaml.RNode
+
+	// MergeKeySpecs declares custom merge keys for list fields in CRD resources
+	// that lack registered OpenAPI schemas. When set, the walker uses these
+	// specs to merge lists by key instead of replacing them.
+	MergeKeySpecs []yaml.MergeKeySpec
 }
 
 var _ kio.Filter = Filter{}
@@ -23,6 +28,7 @@ func (pf Filter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 			pf.Patch, nodes[i],
 			yaml.MergeOptions{
 				ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+				MergeKeySpecs:         pf.MergeKeySpecs,
 			},
 		)
 		if err != nil {

--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -14,9 +14,10 @@ import (
 
 func TestFilter(t *testing.T) {
 	testCases := map[string]struct {
-		input    string
-		patch    *yaml.RNode
-		expected string
+		input         string
+		patch         *yaml.RNode
+		mergeKeySpecs []yaml.MergeKeySpec
+		expected      string
 	}{
 		"simple": {
 			input: `apiVersion: v1
@@ -905,12 +906,47 @@ data:
   "6443": "key-int"
 `,
 		},
+		"customMergeKey": {
+			input: `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: BASE
+    value: base
+`,
+			patch: yaml.MustParse(`apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: PATCH
+    value: patch
+`),
+			mergeKeySpecs: []yaml.MergeKeySpec{
+				{Path: []string{"spec", "env"}, Key: "name"},
+			},
+			expected: `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: PATCH
+    value: patch
+  - name: BASE
+    value: base
+`,
+		},
 	}
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			f := Filter{
-				Patch: tc.patch,
+				Patch:         tc.patch,
+				MergeKeySpecs: tc.mergeKeySpecs,
 			}
 			if !assert.Equal(t,
 				strings.TrimSpace(tc.expected),

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/kustomize/kyaml/resid"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -235,6 +237,7 @@ func (kt *KustTarget) accumulateTarget(ra *accumulator.ResAccumulator) (
 		return nil, errors.WrapPrefixf(err, "accumulating components")
 	}
 
+	kt.setMergeKeySpecsOnResources(ra)
 	err = kt.runTransformers(ra)
 	if err != nil {
 		return nil, err
@@ -262,6 +265,44 @@ func (kt *KustTarget) IgnoreLocal(ra *accumulator.ResAccumulator) error {
 		return err
 	}
 	return ra.Intersection(kt.rFactory.FromResourceSlice(remainRes))
+}
+
+// setMergeKeySpecsOnResources propagates any mergeKeys declared in the
+// kustomization to the matching resources so that ApplySmPatch can merge
+// CRD list fields by key instead of replacing them.
+func (kt *KustTarget) setMergeKeySpecsOnResources(ra *accumulator.ResAccumulator) {
+	if len(kt.kustomization.MergeKeys) == 0 {
+		return
+	}
+	for _, r := range ra.ResMap().Resources() {
+		gvk := r.GetGvk()
+		specs := toYamlMergeKeySpecs(kt.kustomization.MergeKeys, gvk)
+		if len(specs) > 0 {
+			r.SetMergeKeySpecs(specs)
+		}
+	}
+}
+
+// toYamlMergeKeySpecs converts api-layer MergeKeySpec entries to the
+// kyaml-layer equivalent, filtering to only those matching gvk.
+func toYamlMergeKeySpecs(apiSpecs []types.MergeKeySpec, gvk resid.Gvk) []kyaml.MergeKeySpec {
+	result := make([]kyaml.MergeKeySpec, 0)
+	for _, s := range apiSpecs {
+		if s.Kind != "" && s.Kind != gvk.Kind {
+			continue
+		}
+		if s.Group != "" && s.Group != gvk.Group {
+			continue
+		}
+		if s.Version != "" && s.Version != gvk.Version {
+			continue
+		}
+		result = append(result, kyaml.MergeKeySpec{
+			Path: strings.Split(s.Path, "/"),
+			Key:  s.Key,
+		})
+	}
+	return result
 }
 
 func (kt *KustTarget) runGenerators(

--- a/api/krusty/mergekeys_test.go
+++ b/api/krusty/mergekeys_test.go
@@ -1,0 +1,69 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"testing"
+
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+// TestMergeKeys verifies that mergeKeys declared in kustomization.yaml causes
+// strategic merge patches to merge list items by key instead of replacing the
+// list, even for CRD resources that have no registered OpenAPI schema.
+func TestMergeKeys(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	// Base resource with a CRD-like list field.
+	th.WriteF("base/resource.yaml", `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: BASE_VAR
+    value: base-value
+`)
+	th.WriteK("base", `
+resources:
+- resource.yaml
+`)
+
+	// Overlay patch that adds a new env var.
+	th.WriteF("overlay/patch.yaml", `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: OVERLAY_VAR
+    value: overlay-value
+`)
+	th.WriteK("overlay", `
+resources:
+- ../base
+
+patches:
+- path: patch.yaml
+
+mergeKeys:
+- kind: MyApp
+  group: example.com
+  path: spec/env
+  key: name
+`)
+
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: OVERLAY_VAR
+    value: overlay-value
+  - name: BASE_VAR
+    value: base-value
+`)
+}

--- a/api/resource/resource.go
+++ b/api/resource/resource.go
@@ -24,7 +24,8 @@ import (
 // paired with metadata used by kustomize.
 type Resource struct {
 	kyaml.RNode
-	refVarNames []string
+	refVarNames   []string
+	mergeKeySpecs []kyaml.MergeKeySpec
 }
 
 var BuildAnnotations = []string{
@@ -491,6 +492,13 @@ func (r *Resource) AppendRefVarName(variable types.Var) {
 	r.refVarNames = append(r.refVarNames, variable.Name)
 }
 
+// SetMergeKeySpecs sets the custom merge key specs for this resource.
+// These are used by ApplySmPatch to merge list fields in CRD resources
+// that lack registered OpenAPI schemas.
+func (r *Resource) SetMergeKeySpecs(specs []kyaml.MergeKeySpec) {
+	r.mergeKeySpecs = specs
+}
+
 // ApplySmPatch applies the provided strategic merge patch.
 func (r *Resource) ApplySmPatch(patch *Resource) error {
 	n, ns, k := r.GetName(), r.GetNamespace(), r.GetKind()
@@ -498,7 +506,8 @@ func (r *Resource) ApplySmPatch(patch *Resource) error {
 		r.StorePreviousId()
 	}
 	if err := r.ApplyFilter(patchstrategicmerge.Filter{
-		Patch: &patch.RNode,
+		Patch:         &patch.RNode,
+		MergeKeySpecs: r.mergeKeySpecs,
 	}); err != nil {
 		return err
 	}

--- a/api/resource/resource_test.go
+++ b/api/resource/resource_test.go
@@ -1626,3 +1626,38 @@ spec:
   numReplicas: 1
 `, r.MustString())
 }
+
+func TestApplySmPatchWithMergeKeySpecs(t *testing.T) {
+	r, err := factory.FromBytes([]byte(`apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: BASE
+    value: base
+`))
+	require.NoError(t, err)
+
+	r.SetMergeKeySpecs([]kyaml.MergeKeySpec{
+		{Path: []string{"spec", "env"}, Key: "name"},
+	})
+
+	patch, err := factory.FromBytes([]byte(`apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: PATCH
+    value: patch
+`))
+	require.NoError(t, err)
+
+	require.NoError(t, r.ApplySmPatch(patch))
+
+	out, err := r.AsYAML()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "BASE")
+	assert.Contains(t, string(out), "PATCH")
+}

--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -180,6 +180,11 @@ type Kustomization struct {
 
 	// BuildMetadata is a list of strings used to toggle different build options
 	BuildMetadata []string `json:"buildMetadata,omitempty" yaml:"buildMetadata,omitempty"`
+
+	// MergeKeys is a list of custom merge key declarations for list fields in
+	// CRD resources that lack registered OpenAPI schemas. Without this,
+	// strategic merge patches replace those lists entirely instead of merging.
+	MergeKeys []MergeKeySpec `json:"mergeKeys,omitempty" yaml:"mergeKeys,omitempty"`
 }
 
 const (

--- a/api/types/mergekey.go
+++ b/api/types/mergekey.go
@@ -1,0 +1,22 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+// MergeKeySpec declares a custom merge key for a list field in a specific
+// resource type. This is useful for CRDs that don't have registered OpenAPI
+// schemas, where strategic merge patch would otherwise replace list contents
+// instead of merging them.
+type MergeKeySpec struct {
+	// Group is the API group of the resource (e.g. "helm.toolkit.fluxcd.io").
+	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	// Version is the API version of the resource (optional).
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	// Kind is the kind of the resource (e.g. "HelmRelease").
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	// Path is the slash-separated path to the list field
+	// (e.g. "spec/values/myapp/env").
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	// Key is the field name to use as the merge key for items in the list.
+	Key string `json:"key,omitempty" yaml:"key,omitempty"`
+}

--- a/api/types/mergekey_test.go
+++ b/api/types/mergekey_test.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/yaml"
+)
+
+func TestMergeKeySpecRoundTrip(t *testing.T) {
+	y := `mergeKeys:
+- kind: HelmRelease
+  group: helm.toolkit.fluxcd.io
+  path: spec/values/myapp/env
+  key: name
+`
+	k := &Kustomization{}
+	require.NoError(t, yaml.Unmarshal([]byte(y), k))
+	require.Len(t, k.MergeKeys, 1)
+	assert.Equal(t, "HelmRelease", k.MergeKeys[0].Kind)
+	assert.Equal(t, "helm.toolkit.fluxcd.io", k.MergeKeys[0].Group)
+	assert.Equal(t, "spec/values/myapp/env", k.MergeKeys[0].Path)
+	assert.Equal(t, "name", k.MergeKeys[0].Key)
+}

--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -70,6 +70,7 @@ func determineFieldOrder() []string {
 		"Components",
 		"OpenAPI",
 		"BuildMetadata",
+		"MergeKeys",
 	}
 
 	// Add deprecated fields here.

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -52,6 +52,7 @@ func TestFieldOrder(t *testing.T) {
 		"Components",
 		"OpenAPI",
 		"BuildMetadata",
+		"MergeKeys",
 	}
 	actual := determineFieldOrder()
 	if len(expected) != len(actual) {
@@ -199,6 +200,10 @@ func TestReadAndWriteDummy(t *testing.T) {
 		Transformers:   []string{"transformer"},
 		Validators:     []string{"validator"},
 		BuildMetadata:  []string{"buildMetadata"},
+		MergeKeys: []types.MergeKeySpec{{
+			Path: "path",
+			Key:  "key",
+		}},
 	}
 
 	// this check is for forward compatibility: if this fails, add a dummy value to the Kustomization above
@@ -614,4 +619,7 @@ transformers:
 - transformer
 buildMetadata:
 - buildMetadata
+mergeKeys:
+- key: key
+  path: path
 `

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -558,6 +558,18 @@ func (rs *ResourceSchema) PatchStrategyAndKeyList() (string, []string) {
 	return ps.(string), []string{mk.(string)}
 }
 
+// SyntheticMergeSchema returns a ResourceSchema that declares
+// x-kubernetes-patch-strategy: merge and x-kubernetes-patch-merge-key: key.
+// It is used to provide ad-hoc merge semantics for CRD list fields that have
+// no registered OpenAPI schema.
+func SyntheticMergeSchema(key string) *ResourceSchema {
+	s := spec.Schema{}
+	s.Extensions = spec.Extensions{}
+	s.Extensions[kubernetesPatchStrategyExtensionKey] = "merge"
+	s.Extensions[kubernetesMergeKeyExtensionKey] = key
+	return &ResourceSchema{Schema: &s}
+}
+
 // PatchStrategyAndKey returns the patch strategy and merge key extensions
 func (rs *ResourceSchema) PatchStrategyAndKey() (string, string) {
 	ps, found := rs.Schema.Extensions[kubernetesPatchStrategyExtensionKey]

--- a/kyaml/yaml/merge2/mergekeys_test.go
+++ b/kyaml/yaml/merge2/mergekeys_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package merge2_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	. "sigs.k8s.io/kustomize/kyaml/yaml/merge2"
+)
+
+// TestMergeWithCustomMergeKey demonstrates that a CRD-like resource with no
+// registered schema has its list replaced by default, but when MergeKeySpecs
+// are provided the list items are merged instead.
+func TestMergeWithCustomMergeKey(t *testing.T) {
+	base := `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: BASE
+    value: base`
+
+	patch := `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: PATCH
+    value: patch`
+
+	got, err := MergeStrings(patch, base, false, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		MergeKeySpecs: []yaml.MergeKeySpec{
+			{Path: []string{"spec", "env"}, Key: "name"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "BASE")
+	assert.Contains(t, got, "PATCH")
+}
+
+// TestMergeKeyPathResetsInsideAssociativeList documents the path-scoping
+// behaviour when a target list is nested inside another associative list.
+// Because the walker does not propagate Path through associative-list element
+// boundaries, the path in MergeKeySpec must be relative to the list-element
+// level where the target list lives, NOT from the document root.
+//
+// Here the target is spec.volumes[*].configMap.items. Each volume element is
+// matched by the outer associative list (key "name"), and inside a matched
+// element the path resets to []. So the correct path to declare is
+// ["configMap", "items"], not ["spec", "volumes", "configMap", "items"].
+func TestMergeKeyPathResetsInsideAssociativeList(t *testing.T) {
+	base := `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  volumes:
+  - name: config
+    configMap:
+      items:
+      - key: foo
+        path: foo`
+
+	patch := `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  volumes:
+  - name: config
+    configMap:
+      items:
+      - key: bar
+        path: bar`
+
+	// Correct: path is relative to inside a volume element.
+	got, err := MergeStrings(patch, base, false, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		MergeKeySpecs: []yaml.MergeKeySpec{
+			{Path: []string{"configMap", "items"}, Key: "key"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, got, "key: foo", "base item should be present")
+	assert.Contains(t, got, "key: bar", "patch item should be present")
+
+	// Wrong: root-relative path does NOT match and items are replaced.
+	gotWrong, err := MergeStrings(patch, base, false, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		MergeKeySpecs: []yaml.MergeKeySpec{
+			{Path: []string{"spec", "volumes", "configMap", "items"}, Key: "key"},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, gotWrong, "key: foo", "base item should be replaced when path is wrong")
+}
+
+// TestMergeWithoutCustomMergeKeyReplacesLists confirms that without
+// MergeKeySpecs the list is replaced (existing behaviour for CRDs).
+func TestMergeWithoutCustomMergeKeyReplacesLists(t *testing.T) {
+	base := `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: BASE
+    value: base`
+
+	patch := `apiVersion: example.com/v1
+kind: MyApp
+metadata:
+  name: app
+spec:
+  env:
+  - name: PATCH
+    value: patch`
+
+	got, err := MergeStrings(patch, base, false, yaml.MergeOptions{
+		ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+	})
+	require.NoError(t, err)
+	// Without custom merge key the patch list replaces the base list.
+	assert.NotContains(t, got, "BASE")
+	assert.Contains(t, got, "PATCH")
+}

--- a/kyaml/yaml/types.go
+++ b/kyaml/yaml/types.go
@@ -241,11 +241,25 @@ const (
 	MergeOptionsListPrepend
 )
 
+// MergeKeySpec declares that a particular list field (identified by its path)
+// should be merged by the named key. Used to support CRD list fields that lack
+// OpenAPI schema definitions.
+type MergeKeySpec struct {
+	// Path is the field path segments leading to the list (e.g. ["spec","env"]).
+	Path []string
+	// Key is the field name used as the merge key for items in the list.
+	Key string
+}
+
 // MergeOptions is a struct which contains the options for merge
 type MergeOptions struct {
 	// ListIncreaseDirection indicates should merge function prepend the items from
 	// source list to destination or append.
 	ListIncreaseDirection MergeOptionsListIncreaseDirection
+
+	// MergeKeySpecs declares custom merge keys for list fields that lack
+	// OpenAPI schema definitions (e.g. CRD fields).
+	MergeKeySpecs []MergeKeySpec
 }
 
 // Since ObjectMeta and TypeMeta are stable, we manually create DeepCopy funcs for ResourceMeta and ObjectMeta.

--- a/kyaml/yaml/walk/walk.go
+++ b/kyaml/yaml/walk/walk.go
@@ -55,6 +55,9 @@ func (l Walker) Kind() yaml.Kind {
 // actions on them
 func (l Walker) Walk() (*yaml.RNode, error) {
 	l.Schema = l.GetSchema()
+	if synth := l.schemaFromMergeKeySpecs(); synth != nil {
+		l.Schema = synth
+	}
 
 	// invoke the handler for the corresponding node type
 	switch l.Kind() {
@@ -128,6 +131,30 @@ func (l Walker) GetSchema() *openapi.ResourceSchema {
 		}
 	}
 	return nil
+}
+
+// schemaFromMergeKeySpecs returns a synthetic ResourceSchema if l.Path matches
+// any entry in l.MergeOptions.MergeKeySpecs, or nil otherwise.
+func (l Walker) schemaFromMergeKeySpecs() *openapi.ResourceSchema {
+	for _, spec := range l.MergeOptions.MergeKeySpecs {
+		if pathsEqual(spec.Path, l.Path) {
+			return openapi.SyntheticMergeSchema(spec.Key)
+		}
+	}
+	return nil
+}
+
+// pathsEqual returns true when a and b have the same length and identical elements.
+func pathsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 const (

--- a/site/content/en/docs/Reference/API/Kustomization File/kustomization.md
+++ b/site/content/en/docs/Reference/API/Kustomization File/kustomization.md
@@ -138,3 +138,7 @@ description: >
 * **buildMetadata** ([]string)
 
 	[BuildMetadata]({{< ref "buildMetadata.md" >}}) is a list of strings used to toggle different build options
+
+* **mergeKeys** ([][MergeKeySpec]({{< ref "mergeKeys.md" >}}))
+
+	[MergeKeys]({{< ref "mergeKeys.md" >}}) declares custom merge keys for list fields in CRD resources that lack registered OpenAPI schemas, preventing strategic merge patches from replacing those lists entirely.

--- a/site/content/en/docs/Reference/API/Kustomization File/mergeKeys.md
+++ b/site/content/en/docs/Reference/API/Kustomization File/mergeKeys.md
@@ -1,0 +1,152 @@
+---
+title: "mergeKeys"
+linkTitle: "mergeKeys"
+type: docs
+weight: 16
+description: >
+    Declare custom merge keys for CRD list fields that lack OpenAPI schemas.
+---
+
+`apiVersion: kustomize.config.k8s.io/v1beta1`
+
+## Problem
+
+Kustomize's strategic merge patch uses OpenAPI schema information to decide
+whether a list field should be **merged** (by a merge key such as `name`) or
+**replaced** entirely. For Kubernetes built-in types this works automatically.
+For Custom Resources (CRDs) — such as a Flux `HelmRelease` with arbitrary
+values nested under `spec.values` — there is no registered schema, so patches
+that add items to those lists silently **wipe** the base items.
+
+## Solution
+
+The `mergeKeys` field lets you declare "for resources of this type, treat this
+list field as an associative list merged on this key" — without registering an
+OpenAPI schema or using the deprecated `configurations` feature.
+
+### mergeKeys
+
+`mergeKeys` accepts a list of `MergeKeySpec` objects:
+
+| Field     | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `kind`    | string | no       | Resource kind to match (e.g. `HelmRelease`). Omit to match any kind. |
+| `group`   | string | no       | API group to match (e.g. `helm.toolkit.fluxcd.io`). Omit to match any group. |
+| `version` | string | no       | API version to match (e.g. `v2beta1`). Omit to match any version. |
+| `path`    | string | yes      | Slash-separated path to the list field (e.g. `spec/values/myapp/env`). |
+| `key`     | string | yes      | Field name within each list item to use as the merge key (e.g. `name`). |
+
+## Example
+
+### Problem without mergeKeys
+
+Given a base `HelmRelease`:
+
+```yaml
+# base/helmrelease.yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: myapp
+spec:
+  values:
+    env:
+    - name: LOG_LEVEL
+      value: info
+```
+
+And an overlay patch that adds a new env var:
+
+```yaml
+# overlay/patch.yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: myapp
+spec:
+  values:
+    env:
+    - name: DEBUG
+      value: "true"
+```
+
+Without `mergeKeys`, the overlay **replaces** the entire `env` list, and
+`LOG_LEVEL` is lost.
+
+### Fix with mergeKeys
+
+```yaml
+# overlay/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base
+
+patches:
+- path: patch.yaml
+
+mergeKeys:
+- kind: HelmRelease
+  group: helm.toolkit.fluxcd.io
+  path: spec/values/env
+  key: name
+```
+
+Now the patch **merges** by `name`, and both env vars appear in the output:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: myapp
+spec:
+  values:
+    env:
+    - name: DEBUG
+      value: "true"
+    - name: LOG_LEVEL
+      value: info
+```
+
+## Notes
+
+### `path` uses `/` as separator
+
+`path` uses `/` as a separator (not `.`), matching the same convention as
+`configurations` field specs.
+
+### `key` must be a direct field on list items
+
+`key` must be the name of a **direct, top-level field** on each list item — it
+cannot be a nested path. For example, if items look like `{name: foo, value:
+bar}`, use `key: name`. If the identifier is nested (e.g. `metadata.name` on a
+PersistentVolumeClaim), `mergeKeys` cannot be used to merge that list.
+
+### Paths reset at associative-list boundaries
+
+When a target list is nested inside another associative list, the walker resets
+its path counter at each list-element boundary. This means `path` must be
+expressed **relative to the element that contains the target list**, not from
+the document root.
+
+For example, for a list at `spec.volumes[*].configMap.items` (where `volumes`
+is itself an associative list), declare:
+
+```yaml
+mergeKeys:
+- path: configMap/items   # relative to inside a volume element
+  key: key
+```
+
+**not** `spec/volumes/configMap/items`.
+
+### Scope
+
+- `version` is optional — most CRD users only know group and kind.
+- Multiple entries can target different paths or different resource types.
+- `mergeKeys` affects strategic merge patches (`patches` with SM patch content)
+  and `patchesStrategicMerge`. JSON 6902 patches are unaffected.
+- This feature works for both CRDs (no registered schema) and native Kubernetes
+  resource fields that have a schema but no merge key annotation.
+- This feature does not modify or replace the `configurations` field.


### PR DESCRIPTION
## Summary

Fixes #5110

Kustomize's strategic merge patch falls back to full-list replacement when it has no schema for a field path. For CRDs (and some native k8s fields that lack a `x-kubernetes-patch-merge-key` annotation), this means patches that add items to those lists silently wipe base items.

This PR adds a new top-level `mergeKeys` field in `kustomization.yaml` that lets users declare "this list, in this resource type, should be merged on this key" — no OpenAPI schema registration required.

```yaml
# kustomization.yaml
mergeKeys:
- kind: HelmRelease
  group: helm.toolkit.fluxcd.io
  path: spec/values/myapp/env
  key: name
```

- **`api/types`**: new `MergeKeySpec` struct; `MergeKeys []MergeKeySpec` field on `Kustomization`
- **`kyaml/yaml`**: `MergeKeySpec` and `MergeOptions.MergeKeySpecs`
- **`kyaml/openapi`**: `SyntheticMergeSchema(key)` — builds a schema with `x-kubernetes-patch-strategy: merge` and `x-kubernetes-patch-merge-key: <key>`
- **`kyaml/yaml/walk`**: `Walk()` checks `MergeKeySpecs` when the field has no (or an incomplete) schema, returning the synthetic schema so `IsAssociative` returns true
- **`api/filters/patchstrategicmerge`**: `Filter.MergeKeySpecs` threaded into `merge2.Merge`
- **`api/resource`**: `Resource.SetMergeKeySpecs` / `ApplySmPatch` passes specs to the filter
- **`api/internal/target`**: `kusttarget` converts `kustomization.MergeKeys` → per-GVK `[]yaml.MergeKeySpec` and sets them on matching resources before running patch transformers
- **`site/docs`**: new `mergeKeys.md` reference page; entry in `kustomization.md`

## Known constraints

- **`key` must be a direct field** on list items (e.g. `name` works; `metadata.name` does not). Nested key support would require changes to `ElementSetter`, `ElementValuesList`, and `ElementList` across `associative_sequence.go` — feasible but out of scope for this PR.
- **`path` resets at associative-list element boundaries** — if the target list is nested inside another list, `path` must be relative to the containing element, not the document root. This is documented and tested.

## Test plan

- [x] `api/types` — round-trip YAML unmarshal of `mergeKeys` field
- [x] `kyaml/yaml/merge2` — merge vs. replace behaviour with/without `MergeKeySpecs`; path-reset boundary test
- [x] `api/filters/patchstrategicmerge` — `customMergeKey` filter test case
- [x] `api/resource` — `TestApplySmPatchWithMergeKeySpecs`
- [x] `api/krusty` — end-to-end `TestMergeKeys` build test
- [x] Full `api/...` and `kyaml/...` test suites pass (only pre-existing failures in `provenance` and one `krusty` version-string test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)