### PR TITLE
hack: parse compact release JSON in installer

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -79,7 +79,7 @@ function find_release_url() {
   local arch=$3
 
   echo "${releases}" |\
-    grep "browser_download.*${opsys}_${arch}" |\
+    grep -Eo "\"browser_download_url\"[[:space:]]*:[[:space:]]*\"[^\"]*${opsys}_${arch}[^\"]*\"" |\
     cut -d '"' -f 4 |\
     sort -V | tail -n 1
 }


### PR DESCRIPTION
## Summary
- Make install_kustomize.sh extract the browser_download_url field directly instead of relying on line-oriented JSON formatting.
- Preserve the existing sort/cut behavior once the matching download URL field has been isolated.

Fixes #6163.

## Evidence
- Issue #6163 is open, unassigned, labeled kind/bug, and has no existing PR matching 6163/install_kustomize.
- The reported failure happens when GitHub release JSON is compact: the old grep/cut pipeline can match the whole release object and return the release API URL, for example https://api.github.com/repos/kubernetes-sigs/kustomize/releases/284452445, instead of a tarball URL.
- The updated grep pattern extracts only the browser_download_url key/value pair before cut runs, so compact and pretty JSON return the same tarball URL.

## Validation
- Git Bash compact JSON reproduction: old logic returned the release API URL; new logic returned https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz.
- Git Bash pretty JSON check returned the same tarball URL.
- Authenticated live GitHub API extraction returned https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz.
- git diff --check

Note: shellcheck is not installed in this local environment.