### PR TITLE
fix statefulset volume claim template merging

### DIFF
--- a/api/krusty/inlinelabels_test.go
+++ b/api/krusty/inlinelabels_test.go
@@ -656,6 +656,136 @@ spec:
 `)
 }
 
+func TestKustomizationLabelsInNestedStatefulSetVolumeClaimTemplateWithPatch(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK("app/source", `
+resources:
+- sts.yaml
+labels:
+- pairs:
+    app.kubernetes.io/name: vmcluster
+    app.kubernetes.io/stack: victoriametrics
+  includeSelectors: true
+  includeTemplates: true
+  includeVolumeClaimTemplates: true
+`)
+	th.WriteF("app/source/sts.yaml", `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: vmstorage
+  name: vmstorage
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: vmstorage
+    spec:
+      containers:
+      - name: vmstorage
+        image: quay.io/victoriametrics/vmstorage:v1.128.0-cluster
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app.kubernetes.io/component: vmstorage
+      name: vmstorage-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: gp3
+      volumeMode: Filesystem
+`)
+	th.WriteK("app", `
+resources:
+- source
+labels:
+- pairs:
+    app.kubernetes.io/instance: vmcluster-internal
+  includeSelectors: true
+  includeTemplates: true
+  includeVolumeClaimTemplates: true
+patches:
+- path: patch.yaml
+`)
+	th.WriteF("app/patch.yaml", `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: vmstorage
+  name: vmstorage
+spec:
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app.kubernetes.io/component: vmstorage
+      name: vmstorage-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 600Gi
+      storageClassName: gp3
+      volumeMode: Filesystem
+`)
+	m := th.Run("app", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: vmstorage
+    app.kubernetes.io/instance: vmcluster-internal
+    app.kubernetes.io/name: vmcluster
+    app.kubernetes.io/stack: victoriametrics
+  name: vmstorage
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: vmcluster-internal
+      app.kubernetes.io/name: vmcluster
+      app.kubernetes.io/stack: victoriametrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: vmstorage
+        app.kubernetes.io/instance: vmcluster-internal
+        app.kubernetes.io/name: vmcluster
+        app.kubernetes.io/stack: victoriametrics
+    spec:
+      containers:
+      - image: quay.io/victoriametrics/vmstorage:v1.128.0-cluster
+        name: vmstorage
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app.kubernetes.io/component: vmstorage
+        app.kubernetes.io/instance: vmcluster-internal
+        app.kubernetes.io/name: vmcluster
+        app.kubernetes.io/stack: victoriametrics
+      name: vmstorage-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 600Gi
+      storageClassName: gp3
+      volumeMode: Filesystem
+`)
+}
+
 func TestKustomizationLabelsInStatefulSetTemplateWithIncludeSelectorsTrue(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)
 	th.WriteF("app/sts.yaml", `

--- a/kyaml/openapi/openapi.go
+++ b/kyaml/openapi/openapi.go
@@ -714,6 +714,7 @@ func parseBuiltinSchema(version string) {
 		// this should never happen
 		panic(err)
 	}
+	fixKubernetesBuiltInSchema()
 }
 
 // parse parses and indexes a single json or proto schema
@@ -748,6 +749,49 @@ func parse(b []byte, format format) error {
 	AddDefinitions(swagger.Definitions)
 	findNamespaceability(swagger.Paths)
 	return nil
+}
+
+func fixKubernetesBuiltInSchema() {
+	statefulSetSchema := globalSchema.schemaByResourceType[yaml.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "StatefulSet",
+	}]
+	if statefulSetSchema == nil {
+		return
+	}
+	addFieldExtensions(statefulSetSchema, []string{"spec", "volumeClaimTemplates"}, spec.Extensions{
+		kubernetesPatchStrategyExtensionKey: "merge",
+		kubernetesMergeKeyExtensionKey:      "metadata/name",
+	})
+}
+
+func addFieldExtensions(schema *spec.Schema, path []string, extensions spec.Extensions) bool {
+	if len(path) == 0 {
+		if schema.Extensions == nil {
+			schema.Extensions = spec.Extensions{}
+		}
+		for key, value := range extensions {
+			schema.Extensions[key] = value
+		}
+		return true
+	}
+
+	field, found := schema.Properties[path[0]]
+	if !found {
+		return false
+	}
+	for field.Ref.String() != "" {
+		referredSchema, err := Resolve(&field.Ref, &globalSchema.schema)
+		if err != nil {
+			return false
+		}
+		return addFieldExtensions(referredSchema, path[1:], extensions)
+	}
+	if !addFieldExtensions(&field, path[1:], extensions) {
+		return false
+	}
+	schema.Properties[path[0]] = field
+	return true
 }
 
 // findNamespaceability looks at the api paths for the resource to determine

--- a/kyaml/openapi/openapi_test.go
+++ b/kyaml/openapi/openapi_test.go
@@ -107,6 +107,22 @@ func TestSchemaForResourceType(t *testing.T) {
 	}
 }
 
+func TestStatefulSetVolumeClaimTemplatesPatchStrategy(t *testing.T) {
+	// reset package vars
+	globalSchema = openapiData{}
+
+	s := SchemaForResourceType(
+		yaml.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"})
+	require.NotNil(t, s)
+
+	volumeClaimTemplates := s.Lookup("spec", "volumeClaimTemplates")
+	require.NotNil(t, volumeClaimTemplates)
+
+	strategy, keys := volumeClaimTemplates.PatchStrategyAndKeyList()
+	assert.Equal(t, "merge", strategy)
+	assert.Equal(t, []string{"metadata/name"}, keys)
+}
+
 func TestSchemaFromFile(t *testing.T) {
 	ResetOpenAPI()
 	inputyaml := `

--- a/kyaml/yaml/fns.go
+++ b/kyaml/yaml/fns.go
@@ -11,6 +11,7 @@ import (
 
 	yaml "go.yaml.in/yaml/v3"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/utils"
 )
 
 // Append creates an ElementAppender
@@ -106,7 +107,7 @@ func (e ElementSetter) Filter(rn *RNode) (*RNode, error) {
 		found := true
 		for j := range e.Keys {
 			if j < len(e.Values) {
-				val, err = newNode.Pipe(FieldMatcher{Name: e.Keys[j], StringValue: e.Values[j]})
+				val, err = newNode.matchFieldValue(e.Keys[j], e.Values[j])
 			}
 			if err != nil {
 				return nil, err
@@ -311,9 +312,9 @@ func (e ElementMatcher) Filter(rn *RNode) (*RNode, error) {
 		matchesElement := true
 		for i := range e.Keys {
 			if e.MatchAnyValue {
-				field, err = elem.Pipe(Get(e.Keys[i]))
+				field, err = elem.fieldByKeyPath(e.Keys[i])
 			} else {
-				field, err = elem.Pipe(MatchField(e.Keys[i], e.Values[i]))
+				field, err = elem.matchFieldValue(e.Keys[i], e.Values[i])
 			}
 			if !IsFoundOrError(field, err) {
 				// this is not the element we are looking for
@@ -344,6 +345,35 @@ func MatchField(name, value string) FieldMatcher {
 
 func Match(value string) FieldMatcher {
 	return FieldMatcher{Value: NewScalarRNode(value)}
+}
+
+func splitKeyPath(key string) []string {
+	if strings.Contains(key, "/") {
+		return utils.PathSplitter(key, "/")
+	}
+	return []string{key}
+}
+
+func (rn *RNode) fieldByKeyPath(key string) (*RNode, error) {
+	path := splitKeyPath(key)
+	if len(path) == 1 {
+		return rn.Pipe(Get(path[0]))
+	}
+	return rn.Pipe(Lookup(path...))
+}
+
+func (rn *RNode) matchFieldValue(key, value string) (*RNode, error) {
+	if key == "" {
+		return rn.Pipe(Match(value))
+	}
+	field, err := rn.fieldByKeyPath(key)
+	if err != nil || IsMissingOrNull(field) {
+		return field, err
+	}
+	if field.YNode().Value != value {
+		return nil, nil
+	}
+	return field, nil
 }
 
 // FieldMatcher returns the value of a named field or map entry.

--- a/kyaml/yaml/fns_test.go
+++ b/kyaml/yaml/fns_test.go
@@ -418,6 +418,61 @@ func TestElementMatcherMultipleKeys(t *testing.T) {
 	assert.Nil(t, rn)
 }
 
+func TestElementMatcherNestedKeyPath(t *testing.T) {
+	node, err := Parse(`
+- metadata:
+    name: data
+  value: base
+- metadata:
+    name: cache
+  value: patch
+`)
+	require.NoError(t, err)
+
+	rn, err := node.Pipe(MatchElementList(
+		[]string{"metadata/name"},
+		[]string{"cache"},
+	))
+	require.NoError(t, err)
+	require.NotNil(t, rn)
+	assert.Equal(t, "patch", rn.Field("value").Value.YNode().Value)
+
+	rn, err = node.Pipe(GetElementByKey("metadata/name"))
+	require.NoError(t, err)
+	require.NotNil(t, rn)
+	assert.Equal(t, "base", rn.Field("value").Value.YNode().Value)
+}
+
+func TestElementSetterNestedKeyPath(t *testing.T) {
+	node, err := Parse(`
+- metadata:
+    name: data
+  value: base
+- metadata:
+    name: cache
+  value: patch
+`)
+	require.NoError(t, err)
+
+	_, err = node.Pipe(ElementSetter{
+		Element: MustParse(`
+metadata:
+  name: cache
+value: updated
+`).YNode(),
+		Keys:   []string{"metadata/name"},
+		Values: []string{"cache"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `- metadata:
+    name: data
+  value: base
+- metadata:
+    name: cache
+  value: updated
+`, assertNoErrorString(t)(node.String()))
+}
+
 func TestClearField_Fn(t *testing.T) {
 	node, err := Parse(NodeSampleData)
 	require.NoError(t, err)

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -883,11 +883,14 @@ func (rn *RNode) ElementValuesList(keys []string) ([][]string, error) {
 
 	for i := 0; i < len(rn.Content()); i++ {
 		for _, key := range keys {
-			field := NewRNode(rn.Content()[i]).Field(key)
+			field, err := NewRNode(rn.Content()[i]).fieldByKeyPath(key)
+			if err != nil {
+				return nil, err
+			}
 			if field.IsNilOrEmpty() {
 				elements[i] = append(elements[i], "")
 			} else {
-				elements[i] = append(elements[i], field.Value.YNode().Value)
+				elements[i] = append(elements[i], field.YNode().Value)
 			}
 		}
 	}

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -9,8 +9,20 @@ import (
 	"github.com/go-errors/errors"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/sets"
+	"sigs.k8s.io/kustomize/kyaml/utils"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+func lookupElementValue(elem *yaml.Node, key string) (*yaml.RNode, error) {
+	return yaml.NewRNode(elem).Pipe(yaml.Lookup(keyPath(key)...))
+}
+
+func keyPath(key string) []string {
+	if strings.Contains(key, "/") {
+		return utils.PathSplitter(key, "/")
+	}
+	return []string{key}
+}
 
 // appendListNode will append the nodes from src to dst and return dst.
 // src and dst should be both sequence node. key is used to call ElementSetter.
@@ -37,8 +49,7 @@ func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
 		// in sequence.
 		v := []string{}
 		for _, key := range keys {
-			tmpNode := yaml.NewRNode(elem)
-			valueNode, err := tmpNode.Pipe(yaml.Get(key))
+			valueNode, err := lookupElementValue(elem, key)
 			if err != nil {
 				return nil, err
 			}
@@ -203,12 +214,16 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 					return nil, err
 				}
 				exit = true
-			} else if val.Field(key) == nil && validValues[i] != "" {
+			} else if keyNode, lookupErr := val.Pipe(yaml.Lookup(keyPath(key)...)); lookupErr != nil {
+				return nil, lookupErr
+			} else if keyNode == nil && validValues[i] != "" {
 				// make sure the key is set on the field
-				_, err = val.Pipe(yaml.SetField(key, yaml.NewScalarRNode(validValues[i])))
+				keyNode, err = val.Pipe(yaml.LookupCreate(yaml.ScalarNode, keyPath(key)...))
 				if err != nil {
 					return nil, err
 				}
+				keyNode.YNode().Value = validValues[i]
+				keyNode.YNode().Tag = yaml.NodeTagString
 			}
 		}
 		if exit {


### PR DESCRIPTION
Fixes #6000.

## What changed
- Treat built-in `apps/v1` StatefulSet `spec.volumeClaimTemplates` as an associative list keyed by `metadata/name`.
- Teach kyaml associative sequence helpers to resolve slash-separated nested merge keys when extracting, matching, and setting list elements.
- Add regression coverage for nested kustomizations where labels added to a StatefulSet PVC template are lost after an overlay patch changes the same claim template.

## Why
The embedded Kubernetes OpenAPI schema does not expose patch metadata for `spec.volumeClaimTemplates`, so kyaml handled the list as replace-only. In the reported nested overlay case, the patch replaced the PVC template element and dropped labels previously added by the nested kustomization.

## Validation
- `go test ./kyaml/yaml ./kyaml/openapi ./api/krusty -run 'TestElementMatcherNestedKeyPath|TestElementSetterNestedKeyPath|TestStatefulSetVolumeClaimTemplatesPatchStrategy|TestKustomizationLabelsInNestedStatefulSetVolumeClaimTemplateWithPatch' -count=1`\n- `go test ./kyaml/yaml ./kyaml/openapi -count=1`\n- `go test ./api/krusty -skip 'TestFnContainer|TestAddManagedbyLabel' -count=1`\n- `go test ./api/filters/patchstrategicmerge ./kyaml/yaml/merge2 -count=1`\n- `git diff --check`\n\nThe full local `go test ./api/krusty -count=1` is blocked in this environment by Docker-dependent fn-container tests and the existing local `kustomize-(devel)` vs `kustomize-(test)` managed-by label expectation.