### PR TITLE
Guard the empty-file case when loading CRDs

### DIFF
--- a/api/internal/accumulator/loadconfigfromcrds.go
+++ b/api/internal/accumulator/loadconfigfromcrds.go
@@ -54,7 +54,7 @@ func LoadConfigFromCRDs(
 }
 
 func makeNameToApiMap(content []byte) (result nameToApiMap, err error) {
-	if content[0] == '{' {
+	if len(content) > 0 && content[0] == '{' {
 		err = json.Unmarshal(content, &result)
 	} else {
 		err = yaml.Unmarshal(content, &result)

--- a/api/internal/accumulator/loadconfigfromcrds_test.go
+++ b/api/internal/accumulator/loadconfigfromcrds_test.go
@@ -174,3 +174,17 @@ func TestLoadCRDs(t *testing.T) {
 		t.Fatalf("expected\n %v\n but got\n %v\n", expectedTc, actualTc)
 	}
 }
+
+func TestLoadCRDsEmptyFile(t *testing.T) {
+	// A crds entry pointing at a zero-byte file should contribute nothing
+	// rather than crashing the build.
+	fSys := filesys.MakeFsInMemory()
+	err := fSys.WriteFile("/testpath/empty.json", []byte(""))
+	require.NoError(t, err)
+	ldr, err := loader.NewLoader(loader.RestrictionRootOnly, "/testpath", fSys)
+	require.NoError(t, err)
+
+	actualTc, err := LoadConfigFromCRDs(ldr, []string{"empty.json"})
+	require.NoError(t, err)
+	require.Equal(t, &builtinconfig.TransformerConfig{}, actualTc)
+}


### PR DESCRIPTION
A `crds:` entry that points at a zero-byte file crashes the build:

```
panic: runtime error: index out of range [0] with length 0
```

`makeNameToApiMap` looks at the first byte to decide between JSON and YAML:

```go
if content[0] == '{' {
    err = json.Unmarshal(content, &result)
} else {
    err = yaml.Unmarshal(content, &result)
}
```

`kustomization.yaml` `crds:` takes relative paths, `kusttarget.go` hands each file to `LoadConfigFromCRDs`, and nothing checks the contents are non-empty on the way. So an empty file in that list panics rather than contributing no CRDs. A whitespace-only file does not trip it, since a space just routes to the YAML branch, which is what made this specific to zero-length files.

The fix uses the same shape the repo already uses in `kyaml/openapi/openapi.go`:

```go
if len(content) > 0 && content[0] == '{' {
```

An empty file then goes to `yaml.Unmarshal([]byte{})`, which returns a nil map and no error, so it contributes nothing.

Test added next to `TestLoadCRDs`. It panics on master and passes with the change; `go test ./internal/accumulator/` is green.