### PR TITLE
fix: preserve comments when editing kustomization fields

### DIFF
--- a/kustomize/commands/edit/set/setimage_test.go
+++ b/kustomize/commands/edit/set/setimage_test.go
@@ -468,3 +468,33 @@ func TestSetImage(t *testing.T) {
 		})
 	}
 }
+
+func TestSetImagePreservesResourceComments(t *testing.T) {
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(fSys, []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Keep this comment attached to the resource.
+  - https://example.com/resource.yaml
+  -
+images:
+- name: example
+  newName: example
+  newTag: "123"
+`))
+
+	cmd := newCmdSetImage(fSys)
+	if err := cmd.RunE(cmd, []string{"example=example:234"}); err != nil {
+		t.Fatalf("unexpected error from set image command: %v", err)
+	}
+
+	content, err := testutils_test.ReadTestKustomization(fSys)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+
+	const expectedResourceComment = "resources:\n  # Keep this comment attached to the resource.\n  - https://example.com/resource.yaml"
+	if !strings.Contains(string(content), expectedResourceComment) {
+		t.Fatalf("resource comment was not preserved in place:\n%s", content)
+	}
+}

--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -16,7 +16,10 @@ import (
 	"golang.org/x/text/language"
 	"sigs.k8s.io/kustomize/api/konfig"
 	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/comments"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/order"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -115,6 +118,7 @@ type kustomizationFile struct {
 	path           string
 	fSys           filesys.FileSystem
 	originalFields []*commentedField
+	original       *kyaml.RNode
 }
 
 // NewKustomizationFile returns a new instance.
@@ -172,6 +176,12 @@ func (mf *kustomizationFile) Read() (*types.Kustomization, error) {
 		return nil, err
 	}
 
+	original, err := kyaml.Parse(string(data))
+	if err != nil {
+		return nil, err
+	}
+	mf.original = original
+
 	k.FixKustomization()
 
 	if err := mf.parseCommentedFields(data); err != nil {
@@ -187,6 +197,22 @@ func (mf *kustomizationFile) Write(kustomization *types.Kustomization) error {
 	data, err := mf.marshal(kustomization)
 	if err != nil {
 		return err
+	}
+	if mf.original != nil {
+		updated, err := kyaml.Parse(string(data))
+		if err != nil {
+			return err
+		}
+		if err := comments.CopyComments(mf.original, updated); err != nil {
+			return err
+		}
+		if err := order.SyncOrder(mf.original, updated); err != nil {
+			return err
+		}
+		data, err = updated.String()
+		if err != nil {
+			return err
+		}
 	}
 	return mf.fSys.WriteFile(mf.path, data)
 }


### PR DESCRIPTION
## Summary\n\n- preserve comments attached to list items when kustomize edit set image rewrites a Kustomization\n- retain the original field order while applying the updated typed model\n- add a regression test for comments above resource entries\n\nFixes #4481\n\n## Implementation\n\nThe existing typed marshal path cannot retain comments inside sequences. The kustomization file now keeps the parsed source node from Read, then copies comments and synchronizes order onto the updated node before writing.\n\n## Validation\n\n- git diff --check\n- regression test added as the first commit, followed by the fix as a separate commit per CONTRIBUTING.md\n\nGo tooling is unavailable in this environment, so the focused Go test remains for CI.