### PR TITLE
fix: stop duplicating block-scalar lines that look like comments

### DIFF
--- a/kustomize/commands/internal/kustfile/kustomizationfile.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile.go
@@ -194,9 +194,22 @@ func (mf *kustomizationFile) Write(kustomization *types.Kustomization) error {
 func (mf *kustomizationFile) parseCommentedFields(content []byte) error {
 	buffer := bytes.NewBuffer(content)
 	var comments [][]byte
+	inBlockScalar := false
+	blockScalarIndent := 0
 
 	line, err := buffer.ReadBytes('\n')
 	for err == nil {
+		if inBlockScalar && !isBlankLine(line) {
+			if lineIndent(line) > blockScalarIndent {
+				// This line is literal content of the block scalar (e.g. a line
+				// beginning with '#' that is not actually a YAML comment), so it
+				// must not be mistaken for a comment or a field declaration.
+				line, err = buffer.ReadBytes('\n')
+				continue
+			}
+			inBlockScalar = false
+		}
+
 		if isCommentOrBlankLine(line) {
 			comments = append(comments, line)
 		} else {
@@ -208,6 +221,10 @@ func (mf *kustomizationFile) parseCommentedFields(content []byte) error {
 				mf.originalFields[len(mf.originalFields)-1].appendComment(squash(comments))
 				comments = [][]byte{}
 			}
+			if isBlockScalarStart(line) {
+				inBlockScalar = true
+				blockScalarIndent = lineIndent(line)
+			}
 		}
 		line, err = buffer.ReadBytes('\n')
 	}
@@ -216,6 +233,30 @@ func (mf *kustomizationFile) parseCommentedFields(content []byte) error {
 		return err
 	}
 	return nil
+}
+
+// lineIndent returns the number of leading space characters in line.
+func lineIndent(line []byte) int {
+	return len(line) - len(bytes.TrimLeft(line, " "))
+}
+
+// isBlankLine mirrors the blank-line half of isCommentOrBlankLine, so the two
+// stay consistent about what counts as blank.
+func isBlankLine(line []byte) bool {
+	return len(bytes.TrimRight(bytes.TrimLeft(line, " "), "\n")) == 0
+}
+
+// blockScalarHeader matches a YAML block scalar header at the end of a line,
+// e.g. "|", "|-", ">+", "|2", ">-2" or "|2-" (the chomping and explicit
+// indentation indicators may appear in either order).
+var blockScalarHeader = regexp.MustCompile(`[|>][+-]?[1-9]?[+-]?$`)
+
+// isBlockScalarStart returns true if line ends with a YAML block scalar
+// header, meaning the following more-indented lines are literal scalar
+// content rather than kustomization fields or comments.
+func isBlockScalarStart(line []byte) bool {
+	trimmed := bytes.TrimRight(line, " \t\r\n")
+	return blockScalarHeader.Match(trimmed)
 }
 
 // marshal converts a kustomization to a byte stream.

--- a/kustomize/commands/internal/kustfile/kustomizationfile_test.go
+++ b/kustomize/commands/internal/kustfile/kustomizationfile_test.go
@@ -4,6 +4,7 @@
 package kustfile
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
@@ -334,6 +335,57 @@ patchesStrategicMerge:
 
 	if diff := cmp.Diff(kustomizationContentWithComments, bytes); diff != "" {
 		t.Errorf("Mismatch (-expected, +actual):\n%s", diff)
+	}
+}
+
+// TestPreserveBlockScalarCommentLikeContent guards against
+// https://github.com/kubernetes-sigs/kustomize/issues/6225: lines beginning
+// with '#' inside a literal block scalar are scalar content, not YAML
+// comments, and must not be duplicated into the following field on write.
+func TestPreserveBlockScalarCommentLikeContent(t *testing.T) {
+	kustomizationContentWithBlockScalar := []byte(
+		`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+transformers:
+- |-
+  apiVersion: widgets.example.com/v1
+  kind: ExampleTransformer
+  metadata:
+    name: example-transformer
+  # this looks like a comment but is literal block scalar content
+  # and must not be duplicated when other fields are rewritten
+
+images:
+- name: example-service
+  newTag: example-old
+`)
+	fSys := filesys.MakeFsInMemory()
+	testutils_test.WriteTestKustomizationWith(fSys, kustomizationContentWithBlockScalar)
+
+	// Simulate repeated `kustomize edit set image` invocations: each one
+	// opens and re-parses the file from scratch, like RunSetImage does.
+	var mf *kustomizationFile
+	for i := 0; i < 3; i++ {
+		var err error
+		mf, err = NewKustomizationFile(fSys)
+		if err != nil {
+			t.Fatalf("Unexpected Error: %v", err)
+		}
+		kustomization, err := mf.Read()
+		if err != nil {
+			t.Fatalf("Unexpected Error: %v", err)
+		}
+		kustomization.Images[0].NewTag = fmt.Sprintf("example-new-%d", i)
+		if err = mf.Write(kustomization); err != nil {
+			t.Fatalf("Unexpected Error: %v", err)
+		}
+	}
+
+	bytes, _ := fSys.ReadFile(mf.path)
+	got := strings.Count(string(bytes), "this looks like a comment")
+	if got != 1 {
+		t.Errorf("expected block scalar comment-like line to appear exactly once, got %d\ncontent:\n%s", got, string(bytes))
 	}
 }
 


