### PR TITLE
feat(nameref): follow name references inside embedded YAML/JSON 

### DIFF
--- a/api/filters/nameref/nameref.go
+++ b/api/filters/nameref/nameref.go
@@ -8,14 +8,25 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kustomize/api/filters/fieldspec"
+	"sigs.k8s.io/kustomize/api/internal/structuredscalar"
 	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/resid"
+	kyaml_utils "sigs.k8s.io/kustomize/kyaml/utils"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+// structuredPathSep separates the manifest field path (slash-separated, as for
+// FieldSpec.Path) from a path inside embedded JSON/YAML in that field's string
+// value. The inner path uses dot-separated segments with the same escaping
+// rules as replacement targets (see kyaml/utils.SmarterPathSplitter).
+//
+// Example: data/config.yaml//auth.secretName selects the scalar at auth.secretName
+// inside the YAML document stored in data["config.yaml"].
+const structuredPathSep = "//"
 
 // Filter updates a name references.
 type Filter struct {
@@ -60,15 +71,79 @@ func (f Filter) run(node *yaml.RNode) (*yaml.RNode, error) {
 		return nil, err
 	}
 	f.NameFieldToUpdate.Gvk = f.Referrer.GetGvk()
+	manifestPath, innerPath, structured := splitStructuredNameRefPath(f.NameFieldToUpdate.Path)
+	fieldSpec := f.NameFieldToUpdate
+	if structured {
+		fieldSpec.Path = manifestPath
+	}
+	setFn := f.set
+	if structured {
+		setFn = func(n *yaml.RNode) error {
+			return f.setStructuredEmbeddedScalar(n, innerPath)
+		}
+	}
 	if err := node.PipeE(fieldspec.Filter{
-		FieldSpec: f.NameFieldToUpdate,
-		SetValue:  f.set,
+		FieldSpec: fieldSpec,
+		SetValue:  setFn,
 	}); err != nil {
 		return nil, errors.WrapPrefixf(
 			err, "updating name reference in '%s' field of '%s'",
 			f.NameFieldToUpdate.Path, f.Referrer.CurId().String())
 	}
 	return node, nil
+}
+
+func splitStructuredNameRefPath(path string) (manifestPath, innerPath string, ok bool) {
+	idx := strings.Index(path, structuredPathSep)
+	if idx < 0 {
+		return path, "", false
+	}
+	manifestPath = strings.TrimSpace(path[:idx])
+	innerPath = strings.TrimSpace(path[idx+len(structuredPathSep):])
+	if manifestPath == "" || innerPath == "" {
+		return "", "", false
+	}
+	return manifestPath, innerPath, true
+}
+
+func (f Filter) setStructuredEmbeddedScalar(node *yaml.RNode, innerPath string) error {
+	if yaml.IsMissingOrNull(node) {
+		return nil
+	}
+	if node.YNode().Kind != yaml.ScalarNode {
+		return fmt.Errorf(
+			"structured nameReference path requires a scalar string field at %q",
+			structuredPathSep)
+	}
+	scalarValue := node.YNode().Value
+	var parsedNode yaml.Node
+	if err := yaml.Unmarshal([]byte(scalarValue), &parsedNode); err != nil {
+		return fmt.Errorf("parse embedded structured data: %w", err)
+	}
+	structuredData := yaml.NewRNode(&parsedNode)
+	pathParts := kyaml_utils.SmarterPathSplitter(innerPath, ".")
+	matched, err := structuredData.Pipe(&yaml.PathMatcher{Path: pathParts})
+	if err != nil {
+		return err
+	}
+	targetFields, err := matched.Elements()
+	if err != nil {
+		return err
+	}
+	if len(targetFields) == 0 {
+		return nil
+	}
+	for _, t := range targetFields {
+		if err := f.set(t); err != nil {
+			return err
+		}
+	}
+	serialized, err := structuredscalar.Serialize(structuredData, scalarValue)
+	if err != nil {
+		return err
+	}
+	node.YNode().Value = serialized
+	return nil
 }
 
 // This function is called on the node found at FieldSpec.Path.
