### PR TITLE
feat: allow loading configurations from parent directories

### DIFF
--- a/api/internal/loader/fileloader.go
+++ b/api/internal/loader/fileloader.go
@@ -121,6 +121,13 @@ func (fl *FileLoader) Root() string {
 	return fl.root.String()
 }
 
+// WithLoadRestrictor returns a copy of the FileLoader with a different load restrictor.
+func (fl *FileLoader) WithLoadRestrictor(lr LoadRestrictorFunc) *FileLoader {
+	newFl := *fl
+	newFl.loadRestrictor = lr
+	return &newFl
+}
+
 func NewLoaderOrDie(
 	lr LoadRestrictorFunc,
 	fSys filesys.FileSystem, path string) *FileLoader {

--- a/api/internal/loader/loadrestrictions.go
+++ b/api/internal/loader/loadrestrictions.go
@@ -33,3 +33,24 @@ func RestrictionNone(
 	_ filesys.FileSystem, _ filesys.ConfirmedDir, path string) (string, error) {
 	return path, nil
 }
+
+// RestrictionRootAndAncestors allows loading files from the root and its ancestor directories.
+func RestrictionRootAndAncestors(
+	fSys filesys.FileSystem, root filesys.ConfirmedDir, path string) (string, error) {
+	d, f, err := fSys.CleanedAbs(path)
+	if err != nil {
+		return "", err
+	}
+	if f == "" {
+		return "", fmt.Errorf("'%s' must resolve to a file", path)
+	}
+	if d.HasPrefix(root) {
+		return d.Join(f), nil
+	}
+	if root.HasPrefix(d) {
+		return d.Join(f), nil
+	}
+	return "", fmt.Errorf(
+		"security; file '%s' is not in or below '%s' and is not in an ancestor directory",
+		path, root)
+}

--- a/api/internal/loader/loadrestrictions_test.go
+++ b/api/internal/loader/loadrestrictions_test.go
@@ -65,3 +65,64 @@ func TestRestrictionRootOnly(t *testing.T) {
 		t.Fatalf("unexpected err: %s", err)
 	}
 }
+
+func TestRestrictionRootAndAncestors(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	root := filesys.ConfirmedDir(
+		filesys.Separator + filepath.Join("tmp", "foo", "bar"))
+
+	// Legal: file in root directory.
+	path := filepath.Join(string(root), "config.yaml")
+	fSys.Create(path)
+	p, err := RestrictionRootAndAncestors(fSys, root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != path {
+		t.Fatalf("expected '%s', got '%s'", path, p)
+	}
+
+	// Legal: file in subdirectory of root.
+	path = filepath.Join(string(root), "sub", "config.yaml")
+	fSys.Create(path)
+	p, err = RestrictionRootAndAncestors(fSys, root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != path {
+		t.Fatalf("expected '%s', got '%s'", path, p)
+	}
+
+	// Legal: file in parent directory (ancestor).
+	path = filepath.Join(filesys.Separator+"tmp", "foo", "config.yaml")
+	fSys.Create(path)
+	p, err = RestrictionRootAndAncestors(fSys, root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != path {
+		t.Fatalf("expected '%s', got '%s'", path, p)
+	}
+
+	// Legal: file in grandparent directory (ancestor).
+	path = filepath.Join(filesys.Separator+"tmp", "config.yaml")
+	fSys.Create(path)
+	p, err = RestrictionRootAndAncestors(fSys, root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != path {
+		t.Fatalf("expected '%s', got '%s'", path, p)
+	}
+
+	// Illegal: file in sibling directory (not ancestor or descendant).
+	path = filepath.Join(filesys.Separator+"tmp", "other", "config.yaml")
+	fSys.Create(path)
+	_, err = RestrictionRootAndAncestors(fSys, root, path)
+	if err == nil {
+		t.Fatal("should have an error for sibling directory")
+	}
+	if !strings.Contains(err.Error(), "is not in or below") {
+		t.Fatalf("unexpected err: %s", err)
+	}
+}

--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -203,8 +203,13 @@ func (kt *KustTarget) accumulateTarget(ra *accumulator.ResAccumulator) (
 	if err != nil {
 		return nil, errors.WrapPrefixf(err, "accumulating resources")
 	}
+	// Allow configurations to reference files in parent directories.
+	configLdr := kt.ldr
+	if fl, ok := configLdr.(*load.FileLoader); ok {
+		configLdr = fl.WithLoadRestrictor(load.RestrictionRootAndAncestors)
+	}
 	tConfig, err := builtinconfig.MakeTransformerConfig(
-		kt.ldr, kt.kustomization.Configurations)
+		configLdr, kt.kustomization.Configurations)
 	if err != nil {
 		return nil, err
 	}

--- a/api/krusty/customconfig_test.go
+++ b/api/krusty/customconfig_test.go
@@ -732,3 +732,63 @@ spec:
 		})
 	}
 }