### PR DESCRIPTION
Motivation:
kustomize/commands/internal/kustfile/kustomizationfile.go preserves
comments across `kustomize edit` calls with a hand-written, line-based
scan (parseCommentedFields) rather than a YAML-aware parser. It treats
any line that, after trimming leading spaces, starts with '#' as a
comment to reattach to the next recognized top-level field. That
heuristic doesn't know about YAML block scalars: when a field's value
is a literal/folded block scalar (e.g. `transformers: |-`) and its
content happens to contain lines starting with '#' at the scalar's
indentation, those lines are literal string content, not comments.
They already appear once in the correctly marshaled scalar value, but
the parser also mis-captures them as a "comment" and reattaches that
copy ahead of the next field, duplicating them. Because the duplicate
copy is itself re-captured as a "comment" on the next parse, repeated
`kustomize edit set image` invocations double the duplicated lines
each time (1 -> 2 -> 4 -> 8 -> 16 ...), growing the file without
bound.

Approach:
Track block-scalar state while scanning: when a line ends with a block
scalar header (|, |-, |+, >, >-, >+, and their explicit-indentation
variants like |2 or |-2), remember that line's indentation. While
inside the block, any non-blank line indented more than the header
line is treated as opaque scalar content and bypasses the
comment/field-match logic entirely, so '#'-prefixed content lines are
no longer mistaken for comments. The block ends at the first non-blank
line whose indentation drops to the header's level or below, matching
how YAML determines block scalar extent. Blank-line handling is
otherwise unchanged.

Known limitation, disclosed rather than fixed here: a block scalar
containing a genuinely blank interior line can still cause the number
of blank lines before the next field to grow by one on each repeated
write. This is a distinct, pre-existing bug (confirmed present with
this change reverted too, growing at the same linear rate) about
blank-line accounting, not the exponential content-duplication bug
reported in the issue below. Fixing it would require a larger rework
of this file's ad hoc comment-preservation model, so it's left out of
scope for this minimal fix.

Validation:
- go test ./commands/internal/kustfile/... -run TestPreserve -v
  (in the kustomize module): passes, including a new regression test,
  TestPreserveBlockScalarCommentLikeContent, which performs 3 simulated
  `kustomize edit set image` invocations (fresh NewKustomizationFile /
  Read / Write per iteration, matching RunSetImage's real usage) against
  a kustomization.yaml with a '#'-prefixed line inside a transformers
  block scalar, and asserts the line appears exactly once afterward.
  Confirmed this test fails (line duplicated) on the pre-fix code and
  passes after the fix.
- go build ./... and go test ./... in the kustomize module: all pass.
- Built the kustomize binary and reran the exact reproduction from the
  issue (transformers block scalar with two '#'-prefixed marker lines,
  4 repeated `kustomize edit set image` calls): marker count stays at 1
  throughout, versus exponential 1/2/4/8/16 before the fix.
- gofmt -l and go vet ./commands/internal/kustfile/...: clean.
- make lint (this module's golangci-lint target, matching this repo's
  CI Lint job for the kustomize module): exits 0 with no findings
  against the changed files.

Report: https://github.com/kubernetes-sigs/kustomize/issues/6225
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #6225

```release-note
fix: stop duplicating block-scalar lines that look like comments
```