### PR TITLE
docs: link kustomize.io from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ and it's like [`sed`], in that it emits edited text.
 
 This tool is sponsored by [sig-cli] ([KEP]).
 
+Project site: https://kustomize.io/
+
  - [Installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/)
  - [General documentation](https://kubectl.docs.kubernetes.io/references/kustomize/)
  - [Examples](examples)


### PR DESCRIPTION
README didn't surface the project site. One line so people landing on GitHub can get to https://kustomize.io/ without hunting.

Fixes #5654