### PR TITLE
feat: add rooted io/fs adapter

### DIFF
--- a/kyaml/filesys/rootedfs.go
+++ b/kyaml/filesys/rootedfs.go
@@ -1,0 +1,311 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filesys
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"sync"
+	"syscall"
+)
+
+// RootedFS exposes a FileSystem subtree using the standard io/fs interfaces.
+// Call Close when the RootedFS is no longer needed.
+type RootedFS struct {
+	fsys      fs.FS
+	close     func() error
+	closeOnce sync.Once
+	closeErr  error
+}
+
+var (
+	_ fs.FS         = (*RootedFS)(nil)
+	_ fs.ReadFileFS = (*RootedFS)(nil)
+	_ fs.ReadDirFS  = (*RootedFS)(nil)
+	_ fs.StatFS     = (*RootedFS)(nil)
+	_ fs.SubFS      = (*RootedFS)(nil)
+)
+
+// NewRootedFS returns an io/fs view of fSys rooted at root.
+//
+// When fSys is the on-disk filesystem returned by MakeFsOnDisk, the view is
+// backed by os.Root so that operations cannot escape root through relative
+// paths or symbolic links. Other FileSystem implementations are adapted to
+// the same relative, slash-separated path convention used by io/fs.
+func NewRootedFS(fSys FileSystem, root string) (*RootedFS, error) {
+	confirmedRoot, err := ConfirmDir(fSys, root)
+	if err != nil {
+		return nil, err
+	}
+
+	if isOnDiskFileSystem(fSys) {
+		osRoot, err := os.OpenRoot(confirmedRoot.String())
+		if err != nil {
+			return nil, err //nolint:wrapcheck // Preserve os.OpenRoot's PathError.
+		}
+		return &RootedFS{
+			fsys:  osRoot.FS(),
+			close: osRoot.Close,
+		}, nil
+	}
+
+	return &RootedFS{
+		fsys: &fileSystemFS{
+			fsys: fSys,
+			root: confirmedRoot,
+		},
+		close: func() error { return nil },
+	}, nil
+}
+
+func isOnDiskFileSystem(fSys FileSystem) bool {
+	switch typed := fSys.(type) {
+	case fsOnDisk, *fsOnDisk:
+		return true
+	case FileSystemOrOnDisk:
+		return typed.FileSystem == nil || isOnDiskFileSystem(typed.FileSystem)
+	case *FileSystemOrOnDisk:
+		return typed.FileSystem == nil || isOnDiskFileSystem(typed.FileSystem)
+	default:
+		return false
+	}
+}
+
+// Open implements fs.FS.
+func (r *RootedFS) Open(name string) (fs.File, error) {
+	return r.fsys.Open(name) //nolint:wrapcheck // Preserve the io/fs PathError contract.
+}
+
+// ReadFile implements fs.ReadFileFS.
+func (r *RootedFS) ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(r.fsys, name) //nolint:wrapcheck // Preserve the io/fs PathError contract.
+}
+
+// ReadDir implements fs.ReadDirFS.
+func (r *RootedFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return fs.ReadDir(r.fsys, name) //nolint:wrapcheck // Preserve the io/fs PathError contract.
+}
+
+// Stat implements fs.StatFS.
+func (r *RootedFS) Stat(name string) (fs.FileInfo, error) {
+	return fs.Stat(r.fsys, name) //nolint:wrapcheck // Preserve the io/fs PathError contract.
+}
+
+// Sub implements fs.SubFS. The returned filesystem remains valid until the
+// parent RootedFS is closed.
+func (r *RootedFS) Sub(dir string) (fs.FS, error) {
+	return fs.Sub(r.fsys, dir) //nolint:wrapcheck // Preserve the io/fs PathError contract.
+}
+
+// Close releases resources held by the rooted filesystem.
+func (r *RootedFS) Close() error {
+	r.closeOnce.Do(func() {
+		r.closeErr = r.close()
+	})
+	return r.closeErr
+}
+
+type fileSystemFS struct {
+	fsys FileSystem
+	root ConfirmedDir
+}
+
+func (f *fileSystemFS) Open(name string) (fs.File, error) {
+	mapped, err := f.mappedPath("open", name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := f.fsys.Open(mapped)
+	if err != nil {
+		return nil, newPathError("open", name, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, newPathError("open", name, err)
+	}
+	if info.IsDir() {
+		if err := file.Close(); err != nil {
+			return nil, newPathError("open", name, err)
+		}
+		return &fileSystemFile{
+			fsys: f,
+			name: name,
+			info: normalizeFileInfo(info),
+		}, nil
+	}
+	return &fileSystemFile{
+		File: file,
+		fsys: f,
+		name: name,
+	}, nil
+}
+
+func (f *fileSystemFS) ReadFile(name string) ([]byte, error) {
+	mapped, err := f.mappedPath("readfile", name)
+	if err != nil {
+		return nil, err
+	}
+	content, err := f.fsys.ReadFile(mapped)
+	if err != nil {
+		return nil, newPathError("readfile", name, err)
+	}
+	return content, nil
+}
+
+func (f *fileSystemFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	mapped, err := f.mappedPath("readdir", name)
+	if err != nil {
+		return nil, err
+	}
+	names, err := f.fsys.ReadDir(mapped)
+	if err != nil {
+		return nil, newPathError("readdir", name, err)
+	}
+	sort.Strings(names)
+
+	entries := make([]fs.DirEntry, 0, len(names))
+	for _, childName := range names {
+		child, err := f.fsys.Open(filepath.Join(mapped, childName))
+		if err != nil {
+			return nil, newPathError("readdir", path.Join(name, childName), err)
+		}
+		info, statErr := child.Stat()
+		closeErr := child.Close()
+		if statErr != nil {
+			return nil, newPathError("readdir", path.Join(name, childName), statErr)
+		}
+		if closeErr != nil {
+			return nil, newPathError("readdir", path.Join(name, childName), closeErr)
+		}
+		entries = append(entries, fs.FileInfoToDirEntry(normalizeFileInfo(info)))
+	}
+	return entries, nil
+}
+
+func (f *fileSystemFS) Stat(name string) (fs.FileInfo, error) {
+	file, err := f.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, newPathError("stat", name, err)
+	}
+	return info, nil
+}
+
+func (f *fileSystemFS) mappedPath(op, name string) (string, error) {
+	if !fs.ValidPath(name) {
+		return "", newPathError(op, name, fs.ErrInvalid)
+	}
+	localName, err := filepath.Localize(name)
+	if err != nil {
+		return "", newPathError(op, name, fs.ErrInvalid)
+	}
+	return f.root.Join(localName), nil
+}
+
+func newPathError(op, name string, err error) error {
+	return &fs.PathError{Op: op, Path: name, Err: err}
+}
+
+type fileSystemFile struct {
+	File
+	fsys *fileSystemFS
+	name string
+	info fs.FileInfo
+
+	closed bool
+
+	readDirMu     sync.Mutex
+	dirEntries    []fs.DirEntry
+	dirEntriesSet bool
+	dirOffset     int
+}
+
+var _ fs.ReadDirFile = (*fileSystemFile)(nil)
+
+func (f *fileSystemFile) Read(p []byte) (int, error) {
+	if f.File != nil {
+		return f.File.Read(p) //nolint:wrapcheck // Preserve io.Reader errors, including io.EOF.
+	}
+	if f.closed {
+		return 0, newPathError("read", f.name, os.ErrClosed)
+	}
+	return 0, newPathError("read", f.name, syscall.EISDIR)
+}
+
+func (f *fileSystemFile) Close() error {
+	if f.File != nil {
+		return f.File.Close() //nolint:wrapcheck // Preserve the adapted file's close error.
+	}
+	f.closed = true
+	return nil
+}
+
+func (f *fileSystemFile) Stat() (fs.FileInfo, error) {
+	if f.info != nil {
+		return f.info, nil
+	}
+	info, err := f.File.Stat()
+	if err != nil {
+		return nil, newPathError("stat", f.name, err)
+	}
+	return normalizeFileInfo(info), nil
+}
+
+// ReadDir implements fs.ReadDirFile.
+func (f *fileSystemFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	f.readDirMu.Lock()
+	defer f.readDirMu.Unlock()
+
+	if !f.dirEntriesSet {
+		entries, err := f.fsys.ReadDir(f.name)
+		if err != nil {
+			return nil, err
+		}
+		f.dirEntries = entries
+		f.dirEntriesSet = true
+	}
+
+	if n <= 0 {
+		entries := f.dirEntries[f.dirOffset:]
+		f.dirOffset = len(f.dirEntries)
+		return entries, nil
+	}
+	if f.dirOffset >= len(f.dirEntries) {
+		return nil, io.EOF
+	}
+
+	end := min(f.dirOffset+n, len(f.dirEntries))
+	entries := f.dirEntries[f.dirOffset:end]
+	f.dirOffset = end
+	return entries, nil
+}
+
+type normalizedFileInfo struct {
+	fs.FileInfo
+}
+
+func (i normalizedFileInfo) Mode() fs.FileMode {
+	mode := i.FileInfo.Mode()
+	if i.IsDir() {
+		mode |= fs.ModeDir
+	}
+	return mode
+}
+
+func normalizeFileInfo(info fs.FileInfo) fs.FileInfo {
+	if info.IsDir() && info.Mode()&fs.ModeDir == 0 {
+		return normalizedFileInfo{FileInfo: info}
+	}
+	return info
+}

--- a/kyaml/filesys/rootedfs.go
+++ b/kyaml/filesys/rootedfs.go
@@ -140,7 +140,7 @@ func (f *fileSystemFS) Open(name string) (fs.File, error) {
 		}, nil
 	}
 	return &fileSystemFile{
-		File: file,
+		file: file,
 		fsys: f,
 		name: name,
 	}, nil
