### PR TITLE
Fix typos in cfg docs and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ BREAKING CHANGE: parse() function now works with 2 arguments.
 If you ran `git push` in the previous step, GitHub will return a useful link to create a Pull Request.
 
 ### Build Kustomize
-The [Kustomize Architecture] document describes the respository organization and the kustomize build process.
+The [Kustomize Architecture] document describes the repository organization and the kustomize build process.
 ```bash
 # For go version >= 1.13
 unset GOPATH

--- a/cmd/config/docs/commands/tree.md
+++ b/cmd/config/docs/commands/tree.md
@@ -15,7 +15,7 @@ Args:
 
 Resource fields may be printed as part of the Resources by specifying the fields as flags.
 
-kustomize cfg tree has build-in support for printing common fields, such as replicas, container images,
+kustomize cfg tree has built-in support for printing common fields, such as replicas, container images,
 container names, etc.
 
 kustomize cfg tree supports printing arbitrary fields using the '--field' flag.

--- a/cmd/config/docs/tutorials/function-basics.md
+++ b/cmd/config/docs/tutorials/function-basics.md
@@ -49,7 +49,7 @@
 
   `run` facilitates a non-destructive *smart templating* approach that allows templating
   to be composed with manual modifications directly to the template output, as well as
-  composition with other functions which may appy validation or injection of values.
+  composition with other functions which may apply validation or injection of values.
 
   #### 3. Function Implementation
 

--- a/cmd/config/internal/generateddocs/commands/docs.go
+++ b/cmd/config/internal/generateddocs/commands/docs.go
@@ -422,7 +422,7 @@ Args:
 
 Resource fields may be printed as part of the Resources by specifying the fields as flags.
 
-kustomize cfg tree has build-in support for printing common fields, such as replicas, container images,
+kustomize cfg tree has built-in support for printing common fields, such as replicas, container images,
 container names, etc.
 
 kustomize cfg tree supports printing arbitrary fields using the '--field' flag.

--- a/cmd/config/internal/generateddocs/tutorials/docs.go
+++ b/cmd/config/internal/generateddocs/tutorials/docs.go
@@ -325,7 +325,7 @@ var (
 
   ` + "`" + `run` + "`" + ` facilitates a non-destructive *smart templating* approach that allows templating
   to be composed with manual modifications directly to the template output, as well as
-  composition with other functions which may appy validation or injection of values.
+  composition with other functions which may apply validation or injection of values.
 
   #### 3. Function Implementation
 


### PR DESCRIPTION
Three typo fixes. No functional changes.

- `appy` -> `apply` in the function-basics tutorial
- `build-in` -> `built-in` in the `kustomize cfg tree` command help
- `respository` -> `repository` in CONTRIBUTING.md

The first two live in `cmd/config/docs/` markdown that `mdtogo` compiles into `cmd/config/internal/generateddocs/`. I updated the generated Go files in the same commit so the two stay in sync — the edits match exactly what a regeneration would produce, so no `DO NOT EDIT` drift is introduced.