### PR TITLE
fix: preserve quoted string style when a var-reference field has no $(VAR)

### DIFF
--- a/api/filters/refvar/refvar.go
+++ b/api/filters/refvar/refvar.go
@@ -80,7 +80,7 @@ func (f Filter) setScalar(node *yaml.RNode) error {
 		return nil
 	}
 	v := DoReplacements(node.YNode().Value, f.MappingFunc)
-	updateNodeValue(node.YNode(), v)
+	setReplacedValue(node.YNode(), v)
 	return nil
 }
 
@@ -96,7 +96,7 @@ func (f Filter) setMap(node *yaml.RNode) error {
 			continue
 		}
 		newValue := DoReplacements(contents[i+1].Value, f.MappingFunc)
-		updateNodeValue(contents[i+1], newValue)
+		setReplacedValue(contents[i+1], newValue)
 	}
 	return nil
 }
@@ -107,7 +107,19 @@ func (f Filter) setSeq(node *yaml.RNode) error {
 			return fmt.Errorf("invalid value type expect a string")
 		}
 		newValue := DoReplacements(item.Value, f.MappingFunc)
-		updateNodeValue(item, newValue)
+		setReplacedValue(item, newValue)
 	}
 	return nil
+}
+
+// setReplacedValue updates the node with the result of a variable
+// replacement, unless no replacement actually happened (i.e. the value
+// contained no $(VAR) reference and was returned unchanged). In that case
+// the node is left untouched so its original style/tag (e.g. quoting that
+// disambiguates strings like "yes" or "no" from YAML 1.1 booleans) survives.
+func setReplacedValue(node *yaml.Node, newValue interface{}) {
+	if s, ok := newValue.(string); ok && s == node.Value {
+		return
+	}
+	updateNodeValue(node, newValue)
 }

--- a/api/filters/refvar/refvar_test.go
+++ b/api/filters/refvar/refvar_test.go
@@ -194,6 +194,38 @@ data:
 				FieldSpec: types.FieldSpec{Path: "data/slice2"},
 			},
 		},
+		"quoted string with no var reference is left untouched": {
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: SHOULD_BE_NO
+          value: "no"`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dep
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: SHOULD_BE_NO
+          value: "no"`,
+			filter: Filter{
+				MappingFunc: makeMf(map[string]interface{}{
+					"VAR": int64(5),
+				}),
+				FieldSpec: types.FieldSpec{Path: "spec/template/spec/containers/env/value"},
+			},
+		},
 		"null value": {
 			input: `
 apiVersion: apps/v1

--- a/api/krusty/variableref_test.go
+++ b/api/krusty/variableref_test.go
@@ -2274,3 +2274,72 @@ metadata:
   name: theConfigMap-hdd8h8cgdt
 `)
 }
+
+// TestVariableRefDoesNotClobberUnrelatedQuotedStrings ensures that declaring
+// vars, and running the var-reference filter over fields that don't actually
+// contain a $(VAR) reference, does not strip the quoting off of other
+// scalars in those same fields (e.g. env values "yes"/"no" that YAML 1.1
+// would otherwise interpret as booleans).
+func TestVariableRefDoesNotClobberUnrelatedQuotedStrings(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- resources.yaml
+generators:
+- configmaps.yaml
+vars:
+- name: VARIABLE
+  objref:
+    kind: ConfigMap
+    name: var-source
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.VARIABLE
+`)
+	th.WriteF("resources.yaml", `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-value-conversion
+spec:
+  containers:
+    - name: nginx-container
+      image: nginx:1.25
+      env:
+      - name: SHOULD_BE_NO
+        value: "no"
+      - name: SHOULD_BE_YES
+        value: "yes"
+`)
+	th.WriteF("configmaps.yaml", `
+apiVersion: builtin
+kind: ConfigMapGenerator
+metadata:
+  name: var-source
+literals:
+- VARIABLE=value
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-value-conversion
+spec:
+  containers:
+  - env:
+    - name: SHOULD_BE_NO
+      value: "no"
+    - name: SHOULD_BE_YES
+      value: "yes"
+    image: nginx:1.25
+    name: nginx-container
+---
+apiVersion: v1
+data:
+  VARIABLE: value
+kind: ConfigMap
+metadata:
+  name: var-source-mcc7828fcc
+`)
+}


### PR DESCRIPTION
Motivation:
Declaring any `vars:` entry in a kustomization caused unrelated quoted
string values (e.g. env values written as "no" or "yes") to silently
turn into real YAML/JSON booleans (false/true) in the built output,
even when those values never referenced a var at all.

Approach:
The var-reference filter (api/filters/refvar/refvar.go) walks every
scalar/map/seq node matching the built-in var-reference FieldSpecs
(e.g. spec/containers/env/value) looking for $(VAR) occurrences.
Previously it called updateNodeValue() on every visited node
unconditionally, even when DoReplacements() found nothing to
substitute and returned the value unchanged. updateNodeValue() always
resets node.Style to 0 (plain style), which strips an explicit
double-quote style from a value like "no". Once unquoted, the scalar
still carries a "!!str" tag, but that tag is not written back out to
the intermediate YAML text used later to render JSON, so a
YAML 1.1-based reparse resolves the now-bare "no"/"yes" as booleans.

This adds setReplacedValue(), used by setScalar/setMap/setSeq instead
of calling updateNodeValue() directly. It only updates the node (and
therefore only resets style/tag) when a replacement actually produced
a different string; otherwise the node, including its original
quoting, is left untouched. This does not touch RNode.MarshalJSON or
the integer-key JSON marshaling fix in kyaml/yaml/rnode.go.

Validation:
- Reproduced the exact scenario from the report locally with
  `kustomize build`, confirming "no"/"yes" became false/true before
  this change and remained "no"/"yes" after.
- Added TestVariableRefDoesNotClobberUnrelatedQuotedStrings to
  api/krusty/variableref_test.go, an end-to-end krusty test using the
  report's exact kustomization/resources; it fails before this change
  and passes after.
- Added a table case to TestFilter in
  api/filters/refvar/refvar_test.go exercising the same scenario at
  the filter level.
- Ran `go test ./... -ldflags "-X sigs.k8s.io/kustomize/api/provenance.buildDate=2023-01-31T23:38:41Z -X sigs.k8s.io/kustomize/api/provenance.version=(test)"` in api/, matching this repo's CI `test-modules` job for the api
  module exactly: all packages pass.
- Ran `go build ./...` in api/: succeeds.
- Ran golangci-lint v1.64.8 (the version pinned in hack/go.mod, since
  a globally installed v2 could not load this repo's v1-style
  .golangci.yml) against the changed packages: no findings.

Report: https://github.com/kubernetes-sigs/kustomize/issues/6233
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #6233

```release-note
fix: preserve quoted string style when a var-reference field has no $(VAR)
```