### PR TITLE
fix: make `edit add label` generate the labels field instead of deprecated commonLabels

### DIFF
--- a/kustomize/commands/edit/add/addmetadata.go
+++ b/kustomize/commands/edit/add/addmetadata.go
@@ -63,14 +63,14 @@ func newCmdAddAnnotation(fSys filesys.FileSystem, v func(map[string]string) erro
 	return cmd
 }
 
-// newCmdAddLabel adds one or more commonLabels to the kustomization file.
+// newCmdAddLabel adds one or more labels to the kustomization file.
 func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *cobra.Command {
 	var o addMetadataOptions
 	o.kind = label
 	o.mapValidator = v
 	cmd := &cobra.Command{
 		Use: "label",
-		Short: "Adds one or more commonLabels to " +
+		Short: "Adds one or more commonLabels or labels to " +
 			konfig.DefaultKustomizationFileName(),
 		Example: `
 		add label {labelKey1:labelValue1} {labelKey2:labelValue2}`,
@@ -79,7 +79,7 @@ func newCmdAddLabel(fSys filesys.FileSystem, v func(map[string]string) error) *c
 		},
 	}
 	cmd.Flags().BoolVarP(&o.force, "force", "f", false,
-		"overwrite commonLabel if it already exists",
+		"overwrite label if it already exists",
 	)
 	cmd.Flags().BoolVar(&o.labelsWithoutSelector, "without-selector", false,
 		"using add labels without selector option",
@@ -138,13 +138,16 @@ func (o *addMetadataOptions) addAnnotations(m *types.Kustomization) error {
 }
 
 func (o *addMetadataOptions) addLabels(m *types.Kustomization) error {
-	if o.labelsWithoutSelector {
-		return o.writeToLabels(m, label)
+	// If the kustomization file already uses the deprecated commonLabels
+	// field, keep updating it so that the file does not end up mixing
+	// commonLabels with the labels field that replaces it. Otherwise, add
+	// the labels to the labels field: with includeSelectors by default,
+	// which is equivalent to commonLabels, or without it if
+	// --without-selector was specified.
+	if !o.labelsWithoutSelector && len(m.CommonLabels) > 0 { //nolint:staticcheck
+		return o.writeToMap(m.CommonLabels, label) //nolint:staticcheck
 	}
-	if m.CommonLabels == nil {
-		m.CommonLabels = make(map[string]string)
-	}
-	return o.writeToMap(m.CommonLabels, label)
+	return o.writeToLabels(m, label)
 }
 
 func (o *addMetadataOptions) writeToMap(m map[string]string, kind kindOfAdd) error {
@@ -167,7 +170,7 @@ func (o *addMetadataOptions) writeToMapEntry(m map[string]string, k, v string, k
 func (o *addMetadataOptions) writeToLabels(m *types.Kustomization, kind kindOfAdd) error {
 	lbl := types.Label{
 		Pairs:            make(map[string]string),
-		IncludeSelectors: false,
+		IncludeSelectors: !o.labelsWithoutSelector,
 		IncludeTemplates: o.includeTemplates,
 	}
 	for k, v := range o.metadata {

--- a/kustomize/commands/edit/add/addmetadata_test.go
+++ b/kustomize/commands/edit/add/addmetadata_test.go
@@ -275,6 +275,110 @@ func TestAddLabelForce(t *testing.T) {
 	v.VerifyCall()
 }
 
+func TestAddLabelGeneratesLabelsField(t *testing.T) {
+	// A kustomization file that does not already use the deprecated
+	// commonLabels field must get the labels field instead.
+	// See https://github.com/kubernetes-sigs/kustomize/issues/5726.
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(fSys, []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+`))
+	v := valtest_test.MakeHappyMapValidator(t)
+	cmd := newCmdAddLabel(fSys, v.Validator)
+	args := []string{"environment:dev"}
+	require.NoError(t, cmd.RunE(cmd, args))
+	v.VerifyCall()
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), `labels:
+- includeSelectors: true
+  pairs:
+    environment: dev`)
+	assert.NotContains(t, string(content), "commonLabels")
+}
+
+func TestAddLabelDefaultsToLabelsField(t *testing.T) {
+	tests := []struct {
+		name                 string
+		commonLabels         map[string]string
+		baseLabels           []types.Label
+		options              addMetadataOptions
+		expectedLabels       []types.Label
+		expectedCommonLabels map[string]string
+	}{
+		{
+			name: "creates a labels entry with includeSelectors when commonLabels is absent",
+			options: addMetadataOptions{
+				metadata: map[string]string{"new": "label"},
+			},
+			expectedLabels: []types.Label{
+				{
+					Pairs:            map[string]string{"new": "label"},
+					IncludeSelectors: true,
+				},
+			},
+		},
+		{
+			name: "adds to an existing includeSelectors labels entry",
+			baseLabels: []types.Label{
+				{
+					Pairs:            map[string]string{"existing": "label"},
+					IncludeSelectors: true,
+				},
+			},
+			options: addMetadataOptions{
+				metadata: map[string]string{"new": "label"},
+			},
+			expectedLabels: []types.Label{
+				{
+					Pairs:            map[string]string{"existing": "label", "new": "label"},
+					IncludeSelectors: true,
+				},
+			},
+		},
+		{
+			name: "does not mix with labels added without selector",
+			baseLabels: []types.Label{
+				{
+					Pairs: map[string]string{"existing": "label"},
+				},
+			},
+			options: addMetadataOptions{
+				metadata: map[string]string{"new": "label"},
+			},
+			expectedLabels: []types.Label{
+				{
+					Pairs: map[string]string{"existing": "label"},
+				},
+				{
+					Pairs:            map[string]string{"new": "label"},
+					IncludeSelectors: true,
+				},
+			},
+		},
+		{
+			name:         "keeps updating commonLabels when the field is already used",
+			commonLabels: map[string]string{"existing": "label"},
+			options: addMetadataOptions{
+				metadata: map[string]string{"new": "label"},
+			},
+			expectedCommonLabels: map[string]string{"existing": "label", "new": "label"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := makeKustomization(t)
+			//nolint:staticcheck
+			m.CommonLabels = tt.commonLabels
+			m.Labels = tt.baseLabels
+			require.NoError(t, tt.options.addLabels(m))
+			assert.Equal(t, tt.expectedLabels, m.Labels)
+			//nolint:staticcheck
+			assert.Equal(t, tt.expectedCommonLabels, m.CommonLabels)
+		})
+	}
+}
+
 func TestAddLabelIncludeTemplatesWithoutRequiredFlag(t *testing.T) {
 	fSys := filesys.MakeFsInMemory()
 	v := valtest_test.MakeHappyMapValidator(t)

--- a/kustomize/commands/edit/remove/removemetadata.go
+++ b/kustomize/commands/edit/remove/removemetadata.go
@@ -61,14 +61,14 @@ func newCmdRemoveAnnotation(fSys filesys.FileSystem, v func([]string) error) *co
 	return cmd
 }
 
-// newCmdRemoveLabel removes one or more commonLabels from the kustomization file.
+// newCmdRemoveLabel removes one or more labels from the kustomization file.
 func newCmdRemoveLabel(fSys filesys.FileSystem, v func([]string) error) *cobra.Command {
 	var o removeMetadataOptions
 	o.kind = label
 	o.arrayValidator = v
 	cmd := &cobra.Command{
 		Use: "label",
-		Short: "Removes one or more commonLabels from " +
+		Short: "Removes one or more commonLabels or labels from " +
 			konfig.DefaultKustomizationFileName(),
 		Example: `
 		remove label {labelKey1},{labelKey2}`,
@@ -143,10 +143,41 @@ func (o *removeMetadataOptions) removeAnnotations(m *types.Kustomization) error 
 }
 
 func (o *removeMetadataOptions) removeLabels(m *types.Kustomization) error {
-	if m.CommonLabels == nil && !o.ignore {
-		return fmt.Errorf("commonLabels is not defined in kustomization file")
+	//nolint:staticcheck
+	if m.CommonLabels == nil && m.Labels == nil && !o.ignore {
+		return fmt.Errorf("commonLabels and labels are not defined in kustomization file")
 	}
-	return o.removeFromMap(m.CommonLabels, label)
+	for _, key := range o.metadata {
+		//nolint:staticcheck
+		_, inCommonLabels := m.CommonLabels[key]
+		//nolint:staticcheck
+		delete(m.CommonLabels, key)
+		inLabels := o.removeFromLabels(m, key)
+		if !inCommonLabels && !inLabels && !o.ignore {
+			return fmt.Errorf("%s %s is not defined in kustomization file", label, key)
+		}
+	}
+	return nil
+}
+
+// removeFromLabels removes the given key from every entry of the labels
+// field, dropping entries left without any pairs, and reports whether the
+// key was found in at least one of them.
+func (o *removeMetadataOptions) removeFromLabels(m *types.Kustomization, key string) bool {
+	found := false
+	labels := make([]types.Label, 0, len(m.Labels))
+	for _, lbl := range m.Labels {
+		if _, ok := lbl.Pairs[key]; ok {
+			found = true
+			delete(lbl.Pairs, key)
+			if len(lbl.Pairs) == 0 {
+				continue
+			}
+		}
+		labels = append(labels, lbl)
+	}
+	m.Labels = labels
+	return found
 }
 
 func (o *removeMetadataOptions) removeFromMap(m map[string]string, kind kindOfAdd) error {

--- a/kustomize/commands/edit/remove/removemetadata_test.go
+++ b/kustomize/commands/edit/remove/removemetadata_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	valtest_test "sigs.k8s.io/kustomize/api/testutils/valtest"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kustomize/v5/commands/internal/kustfile"
@@ -220,6 +222,75 @@ func TestRemoveLabel(t *testing.T) {
 	}
 }
 
+func TestRemoveLabelFromLabelsField(t *testing.T) {
+	var o removeMetadataOptions
+	o.metadata = []string{"label1"}
+
+	m := makeKustomization(t)
+	//nolint:staticcheck
+	m.CommonLabels = nil
+	m.Labels = []types.Label{
+		{
+			Pairs:            map[string]string{"label1": "val1", "label2": "val2"},
+			IncludeSelectors: true,
+		},
+		{
+			Pairs: map[string]string{"label1": "val1"},
+		},
+	}
+	require.NoError(t, o.removeLabels(m))
+	// the label is removed from every entry and the entry left without
+	// pairs is dropped entirely
+	assert.Equal(t, []types.Label{
+		{
+			Pairs:            map[string]string{"label2": "val2"},
+			IncludeSelectors: true,
+		},
+	}, m.Labels)
+
+	// removing the same label again should not work
+	err := o.removeLabels(m)
+	require.Error(t, err)
+	assert.Equal(t, "label label1 is not defined in kustomization file", err.Error())
+}
+
+func TestRemoveLabelFromCommonLabelsAndLabelsFields(t *testing.T) {
+	var o removeMetadataOptions
+	o.metadata = []string{"label1", "label2"}
+
+	m := makeKustomization(t)
+	m.Labels = []types.Label{
+		{
+			Pairs:            map[string]string{"label2": "val2"},
+			IncludeSelectors: true,
+		},
+	}
+	require.NoError(t, o.removeLabels(m))
+	//nolint:staticcheck
+	assert.Empty(t, m.CommonLabels)
+	assert.Empty(t, m.Labels)
+}
+
+func TestRemoveLabelNoCommonLabelsDefinition(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(fSys, []byte(`
+labels:
+- includeSelectors: true
+  pairs:
+    label1: val1
+`))
+
+	v := valtest_test.MakeHappyMapValidator(t)
+	cmd := newCmdRemoveLabel(fSys, v.ValidatorArray)
+	args := []string{"label1"}
+	require.NoError(t, cmd.RunE(cmd, args))
+	v.VerifyCall()
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "labels")
+}
+
 func TestRemoveLabelIgnore(t *testing.T) {
 	fSys := makeKustomizationFS()
 
@@ -248,7 +319,7 @@ func TestRemoveLabelNoDefinition(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected an error")
 	}
-	if err.Error() != "commonLabels is not defined in kustomization file" {
+	if err.Error() != "commonLabels and labels are not defined in kustomization file" {
 		t.Errorf("incorrect error: %v", err.Error())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`kustomize edit add label environment:dev` wrote the deprecated `commonLabels` field, so `kustomize build` immediately printed a deprecation warning about configuration the CLI itself had just generated (#5726, triage/accepted).

With this change, `edit add label` (no flags) appends to the `labels` field with `includeSelectors: true`, which is semantically identical to `commonLabels` — `kustomize build` output is byte-identical between the two forms, but no deprecation warning is triggered:

```yaml
# kustomization.yaml after `kustomize edit add label environment:dev`
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
labels:
- includeSelectors: true
  pairs:
    environment: dev
```

Design decisions (flagging explicitly for review):

- **Backward compatibility**: if the kustomization file already uses `commonLabels`, the command keeps updating `commonLabels` in place, so a single file never ends up mixing both fields. `kustomize edit fix` remains the migration path. This means existing files/scripts see no change; only freshly-generated configuration switches to the non-deprecated field, per the maintainer guidance on the issue ("update the existing command to do so"). The alternative — a new opt-in flag — would keep emitting deprecated config by default, which is what the issue asks to stop.
- **`edit remove label`** now removes keys from both `commonLabels` and every `labels` entry (dropping entries left without pairs), so labels created by the new default remain removable and the command family stays round-trippable. Previously, labels in the `labels` field could not be removed via the CLI at all.
- `--without-selector` / `--include-templates` behavior is unchanged. `edit set label` is intentionally untouched, since #6039 covers it (only overlap is an identical one-line help-string change).

**Which issue(s) this PR fixes**:

Fixes #5726

**Testing**:

- New `TestAddLabelGeneratesLabelsField` reproduces the issue's exact scenario end to end; new table-driven `TestAddLabelDefaultsToLabelsField` covers the new default, appending to an existing `includeSelectors` entry, not mixing with `--without-selector` entries, and the `commonLabels` back-compat path.
- New remove-side tests: removal from the `labels` field (with empty entries dropped), removal spanning both fields, file-level removal leaving no empty `labels:` key, and the updated "neither field defined" error.
- All 6 new/updated tests fail without the fix. `go test ./commands/...` (kustomize module) passes; `golangci-lint run` (repo-pinned v1.64.8) is clean on the changed packages.
- Manually verified with a built binary: fresh file gets the issue's expected output; `build` emits no warning; `commonLabels` vs new `labels` form produce identical rendered resources; legacy `commonLabels` files keep their format on `add`.

/kind cleanup
/kind deprecation

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
