### PR TITLE
feat: add Gateway certificateRefs to builtin nameReference config

### DIFF
--- a/api/internal/konfig/builtinpluginconsts/namereference.go
+++ b/api/internal/konfig/builtinpluginconsts/namereference.go
@@ -273,6 +273,9 @@ nameReference:
     kind: Ingress
   - path: spec/tls/secretName
     kind: Ingress
+  - path: spec/listeners/tls/certificateRefs/name
+    kind: Gateway
+    group: gateway.networking.k8s.io
   - path: imagePullSecrets/name
     kind: ServiceAccount
   - path: parameters/secretName

--- a/api/krusty/namereference_test.go
+++ b/api/krusty/namereference_test.go
@@ -868,3 +868,61 @@ spec:
   - Deny
 `)
 }
+
+func TestNameReferenceGatewayCertificateRefs(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- gateway.yaml
+
+secretGenerator:
+- name: tls-certificate
+  type: kubernetes.io/tls
+  literals:
+  - tls.crt=cert
+  - tls.key=key
+`)
+	th.WriteF("gateway.yaml", `
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-web
+spec:
+  gatewayClassName: traefik
+  listeners:
+  - name: websecure
+    protocol: HTTPS
+    port: 8443
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: tls-certificate
+`)
+
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-web
+spec:
+  gatewayClassName: traefik
+  listeners:
+  - name: websecure
+    port: 8443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - kind: Secret
+        name: tls-certificate-8gkh55dgdg
+---
+apiVersion: v1
+data:
+  tls.crt: Y2VydA==
+  tls.key: a2V5
+kind: Secret
+metadata:
+  name: tls-certificate-8gkh55dgdg
+type: kubernetes.io/tls
+`)
+}

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -497,6 +497,9 @@ nameReference:
       kind: Ingress
     - path: spec/tls/secretName
       kind: Ingress
+    - path: spec/listeners/tls/certificateRefs/name
+      kind: Gateway
+      group: gateway.networking.k8s.io
     - path: imagePullSecrets/name
       kind: ServiceAccount
     - path: parameters/secretName


### PR DESCRIPTION
## What this does

Adds a `fieldSpec` to the builtin `nameReference` transformer config (`api/internal/konfig/builtinpluginconsts/namereference.go`) under the `Secret` kind so the transformer updates a Gateway listener's `spec/listeners/tls/certificateRefs/name` when the referenced Secret is renamed (by `namePrefix`, `nameSuffix`, or `secretGenerator` hash suffix).

```yaml
- path: spec/listeners/tls/certificateRefs/name
  kind: Gateway
  group: gateway.networking.k8s.io
```

The fieldSpec is scoped to group `gateway.networking.k8s.io` so it only matches the Gateway API resource and not unrelated CRDs named `Gateway` (e.g. Istio's `gateway.networking.istio.io`). It mirrors the existing `Ingress` `spec/tls/secretName` entry just above it.

## Why

When a TLS cert Secret is produced by `secretGenerator` (which appends a content hash) or renamed by prefix/suffix, a referencing `Gateway`'s `certificateRefs[].name` is left pointing at the original name, breaking the reference. This matches the motivating use case in the issue.

## Changes

- `api/internal/konfig/builtinpluginconsts/namereference.go`: add the Gateway certificateRefs fieldSpec.
- `examples/transformerconfigs/README.md`: keep the documented builtin config in sync (enforced by the `LINT.IfChange` / `LINT.ThenChange` directive on the const).
- `api/krusty/namereference_test.go`: add `TestNameReferenceGatewayCertificateRefs`, an integration test that uses a `secretGenerator` + a `Gateway` referencing the secret via `certificateRefs`, and asserts the reference is updated to the hashed Secret name.

## Testing

`go test ./krusty/ -run TestNameReferenceGatewayCertificateRefs` passes. The test fails before the const change (the Gateway's `certificateRefs.name` stays `tls-certificate` while the Secret becomes `tls-certificate-8gkh55dgdg`) and passes after.

Fixes #6161

```release-note
The builtin nameReference transformer now updates `spec.listeners.tls.certificateRefs.name` on `gateway.networking.k8s.io` Gateway resources, so Gateway TLS certificate references follow Secret renames from namePrefix, nameSuffix, and secretGenerator hashing.
```
