### PR TITLE
docs: migrate more examples off deprecated commonLabels

### DIFF
--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -129,8 +129,10 @@ Now, create `kustomization.yaml` add all your resources.
 <!-- @createKustomizationYaml @testE2EAgainstLatestRelease-->
 ```
 cat <<EOF >$BASE/kustomization.yaml
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 
 resources:
 - deployment.yaml

--- a/examples/configGeneration.md
+++ b/examples/configGeneration.md
@@ -41,8 +41,10 @@ curl -s -o "$BASE/#1.yaml" "https://raw.githubusercontent.com\
 /{deployment,service}.yaml"
 
 cat <<'EOF' >$BASE/kustomization.yaml
-commonLabels:
-  app: hello
+labels:
+- includeSelectors: true
+  pairs:
+    app: hello
 resources:
 - deployment.yaml
 - service.yaml
@@ -65,9 +67,11 @@ mkdir -p $OVERLAYS/staging
 cat <<'EOF' >$OVERLAYS/staging/kustomization.yaml
 namePrefix: staging-
 nameSuffix: -v1
-commonLabels:
-  variant: staging
-  org: acmeCorporation
+labels:
+- includeSelectors: true
+  pairs:
+    variant: staging
+    org: acmeCorporation
 commonAnnotations:
   note: Hello, I am staging!
 resources:

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -183,8 +183,10 @@ add a label, but one can always edit
 <!-- @customizeLabels @testAgainstLatestRelease -->
 ```
 cat <<EOF >>$DEMO_HOME/kustomization.yaml
-commonLabels:
-  env: prod
+labels:
+- includeSelectors: true
+  pairs:
+    env: prod
 EOF
 ```
 


### PR DESCRIPTION
Follow-up to the helloWorld/breakfast cleanup. springboot, configGeneration, and the alphaTestExamples helloapp demos still used `commonLabels` and trip the deprecation warning.

Switched those to `labels` with `includeSelectors: true`.