### PR TITLE
fix: validate --output flag value in version command

### DIFF
--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -15,6 +15,9 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+// errInvalidOutput is returned when --output is set to an unrecognized value.
+var errInvalidOutput = fmt.Errorf("--output must be 'yaml' or 'json'")
+
 type Options struct {
 	Short  bool
 	Output string
@@ -58,6 +61,9 @@ func (o *Options) Validate(_ []string) error {
 			return fmt.Errorf("--short and --output are mutually exclusive")
 		}
 	}
+	if o.Output != "" && o.Output != "yaml" && o.Output != "json" {
+		return errInvalidOutput
+	}
 	return nil
 }
 
@@ -81,6 +87,8 @@ func (o *Options) Run() error {
 			return errors.WrapPrefixf(err, "marshalling provenance to json")
 		}
 		fmt.Fprintln(o.Writer, string(marshalled))
+	default:
+		return errInvalidOutput
 	}
 	return nil
 }

--- a/kustomize/commands/version/version_test.go
+++ b/kustomize/commands/version/version_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newOptionsWithOutput returns an Options with the given output format and a
+// bytes.Buffer as its writer, preventing potential nil-Writer panics in Run().
+func newOptionsWithOutput(output string) *Options {
+	o := NewOptions(&bytes.Buffer{})
+	o.Output = output
+	return o
+}
+
+// newOptionsWithShortAndOutput returns an Options with the given short and
+// output settings and a bytes.Buffer as its writer.
+func newOptionsWithShortAndOutput(short bool, output string) *Options {
+	o := NewOptions(&bytes.Buffer{})
+	o.Short = short
+	o.Output = output
+	return o
+}
+
+func TestOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *Options
+		wantErr string
+	}{
+		{
+			name:    "valid empty output",
+			opts:    NewOptions(&bytes.Buffer{}),
+			wantErr: "",
+		},
+		{
+			name:    "valid yaml output",
+			opts:    newOptionsWithOutput("yaml"),
+			wantErr: "",
+		},
+		{
+			name:    "valid json output",
+			opts:    newOptionsWithOutput("json"),
+			wantErr: "",
+		},
+		{
+			name:    "invalid output yml",
+			opts:    newOptionsWithOutput("yml"),
+			wantErr: "--output must be 'yaml' or 'json'",
+		},
+		{
+			name:    "invalid output xml",
+			opts:    newOptionsWithOutput("xml"),
+			wantErr: "--output must be 'yaml' or 'json'",
+		},
+		{
+			name:    "short and output mutually exclusive",
+			opts:    newOptionsWithShortAndOutput(true, "yaml"),
+			wantErr: "--short and --output are mutually exclusive",
+		},
+		{
+			name:    "short fires before invalid output",
+			opts:    newOptionsWithShortAndOutput(true, "yml"),
+			wantErr: "--short and --output are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate(nil)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOptions_Run_ValidOutputs(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		check  func(t *testing.T, buf *bytes.Buffer)
+	}{
+		{
+			name:   "yaml output",
+			output: "yaml",
+			check: func(t *testing.T, buf *bytes.Buffer) {
+				assert.Greater(t, buf.Len(), 0, "expected non-empty yaml output")
+				assert.Contains(t, buf.String(), "version:")
+			},
+		},
+		{
+			name:   "json output",
+			output: "json",
+			check: func(t *testing.T, buf *bytes.Buffer) {
+				assert.Greater(t, buf.Len(), 0, "expected non-empty json output")
+				assert.True(t, strings.HasPrefix(buf.String(), "{"), "expected json output to start with '{'")
+				assert.Contains(t, buf.String(), "version")
+			},
+		},
+		{
+			name:   "default output",
+			output: "",
+			check: func(t *testing.T, buf *bytes.Buffer) {
+				assert.Greater(t, buf.Len(), 0, "expected non-empty default output")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			o := NewOptions(buf)
+			o.Output = tt.output
+			err := o.Run()
+			require.NoError(t, err)
+			tt.check(t, buf)
+		})
+	}
+}
+
+func TestOptions_Run_InvalidOutputReturnsError(t *testing.T) {
+	o := newOptionsWithOutput("yml")
+	err := o.Run()
+	require.EqualError(t, err, "--output must be 'yaml' or 'json'")
+}
+
+func TestNewCmdVersion_InvalidOutputFlag(t *testing.T) {
+	buf := &bytes.Buffer{}
+	cmd := NewCmdVersion(buf)
+	cmd.SilenceErrors = true // prevent cobra from printing to os.Stderr
+	cmd.SilenceUsage = true  // prevent cobra from printing usage to os.Stderr
+	cmd.SetArgs([]string{"--output=yml"})
+	err := cmd.Execute()
+	require.EqualError(t, err, "--output must be 'yaml' or 'json'")
+}

--- a/kustomize/commands/version/version_test.go
+++ b/kustomize/commands/version/version_test.go
@@ -53,12 +53,12 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name:    "invalid output yml",
 			opts:    newOptionsWithOutput("yml"),
-			wantErr: "--output must be 'yaml' or 'json'",
+			wantErr: errInvalidOutput.Error(),
 		},
 		{
 			name:    "invalid output xml",
 			opts:    newOptionsWithOutput("xml"),
-			wantErr: "--output must be 'yaml' or 'json'",
+			wantErr: errInvalidOutput.Error(),
 		},
 		{
 			name:    "short and output mutually exclusive",
@@ -131,7 +131,7 @@ func TestOptions_Run_ValidOutputs(t *testing.T) {
 func TestOptions_Run_InvalidOutputReturnsError(t *testing.T) {
 	o := newOptionsWithOutput("yml")
 	err := o.Run()
-	require.EqualError(t, err, "--output must be 'yaml' or 'json'")
+	require.EqualError(t, err, errInvalidOutput.Error())
 }
 
 func TestNewCmdVersion_InvalidOutputFlag(t *testing.T) {
@@ -141,5 +141,5 @@ func TestNewCmdVersion_InvalidOutputFlag(t *testing.T) {
 	cmd.SilenceUsage = true  // prevent cobra from printing usage to os.Stderr
 	cmd.SetArgs([]string{"--output=yml"})
 	err := cmd.Execute()
-	require.EqualError(t, err, "--output must be 'yaml' or 'json'")
+	require.EqualError(t, err, errInvalidOutput.Error())
 }


### PR DESCRIPTION
fixes #6032

When a user passes an unrecognized value to the `--output` flag of `kustomize version` (for example, `--output=yml`), the command produces no output and exits silently with no error, leaving the user no indication of what went wrong.

This PR adds validation in `Validate()` that rejects unrecognized output values before `Run()` is called, consistent with how other kustomize commands structure pre-flight checks and how `kubectl version` handles the same flag. `Validate()` is the correct location because it gives Cobra a chance to surface the error with usage text before any I/O occurs. `Run()` also gains a defensive `default:` branch that returns an explicit error for callers that invoke it directly without going through `Validate()`. The error string is extracted to a `const` (`errInvalidOutput`) shared by both sites.

Test coverage: 7 table-driven cases in `TestOptions_Validate` covering valid values (`yaml`, `json`, `""`) and invalid ones, 3 cases in `TestOptions_Run_ValidOutputs` confirming correct output format, `TestOptions_Run_InvalidOutputReturnsError` exercising the `Run()` defensive branch directly, and `TestNewCmdVersion_InvalidOutputFlag` exercising the full Cobra command path. All 12 tests pass.

Note: #6033 addresses the same issue but adds only the `Run()` default branch without a `Validate()` step or any tests.