### PR TITLE
Fix kyaml merge2: $patch directives ignored with ListPrepend

### DIFF
--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -231,8 +231,12 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	var err error
 	if len(valuesList) > 0 {
 		if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
-			// items from patches are needed to be prepended. so we append the
-			// dest to itemsToBeAdded
+			// First update dest with the patched items so that patches are not overwritten
+			dest, err = appendListNode(dest, itemsToBeAdded, validKeys)
+			if err != nil {
+				return nil, err
+			}
+			// Then use itemsToBeAdded to establish the prepended order
 			dest, err = appendListNode(itemsToBeAdded, dest, validKeys)
 		} else {
 			// append the items


### PR DESCRIPTION
Fixes #6146.

When using `merge2.MergeStrings` with `ListIncreaseDirection: MergeOptionsListPrepend`, strategic merge patch directives (`$patch: replace`, `$patch: delete`) on individual list elements were silently ignored.

The root cause was in `kyaml/yaml/walk/associative_sequence.go` where `appendListNode(itemsToBeAdded, dest, ...)` was called. Because `dest` contained the original unmerged items, appending `dest` into `itemsToBeAdded` (which contained the correctly merged items) caused the merged elements to be overwritten by the original elements.

This fix properly updates `dest` with `itemsToBeAdded` (the merged items) first so that the patches are applied. Then it applies the fully patched `dest` to `itemsToBeAdded` to correctly prepend the new items while retaining the patch updates.