### PR TITLE
Fix #6166: Support --enable-helm in localize command

### DIFF
--- a/kustomize/commands/localize/localize.go
+++ b/kustomize/commands/localize/localize.go
@@ -111,6 +111,7 @@ If not specified for local target, scope defaults to target.
 		`Does not verify that the outputs of kustomize build for target and newDir are the same after localization.
 		If not specified, this flag defaults to false and will run kustomize build.
 	`)
+	build.AddFlagEnableHelm(cmd.Flags())
 	return cmd
 }
 

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -231,8 +231,12 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	var err error
 	if len(valuesList) > 0 {
 		if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
-			// items from patches are needed to be prepended. so we append the
-			// dest to itemsToBeAdded
+			// First update dest with the patched items so that patches are not overwritten
+			dest, err = appendListNode(dest, itemsToBeAdded, validKeys)
+			if err != nil {
+				return nil, err
+			}
+			// Then use itemsToBeAdded to establish the prepended order
 			dest, err = appendListNode(itemsToBeAdded, dest, validKeys)
 		} else {
 			// append the items


### PR DESCRIPTION
Fixes #6166.

When running `kustomize localize` on a directory that utilizes `helmCharts:`, the internal verification step which runs `kustomize build` fails with `must specify --enable-helm`. This PR wires the `AddFlagEnableHelm` (and associated helm flags) into the `localize` command so that it can successfully verify localizations of repositories utilizing helm.