### PR TITLE
ci: add permissions and concurrency settings to workflows

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -5,6 +5,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-apidiff:
     name: Verify API differences

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ## TODO: conditional-changes checker is not working
   conditional-changes:


### PR DESCRIPTION
Add `permissions: contents: read` to apidiff.yml and `concurrency` groups to apidiff.yml and go.yml to cancel stale runs.