### PR TITLE
fix: pull helm charts atomically to survive concurrent kustomize builds

### DIFF
--- a/api/internal/builtins/HelmChartInflationGenerator.go
+++ b/api/internal/builtins/HelmChartInflationGenerator.go
@@ -275,7 +275,7 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err er
 			return nil, fmt.Errorf(
 				"no repo specified for pull, no chart found at '%s'", path)
 		}
-		if _, err := p.runHelmCommand(p.pullCommand()); err != nil {
+		if err := p.pullChart(); err != nil {
 			return nil, err
 		}
 	}
@@ -321,11 +321,40 @@ func (p *HelmChartInflationGeneratorPlugin) Generate() (rm resmap.ResMap, err er
 	return nil, fmt.Errorf("could not parse bytes into resource map: %w", resMapErr)
 }
 
-func (p *HelmChartInflationGeneratorPlugin) pullCommand() []string {
+// pullChart downloads the chart into a temporary directory inside the
+// chart home and then moves it into place. Concurrent kustomize processes
+// sharing a chart home may all try to pull the same chart, and helm refuses
+// to untar over an existing directory; pulling into a private directory
+// and renaming lets the first process win while the others keep the chart
+// it placed.
+func (p *HelmChartInflationGeneratorPlugin) pullChart() error {
+	chartHome := p.absChartHome()
+	if err := os.MkdirAll(chartHome, 0o755); err != nil {
+		return errors.WrapPrefixf(err, "unable to create chart home %s", chartHome)
+	}
+	tmpDir, err := os.MkdirTemp(chartHome, ".kustomize-pull-")
+	if err != nil {
+		return errors.WrapPrefixf(err, "unable to create temp dir in chart home %s", chartHome)
+	}
+	defer os.RemoveAll(tmpDir)
+	if _, err := p.runHelmCommand(p.pullCommand(tmpDir)); err != nil {
+		return err
+	}
+	chartDir := filepath.Join(chartHome, p.Name)
+	if err := os.Rename(filepath.Join(tmpDir, p.Name), chartDir); err != nil {
+		if _, exists := p.chartExistsLocally(); exists {
+			return nil
+		}
+		return errors.WrapPrefixf(err, "unable to move chart to %s", chartDir)
+	}
+	return nil
+}
+
+func (p *HelmChartInflationGeneratorPlugin) pullCommand(untarDir string) []string {
 	args := []string{
 		"pull",
 		"--untar",
-		"--untardir", p.absChartHome(),
+		"--untardir", untarDir,
 	}
 
 	switch {

--- a/api/testutils/kusttest/harnessenhanced.go
+++ b/api/testutils/kusttest/harnessenhanced.go
@@ -158,6 +158,16 @@ func (th *HarnessEnhanced) LoadAndRunGenerator(
 
 func (th *HarnessEnhanced) LoadAndRunGeneratorWithBuildAnnotations(
 	config string) resmap.ResMap {
+	rm, err := th.LoadGenerator(config).Generate()
+	if err != nil {
+		th.t.Fatalf("generate err: %v", err)
+	}
+	return rm
+}
+
+// LoadGenerator loads and configures a generator from config
+// without running it.
+func (th *HarnessEnhanced) LoadGenerator(config string) resmap.Generator {
 	res, err := th.rf.RF().FromBytes([]byte(config))
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
@@ -167,11 +177,7 @@ func (th *HarnessEnhanced) LoadAndRunGeneratorWithBuildAnnotations(
 	if err != nil {
 		th.t.Fatalf("Err: %v", err)
 	}
-	rm, err := g.Generate()
-	if err != nil {
-		th.t.Fatalf("generate err: %v", err)
-	}
-	return rm
+	return g
 }
 
 func (th *HarnessEnhanced) LoadAndRunTransformer(

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator.go
@@ -283,7 +283,7 @@ func (p *plugin) Generate() (rm resmap.ResMap, err error) {
 			return nil, fmt.Errorf(
 				"no repo specified for pull, no chart found at '%s'", path)
 		}
-		if _, err := p.runHelmCommand(p.pullCommand()); err != nil {
+		if err := p.pullChart(); err != nil {
 			return nil, err
 		}
 	}
@@ -329,11 +329,40 @@ func (p *plugin) Generate() (rm resmap.ResMap, err error) {
 	return nil, fmt.Errorf("could not parse bytes into resource map: %w", resMapErr)
 }
 
-func (p *plugin) pullCommand() []string {
+// pullChart downloads the chart into a temporary directory inside the
+// chart home and then moves it into place. Concurrent kustomize processes
+// sharing a chart home may all try to pull the same chart, and helm refuses
+// to untar over an existing directory; pulling into a private directory
+// and renaming lets the first process win while the others keep the chart
+// it placed.
+func (p *plugin) pullChart() error {
+	chartHome := p.absChartHome()
+	if err := os.MkdirAll(chartHome, 0o755); err != nil {
+		return errors.WrapPrefixf(err, "unable to create chart home %s", chartHome)
+	}
+	tmpDir, err := os.MkdirTemp(chartHome, ".kustomize-pull-")
+	if err != nil {
+		return errors.WrapPrefixf(err, "unable to create temp dir in chart home %s", chartHome)
+	}
+	defer os.RemoveAll(tmpDir)
+	if _, err := p.runHelmCommand(p.pullCommand(tmpDir)); err != nil {
+		return err
+	}
+	chartDir := filepath.Join(chartHome, p.Name)
+	if err := os.Rename(filepath.Join(tmpDir, p.Name), chartDir); err != nil {
+		if _, exists := p.chartExistsLocally(); exists {
+			return nil
+		}
+		return errors.WrapPrefixf(err, "unable to move chart to %s", chartDir)
+	}
+	return nil
+}
+
+func (p *plugin) pullCommand(untarDir string) []string {
 	args := []string{
 		"pull",
 		"--untar",
-		"--untardir", p.absChartHome(),
+		"--untardir", untarDir,
 	}
 
 	switch {

--- a/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
+++ b/plugin/builtin/helmchartinflationgenerator/HelmChartInflationGenerator_test.go
@@ -5,12 +5,17 @@ package main_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/resmap"
 	kusttest_test "sigs.k8s.io/kustomize/api/testutils/kusttest"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
 )
@@ -1024,4 +1029,85 @@ devel: true
 	require.NoError(t, err)
 	assert.Contains(t, string(chartYamlContent), "name: sm-operator")
 	assert.Contains(t, string(chartYamlContent), "version: 0.1.0-Beta")
+}
+
+// serveTestChartRepo packages a chart from testdata/charts and serves it
+// as a helm repository over HTTP, returning the repository URL.
+func serveTestChartRepo(t *testing.T, th *kusttest_test.HarnessEnhanced, chart string) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	srv := httptest.NewServer(http.FileServer(http.Dir(repoDir)))
+	t.Cleanup(srv.Close)
+
+	helm := th.GetPluginConfig().HelmConfig.Command
+	for _, args := range [][]string{
+		{"package", filepath.Join("testdata", "charts", chart), "--destination", repoDir},
+		{"repo", "index", repoDir, "--url", srv.URL},
+	} {
+		out, err := exec.Command(helm, args...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+	return srv.URL
+}
+
+func TestHelmChartInflationGeneratorConcurrentPull(t *testing.T) {
+	th := kusttest_test.MakeEnhancedHarnessWithTmpRoot(t).
+		PrepBuiltin("HelmChartInflationGenerator")
+	defer th.Reset()
+	if err := th.ErrIfNoHelm(); err != nil {
+		t.Skip("skipping: " + err.Error())
+	}
+
+	repo := serveTestChartRepo(t, th, "test-chart")
+
+	// Several generators share one chartHome and none of them finds the
+	// chart there, so all of them pull it at the same time.
+	const n = 8
+	generators := make([]resmap.Generator, n)
+	for i := range generators {
+		generators[i] = th.LoadGenerator(fmt.Sprintf(`
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: test-chart
+name: test-chart
+version: 1.0.0
+repo: %s
+releaseName: test-chart
+chartHome: ./charts
+`, repo))
+	}
+
+	results := make([]resmap.ResMap, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i, g := range generators {
+		wg.Add(1)
+		go func(i int, g resmap.Generator) {
+			defer wg.Done()
+			results[i], errs[i] = g.Generate()
+		}(i, g)
+	}
+	wg.Wait()
+
+	for i := range generators {
+		require.NoError(t, errs[i], "generator %d", i)
+		results[i].RemoveBuildAnnotations()
+		th.AssertActualEqualsExpected(results[i], `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bar
+`)
+	}
+
+	// Only the chart itself is left behind in the chart home.
+	entries, err := os.ReadDir(filepath.Join(th.GetRoot(), "charts", "test-chart-1.0.0"))
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.Equal(t, []string{"test-chart"}, names)
 }


### PR DESCRIPTION
Concurrent `kustomize build --enable-helm` runs that share a `chartHome` race on `helm pull --untar`: all but the first fail with `failed to untar: a file or directory with the name ... already exists` (#5271).

Fix: `pullChart()` pulls into a private temp dir inside the chart home and moves the chart into place with `os.Rename`, so helm never sees a collision and the chart directory is either absent or complete. If another process placed the chart first, that copy is used. `pullCommand()` takes the untar dir as a parameter; the on-disk layout of `chartHome` is unchanged.

Test: `TestHelmChartInflationGeneratorConcurrentPull` runs eight generators sharing one `chartHome` against a local httptest chart repo. It fails on master and passes with the fix.

Fixes #5271

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