+
+// TestConfigurationsFromParentDirectory verifies that the configurations
+// field can reference files in parent directories.
+// See https://github.com/kubernetes-sigs/kustomize/issues/6124
+func TestConfigurationsFromParentDirectory(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+
+	// Shared configuration in the parent directory.
+	th.WriteF("kustomizeconfig.yaml", `
+nameReference:
+- kind: Gorilla
+  fieldSpecs:
+  - kind: AnimalPark
+    path: spec/gorillaRef/name
+`)
+
+	// Kustomization in a subdirectory referencing parent config.
+	th.WriteK("overlay", `
+resources:
+- gorilla.yaml
+- animalPark.yaml
+configurations:
+- ../kustomizeconfig.yaml
+namePrefix: x-
+`)
+	th.WriteF("overlay/gorilla.yaml", `
+apiVersion: foo/v1
+kind: Gorilla
+metadata:
+  name: koko
+spec:
+  diet: bambooshoots
+`)
+	th.WriteF("overlay/animalPark.yaml", `
+apiVersion: foo/v1
+kind: AnimalPark
+metadata:
+  name: sandiego
+spec:
+  gorillaRef:
+    name: koko
+`)
+	m := th.Run("overlay", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: foo/v1
+kind: Gorilla
+metadata:
+  name: x-koko
+spec:
+  diet: bambooshoots
+---
+apiVersion: foo/v1
+kind: AnimalPark
+metadata:
+  name: x-sandiego
+spec:
+  gorillaRef:
+    name: x-koko
+`)
+}


### PR DESCRIPTION
Fixes #6124 

## What this PR does

Allows the `configurations` field in `kustomization.yaml` to reference files in parent directories (e.g., `configurations: [../kustomizeconfig.yaml]`).

Previously, this was blocked by the `RestrictionRootOnly` load restrictor, forcing users to duplicate shared configuration files across every overlay.

## Changes

- Add `RestrictionRootAndAncestors` load restrictor that permits files in root and ancestor directories, while still blocking sibling/unrelated paths
- Add `WithLoadRestrictor` method to `FileLoader` for per-field restriction overrides
- Apply relaxed restriction specifically to the `configurations` field in `kusttarget.go`
- Add unit tests for the new restrictor and integration test for parent-dir configurations

## Why

Configuration files (nameReference, varReference, etc.) are metadata commonly shared across multiple kustomizations. Unlike resources or patches, they don't contain actual Kubernetes objects — they only define how kustomize should process fields. Requiring them to live under each overlay leads to duplication and drift.

## How to test

```yaml
# repo-root/kustomizeconfig.yaml  (shared config)
nameReference:
- kind: ConfigMap
  fieldSpecs:
  - kind: Deployment
    path: spec/template/spec/containers/env/valueFrom/configMapKeyRef/name

# repo-root/overlay/kustomization.yaml
configurations:
- ../kustomizeconfig.yaml
resources:
- deployment.yaml