### PR TITLE
chore: replace deprecated os.IsNotExist with errors.Is

### DIFF
--- a/api/internal/plugins/utils/utils.go
+++ b/api/internal/plugins/utils/utils.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func DeterminePluginSrcRoot(fSys filesys.FileSystem) (string, error) {
 func FileYoungerThan(path string, d time.Duration) bool {
 	fi, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return false
 		}
 	}
@@ -111,7 +112,7 @@ func FileYoungerThan(path string, d time.Duration) bool {
 func FileModifiedAfter(path string, t time.Time) bool {
 	fi, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return false
 		}
 	}
@@ -120,7 +121,7 @@ func FileModifiedAfter(path string, t time.Time) bool {
 
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return false
 		}
 	}

--- a/cmd/gorepomod/internal/utils/utils.go
+++ b/cmd/gorepomod/internal/utils/utils.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -13,7 +14,7 @@ import (
 
 func DirExists(name string) bool {
 	info, err := os.Stat(name)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false
 	}
 	return info.IsDir()

--- a/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
+++ b/kyaml/fn/framework/frameworktestutil/frameworktestutil.go
@@ -6,6 +6,7 @@ package frameworktestutil
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -111,7 +112,7 @@ func (rc *CommandResultsChecker) isTestDir(path string) bool {
 func (rc *CommandResultsChecker) runInCurrentDir(t *testing.T) (string, string) {
 	t.Helper()
 	_, err := os.Stat(rc.ConfigInputFilename)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		t.Errorf("Test case is missing FunctionConfig input file (default: %s)", DefaultConfigInputFilename)
 	}
 	require.NoError(t, err)
@@ -209,7 +210,7 @@ func (rc *ProcessorResultsChecker) isTestDir(path string) bool {
 func (rc *ProcessorResultsChecker) runInCurrentDir(t *testing.T) (string, string) {
 	t.Helper()
 	_, err := os.Stat(rc.InputFilename)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		t.Errorf("Test case is missing input file (default: %s)", DefaultInputFilename)
 	}
 	require.NoError(t, err)
@@ -361,7 +362,7 @@ func (rc *checkerCore) readAssertionFiles(t *testing.T) (string, string) {
 	var expectedOutput, expectedError string
 	if rc.expectedOutputFilename != "" {
 		_, err := os.Stat(rc.expectedOutputFilename)
-		if !os.IsNotExist(err) && err != nil {
+		if !errors.Is(err, os.ErrNotExist) && err != nil {
 			t.FailNow()
 		}
 		if err == nil {
@@ -375,7 +376,7 @@ func (rc *checkerCore) readAssertionFiles(t *testing.T) (string, string) {
 	}
 	if rc.expectedErrorFilename != "" {
 		_, err := os.Stat(rc.expectedErrorFilename)
-		if !os.IsNotExist(err) && err != nil {
+		if !errors.Is(err, os.ErrNotExist) && err != nil {
 			t.FailNow()
 		}
 		if err == nil {

--- a/kyaml/kio/tree.go
+++ b/kyaml/kio/tree.go
@@ -4,6 +4,7 @@
 package kio
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -103,7 +104,7 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 func branchName(root, dirRelPath, openAPIFileName string) string {
 	name := filepath.Base(dirRelPath)
 	_, err := os.Stat(filepath.Join(root, dirRelPath, openAPIFileName))
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		// add Pkg: prefix indicating that it is a separate package as it has
 		// openAPIFile
 		return fmt.Sprintf("Pkg: %s", name)

--- a/kyaml/pathutil/pathutil.go
+++ b/kyaml/pathutil/pathutil.go
@@ -4,6 +4,7 @@
 package pathutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 )
@@ -17,7 +18,7 @@ func DirsWithFile(root, fileName string, recurse bool) ([]string, error) {
 		// check if the file with fileName is present in root and return it
 		// else return empty list
 		_, err := os.Stat(filepath.Join(root, fileName))
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			res = append(res, filepath.Clean(root))
 		}
 		return res, nil


### PR DESCRIPTION
`errors.Is` handles wrapped errors correctly unlike `os.IsNotExist`.