### PR TITLE
docs(plugin): document KUSTOMIZE_PLUGIN_HOME and plugin-home resolution

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -32,6 +32,29 @@ each in its own sub-directory.
    may soon be deleted, or they might be WIP plugins that will
    someday become examples or builtins.
 
+### Plugin home
+
+Kustomize looks up Exec and Go plugins relative to a plugin home
+directory. When resolving it, kustomize tries the following paths in
+order and uses the first one that exists:
+
+1. `$KUSTOMIZE_PLUGIN_HOME` — set this to override the default search
+   paths below (useful when plugins live outside `$HOME`).
+2. `$XDG_CONFIG_HOME/kustomize/plugin`.
+3. `$HOME/.config/kustomize/plugin` — used when `$XDG_CONFIG_HOME` is
+   unset.
+4. `$HOME/kustomize/plugin`.
+
+If none of the above exist, plugin resolution fails. On Windows,
+`$HOME` falls back to `$USERPROFILE`. See
+[`api/konfig/plugins.go`](../api/konfig/plugins.go) for the resolution
+code.
+
+Within the plugin home, an individual plugin is loaded from
+`<apiVersion group>/<apiVersion version>/<lowercase kind>/<Kind>`,
+matching the `apiVersion` and `kind` fields of the generator or
+transformer entry in `kustomization.yaml`.
+
 #### Testing
 
 Regardless of the [style](#plugin-styles) used to write a plugin,

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -32,6 +32,46 @@ each in its own sub-directory.
    may soon be deleted, or they might be WIP plugins that will
    someday become examples or builtins.
 
+### Plugin home
+
+Kustomize looks up Exec and Go plugins relative to a plugin home
+directory. When resolving it, kustomize tries the following paths in
+order and uses the first one that exists:
+
+1. `$KUSTOMIZE_PLUGIN_HOME` — set this to override the default search
+   paths below (useful when plugins live outside `$HOME`).
+2. `$XDG_CONFIG_HOME/kustomize/plugin`.
+3. `$HOME/.config/kustomize/plugin` — used when `$XDG_CONFIG_HOME` is
+   unset.
+4. `$HOME/kustomize/plugin`.
+
+If none of the above exist, plugin resolution fails. On Windows,
+`$HOME` falls back to `$USERPROFILE`. See
+[`api/konfig/plugins.go`](../api/konfig/plugins.go) for the resolution
+code.
+
+The `generators` and `transformers` fields in `kustomization.yaml` are lists
+of file paths, each pointing to a plugin configuration file. The `apiVersion`
+and `kind` are read from that referenced configuration file, not from the list
+entry itself.
+
+From those fields kustomize derives the plugin directory
+`<plugin-home>/<apiVersion group>/<apiVersion version>/<lowercase kind>/` and
+looks for the plugin there in two forms: first an executable file named
+`<Kind>` (an Exec plugin), then `<Kind>.so` (a Go plugin).
+
+For example, given a configuration file referenced from `transformers`:
+
+```yaml
+apiVersion: someteam.example.com/v1
+kind: SedTransformer
+```
+
+kustomize looks for the executable
+`<plugin-home>/someteam.example.com/v1/sedtransformer/SedTransformer`, and
+failing that, the Go plugin
+`<plugin-home>/someteam.example.com/v1/sedtransformer/SedTransformer.so`.
+
 #### Testing
 
 Regardless of the [style](#plugin-styles) used to write a plugin,

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -32,6 +32,27 @@ each in its own sub-directory.
    may soon be deleted, or they might be WIP plugins that will
    someday become examples or builtins.
 
+#### Testing
+
+Regardless of the [style](#plugin-styles) used to write a plugin,
+it should be accompanied by a Go unit test, written using the framework
+maintained by the kustomize maintainers for just that purpose.
+
+To see how this works, run any plugin test, e.g.
+this plugin written in bash:
+```
+pushd plugin/someteam.example.com/v1/bashedconfigmap
+go test -v .
+popd
+```
+
+For plugins with many tests, it's possible to target just one test:
+```
+pushd plugin/builtin/patchstrategicmergetransformer
+go test -v -run TestBadPatchStrategicMergeTransformer PatchStrategicMergeTransformer_test.go
+popd
+```
+
 ### Plugin home
 
 Kustomize looks up Exec and Go plugins relative to a plugin home
@@ -41,12 +62,13 @@ order and uses the first one that exists:
 1. `$KUSTOMIZE_PLUGIN_HOME` — set this to override the default search
    paths below (useful when plugins live outside `$HOME`).
 2. `$XDG_CONFIG_HOME/kustomize/plugin`.
-3. `$HOME/.config/kustomize/plugin` — used when `$XDG_CONFIG_HOME` is
-   unset.
+3. `$HOME/.config/kustomize/plugin`, the default XDG location. This is
+   also tried when `$XDG_CONFIG_HOME` is set but the path in step 2
+   does not exist.
 4. `$HOME/kustomize/plugin`.
 
 If none of the above exist, plugin resolution fails. On Windows,
-`$HOME` falls back to `$USERPROFILE`. See
+`$USERPROFILE` is used in place of `$HOME`. See
 [`api/konfig/plugins.go`](../api/konfig/plugins.go) for the resolution
 code.
 
@@ -71,27 +93,6 @@ kustomize looks for the executable
 `<plugin-home>/someteam.example.com/v1/sedtransformer/SedTransformer`, and
 failing that, the Go plugin
 `<plugin-home>/someteam.example.com/v1/sedtransformer/SedTransformer.so`.
-
-#### Testing
-
-Regardless of the [style](#plugin-styles) used to write a plugin,
-it should be accompanied by a Go unit test, written using the framework
-maintained by the kustomize maintainers for just that purpose.
-
-To see how this works, run any plugin test, e.g.
-this plugin written in bash:
-```
-pushd plugin/someteam.example.com/v1/bashedconfigmap
-go test -v .
-popd
-```
-
-For plugins with many tests, it's possible to target just one test:
-```
-pushd plugin/builtin/patchstrategicmergetransformer
-go test -v -run TestBadPatchStrategicMergeTransformer PatchStrategicMergeTransformer_test.go
-popd
-```
 
 ### Plugin styles
 


### PR DESCRIPTION
## Summary

Adds a "Plugin home" section to [\`plugin/README.md\`](https://github.com/kubernetes-sigs/kustomize/blob/master/plugin/README.md) describing the directory kustomize uses to look up Exec and Go plugins.

The section documents the four-step resolution order kustomize applies to find the plugin home:

1. \`$KUSTOMIZE_PLUGIN_HOME\`
2. \`$XDG_CONFIG_HOME/kustomize/plugin\`
3. \`$HOME/.config/kustomize/plugin\` (used when \`$XDG_CONFIG_HOME\` is unset)
4. \`$HOME/kustomize/plugin\`

It also notes the Windows \`$USERPROFILE\` fallback for \`$HOME\` and the relative layout kustomize uses to load an individual plugin (\`<apiVersion group>/<apiVersion version>/<lowercase kind>/<Kind>\`).

Content comes directly from [\`api/konfig/plugins.go\`](https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/plugins.go) and [\`api/internal/plugins/loader/loader.go\`](https://github.com/kubernetes-sigs/kustomize/blob/master/api/internal/plugins/loader/loader.go).

Fixes #5706.

/kind documentation