### PR TITLE
fix: support integer keys when marshaling resources to JSON

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -9,6 +9,31 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
+func TestIntegerKey(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- cm.yaml
+`)
+	th.WriteF("cm.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data:
+  123: abc
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+data:
+  "123": abc
+kind: ConfigMap
+metadata:
+  name: cm
+`)
+}
+
 // Numbers and booleans are quoted
 func TestGeneratorIntVsStringNoMerge(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)

--- a/api/krusty/duplicatekeys_test.go
+++ b/api/krusty/duplicatekeys_test.go
@@ -43,5 +43,5 @@ spec:
 	m := th.Run(".", th.MakeDefaultOptions())
 	_, err := m.AsYaml()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "mapping key \"env\" already defined")
+	assert.Contains(t, err.Error(), "key \"env\" already set in map")
 }

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/sliceutil"
 	"sigs.k8s.io/kustomize/kyaml/utils"
 	"sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/labels"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 // MakeNullNode returns an RNode that represents an empty document.
@@ -983,20 +984,11 @@ func (rn *RNode) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	if yNode.Kind == SequenceNode {
-		var a []interface{}
-		if err := Unmarshal([]byte(s), &a); err != nil {
-			return nil, err
-		}
-		return json.Marshal(a)
+	b, err := k8syaml.YAMLToJSONStrict([]byte(s))
+	if err != nil {
+		return nil, errors.Wrap(err)
 	}
-
-	m := map[string]interface{}{}
-	if err := Unmarshal([]byte(s), &m); err != nil {
-		return nil, err
-	}
-
-	return json.Marshal(m)
+	return b, nil
 }
 
 // UnmarshalJSON overwrites this RNode with data from []byte.


### PR DESCRIPTION
**What this PR does / why we need it**:

`RNode.MarshalJSON` currently decodes YAML into Go maps before marshaling JSON. YAML mappings with integer keys become `map[interface{}]interface{}`, which `encoding/json` cannot marshal.

This uses `YAMLToJSONStrict` for the conversion instead. Integer-looking mapping keys are preserved as JSON object keys, and duplicate YAML keys remain validation errors.

Fixes #3446

**Testing**:

- `go test ./yaml -count=1` from `kyaml`
- `go test ./krusty -run 'Test(IntegerKey|DuplicateKeys)$' -count=1` from `api`

/kind bug
