### PR TITLE
kyaml: fix `$patch` directives ignored with `ListPrepend` merge

### DIFF
--- a/kyaml/yaml/merge2/list_test.go
+++ b/kyaml/yaml/merge2/list_test.go
@@ -336,6 +336,93 @@ spec:
 `,
 	},
 
+	{description: `strategic merge patch replace element -- with ListPrepend`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - $patch: replace
+          name: foo-volume
+          persistentVolumeClaim:
+            claimName: my-pvc
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          name: foo-volume
+        - name: other-volume
+          emptyDir: {}
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+      - name: foo-volume
+        persistentVolumeClaim:
+          claimName: my-pvc
+      - name: other-volume
+        emptyDir: {}
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+	},
+	{description: `strategic merge patch delete element -- with ListPrepend`,
+		source: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo1
+        $patch: delete
+      - name: foo2
+`,
+		dest: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo1
+      - name: foo2
+      - name: foo3
+`,
+		expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo2
+      - name: foo3
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+	},
+
 	{description: `replace List -- different value in dest`,
 		source: `
 kind: Deployment

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -81,6 +81,58 @@ func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
 	return dst, nil
 }
 
+// appendMissingListNode appends nodes from src to dst only if they do not
+// already exist in dst (matched by merge key). Unlike appendListNode it never
+// overwrites an element that is already present in dst.
+func appendMissingListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
+	for _, elem := range src.Content() {
+		if keys[0] == "" {
+			found := false
+			for _, existing := range dst.Content() {
+				if existing.Value == elem.Value {
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+			_, err := dst.Pipe(yaml.ElementSetter{
+				Element: elem,
+				Keys:    []string{""},
+				Values:  []string{elem.Value},
+			})
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		v := []string{}
+		for _, key := range keys {
+			tmpNode := yaml.NewRNode(elem)
+			valueNode, err := tmpNode.Pipe(yaml.Get(key))
+			if err != nil {
+				return nil, err
+			}
+			if valueNode.IsNil() {
+				break
+			}
+			v = append(v, valueNode.YNode().Value)
+		}
+
+		if len(v) == len(keys) && dst.ElementList(keys, v) != nil {
+			continue
+		}
+
+		err := dst.PipeE(yaml.Append(elem))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dst, nil
+}
+
 // validateKeys returns a list of valid key-value pairs
 // if secondary merge key values are missing, use only the available merge keys
 func validateKeys(valuesList [][]string, values []string, keys []string) ([]string, []string) {
@@ -232,8 +284,9 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	if len(valuesList) > 0 {
 		if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
 			// items from patches are needed to be prepended. so we append the
-			// dest to itemsToBeAdded
-			dest, err = appendListNode(itemsToBeAdded, dest, validKeys)
+			// dest to itemsToBeAdded, skipping items already present to avoid
+			// overwriting merged results (e.g. $patch: replace).
+			dest, err = appendMissingListNode(itemsToBeAdded, dest, validKeys)
 		} else {
 			// append the items
 			dest, err = appendListNode(dest, itemsToBeAdded, validKeys)

--- a/kyaml/yaml/walk/associative_sequence_test.go
+++ b/kyaml/yaml/walk/associative_sequence_test.go
@@ -1,0 +1,201 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package walk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestAppendMissingListNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		dst      string
+		src      string
+		keys     []string
+		expected string
+	}{
+		{
+			name: "skips element already in dst",
+			dst: `
+- name: foo
+  image: foo:v2
+`,
+			src: `
+- name: foo
+  image: foo:v1
+`,
+			keys: []string{"name"},
+			expected: `
+- name: foo
+  image: foo:v2
+`,
+		},
+		{
+			name: "appends element missing from dst",
+			dst: `
+- name: foo
+  image: foo:v1
+`,
+			src: `
+- name: bar
+  image: bar:v1
+`,
+			keys: []string{"name"},
+			expected: `
+- name: foo
+  image: foo:v1
+- name: bar
+  image: bar:v1
+`,
+		},
+		{
+			name: "mixed: skips existing, appends missing",
+			dst: `
+- name: foo
+  image: foo:v2
+`,
+			src: `
+- name: foo
+  image: foo:v1
+- name: bar
+  image: bar:v1
+`,
+			keys: []string{"name"},
+			expected: `
+- name: foo
+  image: foo:v2
+- name: bar
+  image: bar:v1
+`,
+		},
+		{
+			name: "scalar keys: skips existing values",
+			dst: `
+- a
+- b
+`,
+			src: `
+- b
+- c
+`,
+			keys:     []string{""},
+			expected: `
+- a
+- b
+- c
+`,
+		},
+		{
+			name: "scalar keys: appends all missing",
+			dst: `
+- a
+`,
+			src: `
+- b
+- c
+`,
+			keys:     []string{""},
+			expected: `
+- a
+- b
+- c
+`,
+		},
+		{
+			name: "appends element with missing key",
+			dst: `
+- name: foo
+  image: foo:v1
+`,
+			src: `
+- image: bar:v1
+`,
+			keys: []string{"name"},
+			expected: `
+- name: foo
+  image: foo:v1
+- image: bar:v1
+`,
+		},
+		{
+			name: "multi-key: skips existing",
+			dst: `
+- containerPort: 8080
+  protocol: TCP
+`,
+			src: `
+- containerPort: 8080
+  protocol: TCP
+`,
+			keys: []string{"containerPort", "protocol"},
+			expected: `
+- containerPort: 8080
+  protocol: TCP
+`,
+		},
+		{
+			name: "multi-key: appends when one key differs",
+			dst: `
+- containerPort: 8080
+  protocol: TCP
+`,
+			src: `
+- containerPort: 8080
+  protocol: UDP
+`,
+			keys: []string{"containerPort", "protocol"},
+			expected: `
+- containerPort: 8080
+  protocol: TCP
+- containerPort: 8080
+  protocol: UDP
+`,
+		},
+		{
+			name: "empty src: no changes",
+			dst: `
+- name: foo
+`,
+			src:  `[]`,
+			keys: []string{"name"},
+			expected: `
+- name: foo
+`,
+		},
+		{
+			name: "empty dst: appends all",
+			dst:  `[]`,
+			src: `
+- name: foo
+`,
+			keys:     []string{"name"},
+			expected: `[{name: foo}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst, err := yaml.Parse(tt.dst)
+			require.NoError(t, err)
+			src, err := yaml.Parse(tt.src)
+			require.NoError(t, err)
+			expected, err := yaml.Parse(tt.expected)
+			require.NoError(t, err)
+
+			result, err := appendMissingListNode(dst, src, tt.keys)
+			require.NoError(t, err)
+
+			resultStr, err := result.String()
+			require.NoError(t, err)
+			expectedStr, err := expected.String()
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedStr, resultStr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/kubernetes-sigs/kustomize/issues/6146

- `$patch: replace` and `$patch: delete` directives on individual associative list elements were silently ignored when `ListIncreaseDirection` was set to `MergeOptionsListPrepend`
- Root cause: in `setAssociativeSequenceElements`, the ListPrepend path called `appendListNode(itemsToBeAdded, dest, ...)` with swapped arguments, causing `ElementSetter` to overwrite already-merged items with unmerged originals from dest
- Fix: introduce `appendMissingListNode` that only appends elements not already present in the destination, preserving merged results

**NOTE**:
I've created a branch in the repro repo using the patched kyaml from this PR, and it seems to be fixing the issue: https://github.com/rm3l/kyaml-listprepend-bug/tree/fix/use-patched-kyaml