### PR TITLE
fix: preserve resolved scalar type for replacement-created fields

### DIFF
--- a/api/filters/replacement/replacement.go
+++ b/api/filters/replacement/replacement.go
@@ -248,8 +248,23 @@ func setFieldValue(options *types.FieldOptions, targetField *yaml.RNode, value *
 	}
 
 	if targetField.YNode().Kind == yaml.ScalarNode {
-		// For scalar, only copy the value (leave any type intact to auto-convert int->string or string->int)
+		// For an existing scalar, only copy the value and leave its tag intact,
+		// so it auto-converts to the target's pre-existing type (int->string or
+		// string->int).
 		targetField.YNode().Value = value.YNode().Value
+		if targetField.YNode().Tag == "" {
+			// Unless the field has no resolved type, meaning it was just created
+			// (e.g. via `options.create: true`) rather than copied from source
+			// YAML. Resolve and set its implicit YAML 1.2 tag now, matching what
+			// would be inferred if this value were serialized directly. Without
+			// this, the field would keep rendering correctly until some later step
+			// (e.g. a strategic merge patch) walks the document: FieldSetter's
+			// YAML-1.1-compatibility check treats an untagged scalar as a string
+			// and force-quotes it if its value looks like a bool/int/null keyword,
+			// silently turning e.g. a replacement-sourced "true" into the string
+			// "true" instead of the boolean true.
+			targetField.YNode().Tag = resolveImplicitTag(targetField.YNode().Value)
+		}
 	} else {
 		targetField.SetYNode(value.YNode())
 	}
@@ -402,4 +417,21 @@ func serializeAsYAML(structuredData *yaml.RNode) (string, error) {
 	}
 
 	return strings.TrimSpace(modifiedData), nil
+}
+
+// resolveImplicitTag returns the YAML 1.2 tag that value would resolve to if
+// written out as a plain (unquoted, untagged) scalar, e.g. "true" -> !!bool,
+// "3" -> !!int, "hello" -> !!str.
+func resolveImplicitTag(value string) string {
+	if value == "" {
+		return yaml.NodeTagString
+	}
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(value), &n); err != nil || len(n.Content) != 1 {
+		return yaml.NodeTagString
+	}
+	if c := n.Content[0]; c.Kind == yaml.ScalarNode {
+		return c.Tag
+	}
+	return yaml.NodeTagString
 }

--- a/api/krusty/replacementtransformer_test.go
+++ b/api/krusty/replacementtransformer_test.go
@@ -1002,3 +1002,193 @@ metadata:
   name: pre-app-config-dev-7266b7f2m9
 `)
 }
+
+func TestReplacementsCreateBoolFieldSurvivesUnrelatedStrategicMergePatch(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t)
+	defer th.Reset()
+
+	th.WriteK(".", `
+resources:
+- deployment.yaml
+components:
+- components/add-volume
+patches:
+- path: patch.yaml
+`)
+	th.WriteF("deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: myapp
+        image: myimage
+`)
+	th.WriteF("patch.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    metadata:
+      annotations:
+        foo: bar
+`)
+	th.WriteC("components/add-volume", `
+configMapGenerator:
+- name: volume-config
+  literals:
+  - readOnly=true
+  - mountPath=/mnt/myvolume
+replacements:
+- source:
+    name: volume-config
+    kind: ConfigMap
+    fieldPath: data.readOnly
+  targets:
+  - select:
+      kind: Deployment
+    fieldPaths:
+    - spec.template.spec.containers.0.volumeMounts.[name=myvolume].readOnly
+    options:
+      create: true
+- source:
+    name: volume-config
+    kind: ConfigMap
+    fieldPath: data.mountPath
+  targets:
+  - select:
+      kind: Deployment
+    fieldPaths:
+    - spec.template.spec.containers.0.volumeMounts.[name=myvolume].mountPath
+    options:
+      create: true
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    metadata:
+      annotations:
+        foo: bar
+    spec:
+      containers:
+      - image: myimage
+        name: myapp
+        volumeMounts:
+        - mountPath: /mnt/myvolume
+          name: myvolume
+          readOnly: true
+---
+apiVersion: v1
+data:
+  mountPath: /mnt/myvolume
+  readOnly: "true"
+kind: ConfigMap
+metadata:
+  name: volume-config-kbkmhkchcd
+`)
+}
+
+func TestReplacementsCreateBoolFieldFromLocalConfigSurvivesUnrelatedStrategicMergePatch(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarness(t)
+	defer th.Reset()
+
+	th.WriteK(".", `
+resources:
+- deployment.yaml
+components:
+- components/add-volume
+patches:
+- path: patch.yaml
+`)
+	th.WriteF("deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+      - name: myapp
+        image: myimage
+`)
+	th.WriteF("patch.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    metadata:
+      annotations:
+        foo: bar
+`)
+	th.WriteC("components/add-volume", `
+resources:
+- local-config.yaml
+replacements:
+- source:
+    kind: VolumeConfig
+    name: volume-config
+    fieldPath: spec.readOnly
+  targets:
+  - select:
+      kind: Deployment
+    fieldPaths:
+    - spec.template.spec.containers.0.volumeMounts.[name=myvolume].readOnly
+    options:
+      create: true
+- source:
+    kind: VolumeConfig
+    name: volume-config
+    fieldPath: spec.mountPath
+  targets:
+  - select:
+      kind: Deployment
+    fieldPaths:
+    - spec.template.spec.containers.0.volumeMounts.[name=myvolume].mountPath
+    options:
+      create: true
+`)
+	th.WriteF("components/add-volume/local-config.yaml", `
+apiVersion: example.com/v1
+kind: VolumeConfig
+metadata:
+  name: volume-config
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  readOnly: true
+  mountPath: /mnt/myvolume
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    metadata:
+      annotations:
+        foo: bar
+    spec:
+      containers:
+      - image: myimage
+        name: myapp
+        volumeMounts:
+        - mountPath: /mnt/myvolume
+          name: myvolume
+          readOnly: true
+`)
+}


### PR DESCRIPTION
Every field created by a `replacements` entry (`options.create: true`) was left with an empty YAML tag on its scalar value, since `setFieldValue` only ever copied `.Value` onto the newly created node and never resolved a type for it. This was invisible in isolation, because encoding an untagged, unstyled scalar implicitly resolves its type from its text (e.g. "true" -> bool).

However, once any strategic merge patch was later applied to the same resource -- even to a completely unrelated part of the document -- `kyaml`'s `merge2` walk revisits every field via [`FieldSetter.Filter`](https://github.com/kubernetes-sigs/kustomize/blob/0fd1ae0ce9ba51e9e5ed9396308fa2ff7a08ce95/kyaml/yaml/fns.go#L698-L707), which contains a YAML-1.1-compatibility safeguard that treats an [untagged scalar as a plain string](https://github.com/kubernetes-sigs/kustomize/blob/0fd1ae0ce9ba51e9e5ed9396308fa2ff7a08ce95/kyaml/yaml/types.go#L62-L65) and force-quotes it if the value looks like a YAML 1.1 keyword. That safeguard can't distinguish "this is genuinely a string" from "this has no resolved type yet", so it silently turned e.g. a replacement-created `readOnly: true` into the string `readOnly: "true"`.

This PR was written in part with the assistance of generative AI.