### PR TITLE
configure Dependabot for the Go workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,7 @@ updates:
       interval: "weekly"
 
 - package-ecosystem: gomod
-  directories:
-  - "**/*"
+  directory: "/"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
-  vulnerability-alerts:
-    enabled: true


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/kustomize/pull/6240

## What

Configure the Go modules updater with `directory: "/"` and remove the unsupported `vulnerability-alerts` option.

## Why

The repository root `go.work` lets Dependabot update all workspace modules, while the unsupported option prevents the configuration from being accepted.

## notice
This PR was generated by AI.