### PR TITLE
Revert "fix: support integer keys when marshaling resources to JSON"

### DIFF
--- a/api/krusty/configmaps_test.go
+++ b/api/krusty/configmaps_test.go
@@ -9,31 +9,6 @@ import (
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 )
 
-func TestIntegerKey(t *testing.T) {
-	th := kusttest_test.MakeHarness(t)
-	th.WriteK(".", `
-resources:
-- cm.yaml
-`)
-	th.WriteF("cm.yaml", `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm
-data:
-  123: abc
-`)
-	m := th.Run(".", th.MakeDefaultOptions())
-	th.AssertActualEqualsExpected(m, `
-apiVersion: v1
-data:
-  "123": abc
-kind: ConfigMap
-metadata:
-  name: cm
-`)
-}
-
 // Numbers and booleans are quoted
 func TestGeneratorIntVsStringNoMerge(t *testing.T) {
 	th := kusttest_test.MakeHarness(t)

--- a/api/krusty/duplicatekeys_test.go
+++ b/api/krusty/duplicatekeys_test.go
@@ -43,5 +43,5 @@ spec:
 	m := th.Run(".", th.MakeDefaultOptions())
 	_, err := m.AsYaml()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "key \"env\" already set in map")
+	assert.Contains(t, err.Error(), "mapping key \"env\" already defined")
 }

--- a/kyaml/yaml/rnode.go
+++ b/kyaml/yaml/rnode.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/sliceutil"
 	"sigs.k8s.io/kustomize/kyaml/utils"
 	"sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/labels"
-	k8syaml "sigs.k8s.io/yaml"
 )
 
 // MakeNullNode returns an RNode that represents an empty document.
@@ -984,11 +983,20 @@ func (rn *RNode) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	b, err := k8syaml.YAMLToJSONStrict([]byte(s))
-	if err != nil {
-		return nil, errors.Wrap(err)
+	if yNode.Kind == SequenceNode {
+		var a []interface{}
+		if err := Unmarshal([]byte(s), &a); err != nil {
+			return nil, err
+		}
+		return json.Marshal(a)
 	}
-	return b, nil
+
+	m := map[string]interface{}{}
+	if err := Unmarshal([]byte(s), &m); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
 }
 
 // UnmarshalJSON overwrites this RNode with data from []byte.


### PR DESCRIPTION
Reverts kubernetes-sigs/kustomize#6223
Those PR contains regression for `vars` transformer.
fix: https://github.com/kubernetes-sigs/kustomize/pull/6223