### PR TITLE
api/image: escape images[].name before interpolating into regexp

### DIFF
--- a/api/internal/image/image.go
+++ b/api/internal/image/image.go
@@ -21,11 +21,15 @@ func IsImageMatched(s, t string) bool {
 	// using any OCI-valid digest algorithm match consistently with Split,
 	// which accepts any algorithm.
 	// See https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
-	// The name t comes from kustomization images[].name and is interpolated
-	// into the pattern directly, so it can be an invalid regexp (for example
-	// "["). When it fails to compile, treat it as matching nothing rather than
-	// dereferencing a nil *Regexp, which would panic during the build.
-	pattern, err := regexp.Compile("^" + t + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z0-9]+([.+_-][a-zA-Z0-9]+)*:[a-zA-Z0-9_.{}-]*)?$")
+	// The name t comes from kustomization images[].name and, per the doc
+	// comment above, is supposed to be matched literally/identically, not as
+	// a pattern. It must therefore be escaped with regexp.QuoteMeta before
+	// being interpolated into the pattern: an unescaped t would let regexp
+	// metacharacters it happens to contain (most commonly ".", which is very
+	// common in real registry hostnames such as gcr.io, docker.io, quay.io)
+	// act as wildcards, causing the built pattern to also match image
+	// references that are not actually identical to t.
+	pattern, err := regexp.Compile("^" + regexp.QuoteMeta(t) + "(:[a-zA-Z0-9_.{}-]*)?(@[a-zA-Z0-9]+([.+_-][a-zA-Z0-9]+)*:[a-zA-Z0-9_.{}-]*)?$")
 	if err != nil {
 		return false
 	}

--- a/api/internal/image/image_test.go
+++ b/api/internal/image/image_test.go
@@ -83,6 +83,22 @@ func TestIsImageMatched(t *testing.T) {
 			name:      "[",
 			isMatched: false,
 		},
+		{
+			// name is documented as matched literally/identically, so a "."
+			// in it (very common in real registry hostnames, e.g. gcr.io,
+			// docker.io) must not act as a regexp wildcard and match a value
+			// that merely has some other character in that position.
+			testName:  "dot in name must not act as a regexp wildcard",
+			value:     "gcrXio/my-project/my-app:v1",
+			name:      "gcr.io/my-project/my-app",
+			isMatched: false,
+		},
+		{
+			testName:  "dot in name still matches the literal dot",
+			value:     "gcr.io/my-project/my-app:v1",
+			name:      "gcr.io/my-project/my-app",
+			isMatched: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -534,3 +534,49 @@ spec:
             name: volume
 `)
 }
+
+// An images[].name value is documented as a literal, tag-less image name,
+// not a pattern. A "." in it (very common in real registry hostnames, e.g.
+// gcr.io, docker.io, quay.io) must not act as a regexp wildcard: it must
+// not match a container image whose name merely has some other character
+// in that position.
+func TestTransfomersImageNameDotIsNotAWildcard(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- deploy.yaml
+images:
+- name: gcr.io/my-project/my-app
+  newTag: v2
+`)
+	th.WriteF("deploy.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: intended-match
+        image: gcr.io/my-project/my-app:v1
+      - name: should-not-match
+        image: gcrXio/my-project/my-app:v1
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/my-project/my-app:v2
+        name: intended-match
+      - image: gcrXio/my-project/my-app:v1
+        name: should-not-match
+`)
+}
+

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -440,3 +440,48 @@ spec:
         name: nginx
 `)
 }
+
+// An images[].name value is documented as a literal, tag-less image name,
+// not a pattern. A "." in it (very common in real registry hostnames, e.g.
+// gcr.io, docker.io, quay.io) must not act as a regexp wildcard: it must
+// not match a container image whose name merely has some other character
+// in that position.
+func TestTransfomersImageNameDotIsNotAWildcard(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- deploy.yaml
+images:
+- name: gcr.io/my-project/my-app
+  newTag: v2
+`)
+	th.WriteF("deploy.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: intended-match
+        image: gcr.io/my-project/my-app:v1
+      - name: should-not-match
+        image: gcrXio/my-project/my-app:v1
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/my-project/my-app:v2
+        name: intended-match
+      - image: gcrXio/my-project/my-app:v1
+        name: should-not-match
+`)
+}


### PR DESCRIPTION
## Summary

`images[].name` is documented as an identical/literal image name match:

```go
// Name is a tag-less image name.
```

but `IsImageMatched` splices it unescaped into a regexp pattern:

```go
pattern, err := regexp.Compile("^" + t + "(:...)?(@...)?$")
```

Since `.` is a regexp metacharacter and appears in virtually every real registry hostname (`gcr.io`, `docker.io`, `quay.io`, `ghcr.io`, `*.azurecr.io`), a rule such as:

```yaml
images:
  - name: gcr.io/my-project/my-app
    newTag: v2
```

would also match an unrelated image like `gcrXio/my-project/my-app` if one happened to be present in the same manifest set, contradicting the documented "identical" semantics.

This line has had two recent fixes for adjacent issues (#6184 panic-on-invalid-regexp, #6167 digest-algorithm matching) that didn't touch this particular gap.

## Fix

Wrap the interpolated name in `regexp.QuoteMeta` so it's matched literally, per commit 2.

## Test plan

- [x] Added a failing-first regression test at the unit level (`image_test.go`) and an end-to-end `krusty` test (`transformersimage_test.go`), following this repo's own documented reviewer-guide shape (failing-test commit, then fix commit).
- [x] Verified via `git checkout <test-commit> -- image.go` (pre-fix) that both new tests fail on unmodified HEAD.
- [x] Verified both tests pass after the fix, alongside all existing tests in `api/internal/image/...` and `api/krusty/...`.