### PR TITLE
api/krusty: add SuppressDeprecationWarnings option to suppress lib warnings

### DIFF
--- a/api/internal/target/kusttarget.go
+++ b/api/internal/target/kusttarget.go
@@ -29,14 +29,15 @@ import (
 
 // KustTarget encapsulates the entirety of a kustomization build.
 type KustTarget struct {
-	kustomization     *types.Kustomization
-	kustFileName      string
-	ldr               ifc.Loader
-	validator         ifc.Validator
-	rFactory          *resmap.Factory
-	pLdr              *loader.Loader
-	origin            *resource.Origin
-	helmRootNamespace string // namespace inherited from parent kustomization for HelmCharts
+	kustomization               *types.Kustomization
+	kustFileName                string
+	ldr                         ifc.Loader
+	validator                   ifc.Validator
+	rFactory                    *resmap.Factory
+	pLdr                        *loader.Loader
+	origin                      *resource.Origin
+	helmRootNamespace           string // namespace inherited from parent kustomization for HelmCharts
+	suppressDeprecationWarnings bool
 }
 
 // NewKustTarget returns a new instance of KustTarget.
@@ -53,6 +54,13 @@ func NewKustTarget(
 	}
 }
 
+// SetSuppressDeprecationWarnings controls whether deprecation warnings are
+// written to stderr during Load. Set to true when using kustomize as a library
+// and managing output separately.
+func (kt *KustTarget) SetSuppressDeprecationWarnings(suppress bool) {
+	kt.suppressDeprecationWarnings = suppress
+}
+
 // Load attempts to load the target's kustomization file.
 func (kt *KustTarget) Load() error {
 	content, kustFileName, err := LoadKustFile(kt.ldr)
@@ -66,9 +74,11 @@ func (kt *KustTarget) Load() error {
 	}
 
 	// show warning message when using deprecated fields.
-	if warningMessages := k.CheckDeprecatedFields(); warningMessages != nil {
-		for _, msg := range *warningMessages {
-			fmt.Fprintf(os.Stderr, "%v\n", msg)
+	if !kt.suppressDeprecationWarnings {
+		if warningMessages := k.CheckDeprecatedFields(); warningMessages != nil {
+			for _, msg := range *warningMessages {
+				fmt.Fprintf(os.Stderr, "%v\n", msg)
+			}
 		}
 	}
 

--- a/api/krusty/kustomizer.go
+++ b/api/krusty/kustomizer.go
@@ -71,6 +71,7 @@ func (b *Kustomizer) Run(
 		// The plugin configs are always located on disk, regardless of the fSys passed in
 		pLdr.NewLoader(b.options.PluginConfig, resmapFactory, filesys.MakeFsOnDisk()),
 	)
+	kt.SetSuppressDeprecationWarnings(b.options.SuppressDeprecationWarnings)
 	err = kt.Load()
 	if err != nil {
 		return nil, err

--- a/api/krusty/kustomizer_test.go
+++ b/api/krusty/kustomizer_test.go
@@ -4,12 +4,64 @@
 package krusty_test
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"sigs.k8s.io/kustomize/api/krusty"
+	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
+
+// TestSuppressDeprecationWarnings verifies that SuppressDeprecationWarnings=true
+// prevents deprecation messages from being written to stderr.
+func TestSuppressDeprecationWarnings(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("dep.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm
+`)
+	// Use deprecated 'bases' field to trigger a deprecation warning.
+	th.WriteK(".", `
+bases:
+- dep.yaml
+`)
+
+	captureStderr := func(fn func()) string {
+		r, w, _ := os.Pipe()
+		old := os.Stderr
+		os.Stderr = w
+		fn()
+		w.Close()
+		os.Stderr = old
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		return buf.String()
+	}
+
+	// With default options, deprecation warning should appear on stderr.
+	withWarning := captureStderr(func() {
+		opts := th.MakeDefaultOptions()
+		th.Run(".", opts)
+	})
+	if !strings.Contains(withWarning, "deprecated") {
+		t.Errorf("expected deprecation warning on stderr, got: %q", withWarning)
+	}
+
+	// With SuppressDeprecationWarnings=true, stderr should be silent.
+	withoutWarning := captureStderr(func() {
+		opts := th.MakeDefaultOptions()
+		opts.SuppressDeprecationWarnings = true
+		th.Run(".", opts)
+	})
+	if withoutWarning != "" {
+		t.Errorf("expected no output on stderr when suppressed, got: %q", withoutWarning)
+	}
+}
 
 // A simple usage example to shows what happens when
 // there are no files to read.

--- a/api/krusty/options.go
+++ b/api/krusty/options.go
@@ -45,6 +45,11 @@ type Options struct {
 
 	// Options related to kustomize plugins.
 	PluginConfig *types.PluginConfig
+
+	// When true, suppress deprecation warnings written to stderr during Build.
+	// Useful when calling kustomize as a library from tooling that manages its
+	// own output and does not want kustomize's warnings interleaved.
+	SuppressDeprecationWarnings bool
 }
 
 // MakeDefaultOptions returns a default instance of Options.


### PR DESCRIPTION
## Summary

When kustomize is used as a Go library (calling `krusty.MakeKustomizer(...).Run(...)`), deprecation warnings for fields like `bases`, `vars`, `patchesJson6902`, `patchesStrategicMerge`, `commonLabels`, etc. are unconditionally written to `os.Stderr`. Library consumers that control their own output have no way to silence this noise.

## Changes

- Add `SuppressDeprecationWarnings bool` to `krusty.Options`
- Thread the option through to `KustTarget` via a new `SetSuppressDeprecationWarnings` setter
- Skip the `fmt.Fprintf(os.Stderr, ...)` calls in `KustTarget.Load()` when the option is `true`
- Default is `false` — no change in behavior for existing callers

## Test

Added `TestSuppressDeprecationWarnings` in `api/krusty/kustomizer_test.go` that:
1. Builds a kustomization using the deprecated `bases` field and asserts a warning appears on stderr by default
2. Repeats the same build with `SuppressDeprecationWarnings: true` and asserts stderr is empty

## Fixes

Fixes #5452