### PR TITLE
fix: support legacy release downloads

### DIFF
--- a/.github/workflows/test-install-kustomize.yml
+++ b/.github/workflows/test-install-kustomize.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  expected_kustomize_version: v5.8.1
-
 jobs:
   test-install-kustomize:
     name: Test install_kustomize.sh (${{ matrix.release-file }})
@@ -25,9 +22,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release-file:
-          - hack/test-files/minimized-release.json
-          - hack/test-files/unminimized-release.json
+        include:
+          - release-file: hack/test-files/minimized-release.json
+            expected-version: v5.8.1
+          - release-file: hack/test-files/unminimized-release.json
+            expected-version: v5.8.1
+          - release-file: hack/test-files/legacy-release.json
+            requested-version: 2.0.3
+            expected-version: KustomizeVersion:2.0.3
 
     steps:
       - name: Check out code
@@ -39,12 +41,17 @@ jobs:
           set -euo pipefail
           tmp_dir="$(mktemp -d)"
 
-          ./hack/install_kustomize.sh "$tmp_dir"
+          if [ -n "${requested_kustomize_version}" ]; then
+            ./hack/install_kustomize.sh "${requested_kustomize_version}" "$tmp_dir"
+          else
+            ./hack/install_kustomize.sh "$tmp_dir"
+          fi
 
           actual_kustomize_version=$("$tmp_dir/kustomize" version)
 
           echo "Kustomize version: ${actual_kustomize_version}"
-          [ "${actual_kustomize_version}" = "${expected_kustomize_version}" ] || (echo "Unexpected Kustomize version: Expected ${expected_kustomize_version}, got ${actual_kustomize_version}" && exit 1)
+          [[ "${actual_kustomize_version}" == *"${expected_kustomize_version}"* ]] || (echo "Unexpected Kustomize version: Expected ${expected_kustomize_version}, got ${actual_kustomize_version}" && exit 1)
         env:
-          expected_kustomize_version: ${{ env.expected_kustomize_version }}
+          requested_kustomize_version: ${{ matrix.requested-version }}
+          expected_kustomize_version: ${{ matrix.expected-version }}
           releases_file: ${{ github.workspace }}/${{ matrix.release-file }}

--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -28,11 +28,33 @@ unset CDPATH
 
 where=$PWD
 
+function is_legacy_release {
+  local requested=$1
+  # Kustomize releases published before the kustomize/ tag prefix was introduced.
+  local unprefixed_tags=(
+    v1.0.0 v1.0.1 v1.0.2 v1.0.3 v1.0.4 v1.0.5 v1.0.6 v1.0.7 v1.0.8 v1.0.9 v1.0.10 v1.0.11
+    v2.0.0 v2.0.1 v2.0.2 v2.0.3 v2.1.0
+    v3.0.0 v3.0.1 v3.0.2 v3.0.3 v3.1.0 v3.2.0
+  )
+
+  local tag
+  for tag in "${unprefixed_tags[@]}"; do
+    if [[ "$tag" == "$requested" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 release_url=https://api.github.com/repos/kubernetes-sigs/kustomize/releases
 if [ -n "$1" ]; then
   if [[ "$1" =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
     version=v$1
-    release_url=${release_url}/tags/kustomize%2F$version
+    if is_legacy_release "$version"; then
+      release_url=${release_url}/tags/$version
+    else
+      release_url=${release_url}/tags/kustomize%2F$version
+    fi
   elif [ -n "$2" ]; then
     echo "The first argument should be the requested version."
     exit 1
@@ -171,9 +193,15 @@ if [[ -z "$RELEASE_URL" ]]; then
   exit 1
 fi
 
-curl -sLO "$RELEASE_URL"
+download_file="${RELEASE_URL##*/}"
+curl -sL "$RELEASE_URL" -o "$download_file"
 
-tar xzf ./kustomize_v*_${opsys}_${arch}.tar.gz
+if [[ "$download_file" == *.tar.gz ]]; then
+  tar xzf "$download_file"
+else
+  mv "$download_file" kustomize
+  chmod +x kustomize
+fi
 
 cp ./kustomize "$where"
 

--- a/hack/test-files/legacy-release.json
+++ b/hack/test-files/legacy-release.json
@@ -1,0 +1,7 @@
+{
+  "assets": [
+    {
+      "browser_download_url": "https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64"
+    }
+  ]
+}


### PR DESCRIPTION
Addresses #4130

## What

- route the finite set of pre-module releases to their original unprefixed tags
- install their raw executable assets instead of treating them as tar archives
- add v2.0.3 to the existing mocked-release workflow matrix

## Why

`install_kustomize.sh 2.0.3` currently queries `kustomize/v2.0.3`, even though that release is tagged `v2.0.3`. Its Linux asset is also a raw executable, while the current installer assumes every matching asset is a `.tar.gz` archive.

This follows the finite-tag approach suggested in the review of #4131 and keeps the existing module-era archive path unchanged.

## Verification

- regression fixture fails before the fix when the script tries to extract the raw v2.0.3 asset
- mocked legacy, minimized, and unminimized release payloads install executable binaries
- real v2.0.3, v3.3.0, and v5.8.1 releases install and report the requested versions on Linux
- nonexistent version, missing destination, and existing destination paths still exit 1
- `bash -n hack/install_kustomize.sh`
- `actionlint .github/workflows/test-install-kustomize.yml`
- `go build .` and `go test ./...` in `kustomize/` with Go 1.26.5 on Linux

`make lint` was attempted with the repository-pinned golangci-lint v1.64.8, but package loading timed out in the first `api` module under the local WSL environment. It produced no finding in the changed files; the full repository lint remains to CI.

## AI assistance disclosure

OpenAI Codex assisted with issue research, implementation, and test execution. The contributor remains responsible for the submitted changes. In accordance with the Kubernetes contribution policy, review comments will be answered personally without AI assistance.
