### PR TITLE
fix: hash the real content when ConfigMap data is not a map

### DIFF
--- a/api/hasher/hasher.go
+++ b/api/hasher/hasher.go
@@ -92,9 +92,15 @@ func getNodeValues(
 			if err != nil {
 				return map[string]interface{}{}, err
 			}
-			// data, binaryData and stringData are all maps
-			var v map[string]interface{}
-			json.Unmarshal(vs, &v)
+			// data, binaryData and stringData are normally maps, but a
+			// patch can replace them with any other JSON value, so decode
+			// into interface{} to make sure the hash always reflects the
+			// actual content.
+			var v interface{}
+			if err := json.Unmarshal(vs, &v); err != nil {
+				return map[string]interface{}{}, fmt.Errorf(
+					"unable to decode field %q: %w", p, err)
+			}
 			values[p] = v
 		} else {
 			values[p] = vn.YNode().Value

--- a/api/hasher/hasher_test.go
+++ b/api/hasher/hasher_test.go
@@ -355,3 +355,31 @@ func SkipRest(t *testing.T, desc string, err error, contains string) bool {
 	}
 	return false
 }
+
+// TestHashNonMapData verifies that the hash reflects the content of data even
+// when a patch has replaced it with something that is not a map. Before, the
+// json.Unmarshal error was dropped and every such ConfigMap hashed as if data
+// were null, so two ConfigMaps with different content collided.
+func TestHashNonMapData(t *testing.T) {
+	h := &Hasher{}
+	mk := func(data string) string {
+		t.Helper()
+		n, err := yaml.Parse(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+data: ` + data + "\n")
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		got, err := h.Hash(n)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+		return got
+	}
+	a, b := mk(`["A"]`), mk(`["B"]`)
+	if a == b {
+		t.Errorf("different data hashed identically: %q", a)
+	}
+}


### PR DESCRIPTION
`getNodeValues` collects the fields that feed the ConfigMap/Secret name suffix hash. For any non-scalar field it marshals the node to JSON and decodes it into a `map[string]interface{}`, discarding the decode error:

```go
// data, binaryData and stringData are all maps
var v map[string]interface{}
json.Unmarshal(vs, &v)
```

The comment holds for the value kustomize generates itself, but a `patches` entry can replace `data` with any JSON value. When it is not an object the decode fails, `v` stays nil, and the hash is computed over `"data": null`. Every ConfigMap in that shape hashes to the same suffix no matter what it contains.

Two builds that differ only in content, using a JSON 6902 patch that replaces `/data` with a sequence:

```
data:
- A          ->  name: cm-dk855m5d49
data:
- B          ->  name: cm-dk855m5d49
```

The same pair with an object value behaves correctly, which shows the hash is computed after patches over the final content rather than over the pre-patch value:

```
data: {k: A}  ->  name: cm-c74h26c25g
data: {k: B}  ->  name: cm-t6kk6cfb8c
```

The suffix exists so that changed content produces a new object name. Here the content changes and the name does not, so a rollout is silently skipped, and two such ConfigMaps applied to one namespace collide.

Decoding into `interface{}` keeps every hash that is correct today byte identical, since a JSON object still decodes to `map[string]interface{}` and `encodeConfigMap`'s `values["binaryData"].(map[string]interface{})` assertion is unaffected. Only the currently broken non-object case changes. Confirmed by diffing `kustomize build` output from both binaries across ConfigMap (plain, with binaryData, empty) and Secret (Opaque, kubernetes.io/tls) generators: identical.

After the fix the two sequence cases hash to `cm-9k92ch6bch` and `cm-td45tkc82d`.

Adds a regression test to `hasher_test.go`; it fails on master with `different data hashed identically: "dk855m5d49"`. `TestConfigMapHash` and `TestSecretHash` still pass, and the `api` module suite shows no new failures.
