### PR TITLE
docs: link kustomize website from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and it's like [`sed`], in that it emits edited text.
 
 This tool is sponsored by [sig-cli] ([KEP]).
 
+ - [Website](https://kustomize.io/)
  - [Installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/)
  - [General documentation](https://kubectl.docs.kubernetes.io/references/kustomize/)
  - [Examples](examples)


### PR DESCRIPTION
## Summary
- Add the main Kustomize website link to the README alongside the existing installation, documentation, and examples links.

Fixes #5654.

## Evidence
- Issue #5654 is open, labeled kind/documentation and triage/accepted, and has no assignee.
- No existing PR matched 5654 in the title or body.
- The README primary links previously included installation instructions, general documentation, and examples, but not https://kustomize.io/.
- https://kustomize.io/ responds with HTTP 200 OK.

## Validation
- rg -n "\\[Website\\]\\(https://kustomize.io/\\)|kustomize.io" README.md
- git diff --check
- curl.exe -I https://kustomize.io/