### PR TITLE
fix: Add automatic toolchain downloads to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
+    - name: Enable Automatic Toolchain Downloads
+      run: echo "GOTOOLCHAIN=auto" >> $GITHUB_ENV
     - name: Set up Go 1.x
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,13 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
-    - name: Enable Automatic Toolchain Downloads
-      run: echo "GOTOOLCHAIN=auto" >> $GITHUB_ENV
     - name: Set up Go 1.x
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: go.work
       id: go
+    - name: Enable Automatic Toolchain Downloads
+      run: echo "GOTOOLCHAIN=auto" >> $GITHUB_ENV
     - run: ./releasing/create-release.sh "${tag}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This allows for go.work specified go version to be downloaded

actions/setup-go reads go.work to decide which Go version to install — but it only parses the go line, not the toolchain line. That's a parser limitation; the action predates the toolchain directive (added in Go 1.21) and was never updated to understand it.

After installing Go 1.25.0, setup-go then writes GOTOOLCHAIN=local into the GitHub Actions environment. That env var tells the Go toolchain manager: "never download a different toolchain, just use whatever is on PATH."

So even though go.work says toolchain go1.25.8, when go build runs it sees GOTOOLCHAIN=local and ignores the toolchain directive entirely — it just uses the 1.25.0 that setup-go put on PATH.

In short: setup-go actively kills the mechanism that would have made the toolchain line work.

That's why GOTOOLCHAIN=auto must be set after setup-go — to overwrite the local it set and restore Go's ability to honour the toolchain directive in go.work.

