### PR TITLE
fix: add CronJob Image Volume support to images transformer

### DIFF
--- a/api/filters/imagetag/imagetag_test.go
+++ b/api/filters/imagetag/imagetag_test.go
@@ -957,6 +957,50 @@ spec:
 				},
 			},
 		},
+		"update image volume in cronjob": {
+			input: `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: imagevolume
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: volume
+            image:
+              reference: nginx
+`,
+			expectedOutput: `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: imagevolume
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: volume
+            image:
+              reference: apache@12345
+`,
+			filter: Filter{
+				ImageTag: types.Image{
+					Name:    "nginx",
+					NewName: "apache",
+					Digest:  "12345",
+				},
+			},
+			fsSlice: []types.FieldSpec{
+				{
+					Path: "spec/jobTemplate/spec/template/spec/volumes[]/image/reference",
+				},
+			},
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/api/internal/konfig/builtinpluginconsts/images.go
+++ b/api/internal/konfig/builtinpluginconsts/images.go
@@ -18,5 +18,7 @@ images:
   create: true
 - path: spec/template/spec/volumes[]/image/reference
   create: true
+- path: spec/jobTemplate/spec/template/spec/volumes[]/image/reference
+  create: true
 `
 )

--- a/api/krusty/transformersimage_test.go
+++ b/api/krusty/transformersimage_test.go
@@ -440,3 +440,97 @@ spec:
         name: nginx
 `)
 }
+
+// Image Volume (KEP-4639, spec.volumes[].image) references should be
+// rewritten by the default images config wherever kustomize also rewrites
+// container images: bare Pods, PodTemplate-based workloads, and CronJob,
+// whose containers live one level deeper under spec.jobTemplate.
+func TestTransfomersImageVolumeDefaultConfig(t *testing.T) {
+	th := kusttest_test.MakeHarness(t)
+	th.WriteK(".", `
+resources:
+- pod.yaml
+- deploy.yaml
+- cronjob.yaml
+images:
+- name: nginx
+  newTag: v2
+`)
+	th.WriteF("pod.yaml", `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  volumes:
+  - name: volume
+    image:
+      reference: nginx
+`)
+	th.WriteF("deploy.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      volumes:
+      - name: volume
+        image:
+          reference: nginx
+`)
+	th.WriteF("cronjob.yaml", `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: volume
+            image:
+              reference: nginx
+`)
+	m := th.Run(".", th.MakeDefaultOptions())
+	th.AssertActualEqualsExpected(m, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  volumes:
+  - image:
+      reference: nginx:v2
+    name: volume
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy
+spec:
+  template:
+    spec:
+      volumes:
+      - image:
+          reference: nginx:v2
+        name: volume
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cronjob
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - image:
+              reference: nginx:v2
+            name: volume
+`)
+}


### PR DESCRIPTION
This PR adds the missing `spec/jobTemplate/spec/template/spec/volumes[]/image/reference` path to the default `images` field spec.

CronJob's Image Volume references were not rewritten by `images:` because kubernetes-sigs/kustomize#5921, which added the `images` field spec paths for Pod and PodTemplateSpec-based workloads, did not include CronJob's path, which is nested one level deeper under `spec.jobTemplate`.

Closes kubernetes-sigs/kustomize#6238