### PR TITLE
docs: replace deprecated commonLabels in examples

### DIFF
--- a/examples/breakfast.md
+++ b/examples/breakfast.md
@@ -69,8 +69,10 @@ likes her coffee hot:
 mkdir -p $DEMO_HOME/breakfast/overlays/alice
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/alice/kustomization.yaml
-commonLabels:
-  who: alice
+labels:
+- includeSelectors: true
+  pairs:
+    who: alice
 resources:
 - ../../base
 patches:
@@ -92,8 +94,10 @@ And likewise a [variant] for Bob, who wants _five_ pancakes, with strawberries:
 mkdir -p $DEMO_HOME/breakfast/overlays/bob
 
 cat <<EOF >$DEMO_HOME/breakfast/overlays/bob/kustomization.yaml
-commonLabels:
-  who: bob
+labels:
+- includeSelectors: true
+  pairs:
+    who: bob
 resources:
 - ../../base
 patches:

--- a/examples/helloWorld/README.md
+++ b/examples/helloWorld/README.md
@@ -143,9 +143,11 @@ defining a new name prefix, and some different labels.
 ```
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:
@@ -184,9 +186,11 @@ with a different name prefix and labels.
 ```
 cat <<EOF >$OVERLAYS/production/kustomization.yaml
 namePrefix: production-
-commonLabels:
-  variant: production
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: production
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am production!
 resources:

--- a/examples/helloWorld/kustomization.yaml
+++ b/examples/helloWorld/kustomization.yaml
@@ -5,8 +5,10 @@ metadata:
 
 # Example configuration for the webserver
 # at https://github.com/monopole/hello
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 
 resources:
 - deployment.yaml


### PR DESCRIPTION
`commonLabels` warns to use `labels` instead. The helloWorld base and demo overlays (and the breakfast tutorial) still used the old field, so following them always trips that deprecation.

Switched those examples to `labels` with `includeSelectors: true`, which matches the old commonLabels behavior.

Fixes #5653