@@ -218,7 +218,7 @@ func newPathError(op, name string, err error) error {
 }
 
 type fileSystemFile struct {
-	File
+	file fs.File
 	fsys *fileSystemFS
 	name string
 	info fs.FileInfo
@@ -234,8 +234,8 @@ type fileSystemFile struct {
 var _ fs.ReadDirFile = (*fileSystemFile)(nil)
 
 func (f *fileSystemFile) Read(p []byte) (int, error) {
-	if f.File != nil {
-		return f.File.Read(p) //nolint:wrapcheck // Preserve io.Reader errors, including io.EOF.
+	if f.file != nil {
+		return f.file.Read(p) //nolint:wrapcheck // Preserve io.Reader errors, including io.EOF.
 	}
 	if f.closed {
 		return 0, newPathError("read", f.name, os.ErrClosed)
@@ -244,8 +244,8 @@ func (f *fileSystemFile) Read(p []byte) (int, error) {
 }
 
 func (f *fileSystemFile) Close() error {
-	if f.File != nil {
-		return f.File.Close() //nolint:wrapcheck // Preserve the adapted file's close error.
+	if f.file != nil {
+		return f.file.Close() //nolint:wrapcheck // Preserve the adapted file's close error.
 	}
 	f.closed = true
 	return nil
@@ -255,7 +255,7 @@ func (f *fileSystemFile) Stat() (fs.FileInfo, error) {
 	if f.info != nil {
 		return f.info, nil
 	}
-	info, err := f.File.Stat()
+	info, err := f.file.Stat()
 	if err != nil {
 		return nil, newPathError("stat", f.name, err)
 	}

--- a/kyaml/filesys/rootedfs_test.go
+++ b/kyaml/filesys/rootedfs_test.go
@@ -4,9 +4,11 @@
 package filesys
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -31,6 +33,9 @@ func TestRootedFS(t *testing.T) {
 			fSys, root := setup(t)
 			require.NoError(t, fSys.MkdirAll(filepath.Join(root, "nested")))
 			require.NoError(t, fSys.WriteFile(filepath.Join(root, "nested", "file.yaml"), []byte("content")))
+			if isOnDiskFileSystem(fSys) {
+				forceMetadataUpdateOnWindows(t, root)
+			}
 
 			rooted, err := NewRootedFS(fSys, root)
 			require.NoError(t, err)
@@ -64,6 +69,37 @@ func TestRootedFS(t *testing.T) {
 			require.NoError(t, rooted.Close())
 		})
 	}
+}
+
+func forceMetadataUpdateOnWindows(t *testing.T, root string) {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return
+	}
+
+	// Directory enumeration and Stat can temporarily observe different MFT metadata.
+	// Rewriting the current timestamp synchronizes them before fstest.TestFS compares them.
+	// See https://go.dev/issue/42637.
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("failed to walk %q: %w", path, err)
+		}
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("failed to get directory entry info for %q: %w", path, err)
+		}
+		statInfo, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("failed to stat %q: %w", path, err)
+		}
+		if entryInfo.ModTime() == statInfo.ModTime() {
+			return nil
+		}
+		if err := os.Chtimes(path, statInfo.ModTime(), statInfo.ModTime()); err != nil {
+			return fmt.Errorf("failed to synchronize metadata for %q: %w", path, err)
+		}
+		return nil
+	}))
 }
 
 func TestRootedFSOnDiskRejectsSymlinkEscape(t *testing.T) {

--- a/kyaml/filesys/rootedfs_test.go
+++ b/kyaml/filesys/rootedfs_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filesys
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootedFS(t *testing.T) {
+	for name, setup := range map[string]func(*testing.T) (FileSystem, string){
+		"memory": func(t *testing.T) (FileSystem, string) {
+			t.Helper()
+			fSys := MakeFsInMemory()
+			root := filepath.Join(Separator, "root")
+			require.NoError(t, fSys.MkdirAll(root))
+			return fSys, root
+		},
+		"disk": func(t *testing.T) (FileSystem, string) {
+			t.Helper()
+			return MakeFsOnDisk(), t.TempDir()
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fSys, root := setup(t)
+			require.NoError(t, fSys.MkdirAll(filepath.Join(root, "nested")))
+			require.NoError(t, fSys.WriteFile(filepath.Join(root, "nested", "file.yaml"), []byte("content")))
+
+			rooted, err := NewRootedFS(fSys, root)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, rooted.Close())
+			})
+
+			require.NoError(t, fstest.TestFS(rooted, "nested/file.yaml"))
+			content, err := fs.ReadFile(rooted, "nested/file.yaml")
+			require.NoError(t, err)
+			require.Equal(t, "content", string(content))
+
+			entries, err := fs.ReadDir(rooted, ".")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			require.Equal(t, "nested", entries[0].Name())
+			require.True(t, entries[0].IsDir())
+
+			info, err := fs.Stat(rooted, "nested/file.yaml")
+			require.NoError(t, err)
+			require.Equal(t, int64(len("content")), info.Size())
+
+			sub, err := fs.Sub(rooted, "nested")
+			require.NoError(t, err)
+			content, err = fs.ReadFile(sub, "file.yaml")
+			require.NoError(t, err)
+			require.Equal(t, "content", string(content))
+
+			_, err = rooted.Open("../file.yaml")
+			require.ErrorIs(t, err, fs.ErrInvalid)
+			require.NoError(t, rooted.Close())
+		})
+	}
+}
+
+func TestRootedFSOnDiskRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "inside.yaml")
+	outside := filepath.Join(t.TempDir(), "outside.yaml")
+	require.NoError(t, os.WriteFile(inside, []byte("inside"), 0o600))
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o600))
+
+	rooted, err := NewRootedFS(MakeFsOnDisk(), root)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rooted.Close())
+	})
+
+	insideLink := filepath.Join(root, "inside-link.yaml")
+	if err := os.Symlink(filepath.Base(inside), insideLink); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	content, err := fs.ReadFile(rooted, filepath.Base(insideLink))
+	require.NoError(t, err)
+	require.Equal(t, "inside", string(content))
+
+	escapeLink := filepath.Join(root, "escape-link.yaml")
+	require.NoError(t, os.Symlink(outside, escapeLink))
+	_, err = fs.ReadFile(rooted, filepath.Base(escapeLink))
+	require.Error(t, err)
+}
+
+func TestNewRootedFSRequiresDirectory(t *testing.T) {
+	fSys := MakeFsInMemory()
+	require.NoError(t, fSys.WriteFile("file.yaml", []byte("content")))
+
+	_, err := NewRootedFS(fSys, "file.yaml")
+	require.Error(t, err)
+}

