### PR TITLE
fix(kyaml): correctly handle patches with a partial compound merge key

### DIFF
--- a/kyaml/yaml/merge2/map_test.go
+++ b/kyaml/yaml/merge2/map_test.go
@@ -546,6 +546,100 @@ spec:
 	//
 	// Test Case
 	//
+	{description: `partial-key patch when base has two elements sharing the port (ambiguous)`,
+		source: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 8080
+      targetPort: 9999
+`,
+		dest: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - port: 8080
+      protocol: UDP
+      targetPort: 8080
+`,
+		expected: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 9999
+    - port: 8080
+      protocol: UDP
+      targetPort: 8080
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
+
+	//
+	// Test Case
+	//
+	{description: `partial-key patch missing the primary key (protocol, no port) does not clobber`,
+		source: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - protocol: TCP
+      targetPort: 9999
+`,
+		dest: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+`,
+		expected: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
+
+	//
+	// Test Case
+	//
 	{description: `Verify key style behavior`,
 		source: `
 kind: Deployment

--- a/kyaml/yaml/merge2/map_test.go
+++ b/kyaml/yaml/merge2/map_test.go
@@ -426,6 +426,126 @@ spec:
 	//
 	// Test Case
 	//
+	{description: `port patch adds a field but omits protocol (partial compound key)`,
+		source: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 30900
+      targetPort: 30900
+      nodePort: 30900
+`,
+		dest: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 30900
+      targetPort: 30900
+      protocol: TCP
+`,
+		expected: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+    - port: 30900
+      targetPort: 30900
+      protocol: TCP
+      nodePort: 30900
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
+
+	//
+	// Test Case
+	//
+	{description: `patch with multiple ports, some omitting protocol (#4752)`,
+		source: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: rtmpk
+    port: 1986
+    protocol: UDP
+    targetPort: 1986
+  - name: rtmp
+    port: 1935
+    targetPort: 1935
+  - name: rtmpq
+    port: 1935
+    protocol: UDP
+    targetPort: 1935
+  - name: https
+    port: 443
+    targetPort: 443
+  - name: http3
+    port: 443
+    protocol: UDP
+    targetPort: 443
+`,
+		dest: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+`,
+		expected: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: rtmpk
+    port: 1986
+    protocol: UDP
+    targetPort: 1986
+  - name: rtmp
+    port: 1935
+    targetPort: 1935
+  - name: rtmpq
+    port: 1935
+    protocol: UDP
+    targetPort: 1935
+  - name: https
+    port: 443
+    targetPort: 443
+  - name: http3
+    port: 443
+    protocol: UDP
+    targetPort: 443
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListAppend,
+		},
+	},
+
+	//
+	// Test Case
+	//
 	{description: `Verify key style behavior`,
 		source: `
 kind: Deployment

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -81,25 +81,75 @@ func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
 	return dst, nil
 }
 
-// validateKeys returns the subset of keys (and their values) that this element
-// actually populates -- i.e. those whose value is non-empty. When an element
-// specifies only part of a compound merge key (for example a container port
-// that sets containerPort but omits protocol), it is matched on the keys it
-// populates rather than on the full key, so its fields are not lost. If every
-// value is empty, the original keys and values are returned.
+// validateKeys returns the longest prefix of keys/values whose values are all
+// non-empty. A compound merge key lists the primary (required) key first, so an
+// element may drop a trailing key component (e.g. a port omitting protocol) and
+// still be matched on what it populates. Matching stops at the first empty
+// component: a later one cannot identify an element alone. If the primary key
+// itself is unset, the original keys/values are returned so the element matches
+// nothing and is appended rather than merged onto a sibling.
 func validateKeys(values []string, keys []string) ([]string, []string) {
 	validKeys := make([]string, 0, len(keys))
 	validValues := make([]string, 0, len(values))
 	for i, v := range values {
-		if i < len(keys) && v != "" {
-			validKeys = append(validKeys, keys[i])
-			validValues = append(validValues, v)
+		if i >= len(keys) || v == "" {
+			break
 		}
+		validKeys = append(validKeys, keys[i])
+		validValues = append(validValues, v)
 	}
-	if len(validKeys) == 0 { // if values missing, fall back to primary keys
+	if len(validKeys) == 0 { // primary key unset -- match nothing, append as-is
 		return keys, values
 	}
 	return validKeys, validValues
+}
+
+// elementKeyValues returns the merge-key components val populates, so a merged
+// element is keyed on its full key, not the patch's partial key. E.g. a patch
+// {port: 8080, targetPort: 9999} that matched and merged the TCP element:
+//
+//	elementKeyValues(
+//	  val            = {port: 8080, protocol: TCP, targetPort: 9999},
+//	  keys           = [port, protocol],
+//	  fallbackKeys   = [port],
+//	  fallbackValues = [8080]
+//	) => [port, protocol], [8080, TCP]
+//
+// so it replaces only that element and not a sibling {port: 8080, protocol: UDP}.
+//
+// Falls back to fallbackKeys/fallbackValues when val populates no key, e.g. a
+// scalar list like finalizers, where keys is [""] and val is a bare string:
+//
+//	elementKeyValues(
+//	  val            = "example.com/finalizer"   (a scalar, not a map),
+//	  keys           = [""],
+//	  fallbackKeys   = [""],
+//	  fallbackValues = ["example.com/finalizer"]
+//	) => [""], ["example.com/finalizer"]
+//
+// so the scalar is still matched by value instead of being keyed on nothing.
+func elementKeyValues(val *yaml.RNode, keys, fallbackKeys, fallbackValues []string) ([]string, []string) {
+	if val == nil || len(keys) == 0 || keys[0] == "" {
+		return fallbackKeys, fallbackValues
+	}
+	setKeys := make([]string, 0, len(keys))
+	setValues := make([]string, 0, len(keys))
+	for _, key := range keys {
+		field := val.Field(key)
+		if field == nil || field.Value == nil || field.Value.YNode() == nil {
+			continue
+		}
+		value := field.Value.YNode().Value
+		if value == "" {
+			continue
+		}
+		setKeys = append(setKeys, key)
+		setValues = append(setValues, value)
+	}
+	if len(setKeys) == 0 {
+		return fallbackKeys, fallbackValues
+	}
+	return setKeys, setValues
 }
 
 // setAssociativeSequenceElements recursively set the elements in the list
@@ -119,14 +169,12 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	//          protocol: TCP
 	// `keys` would be [containerPort, protocol]
 	// and `valuesList` would be [ [8080, UDP], [8080, TCP] ]
-	var validKeys []string
-	var validValues []string
 	for _, values := range valuesList {
 		if len(values) == 0 {
 			continue
 		}
 
-		validKeys, validValues = validateKeys(values, keys)
+		validKeys, validValues := validateKeys(values, keys)
 		val, err := Walker{
 			VisitKeysAsScalars:    l.VisitKeysAsScalars,
 			InferAssociativeLists: l.InferAssociativeLists,
@@ -163,13 +211,15 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 			continue
 		}
 
-		// Add the val to the sequence. val will replace the item in the sequence if
-		// there is an item that matches all key-value pairs. Otherwise val will be appended
-		// the sequence.
+		// Add val to the sequence, replacing a matching item or appending. Key it
+		// on the full key val now populates (not the patch's partial key), so a
+		// patch matched on port alone replaces exactly its element instead of
+		// clobbering a sibling that differs only by protocol and duplicating it.
+		addKeys, addValues := elementKeyValues(val, keys, validKeys, validValues)
 		_, err = itemsToBeAdded.Pipe(yaml.ElementSetter{
 			Element: val.YNode(),
-			Keys:    validKeys,
-			Values:  validValues,
+			Keys:    addKeys,
+			Values:  addValues,
 		})
 		if err != nil {
 			return nil, err
@@ -178,13 +228,17 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 
 	var err error
 	if len(valuesList) > 0 {
+		// Use the full compound key, not the last element's narrowed key, so merged
+		// elements set on their exact key; still-partial elements append via the
+		// missing-key path in appendListNode.
+		appendKeys := keys
 		if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
 			// items from patches are needed to be prepended. so we append the
 			// dest to itemsToBeAdded
-			dest, err = appendListNode(itemsToBeAdded, dest, validKeys)
+			dest, err = appendListNode(itemsToBeAdded, dest, appendKeys)
 		} else {
 			// append the items
-			dest, err = appendListNode(dest, itemsToBeAdded, validKeys)
+			dest, err = appendListNode(dest, itemsToBeAdded, appendKeys)
 		}
 	}
 

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -81,74 +81,25 @@ func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
 	return dst, nil
 }
 
-// validateKeys returns a list of valid key-value pairs
-// if secondary merge key values are missing, use only the available merge keys
-func validateKeys(valuesList [][]string, values []string, keys []string) ([]string, []string) {
-	validKeys := make([]string, 0)
-	validValues := make([]string, 0)
-	validKeySet := sets.String{}
-	for _, values := range valuesList {
-		for i, v := range values {
-			if v != "" {
-				validKeySet.Insert(keys[i])
-			}
-		}
-	}
-	if validKeySet.Len() == 0 { // if values missing, fall back to primary keys
-		return keys, values
-	}
-	for _, k := range keys {
-		if validKeySet.Has(k) {
-			validKeys = append(validKeys, k)
-		}
-	}
+// validateKeys returns the subset of keys (and their values) that this element
+// actually populates -- i.e. those whose value is non-empty. When an element
+// specifies only part of a compound merge key (for example a container port
+// that sets containerPort but omits protocol), it is matched on the keys it
+// populates rather than on the full key, so its fields are not lost. If every
+// value is empty, the original keys and values are returned.
+func validateKeys(values []string, keys []string) ([]string, []string) {
+	validKeys := make([]string, 0, len(keys))
+	validValues := make([]string, 0, len(values))
 	for i, v := range values {
-		if v != "" || validKeySet.Has(keys[i]) {
+		if i < len(keys) && v != "" {
+			validKeys = append(validKeys, keys[i])
 			validValues = append(validValues, v)
 		}
 	}
+	if len(validKeys) == 0 { // if values missing, fall back to primary keys
+		return keys, values
+	}
 	return validKeys, validValues
-}
-
-// mergeValues merges values together - e.g. if two containerPorts
-// have the same port and targetPort but one has an empty protocol
-// and the other doesn't, they are treated as the same containerPort
-func mergeValues(valuesList [][]string) [][]string {
-	for i, values1 := range valuesList {
-		for j, values2 := range valuesList {
-			if matched, values := match(values1, values2); matched {
-				valuesList[i] = values
-				valuesList[j] = values
-			}
-		}
-	}
-	return valuesList
-}
-
-// two values match if they have at least one common element and
-// corresponding elements only differ if one is an empty string
-func match(values1 []string, values2 []string) (bool, []string) {
-	if len(values1) != len(values2) {
-		return false, nil
-	}
-	var commonElement bool
-	var res []string
-	for i := range values1 {
-		if values1[i] == values2[i] {
-			commonElement = true
-			res = append(res, values1[i])
-			continue
-		}
-		if values1[i] != "" && values2[i] != "" {
-			return false, nil
-		}
-		if values1[i] != "" {
-			res = append(res, values1[i])
-		} else {
-			res = append(res, values2[i])
-		}
-	}
-	return commonElement, res
 }
 
 // setAssociativeSequenceElements recursively set the elements in the list
@@ -158,9 +109,6 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	var schema *openapi.ResourceSchema
 	if l.Schema != nil {
 		schema = l.Schema.Elements()
-	}
-	if len(keys) > 1 {
-		valuesList = mergeValues(valuesList)
 	}
 
 	// each element in valuesList is a list of values corresponding to the keys
@@ -178,7 +126,7 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 			continue
 		}
 
-		validKeys, validValues = validateKeys(valuesList, values, keys)
+		validKeys, validValues = validateKeys(values, keys)
 		val, err := Walker{
 			VisitKeysAsScalars:    l.VisitKeysAsScalars,
 			InferAssociativeLists: l.InferAssociativeLists,
@@ -370,9 +318,13 @@ func (l Walker) elementPrimitiveValues() [][]string {
 	return returnValues
 }
 
-// fieldValue returns a slice containing each source's value for fieldName
+// elementValueList returns one entry per source: the element in that source's
+// list matching the compound merge key (keys/values), or nil if the source is
+// absent or has no match. keys/values are first narrowed to the subset the
+// element populates, so an element specifying only part of a compound key is
+// still matched.
 func (l Walker) elementValueList(keys []string, values []string) []*yaml.RNode {
-	keys, values = validateKeys([][]string{values}, values, keys)
+	keys, values = validateKeys(values, keys)
 	var fields []*yaml.RNode
 	for i := range l.Sources {
 		if l.Sources[i] == nil {


### PR DESCRIPTION
## What this fixes

When a strategic merge patch targets an element of an associative list by only
**part** of a compound merge key, kustomize mishandles it. With the
`[port, protocol]` merge key for Service ports (`[containerPort, protocol]` for
container ports), a patch that omits part of the key:

- **loses an added field** when it matches an existing port and adds a field;
- **drops the partial entries entirely** when the patch lists several ports and
  some omit `protocol` while sharing a port number with a sibling that supplies
  it (#4752);
- **clobbers a sibling and duplicates the entry** when the base holds two
  elements sharing the port (e.g. `8080/TCP` and `8080/UDP`) and the patch omits
  `protocol`: it overwrote one sibling's protocol and left two identical
  entries; and
- **clobbers an unrelated element** when the patch omits the primary key `port`
  itself (e.g. specifies only `protocol`): it matched on `protocol` alone and
  overwrote the first element carrying that protocol.

## Root cause

`setAssociativeSequenceElements` in `kyaml/yaml/walk/associative_sequence.go`
reconciled partial keys inconsistently:

- an element was narrowed by dropping **any** empty key component, so an element
  that omitted the primary key (`port`) could still match on a secondary
  component (`protocol`) alone; and
- a merged element was set back into the list under the patch's **partial** key,
  which matched **every** element sharing that key, so siblings that differ only
  by a later component were clobbered and the entry was duplicated.

## The fix

- `validateKeys` keeps only the **leading run** of populated key components (a
  trailing component may be dropped, the primary key may not). An element
  missing the primary key matches nothing, so it is left unidentified rather
  than merged onto an unrelated sibling.
- `elementKeyValues` re-keys a merged element on the **full** key it populates
  after merging, so it replaces exactly its counterpart instead of every element
  sharing the partial key.
- `appendListNode` is given the full compound key rather than the last element's
  narrowed key.

Net behavior: a partial-key patch merges into the first element that matches the
components it populates (or appends as a distinct element when none match);
same-port siblings are preserved and never duplicated; and a patch element that
omits the primary key is dropped rather than clobbering an unrelated element.

## Testing

`TestMerge` in `kyaml/yaml/merge2/map_test.go` covers the following, each
failing before the corresponding fix:

- `port patch adds a field but omits protocol (partial compound key)`
- `patch with multiple ports, some omitting protocol (#4752)`
- `partial-key patch when base has two elements sharing the port (ambiguous)`
- `partial-key patch missing the primary key (protocol, no port) does not clobber`

`go test ./yaml/merge2/...` and the full `kyaml` suite pass. Follows the
two-commit bug-fix convention: a test commit adds the failing cases, a fix
commit applies the change.

## Related issues

Fixes #4752

- #3111 introduced the `containerPort,protocol` compound (list) merge key
  (implemented in #3159, shipped v3.8.7); this PR fixes data-loss and clobbering
  bugs in that merge path.
