### PR TITLE
fix: do not panic on an invalid image name regexp

### DIFF
--- a/api/internal/image/image.go
+++ b/api/internal/image/image.go
@@ -21,7 +21,14 @@ func IsImageMatched(s, t string) bool {
 	// using any OCI-valid digest algorithm match consistently with Split,
 	// which accepts any algorithm.
 	// See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
-	pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z0-9]+([.+_-][a-zA-Z0-9]+)*:[a-zA-Z0-9_.{}-]*)?$")
+	// The name t comes from kustomization images[].name and is interpolated
+	// into the pattern directly, so it can be an invalid regexp (for example
+	// "["). When it fails to compile, treat it as matching nothing rather than
+	// dereferencing a nil *Regexp, which would panic during the build.
+	pattern, err := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z0-9]+([.+_-][a-zA-Z0-9]+)*:[a-zA-Z0-9_.{}-]*)?$")
+	if err != nil {
+		return false
+	}
 	return pattern.MatchString(s)
 }
 

--- a/api/internal/image/image_test.go
+++ b/api/internal/image/image_test.go
@@ -75,6 +75,14 @@ func TestIsImageMatched(t *testing.T) {
 			name:      "nginx",
 			isMatched: false,
 		},
+		{
+			// A name that is not a valid regexp must not panic. It can't
+			// compile, so it should simply match nothing.
+			testName:  "name is an invalid regexp",
+			value:     "nginx",
+			name:      "[",
+			isMatched: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -401,3 +401,42 @@ spec:
             image: solsa-echo:foo
 `)
 }
+
+// An images[].name value that is not a valid regexp (here "[") used to crash
+// the build with a nil-pointer panic. It should be treated as matching no
+// container image, so the resource passes through untouched.
+func TestTransfomersImageInvalidNameRegexp(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- deploy.yaml
+images:
+- name: "["
+  newTag: v2
+`)
+	th.WriteF("deploy.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - image: nginx:1.7.9
+        name: nginx
+`)
+}


### PR DESCRIPTION
Hi, I ran into a crash while working with an images override and traced it back to IsImageMatched in the api module.

The image name that comes from a kustomization's `images[].name` is interpolated straight into a regexp, and the compile error was discarded:

```go
pattern, _ := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?...")
return pattern.MatchString(s)
```

If the name isn't a valid regexp (for example `[`), `regexp.Compile` returns `(nil, err)` and the following `pattern.MatchString` dereferences the nil \*Regexp, so `kustomize build` panics with a SIGSEGV instead of failing cleanly. This is reachable in practice: a name like that in a remote base that you don't control (a common GitOps setup) takes down the whole build.

The fix keeps the exact same regex string and just checks the error, returning false when the name can't compile. That preserves the existing semantics, since a name that matches nothing leaves the image untouched, which is the same outcome you already get for any name that doesn't match a container.

Verification:

- `go test ./internal/image/ ./filters/imagetag/` passes.
- Added a unit test in `internal/image` with the name `[`.
- Added a krusty end-to-end case (a kustomization with `images: [{name: "[", newTag: v2}]` over a Deployment) that panics on master and builds through cleanly with this change.

Thanks for taking a look.