### PR TITLE
fix: preserve scalar source tag during merge

### DIFF
--- a/api/krusty/inlinepatch_test.go
+++ b/api/krusty/inlinepatch_test.go
@@ -231,6 +231,48 @@ spec:
 `)
 }
 
+func TestExtendedPatchInlineYAMLReplacesQuotedScalarWithInt(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteF("base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: '6%'
+`)
+	th.WriteK("base", `
+resources:
+- deployment.yaml
+
+patches:
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: test
+    spec:
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 3
+`)
+	m := th.Run("base", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 3
+`)
+}
+
 func TestPathWithCronJobV1(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteK(".", `

--- a/kyaml/yaml/merge2/merge2.go
+++ b/kyaml/yaml/merge2/merge2.go
@@ -100,6 +100,10 @@ func (m Merger) VisitScalar(nodes walk.Sources, s *openapi.ResourceSchema) (*yam
 	}
 	// Override value
 	if nodes.Origin() != nil {
+		if nodes.Dest() != nil && nodes.Dest().YNode() != nil {
+			nodes.Dest().SetYNode(nodes.Origin().YNode())
+			return nodes.Dest(), nil
+		}
 		return nodes.Origin(), nil
 	}
 	// Keep

--- a/kyaml/yaml/merge2/scalar_test.go
+++ b/kyaml/yaml/merge2/scalar_test.go
@@ -25,6 +25,23 @@ field: value1
 			ListIncreaseDirection: yaml.MergeOptionsListAppend,
 		},
 	},
+	{description: `replace scalar -- preserve source tag`,
+		source: `
+kind: Deployment
+field: 3
+`,
+		dest: `
+kind: Deployment
+field: '6%'
+`,
+		expected: `
+kind: Deployment
+field: 3
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
 
 	{description: `replace scalar -- missing from dest`,
 		source: `


### PR DESCRIPTION
Fixes #6140

This PR was written in part with the assistance of generative AI. I have reviewed and tested each change.

/kind bug

Strategic merge scalar replacement returns the patch scalar from merge2.VisitScalar, but map writeback goes through FieldSetter which preserves the existing destination style. So replacing a quoted scalar like '6%' with an integer 3 kept the old quoted style and emitted '3'. Fix: update the destination node with the origin node before returning so the patch scalar's tag and style are carried through.