### PR TITLE
validate version output format

### DIFF
--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -58,6 +58,11 @@ func (o *Options) Validate(_ []string) error {
 			return fmt.Errorf("--short and --output are mutually exclusive")
 		}
 	}
+	switch o.Output {
+	case "", "yaml", "json":
+	default:
+		return fmt.Errorf("--output must be 'yaml' or 'json'")
+	}
 	return nil
 }
 

--- a/kustomize/commands/version/version_test.go
+++ b/kustomize/commands/version/version_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package version_test
+
+import (
+	"bytes"
+	"testing"
+
+	. "sigs.k8s.io/kustomize/kustomize/v5/commands/version"
+)
+
+func TestInvalidOutputReturnsError(t *testing.T) {
+	var out bytes.Buffer
+	cmd := NewCmdVersion(&out)
+	cmd.SetArgs([]string{"--output", "yml"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid output error")
+	}
+	if err.Error() != "--output must be 'yaml' or 'json'" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("expected no output, got %q", out.String())
+	}
+}


### PR DESCRIPTION
Fixes #6032.

This PR was written in part with the assistance of generative AI. I have reviewed and tested each change.

kustomize version --output=yml silently produced no output instead of erroring. Fix validates the flag during command validation and returns a clear error for unsupported values.