### PR TITLE
Add --suppress-deprecation-warnings flag to kustomize build

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -29,14 +29,15 @@ import (
 
 // KustTarget encapsulates the entirety of a kustomization build.
 type KustTarget struct {
-	kustomization     *types.Kustomization
-	kustFileName      string
-	ldr               ifc.Loader
-	validator         ifc.Validator
-	rFactory          *resmap.Factory
-	pLdr              *loader.Loader
-	origin            *resource.Origin
-	helmRootNamespace string // namespace inherited from parent kustomization for HelmCharts
+	kustomization                *types.Kustomization
+	kustFileName                 string
+	ldr                          ifc.Loader
+	validator                    ifc.Validator
+	rFactory                     *resmap.Factory
+	pLdr                         *loader.Loader
+	origin                       *resource.Origin
+	helmRootNamespace            string // namespace inherited from parent kustomization for HelmCharts
+	suppressDeprecationWarnings  bool   // when true, suppresses warnings about deprecated fields
 }
 
 // NewKustTarget returns a new instance of KustTarget.
@@ -53,6 +54,12 @@ func NewKustTarget(
 	}
 }
 
+// SetSuppressDeprecationWarnings controls whether deprecation warnings
+// are printed to stderr when loading kustomization files.
+func (kt *KustTarget) SetSuppressDeprecationWarnings(suppress bool) {
+	kt.suppressDeprecationWarnings = suppress
+}
+
 // Load attempts to load the target's kustomization file.
 func (kt *KustTarget) Load() error {
 	content, kustFileName, err := LoadKustFile(kt.ldr)
@@ -66,9 +73,11 @@ func (kt *KustTarget) Load() error {
 	}
 
 	// show warning message when using deprecated fields.
-	if warningMessages := k.CheckDeprecatedFields(); warningMessages != nil {
-		for _, msg := range *warningMessages {
-			fmt.Fprintf(os.Stderr, "%v\n", msg)
+	if !kt.suppressDeprecationWarnings {
+		if warningMessages := k.CheckDeprecatedFields(); warningMessages != nil {
+			for _, msg := range *warningMessages {
+				fmt.Fprintf(os.Stderr, "%v\n", msg)
+			}
 		}
 	}
 
@@ -490,6 +499,7 @@ func (kt *KustTarget) accumulateDirectory(
 	ra *accumulator.ResAccumulator, ldr ifc.Loader, isComponent bool) (*accumulator.ResAccumulator, error) {
 	defer ldr.Cleanup()
 	subKt := NewKustTarget(ldr, kt.validator, kt.rFactory, kt.pLdr)
+	subKt.suppressDeprecationWarnings = kt.suppressDeprecationWarnings
 	err := subKt.Load()
 	if err != nil {
 		return nil, errors.WrapPrefixf(

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -71,6 +71,7 @@ func (b *Kustomizer) Run(
 		// The plugin configs are always located on disk, regardless of the fSys passed in
 		pLdr.NewLoader(b.options.PluginConfig, resmapFactory, filesys.MakeFsOnDisk()),
 	)
+	kt.SetSuppressDeprecationWarnings(b.options.SuppressDeprecationWarnings)
 	err = kt.Load()
 	if err != nil {
 		return nil, err

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -45,6 +45,10 @@ type Options struct {
 
 	// Options related to kustomize plugins.
 	PluginConfig *types.PluginConfig
+
+	// SuppressDeprecationWarnings suppresses warnings about deprecated fields
+	// in kustomization files (e.g., bases, commonLabels, vars).
+	SuppressDeprecationWarnings bool
 }
 
 // MakeDefaultOptions returns a default instance of Options.

--- a/api/krusty/suppressdeprecationwarnings_test.go
+++ b/api/krusty/suppressdeprecationwarnings_test.go
@@ -1,0 +1,132 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package krusty_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/kustomize/api/krusty"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
+)
+
+func TestSuppressDeprecationWarnings(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteF("deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+`)
+
+	// Use the deprecated 'commonLabels' field to trigger a deprecation warning.
+	th.WriteK(".", `
+commonLabels:
+  app: test
+resources:
+- deployment.yaml
+`)
+
+	// First, verify that warnings ARE produced without suppression.
+	stderrWithWarnings := captureStderr(t, func() {
+		opts := th.MakeDefaultOptions()
+		th.Run(".", opts)
+	})
+	if !strings.Contains(stderrWithWarnings, "commonLabels") {
+		t.Fatalf("expected deprecation warning about 'commonLabels', got: %q", stderrWithWarnings)
+	}
+
+	// Now, verify that warnings are NOT produced with suppression.
+	stderrSuppressed := captureStderr(t, func() {
+		opts := th.MakeDefaultOptions()
+		opts.SuppressDeprecationWarnings = true
+		th.Run(".", opts)
+	})
+	if strings.Contains(stderrSuppressed, "commonLabels") {
+		t.Fatalf("expected no deprecation warning about 'commonLabels' when suppressed, got: %q", stderrSuppressed)
+	}
+}
+
+func TestSuppressDeprecationWarningsWithVars(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	th.WriteF("deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: the-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx
+        env:
+        - name: SERVICE_NAME
+          value: $(SERVICE_NAME)
+`)
+
+	th.WriteF("service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: the-service
+spec:
+  ports:
+  - port: 80
+`)
+
+	// Use the deprecated 'vars' field to trigger a deprecation warning.
+	th.WriteK(".", `
+resources:
+- deployment.yaml
+- service.yaml
+vars:
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    name: the-service
+    apiVersion: v1
+`)
+
+	// Verify that warnings are NOT produced with suppression.
+	stderrSuppressed := captureStderr(t, func() {
+		opts := th.MakeDefaultOptions()
+		opts.SuppressDeprecationWarnings = true
+		th.Run(".", opts)
+	})
+	if strings.Contains(stderrSuppressed, "vars") {
+		t.Fatalf("expected no deprecation warning about 'vars' when suppressed, got: %q", stderrSuppressed)
+	}
+}
+
+func TestSuppressDeprecationWarningsAPI(t *testing.T) {
+	// Verify the API field exists and defaults to false.
+	opts := krusty.MakeDefaultOptions()
+	if opts.SuppressDeprecationWarnings {
+		t.Fatal("expected SuppressDeprecationWarnings to default to false")
+	}
+}
+
+// captureStderr captures anything written to os.Stderr during fn().
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	fn()
+
+	w.Close()
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	r.Close()
+	return string(buf[:n])
+}

--- a/kustomize/commands/build/build.go
+++ b/kustomize/commands/build/build.go
@@ -27,13 +27,14 @@ var theFlags struct {
 		managedByLabel bool
 		helm           bool
 	}
-	helmCommand     string
-	helmApiVersions []string
-	helmKubeVersion string
-	helmDebug       bool
-	loadRestrictor  string
-	reorderOutput   string
-	fnOptions       types.FnPluginLoadingOptions
+	helmCommand                 string
+	helmApiVersions             []string
+	helmKubeVersion             string
+	helmDebug                   bool
+	loadRestrictor              string
+	reorderOutput               string
+	fnOptions                   types.FnPluginLoadingOptions
+	suppressDeprecationWarnings bool
 }
 
 type Help struct {
@@ -128,6 +129,7 @@ func NewCmdBuild(
 	}
 
 	AddFlagEnableHelm(cmd.Flags())
+	AddFlagSuppressDeprecationWarnings(cmd.Flags())
 	return cmd
 }
 
@@ -166,5 +168,6 @@ func HonorKustomizeFlags(kOpts *krusty.Options, flags *flag.FlagSet) *krusty.Opt
 	kOpts.PluginConfig.HelmConfig.KubeVersion = theFlags.helmKubeVersion
 	kOpts.PluginConfig.HelmConfig.Debug = theFlags.helmDebug
 	kOpts.AddManagedbyLabel = isManagedByLabelEnabled()
+	kOpts.SuppressDeprecationWarnings = theFlags.suppressDeprecationWarnings
 	return kOpts
 }

--- a/kustomize/commands/build/flagsuppressdeprecationwarnings.go
+++ b/kustomize/commands/build/flagsuppressdeprecationwarnings.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+import (
+	"github.com/spf13/pflag"
+)
+
+const flagSuppressDeprecationWarningsName = "suppress-deprecation-warnings"
+
+func AddFlagSuppressDeprecationWarnings(set *pflag.FlagSet) {
+	set.BoolVar(
+		&theFlags.suppressDeprecationWarnings,
+		flagSuppressDeprecationWarningsName,
+		false,
+		"suppress warnings about deprecated fields in kustomization files "+
+			"(e.g., bases, commonLabels, vars)")
+}


### PR DESCRIPTION
## Summary

Adds a `SuppressDeprecationWarnings` option to the kustomize API and a corresponding `--suppress-deprecation-warnings` CLI flag. When enabled, deprecation warnings about fields like `bases`, `commonLabels`, `vars`, etc. are silenced.

## Motivation

Users calling `kustomize.Build()` on kustomization files with deprecated fields receive warnings on stderr that can be noisy, especially when building multiple targets programmatically. The library should provide a way to suppress these warnings.

## Changes

- `api/krusty/options.go` — New `SuppressDeprecationWarnings` field in `Options`
- `api/internal/target/kusttarget.go` — Respect the flag before printing warnings; propagate to sub-targets
- `api/krusty/kustomizer.go` — Pass option to `KustTarget`
- `kustomize/commands/build/build.go` — Wire CLI flag
- New flag file and 3 tests

Closes #5452

---

**Generative AI disclosure:** This PR was co-authored with Claude (Anthropic).