### PR TITLE
Fix helm chart rendering without values file

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -26,7 +26,8 @@ type HelmChartInflationGeneratorPlugin struct {
 	h *resmap.PluginHelpers
 	types.HelmGlobals
 	types.HelmChart
-	tmpDir string
+	tmpDir        string
+	valuesFileSet bool
 }
 
 const (
@@ -67,6 +68,13 @@ func (p *HelmChartInflationGeneratorPlugin) Config(
 	}
 
 	p.h = h
+	var valuesFile struct {
+		ValuesFile *string `json:"valuesFile,omitempty" yaml:"valuesFile,omitempty"`
+	}
+	if err = yaml.Unmarshal(config, &valuesFile); err != nil {
+		return
+	}
+	p.valuesFileSet = valuesFile.ValuesFile != nil
 	if err = yaml.Unmarshal(config, p); err != nil {
 		return
 	}
@@ -103,6 +111,9 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 	// The ValuesFile(s) may be consulted by the plugin, so it must
 	// be under the loader root (unless root restrictions are
 	// disabled).
+	if p.ValuesFile == "" && p.valuesFileSet {
+		return fmt.Errorf("valuesFile cannot be empty")
+	}
 	if p.ValuesFile == "" {
 		p.ValuesFile = filepath.Join(p.absChartHome(), p.Name, "values.yaml")
 	}
@@ -128,6 +139,17 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 		p.ConfigHome = filepath.Join(p.tmpDir, "helm")
 	}
 	return nil
+}
+
+func (p *HelmChartInflationGeneratorPlugin) useDefaultValuesFileIfPresent() {
+	if p.valuesFileSet {
+		return
+	}
+	s, err := os.Stat(p.ValuesFile)
+	if err == nil && !s.IsDir() {
+		return
+	}
+	p.ValuesFile = ""
 }
 
 func (p *HelmChartInflationGeneratorPlugin) errIfIllegalValuesMerge() error {
@@ -190,8 +212,8 @@ func (p *HelmChartInflationGeneratorPlugin) runHelmCommand(
 // createNewMergedValuesFile replaces/merges original values file with ValuesInline.
 func (p *HelmChartInflationGeneratorPlugin) createNewMergedValuesFile() (
 	path string, err error) {
-	if p.ValuesMerge == valuesMergeOptionMerge ||
-		p.ValuesMerge == valuesMergeOptionOverride {
+	if p.ValuesFile != "" && (p.ValuesMerge == valuesMergeOptionMerge ||
+		p.ValuesMerge == valuesMergeOptionOverride) {
 		if err = p.replaceValuesInline(); err != nil {
 			return "", err
 		}
@@ -279,9 +301,10 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err er
 			return nil, err
 		}
 	}
+	p.useDefaultValuesFileIfPresent()
 	if len(p.ValuesInline) > 0 {
 		p.ValuesFile, err = p.createNewMergedValuesFile()
-	} else {
+	} else if p.ValuesFile != "" {
 		p.ValuesFile, err = p.copyValuesFile()
 	}
 	if err != nil {

--- a/api/krusty/helmchartinflationgenerator_test.go
+++ b/api/krusty/helmchartinflationgenerator_test.go
@@ -578,6 +578,91 @@ metadata:
 `)
 }
 
+func TestHelmChartInflationGeneratorWithoutValuesFile(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	copyValuesFilesTestChartsIntoHarness(t, th)
+
+	th.WriteK(th.GetRoot(), `
+helmCharts:
+  - name: no-values-chart
+    releaseName: no-values-chart
+`)
+
+	m := th.Run(th.GetRoot(), th.MakeOptionsPluginsEnabled())
+	asYaml, err := m.AsYaml()
+	require.NoError(t, err)
+	require.Equal(t, string(asYaml), `apiVersion: v1
+data:
+  chart: test
+  message: empty
+  release: no-values-chart
+kind: ConfigMap
+metadata:
+  labels:
+    chart: test-1.0.0
+  name: no-values-chart
+`)
+}
+
+func TestHelmChartInflationGeneratorWithoutValuesFileWithInlineValues(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	copyValuesFilesTestChartsIntoHarness(t, th)
+
+	th.WriteK(th.GetRoot(), `
+helmCharts:
+  - name: no-values-chart
+    releaseName: no-values-chart
+    valuesInline:
+      message: inline
+`)
+
+	m := th.Run(th.GetRoot(), th.MakeOptionsPluginsEnabled())
+	asYaml, err := m.AsYaml()
+	require.NoError(t, err)
+	require.Equal(t, string(asYaml), `apiVersion: v1
+data:
+  chart: test
+  message: inline
+  release: no-values-chart
+kind: ConfigMap
+metadata:
+  labels:
+    chart: test-1.0.0
+  name: no-values-chart
+`)
+}
+
+func TestHelmChartInflationGeneratorExplicitMissingValuesFile(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	copyValuesFilesTestChartsIntoHarness(t, th)
+
+	th.WriteK(th.GetRoot(), `
+helmCharts:
+  - name: no-values-chart
+    releaseName: no-values-chart
+    valuesFile: missing-values.yaml
+`)
+
+	err := th.RunWithErr(th.GetRoot(), th.MakeOptionsPluginsEnabled())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "missing-values.yaml")
+}
+
 func TestHelmChartInflationGeneratorApiVersions(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t)
 	defer th.Reset()

--- a/api/krusty/testdata/helmcharts/no-values-chart/Chart.yaml
+++ b/api/krusty/testdata/helmcharts/no-values-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A simple test helm chart without a values file.
+name: test
+version: 1.0.0

--- a/api/krusty/testdata/helmcharts/no-values-chart/templates/configmap.yaml
+++ b/api/krusty/testdata/helmcharts/no-values-chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: {{ .Release.Name }}
+data:
+  chart: {{ .Chart.Name }}
+  message: {{ .Values.message | default "empty" }}
+  release: {{ .Release.Name }}


### PR DESCRIPTION
Fixes Helm chart rendering when chart has no implicit values.yaml, while preserving errors for explicitly missing files. Validation: targeted go test ./api/krusty ..., git diff --check.