### PR TITLE
version: error on invalid --output instead of silent success

### DIFF
--- a/kustomize/commands/version/version.go
+++ b/kustomize/commands/version/version.go
@@ -81,6 +81,8 @@ func (o *Options) Run() error {
 			return errors.WrapPrefixf(err, "marshalling provenance to json")
 		}
 		fmt.Fprintln(o.Writer, string(marshalled))
+	default:
+		return fmt.Errorf("--output must be 'yaml' or 'json'")
 	}
 	return nil
 }

--- a/kustomize/commands/version/version_test.go
+++ b/kustomize/commands/version/version_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunInvalidOutput(t *testing.T) {
+	var buf bytes.Buffer
+	o := NewOptions(&buf)
+	o.Output = "yml"
+	err := o.Run()
+	if err == nil {
+		t.Fatal("expected error for invalid --output")
+	}
+	if !strings.Contains(err.Error(), "--output must be 'yaml' or 'json'") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output on invalid --output, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Reject unrecognized `--output` values for `kustomize version` with `error: --output must be 'yaml' or 'json'`
- Add a unit test covering the previous silent-success path (`--output=yml`)

Addresses kubernetes-sigs/kustomize#6032 (supersedes stale #6033)

## Test plan
- [x] `go test ./commands/version/`