### PR TITLE
docs: add ReplacementTransformer reference

### DIFF
--- a/site/content/en/docs/Reference/API/Transformers/ReplacementTransformer.md
+++ b/site/content/en/docs/Reference/API/Transformers/ReplacementTransformer.md
@@ -1,0 +1,66 @@
+---
+title: "ReplacementTransformer"
+linkTitle: "ReplacementTransformer"
+weight: 6
+date: 2026-05-07
+description: >
+  ReplacementTransformer copies values from a source field or literal value into target fields.
+---
+
+See [Transformers]({{< relref "../Transformers" >}}) for common required fields.
+
+`ReplacementTransformer` uses the same replacement schema as the
+[`replacements` field]({{< relref "../Kustomization File/replacements.md" >}}) in a
+Kustomization file. It can be invoked explicitly through the `transformers` field
+when the replacement configuration should live in a separate transformer file.
+
+* **apiVersion**: builtin
+* **kind**: ReplacementTransformer
+* **metadata** ([ObjectMeta](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta))
+
+  Standard object's metadata.
+
+* **replacements** ([]Replacement)
+
+  List of replacements to apply. Each replacement copies a value from `source` or
+  `sourceValue` into one or more `targets`.
+
+  Each item may also be specified as a `path` to a file containing a single
+  replacement or a list of replacements.
+
+Example transformer file:
+
+```yaml
+apiVersion: builtin
+kind: ReplacementTransformer
+metadata:
+  name: replacement-transformer
+replacements:
+- source:
+    kind: Deployment
+    name: source-deployment
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Service
+      name: target-service
+    fieldPaths:
+    - metadata.annotations.[example.com/source-name]
+    options:
+      create: true
+```
+
+Example Kustomization using the transformer file:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+transformers:
+- replacement-transformer.yaml
+```
+
+For the full replacement schema, field descriptions, selector behavior, and
+field path syntax, see the [`replacements` field documentation]({{< relref "../Kustomization File/replacements.md" >}}).

--- a/site/content/en/docs/Reference/API/Transformers/ReplacementTransformer.md
+++ b/site/content/en/docs/Reference/API/Transformers/ReplacementTransformer.md
@@ -10,7 +10,7 @@ description: >
 See [Transformers]({{< relref "../Transformers" >}}) for common required fields.
 
 `ReplacementTransformer` uses the same replacement schema as the
-[`replacements` field]({{< relref "../Kustomization File/replacements.md" >}}) in a
+[`replacements` field]({{< relref "../Kustomization%20File/replacements.md" >}}) in a
 Kustomization file. It can be invoked explicitly through the `transformers` field
 when the replacement configuration should live in a separate transformer file.
 
@@ -20,13 +20,14 @@ when the replacement configuration should live in a separate transformer file.
 
   Standard object's metadata.
 
-* **replacements** ([]Replacement)
+* **replacements** ([]ReplacementField)
 
-  List of replacements to apply. Each replacement copies a value from `source` or
-  `sourceValue` into one or more `targets`.
+  List of replacements to apply. Each item is either an inline replacement or a
+  `path` to a file containing a single replacement or a list of replacements.
 
-  Each item may also be specified as a `path` to a file containing a single
-  replacement or a list of replacements.
+  Each inline replacement copies a value from `source` or `sourceValue` into one
+  or more `targets`. It must specify exactly one of `source` or `sourceValue`,
+  and at least one target.
 
 Example transformer file:
 
@@ -63,4 +64,4 @@ transformers:
 ```
 
 For the full replacement schema, field descriptions, selector behavior, and
-field path syntax, see the [`replacements` field documentation]({{< relref "../Kustomization File/replacements.md" >}}).
+field path syntax, see the [`replacements` field documentation]({{< relref "../Kustomization%20File/replacements.md" >}}).


### PR DESCRIPTION
## Summary

- Adds a reference page for `ReplacementTransformer` under the API Transformers docs.
- Points readers to the existing `replacements` field documentation for the complete schema and field behavior.
- Includes an explicit `transformers`-based example for using `ReplacementTransformer` from a separate file.

## Test / Verification

- Verified the new page exists at `site/content/en/docs/Reference/API/Transformers/ReplacementTransformer.md`.
- Verified expected references to `ReplacementTransformer` and `replacements` are present.
- Verified local `relref` targets exist for the Transformers index and `replacements` documentation.
- `git diff --check` passes.

Fixes kubernetes-sigs/kustomize#5812.

## Disclosure

This contribution was prepared with AI-assisted tooling and manually reviewed before submission.

