### PR TITLE
chore: set minimum Go toolchain to 1.25.8

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,8 @@
 // Use the minimum patch version to avoid an extra bump in downstream projects.
 go 1.25.0
 
+toolchain go1.25.8
+
 use (
 	./api
 	./cmd/config


### PR DESCRIPTION
This implements https://github.com/kubernetes-sigs/kustomize/issues/6113 for the master branch.