@@ -272,7 +347,11 @@ func previousIdSelectedByGvk(gvk *resid.Gvk) sieveFunc {
 // with some exceptions (e.g. RoleBinding and ServiceAccount are both
 // namespaceable, but the former can refer to accounts in other namespaces).
 func (f Filter) roleRefFilter() sieveFunc {
-	if !strings.HasSuffix(f.NameFieldToUpdate.Path, "roleRef/name") {
+	path := f.NameFieldToUpdate.Path
+	if mp, _, ok := splitStructuredNameRefPath(path); ok {
+		path = mp
+	}
+	if !strings.HasSuffix(path, "roleRef/name") {
 		return acceptAll
 	}
 	roleRefGvk, err := getRoleRefGvk(f.Referrer)

--- a/api/filters/nameref/nameref_test.go
+++ b/api/filters/nameref/nameref_test.go
@@ -187,6 +187,121 @@ map:
 				},
 			},
 		},
+		"structured yaml in scalar": {
+			referrerOriginal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  config.yaml: |
+    auth:
+      secretName: app-credentials
+`,
+			candidates: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-credentials-hashed
+`,
+			originalNames: []string{"app-credentials"},
+			referrerFinal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  config.yaml: |-
+    auth:
+      secretName: app-credentials-hashed
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{
+					Path: "data/config.yaml//auth.secretName",
+				},
+				ReferralTarget: resid.Gvk{
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"structured json in scalar": {
+			referrerOriginal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  cfg.json: '{"auth":{"secretName":"app-credentials"}}'
+`,
+			candidates: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-credentials-hashed
+`,
+			originalNames: []string{"app-credentials"},
+			referrerFinal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  cfg.json: '{"auth":{"secretName":"app-credentials-hashed"}}'
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{
+					Path: "data/cfg.json//auth.secretName",
+				},
+				ReferralTarget: resid.Gvk{
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
+		"structured mapping ref": {
+			referrerOriginal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  cfg.yaml: |
+    spec:
+      secretRef:
+        name: app-credentials
+        namespace: default
+`,
+			candidates: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-credentials-hashed
+  namespace: default
+`,
+			originalNames: []string{"app-credentials"},
+			referrerFinal: `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  cfg.yaml: |-
+    spec:
+      secretRef:
+        name: app-credentials-hashed
+        namespace: default
+`,
+			filter: Filter{
+				NameFieldToUpdate: types.FieldSpec{
+					Path: "data/cfg.yaml//spec.secretRef",
+				},
+				ReferralTarget: resid.Gvk{
+					Version: "v1",
+					Kind:    "Secret",
+				},
+			},
+		},
 		"null value": {
 			referrerOriginal: `
 apiVersion: apps/v1

--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -4,10 +4,10 @@
 package replacement
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
+	"sigs.k8s.io/kustomize/api/internal/structuredscalar"
 	"sigs.k8s.io/kustomize/api/internal/utils"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
@@ -340,9 +340,7 @@ func setValueInStructuredData(target *yaml.RNode, value *yaml.RNode, fieldPath s
 		}
 	}
 
-	// Serialize the modified structured data back to the scalar field
-	// Try to detect if original was JSON or YAML and preserve formatting
-	serializedData, err := serializeStructuredData(structuredData, scalarValue)
+	serializedData, err := structuredscalar.Serialize(structuredData, scalarValue)
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
@@ -351,55 +349,4 @@ func setValueInStructuredData(target *yaml.RNode, value *yaml.RNode, fieldPath s
 	scalarField.YNode().Value = serializedData
 
 	return nil
-}
-
-// serializeStructuredData handles the serialization of structured data back to string format
-// preserving the original format (JSON vs YAML) and style (pretty vs compact)
-func serializeStructuredData(structuredData *yaml.RNode, originalValue string) (string, error) {
-	firstChar := rune(strings.TrimSpace(originalValue)[0])
-	if firstChar == '{' || firstChar == '[' {
-		return serializeAsJSON(structuredData, originalValue)
-	}
-
-	// Fallback to YAML format
-	return serializeAsYAML(structuredData)
-}
-
-// serializeAsJSON converts structured data back to JSON format
-func serializeAsJSON(structuredData *yaml.RNode, originalValue string) (string, error) {
-	modifiedData, err := structuredData.String()
-	if err != nil {
-		return "", fmt.Errorf("failed to serialize structured data: %w", err)
-	}
-
-	// Parse the YAML output as JSON
-	var jsonData interface{}
-	if err := yaml.Unmarshal([]byte(modifiedData), &jsonData); err != nil {
-		return "", fmt.Errorf("failed to unmarshal YAML data: %w", err)
-	}
-
-	// Check if original was pretty-printed by looking for newlines and indentation
-	if strings.Contains(originalValue, "\n") && strings.Contains(originalValue, "  ") {
-		// Pretty-print the JSON to match original formatting
-		if prettyJSON, err := json.MarshalIndent(jsonData, "", "  "); err == nil {
-			return string(prettyJSON), nil
-		}
-	}
-
-	// Compact JSON
-	if compactJSON, err := json.Marshal(jsonData); err == nil {
-		return string(compactJSON), nil
-	}
-
-	return "", fmt.Errorf("failed to marshal JSON data")
-}
-
-// serializeAsYAML converts structured data back to YAML format
-func serializeAsYAML(structuredData *yaml.RNode) (string, error) {
-	modifiedData, err := structuredData.String()
-	if err != nil {
-		return "", fmt.Errorf("failed to serialize YAML data: %w", err)
-	}
-
-	return strings.TrimSpace(modifiedData), nil
 }

--- a/api/internal/structuredscalar/serialize.go
+++ b/api/internal/structuredscalar/serialize.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package structuredscalar serializes YAML RNodes parsed from embedded JSON/YAML
+// strings, preserving the original outer format where possible.
+package structuredscalar
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// Serialize writes structured data back to a string, preserving JSON vs YAML and
+// basic JSON pretty-printing when the original used newlines and indentation.
+func Serialize(structuredData *yaml.RNode, originalValue string) (string, error) {
+	trimmed := strings.TrimSpace(originalValue)
+	if trimmed == "" {
+		return "", fmt.Errorf("empty structured scalar")
+	}
+	firstChar := rune(trimmed[0])
+	if firstChar == '{' || firstChar == '[' {
+		return serializeAsJSON(structuredData, originalValue)
+	}
+	return serializeAsYAML(structuredData)
+}
+
+func serializeAsJSON(structuredData *yaml.RNode, originalValue string) (string, error) {
+	modifiedData, err := structuredData.String()
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize structured data: %w", err)
+	}
+
+	var jsonData interface{}
+	if err := yaml.Unmarshal([]byte(modifiedData), &jsonData); err != nil {
+		return "", fmt.Errorf("failed to unmarshal YAML data: %w", err)
+	}
+
+	if strings.Contains(originalValue, "\n") && strings.Contains(originalValue, "  ") {
+		if prettyJSON, err := json.MarshalIndent(jsonData, "", "  "); err == nil {
+			return string(prettyJSON), nil
+		}
+	}
+
+	if compactJSON, err := json.Marshal(jsonData); err == nil {
+		return string(compactJSON), nil
+	}
+
+	return "", fmt.Errorf("failed to marshal JSON data")
+}
+
+func serializeAsYAML(structuredData *yaml.RNode) (string, error) {
+	modifiedData, err := structuredData.String()
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize YAML data: %w", err)
+	}
+
+	return strings.TrimSpace(modifiedData), nil
+}

--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -4,6 +4,8 @@
 package krusty_test
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
@@ -867,4 +869,53 @@ spec:
   validationActions:
   - Deny
 `)
+}
+
+// Regression for https://github.com/kubernetes-sigs/kustomize/issues/6101 :
+// nameReference updates names inside YAML/JSON embedded in ConfigMap string data.
+func TestIssue6101StructuredNameReference(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- app-configmap.yaml
+secretGenerator:
+- name: app-credentials
+  literals:
+  - username=demo
+  - password=demo
+configurations:
+- nameReference.yaml
+`)
+	th.WriteF("nameReference.yaml", `
+nameReference:
+- kind: Secret
+  fieldSpecs:
+  - kind: ConfigMap
+    path: data/config.yaml//auth.secretName
+`)
+	th.WriteF("app-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+data:
+  config.yaml: |
+    auth:
+      secretName: app-credentials
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	yb, err := m.AsYaml()
+	if err != nil {
+		t.Fatal(err)
+	}
+	y := strings.TrimSpace(string(yb))
+	re := regexp.MustCompile(`secretName: (app-credentials-[a-z0-9]+)`)
+	sm := re.FindStringSubmatch(y)
+	if len(sm) != 2 {
+		t.Fatalf("expected hashed secretName in embedded config, got:\n%s", y)
+	}
+	hashed := sm[1]
+	if strings.Count(y, hashed) < 2 {
+		t.Fatalf("expected generated name %q in both ConfigMap data and Secret metadata, got:\n%s", hashed, y)
+	}
 }


### PR DESCRIPTION
## Fixes

Closes #6101

---

## Summary

[One line: what changed and which subsystem.]

**Example:** Implements structured-data traversal for `nameReference` so names inside YAML/JSON embedded in scalar fields (e.g. `ConfigMap.data`) can be updated, aligned with structured `replacements` behavior.

---

## Related issue

- Issue: https://github.com/kubernetes-sigs/kustomize/issues/6101
- [Optional: related PRs / release note link]

---

## Problem

[What was broken or missing; user-visible symptom.]

**For #6101:**

- `nameReference` only updated normal manifest fields from `fieldSpecs`.
- It did **not** traverse JSON/YAML inside scalar strings (`ConfigMap.data`, `Secret.stringData`, annotations, etc.).
- Generated names (e.g. `secretGenerator` hash suffixes) did not propagate into nested config such as `auth.secretName` inside `data["config.yaml"]`.

---

## Root cause

[Why the old code could not satisfy the issue.]

**For #6101:** The nameref filter stopped at the leaf scalar that contained the whole embedded document as one string; there was no parse → navigate → update → serialize path for that content.

---

## Solution

[Bullets: syntax, main code paths, compatibility.]

**For #6101:**

| Item | Detail |
|------|--------|
| Path syntax | `manifest/path//inner.dot.path` — manifest segment uses `/`; inner segment uses `.` with `SmarterPathSplitter` escaping (same idea as structured `replacements`). |
| Behavior | Parse scalar → `PathMatcher` on inner path → existing nameref `set` / map / sequence logic → serialize back. |
| Refactor | `api/internal/structuredscalar` for serialization; `replacements` calls into it. |
| `roleRef` | Uses manifest-only prefix when path contains `//`. |
| Compatibility | Paths **without** `//` unchanged. |

---

## Impact

| Area | Notes |
|------|--------|
| Users | Can propagate renames and generator hashes into embedded app config without per-key `replacements`. |
| Risk | Low; opt-in via `//` in path. |
| Caveats | Minor YAML style drift on round-trip (e.g. `\|` vs `\|-`), similar to structured `replacements`. |

---

## How to verify

```bash
cd api

go test ./filters/nameref/... -run 'TestNamerefFilter/structured' -count=1 -v
go test ./krusty/... -run TestIssue6101StructuredNameReference -count=1 -v
go test ./filters/replacement/... ./internal/accumulator/... -count=1