### PR TITLE
Add Gateway certificateRefs to nameReference config

### DIFF
--- a/api/internal/konfig/builtinpluginconsts/namereference.go
+++ b/api/internal/konfig/builtinpluginconsts/namereference.go
@@ -293,6 +293,9 @@ nameReference:
     version: v1
   - path: spec/azureFile/secretName
     kind: PersistentVolume
+  - path: spec/listeners/tls/certificateRefs/name
+    kind: Gateway
+    group: gateway.networking.k8s.io
 
 - kind: Service
   version: v1

--- a/examples/transformerconfigs/README.md
+++ b/examples/transformerconfigs/README.md
@@ -517,6 +517,9 @@ nameReference:
       version: v1
     - path: spec/azureFile/secretName
       kind: PersistentVolume
+    - path: spec/listeners/tls/certificateRefs/name
+      kind: Gateway
+      group: gateway.networking.k8s.io
 
 - kind: Service
   version: v1

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,7 +2,21 @@
 
 This directory holds [kustomize plugins][extending kustomize],
 each in its own sub-directory.
- 
+
+### Plugin Discovery & Environment Variables
+
+When executing external plugins, Kustomize locates plugin scripts and binaries by searching for a plugin root directory in the following order of precedence:
+
+1. **`$KUSTOMIZE_PLUGIN_HOME`**: If the `KUSTOMIZE_PLUGIN_HOME` environment variable is defined, Kustomize searches for plugins directly within this directory.
+2. **`$XDG_CONFIG_HOME/kustomize/plugin`**: If `XDG_CONFIG_HOME` is defined, Kustomize searches in the `kustomize/plugin` subdirectory.
+3. **`~/.config/kustomize/plugin`**: The default XDG configuration directory within the user's home directory.
+4. **`~/kustomize/plugin`**: Fallback location in the user's home directory.
+
+To override the default discovery path and point Kustomize to a custom plugin location:
+```bash
+export KUSTOMIZE_PLUGIN_HOME=$HOME/custom-kustomize-plugins
+```
+
 ### Directories
  
  * `builtin`

--- a/site/content/en/docs/Reference/glossary.md
+++ b/site/content/en/docs/Reference/glossary.md
@@ -407,6 +407,8 @@ A chunk of code used by kustomize, but not necessarily
 compiled into kustomize, to generate and/or transform a
 kubernetes resource as part of a kustomization.
 
+External plugins are discovered by searching in the location specified by the `KUSTOMIZE_PLUGIN_HOME` environment variable, defaulting to `$XDG_CONFIG_HOME/kustomize/plugin` or `~/.config/kustomize/plugin`.
+
 Details [here](/docs/extending_kustomize).
 
 ## resource


### PR DESCRIPTION
Fixes #6161 by adding Gateway `certificateRefs` to `nameReferenceFieldSpecs` for Secret. Also updated `examples/transformerconfigs/README.md`.