--- a/kyaml/filesys/rootedfs_test.go
+++ b/kyaml/filesys/rootedfs_test.go
@@ -5,6 +5,7 @@ package filesys
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -67,6 +68,26 @@ func TestRootedFS(t *testing.T) {
 			_, err = rooted.Open("../file.yaml")
 			require.ErrorIs(t, err, fs.ErrInvalid)
 			require.NoError(t, rooted.Close())
+		})
+	}
+}
+
+func TestRootedFSMemoryFilesDoNotExposeWriter(t *testing.T) {
+	fSys := MakeFsInMemory()
+	root := filepath.Join(Separator, "root")
+	require.NoError(t, fSys.MkdirAll(root))
+	require.NoError(t, fSys.WriteFile(filepath.Join(root, "file.yaml"), []byte("content")))
+	rooted, err := NewRootedFS(fSys, root)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rooted.Close()) })
+
+	for _, name := range []string{"file.yaml", "."} {
+		t.Run(name, func(t *testing.T) {
+			file, err := rooted.Open(name)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, file.Close()) })
+			_, writable := file.(io.Writer)
+			require.False(t, writable, "adapter must not expose io.Writer")
 		})
 	}
 }


### PR DESCRIPTION
Adds a `RootedFS` compatibility layer that exposes a rooted `kyaml/filesys.FileSystem` through the standard `io/fs` read interfaces. On-disk filesystems use `os.Root`; in-memory and other implementations use the same rooted relative-path contract through an adapter.

This keeps the existing public `FileSystem` API unchanged and provides a bounded migration path for #6220.

Tests cover `io/fs` conformance, in-memory and on-disk filesystems, sub-filesystems, invalid paths, and on-disk symlink containment.

Tests:
- `go test -race ./filesys`
- `go vet ./filesys`
- `go test ./...`
- repository lint, license, module-tidiness, and API compatibility checks