### PR TITLE
Feature #6054: Add excludeLabelSelector to PrefixTransformer and SuffixTransformer

### DIFF
--- a/api/internal/builtins/PrefixTransformer.go
+++ b/api/internal/builtins/PrefixTransformer.go
@@ -9,12 +9,14 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // Add the given prefix to the field
 type PrefixTransformerPlugin struct {
-	Prefix     string        `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Prefix               string        `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	ExcludeLabelSelector string        `json:"excludeLabelSelector,omitempty" yaml:"excludeLabelSelector,omitempty"`
+	FieldSpecs           types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
 // TODO: Make this gvk skip list part of the config.
@@ -39,12 +41,23 @@ func (p *PrefixTransformerPlugin) Config(
 }
 
 func (p *PrefixTransformerPlugin) Transform(m resmap.ResMap) error {
+	var selector labels.Selector
+	if p.ExcludeLabelSelector != "" {
+		var err error
+		selector, err = labels.Parse(p.ExcludeLabelSelector)
+		if err != nil {
+			return err
+		}
+	}
 	// Even if the Prefix is empty we want to proceed with the
 	// transformation. This allows to add contextual information
 	// to the resources (AddNamePrefix).
 	for _, r := range m.Resources() {
 		// TODO: move this test into the filter (i.e. make a better filter)
 		if p.shouldSkip(r.OrgId()) {
+			continue
+		}
+		if selector != nil && selector.Matches(labels.Set(r.GetLabels())) {
 			continue
 		}
 		id := r.OrgId()

--- a/api/internal/builtins/SuffixTransformer.go
+++ b/api/internal/builtins/SuffixTransformer.go
@@ -9,12 +9,14 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // Add the given suffix to the field
 type SuffixTransformerPlugin struct {
-	Suffix     string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
-	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Suffix               string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
+	ExcludeLabelSelector string        `json:"excludeLabelSelector,omitempty" yaml:"excludeLabelSelector,omitempty"`
+	FieldSpecs           types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
 // TODO: Make this gvk skip list part of the config.
@@ -39,12 +41,23 @@ func (p *SuffixTransformerPlugin) Config(
 }
 
 func (p *SuffixTransformerPlugin) Transform(m resmap.ResMap) error {
+	var selector labels.Selector
+	if p.ExcludeLabelSelector != "" {
+		var err error
+		selector, err = labels.Parse(p.ExcludeLabelSelector)
+		if err != nil {
+			return err
+		}
+	}
 	// Even if the Suffix is empty we want to proceed with the
 	// transformation. This allows to add contextual information
 	// to the resources (AddNameSuffix).
 	for _, r := range m.Resources() {
 		// TODO: move this test into the filter (i.e. make a better filter)
 		if p.shouldSkip(r.OrgId()) {
+			continue
+		}
+		if selector != nil && selector.Matches(labels.Set(r.GetLabels())) {
 			continue
 		}
 		id := r.OrgId()

--- a/plugin/builtin/prefixtransformer/PrefixTransformer.go
+++ b/plugin/builtin/prefixtransformer/PrefixTransformer.go
@@ -12,12 +12,14 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // Add the given prefix to the field
 type plugin struct {
-	Prefix     string        `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Prefix               string        `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	ExcludeLabelSelector string        `json:"excludeLabelSelector,omitempty" yaml:"excludeLabelSelector,omitempty"`
+	FieldSpecs           types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
 var KustomizePlugin plugin //nolint:gochecknoglobals
@@ -44,12 +46,23 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	var selector labels.Selector
+	if p.ExcludeLabelSelector != "" {
+		var err error
+		selector, err = labels.Parse(p.ExcludeLabelSelector)
+		if err != nil {
+			return err
+		}
+	}
 	// Even if the Prefix is empty we want to proceed with the
 	// transformation. This allows to add contextual information
 	// to the resources (AddNamePrefix).
 	for _, r := range m.Resources() {
 		// TODO: move this test into the filter (i.e. make a better filter)
 		if p.shouldSkip(r.OrgId()) {
+			continue
+		}
+		if selector != nil && selector.Matches(labels.Set(r.GetLabels())) {
 			continue
 		}
 		id := r.OrgId()

--- a/plugin/builtin/suffixtransformer/SuffixTransformer.go
+++ b/plugin/builtin/suffixtransformer/SuffixTransformer.go
@@ -12,12 +12,14 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // Add the given suffix to the field
 type plugin struct {
-	Suffix     string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
-	FieldSpecs types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
+	Suffix               string        `json:"suffix,omitempty" yaml:"suffix,omitempty"`
+	ExcludeLabelSelector string        `json:"excludeLabelSelector,omitempty" yaml:"excludeLabelSelector,omitempty"`
+	FieldSpecs           types.FsSlice `json:"fieldSpecs,omitempty" yaml:"fieldSpecs,omitempty"`
 }
 
 var KustomizePlugin plugin //nolint:gochecknoglobals
@@ -44,12 +46,23 @@ func (p *plugin) Config(
 }
 
 func (p *plugin) Transform(m resmap.ResMap) error {
+	var selector labels.Selector
+	if p.ExcludeLabelSelector != "" {
+		var err error
+		selector, err = labels.Parse(p.ExcludeLabelSelector)
+		if err != nil {
+			return err
+		}
+	}
 	// Even if the Suffix is empty we want to proceed with the
 	// transformation. This allows to add contextual information
 	// to the resources (AddNameSuffix).
 	for _, r := range m.Resources() {
 		// TODO: move this test into the filter (i.e. make a better filter)
 		if p.shouldSkip(r.OrgId()) {
+			continue
+		}
+		if selector != nil && selector.Matches(labels.Set(r.GetLabels())) {
 			continue
 		}
 		id := r.OrgId()


### PR DESCRIPTION
Fixes #6054.

Adds an `excludeLabelSelector` field to both the `PrefixTransformer` and `SuffixTransformer` built-in plugins. Resources matching the provided label selector will be entirely skipped during the prefix/suffix transformation, allowing for finer-grained control over naming updates (e.g. for global or shared resources that should retain their original names).