### PR TITLE
fix: reject flag-like helmCharts releaseName and name values

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -92,6 +92,18 @@ func (p *HelmChartInflationGeneratorPlugin) validateArgs() (err error) {
 		return fmt.Errorf("chart name cannot be empty")
 	}
 
+	// ReleaseName and Name are passed to helm as bare positional arguments
+	// (see AsHelmArgs and pullCommand). A value starting with '-' would be
+	// parsed by helm as a flag instead of a release/chart name, allowing
+	// injection of arbitrary helm flags (e.g. --post-renderer) and
+	// resulting in command execution.
+	if strings.HasPrefix(p.ReleaseName, "-") {
+		return fmt.Errorf("releaseName must not start with '-', got %q", p.ReleaseName)
+	}
+	if strings.HasPrefix(p.Name, "-") {
+		return fmt.Errorf("chart name must not start with '-', got %q", p.Name)
+	}
+
 	// ChartHome might be consulted by the plugin (to read
 	// values files below it), so it must be located under
 	// the loader root (unless root restrictions are

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -4,6 +4,7 @@
 package kusttest_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -172,6 +173,24 @@ func (th *HarnessEnhanced) LoadAndRunGeneratorWithBuildAnnotations(
 		th.t.Fatalf("generate err: %v", err)
 	}
 	return rm
+}
+
+func (th *HarnessEnhanced) ErrorFromLoadAndRunGenerator(
+	config string) error {
+	res, err := th.rf.RF().FromBytes([]byte(config))
+	if err != nil {
+		th.t.Fatalf("Err: %v", err)
+	}
+	g, err := th.pl.LoadGenerator(
+		th.ldr, valtest_test.MakeFakeValidator(), res)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	_, err = g.Generate()
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
 }
 
 func (th *HarnessEnhanced) LoadAndRunTransformer(

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -100,6 +100,18 @@ func (p *plugin) validateArgs() (err error) {
 		return fmt.Errorf("chart name cannot be empty")
 	}
 
+	// ReleaseName and Name are passed to helm as bare positional arguments
+	// (see AsHelmArgs and pullCommand). A value starting with '-' would be
+	// parsed by helm as a flag instead of a release/chart name, allowing
+	// injection of arbitrary helm flags (e.g. --post-renderer) and
+	// resulting in command execution.
+	if strings.HasPrefix(p.ReleaseName, "-") {
+		return fmt.Errorf("releaseName must not start with '-', got %q", p.ReleaseName)
+	}
+	if strings.HasPrefix(p.Name, "-") {
+		return fmt.Errorf("chart name must not start with '-', got %q", p.Name)
+	}
+
 	// ChartHome might be consulted by the plugin (to read
 	// values files below it), so it must be located under
 	// the loader root (unless root restrictions are

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -360,6 +360,43 @@ spec:
         name: datadir
 `
 
+func TestHelmChartInflationGeneratorRejectsFlagLikeReleaseName(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+
+	err := th.ErrorFromLoadAndRunGenerator(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: myPipeline
+name: ocp-pipeline
+version: 0.1.16
+repo: https://bcgov.github.io/helm-charts
+releaseName: --post-renderer=./post-renderer.sh
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "releaseName must not start with '-'")
+}
+
+func TestHelmChartInflationGeneratorRejectsFlagLikeChartName(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+
+	err := th.ErrorFromLoadAndRunGenerator(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: myPipeline
+name: --post-renderer=./post-renderer.sh
+version: 0.1.16
+repo: https://bcgov.github.io/helm-charts
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chart name must not start with '-'")
+}
+
 func TestHelmChartInflationGeneratorWithValuesInlineOverride(t *testing.T) {
 	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
 		PrepBuiltin("HelmChartInflationGenerator")


### PR DESCRIPTION
`helmCharts[].releaseName` and `helmCharts[].name` are passed to `helm template` / `helm pull` as bare positional arguments, with no `--` separator. Helm's flag parser can't tell a bare positional from a flag, so a value starting with `-` gets parsed as a flag instead of a name. For example `releaseName: --post-renderer=./evil.sh` in a `kustomization.yaml` makes helm run `evil.sh` as a post-renderer during `kustomize build --enable-helm`. Other HelmChart fields are passed as `--flag value` pairs and aren't affected.

This adds a check in `validateArgs()` that rejects a `releaseName` or `name` starting with `-`, before any helm subprocess is spawned. The check is in the plugin source (`plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go`) and mirrored into the generated copy (`api/internal/builtins/HelmChartInflationGenerator.go`) via `go generate`, matching how this plugin is normally maintained.

Testing: added two tests using the injection string from the report, one for `releaseName` and one for `name`. With the check removed, both fail by reaching the real helm invocation; with it in place, both pass on the new validation error. `go vet` and `golangci-lint` are clean on the changed packages, and `go test` passes for the affected packages. (`go build ./...` in `plugin/builtin/helmchartinflationgenerator` fails both before and after this change with "function main is undeclared" — it's a `//go:generate` pluginator source file, not a standalone main package, so plain `go build` there isn't meaningful.)

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #6241

```release-note
fix: reject flag-like helmCharts releaseName and name values
```
