### PR TITLE
fix: github actions require to sha 256 for external actions

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -13,20 +13,20 @@ jobs:
     if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Clone the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: go.work
       - name: Execute go-apidiff
-        uses: joelanford/go-apidiff@v0.8.3
+        uses: joelanford/go-apidiff@60c4206be8f84348ebda2a3e0c3ac9cb54b8f685
         with:
           compare-imports: true
           print-compatible: true
       - name: Report failure
-        uses: nashmaniac/create-issue-action@v1.2
+        uses: nashmaniac/create-issue-action@6814b79f58a9e25070c226b0c847e67b0c06efdd
         # Only report failures of pushes (PRs have are visible through the Checks section) to the default branch
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       doc: ${{ steps.filter.outputs.doc }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
       id: filter
       with:
         filters: |
@@ -33,11 +33,11 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
         cache: true
@@ -56,11 +56,11 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
         cache: true
@@ -80,9 +80,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
         cache: true
@@ -127,9 +127,9 @@ jobs:
       KUSTOMIZE_DOCKER_E2E: ${{ matrix.docker-e2e }}
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
         cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
       id: go


### PR DESCRIPTION
fix errors that happens on every GitHub Actions.

<img width="966" height="400" alt="Screenshot 2026-04-28 at 9 03 17" src="https://github.com/user-attachments/assets/63b3761f-333a-479e-9667-33971eb70573" />
