### PR TITLE
chore: remove redundant err.Error() calls in fmt functions

### DIFF
--- a/cmd/config/internal/commands/cat.go
+++ b/cmd/config/internal/commands/cat.go
@@ -141,7 +141,7 @@ func (r *CatRunner) ExecuteCmd(w io.Writer, pkgPath string) error {
 			return err
 		}
 		// print error message and continue if there are multiple packages to annotate
-		fmt.Fprintf(w, "%s in package %q\n", err.Error(), pkgPath)
+		fmt.Fprintf(w, "%s in package %q\n", err, pkgPath)
 	}
 	fmt.Fprint(w, out.String())
 	if out.String() != "" {

--- a/cmd/config/internal/commands/count.go
+++ b/cmd/config/internal/commands/count.go
@@ -83,7 +83,7 @@ func (r *CountRunner) ExecuteCmd(w io.Writer, pkgPath string) error {
 			return err
 		}
 		// print error message and continue if there are multiple packages to annotate
-		fmt.Fprintf(w, "%s\n", err.Error())
+		fmt.Fprintf(w, "%s\n", err)
 	}
 	return nil
 }

--- a/cmd/config/internal/commands/grep.go
+++ b/cmd/config/internal/commands/grep.go
@@ -159,7 +159,7 @@ func (r *GrepRunner) ExecuteCmd(w io.Writer, pkgPath string) error {
 			return err
 		}
 		// print error message and continue if there are multiple packages to annotate
-		fmt.Fprintf(w, "%s\n", err.Error())
+		fmt.Fprintf(w, "%s\n", err)
 	}
 	fmt.Fprint(w, out.String())
 	if out.String() != "" {

--- a/cmd/gorepomod/internal/git/runner.go
+++ b/cmd/gorepomod/internal/git/runner.go
@@ -294,7 +294,7 @@ func (gr *Runner) CheckoutReleaseBranch(
 	if yes {
 		gr.comment("checking out branch")
 		if out, err := gr.run(noHarmDone, "checkout", branch); err != nil {
-			fmt.Printf("error with checkout: %q", err.Error())
+			fmt.Printf("error with checkout: %q", err)
 			fmt.Printf("out: %q", out)
 			return fmt.Errorf(
 				"branch %q exists on remote %q, but isn't present locally",

--- a/kustomize/commands/edit/fix/convert.go
+++ b/kustomize/commands/edit/fix/convert.go
@@ -116,7 +116,7 @@ func addTargets(repl *types.Replacement, varName string, files []string, fSys fi
 		for _, n := range nodes {
 			fieldPaths, options, err := findVarName(n, varName, []string{})
 			if err != nil {
-				return fmt.Errorf("error with %s: %s", file, err.Error())
+				return fmt.Errorf("error with %s: %s", file, err)
 			}
 			targets, err := constructTargets(file, n, fieldPaths, options)
 			if err != nil {

--- a/kustomize/commands/edit/fix/fix.go
+++ b/kustomize/commands/edit/fix/fix.go
@@ -90,7 +90,7 @@ We recommend doing this in a clean git repository where the change is easy to un
 	fixedBuildCmd := build.NewCmdBuild(fSys, build.MakeHelp(konfig.ProgramName, "build"), &fixedOutput)
 	err = fixedBuildCmd.RunE(fixedBuildCmd, nil)
 	if err != nil {
-		fmt.Fprintf(w, "Warning: 'Fixed' kustomization now produces the error when running `kustomize build`: %s\n", err.Error())
+		fmt.Fprintf(w, "Warning: 'Fixed' kustomization now produces the error when running `kustomize build`: %s\n", err)
 	} else if fixedOutput.String() != oldOutput.String() {
 		fmt.Fprintf(w, "Warning: 'Fixed' kustomization now produces different output when running `kustomize build`:\n...%s...\n", fixedOutput.String())
 	}


### PR DESCRIPTION
The fmt verbs `%s` and `%q` already call `.Error()` on error values.