### PR TITLE
fix: match image digests with any algorithm, not only sha256

### DIFF
--- a/api/internal/image/image.go
+++ b/api/internal/image/image.go
@@ -14,7 +14,12 @@ func IsImageMatched(s, t string) bool {
 	// Tag values are limited to [a-zA-Z0-9_.{}-].
 	// Some tools like Bazel rules_k8s allow tag patterns with {} characters.
 	// More info: https://github.com/bazelbuild/rules_k8s/pull/423
-	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@sha256:[a-zA-Z0-9_.{}-]*)?$")
+	//
+	// The digest algorithm is matched as [a-zA-Z][a-zA-Z0-9]* (e.g. sha256,
+	// sha512) rather than hard-coded to sha256, so that references using any
+	// OCI-valid digest algorithm match consistently with Split, which accepts
+	// any algorithm. See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z0-9_.{}-]*)?$")
 	return pattern.MatchString(s)
 }
 

--- a/api/internal/image/image.go
+++ b/api/internal/image/image.go
@@ -15,11 +15,13 @@ func IsImageMatched(s, t string) bool {
 	// Some tools like Bazel rules_k8s allow tag patterns with {} characters.
 	// More info: https://github.com/bazelbuild/rules_k8s/pull/423
 	//
-	// The digest algorithm is matched as [a-zA-Z][a-zA-Z0-9]* (e.g. sha256,
-	// sha512) rather than hard-coded to sha256, so that references using any
-	// OCI-valid digest algorithm match consistently with Split, which accepts
-	// any algorithm. See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
-	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z0-9_.{}-]*)?$")
+	// The digest algorithm is matched following the OCI grammar
+	// (algorithm-component separated by one of [+._-], e.g. sha256, sha512,
+	// multihash+base58) rather than hard-coded to sha256, so that references
+	// using any OCI-valid digest algorithm match consistently with Split,
+	// which accepts any algorithm.
+	// See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z0-9]+([.+_-][a-zA-Z0-9]+)*:[a-zA-Z0-9_.{}-]*)?$")
 	return pattern.MatchString(s)
 }
 

--- a/api/internal/image/image_test.go
+++ b/api/internal/image/image_test.go
@@ -54,6 +54,22 @@ func TestIsImageMatched(t *testing.T) {
 			isMatched: true,
 		},
 		{
+			// Registered SHA-512 algorithm with a full-length digest, as in
+			// the OCI image-spec descriptor examples.
+			testName:  "name is match with full sha512 digest",
+			value:     "nginx@sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
+			// Unregistered but OCI-valid algorithm with a separator (+), from
+			// the descriptor example "multihash+base58:Qm...".
+			testName:  "name is match with multihash+base58 digest",
+			value:     "nginx@multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
 			testName:  "name is not a match",
 			value:     "apache:12345",
 			name:      "nginx",

--- a/api/internal/image/image_test.go
+++ b/api/internal/image/image_test.go
@@ -42,6 +42,18 @@ func TestIsImageMatched(t *testing.T) {
 			isMatched: true,
 		},
 		{
+			testName:  "name is match with non-sha256 digest",
+			value:     "nginx@sha512:xyz",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
+			testName:  "name is match with tag and non-sha256 digest",
+			value:     "nginx:12345@sha512:xyz",
+			name:      "nginx",
+			isMatched: true,
+		},
+		{
 			testName:  "name is not a match",
 			value:     "apache:12345",
 			name:      "nginx",


### PR DESCRIPTION
**What this PR does / why we need it**:

The `images:` transformer silently ignores images pinned with a non-`sha256` digest.

`api/internal/image/image.go` has two sibling functions that must agree on what an image reference looks like:
- `Split` splits the digest on `@` and accepts **any** algorithm (`sha256`, `sha512`, ...).
- `IsImageMatched` hard-codes `@sha256:` in its regex:
  ```
  "^" + t + "(:[...])?(@sha256:[...])?$"
  ```

So for `nginx@sha512:...` (a valid OCI digest algorithm), `IsImageMatched` returns false, `imageTagUpdater.SetImageValue` short-circuits, and the image is left unchanged — the user's override is silently dropped.

This generalizes the digest algorithm in the regex to match what `Split` already accepts.

**Testing**:

Added cases to `TestIsImageMatched` (`api/internal/image/image_test.go`): `nginx@sha512:xyz` and `nginx:12345@sha512:xyz` against name `nginx` now match. Both fail before the change, pass after; the consumer package `./filters/imagetag/...` still passes (run from the `api/` module).

/kind bug
