### PR TITLE
fix(api/types): map HelmChartArgs.ReleaseNamespace -> HelmChart.Namespace

### DIFF
--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -148,6 +148,11 @@ func makeHelmChartFromHca(old *HelmChartArgs) (c HelmChart) {
 	c.ValuesInline = old.ValuesLocal
 	c.ValuesMerge = old.ValuesMerge
 	c.ReleaseName = old.ReleaseName
+	// ReleaseNamespace maps onto Namespace in the (non-deprecated)
+	// HelmChart type. Forgetting this mapping is why releaseNamespace
+	// set under the deprecated helmChartInflationGenerator field is
+	// silently ignored — see kubernetes-sigs/kustomize#4593.
+	c.Namespace = old.ReleaseNamespace
 	return
 }
 

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -151,7 +151,7 @@ func makeHelmChartFromHca(old *HelmChartArgs) (c HelmChart) {
 	// ReleaseNamespace maps onto Namespace in the (non-deprecated)
 	// HelmChart type. Forgetting this mapping is why releaseNamespace
 	// set under the deprecated helmChartInflationGenerator field is
-	// silently ignored — see kubernetes-sigs/kustomize#4593.
+	// silently ignored, see kubernetes-sigs/kustomize#4593.
 	c.Namespace = old.ReleaseNamespace
 	return
 }

--- a/api/types/helmchartargs.go
+++ b/api/types/helmchartargs.go
@@ -148,10 +148,6 @@ func makeHelmChartFromHca(old *HelmChartArgs) (c HelmChart) {
 	c.ValuesInline = old.ValuesLocal
 	c.ValuesMerge = old.ValuesMerge
 	c.ReleaseName = old.ReleaseName
-	// ReleaseNamespace maps onto Namespace in the (non-deprecated)
-	// HelmChart type. Forgetting this mapping is why releaseNamespace
-	// set under the deprecated helmChartInflationGenerator field is
-	// silently ignored, see kubernetes-sigs/kustomize#4593.
 	c.Namespace = old.ReleaseNamespace
 	return
 }

--- a/api/types/helmchartargs_test.go
+++ b/api/types/helmchartargs_test.go
@@ -102,3 +102,23 @@ func TestAsHelmArgs(t *testing.T) {
 				"--devel"})
 	})
 }
+
+// Regression test for https://github.com/kubernetes-sigs/kustomize/issues/4593.
+// HelmChartArgs.ReleaseNamespace was not copied into HelmChart.Namespace by
+// makeHelmChartFromHca, so kustomizations that used the deprecated
+// helmChartInflationGenerator with releaseNamespace silently rendered resources
+// into the "default" namespace.
+func TestSplitHelmParametersPropagatesReleaseNamespace(t *testing.T) {
+	args := []types.HelmChartArgs{{
+		ChartName:        "nats",
+		ChartVersion:     "v0.13.1",
+		ReleaseName:      "nats",
+		ReleaseNamespace: "custom-ns",
+	}}
+
+	charts, _ := types.SplitHelmParameters(args)
+
+	require.Len(t, charts, 1)
+	require.Equal(t, "custom-ns", charts[0].Namespace,
+		"ReleaseNamespace from the deprecated HelmChartArgs must map onto HelmChart.Namespace")
+}


### PR DESCRIPTION
Fixes #4593.

## Problem

Kustomizations using the (deprecated) `helmChartInflationGenerator` field with `releaseNamespace` silently emit resources into the `default` namespace instead of the requested one:

```yaml
helmChartInflationGenerator:
  - chartName: nats
    chartVersion: v0.13.1
    chartRepoUrl: https://nats-io.github.io/k8s/helm/charts
    releaseName: nats
    releaseNamespace: custom-ns   # ← ignored
```

## Root cause

`SplitHelmParameters` translates every `HelmChartArgs` (deprecated) into a `HelmChart` (current) via `makeHelmChartFromHca`. That translator was missing one field:

```go
func makeHelmChartFromHca(old *HelmChartArgs) (c HelmChart) {
    c.Name         = old.ChartName
    c.Version      = old.ChartVersion
    c.Repo         = old.ChartRepoURL
    c.ValuesFile   = old.Values
    c.ValuesInline = old.ValuesLocal
    c.ValuesMerge  = old.ValuesMerge
    c.ReleaseName  = old.ReleaseName
    // <-- ReleaseNamespace was never copied onto c.Namespace
    return
}
```

`HelmChart.Namespace` is what later gets passed as `--namespace` to `helm template` in `AsHelmArgs`, so when it was left empty the chart was rendered against `default`.

## Fix

Copy `old.ReleaseNamespace` into `c.Namespace`. One-line change; preserves full backward compatibility with any user that was relying on the broken behaviour (they were never getting the namespace they asked for in the first place).

## Test

Added `TestSplitHelmParametersPropagatesReleaseNamespace` in `api/types/helmchartargs_test.go`, which directly asserts the mapping:

```go
args := []types.HelmChartArgs{{
    ChartName:        "nats",
    ChartVersion:     "v0.13.1",
    ReleaseName:      "nats",
    ReleaseNamespace: "custom-ns",
}}
charts, _ := types.SplitHelmParameters(args)
require.Equal(t, "custom-ns", charts[0].Namespace)
```

Signed-off per DCO.