### PR TITLE
fix: report the real file and index in kyaml input errors

### DIFF
--- a/kyaml/inpututil/inpututil.go
+++ b/kyaml/inpututil/inpututil.go
@@ -57,9 +57,7 @@ func WrapErrorWithFile(err error, meta yaml.ResourceMeta) error {
 		path = meta.Annotations[kioutil.LegacyPathAnnotation]
 	}
 	if index == "" {
-		index = meta.Annotations[kioutil.LegacyPathAnnotation]
+		index = meta.Annotations[kioutil.LegacyIndexAnnotation]
 	}
-	return errors.WrapPrefixf(err, "%s [%s]",
-		meta.Annotations[path],
-		meta.Annotations[index])
+	return errors.WrapPrefixf(err, "%s [%s]", path, index)
 }

--- a/kyaml/inpututil/inpututil_test.go
+++ b/kyaml/inpututil/inpututil_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package inpututil_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/kyaml/inpututil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestMapInputsEWrapsErrorWithFileAndIndex(t *testing.T) {
+	testCases := map[string]struct {
+		annotations string
+	}{
+		"internal annotations": {annotations: `
+      internal.config.kubernetes.io/path: 'deployment.yaml'
+      internal.config.kubernetes.io/index: '3'`},
+		"legacy annotations": {annotations: `
+      config.kubernetes.io/path: 'deployment.yaml'
+      config.kubernetes.io/index: '3'`},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			in, err := yaml.Parse(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  annotations:` + tc.annotations + `
+`)
+			require.NoError(t, err)
+
+			err = inpututil.MapInputsE([]*yaml.RNode{in},
+				func(*yaml.RNode, yaml.ResourceMeta) error {
+					return errors.New("boom")
+				})
+			require.EqualError(t, err, "deployment.yaml [3]: boom")
+		})
+	}
+}


### PR DESCRIPTION
`inpututil.WrapErrorWithFile` is supposed to decorate a KRM function error
with the file and document index the resource came from. It currently
produces ` []: <error>` for every input.

Two things go wrong in the same statement:

```go
path := meta.Annotations[kioutil.PathAnnotation]
index := meta.Annotations[kioutil.IndexAnnotation]
if path == "" {
	path = meta.Annotations[kioutil.LegacyPathAnnotation]
}
if index == "" {
	index = meta.Annotations[kioutil.LegacyPathAnnotation]
}
return errors.WrapPrefixf(err, "%s [%s]",
	meta.Annotations[path],
	meta.Annotations[index])
```

1. `path` and `index` already hold the annotation *values* (`deployment.yaml`,
   `3`), but they are then used as *keys* in a second `meta.Annotations` lookup.
   That lookup misses, so both format arguments are empty strings.
2. The legacy fallback for `index` reads `LegacyPathAnnotation` instead of
   `LegacyIndexAnnotation`, so a resource carrying only the legacy annotations
   resolves its index to the file path.

The fix uses the values that were already resolved and reads the index from
`LegacyIndexAnnotation`. This is the same resolution `kioutil.GetFileAnnotations`
already performs correctly for the identical pair of annotations.

Anything built on `inpututil.MapInputs` / `MapInputsE` is affected: the error a
function author surfaces cannot name the offending file or document, which is
the whole purpose of the wrapper.

**Before**

```
--- FAIL: TestMapInputsEWrapsErrorWithFileAndIndex/internal_annotations
    Error: Error message not equal:
           expected: "deployment.yaml [3]: boom"
           actual  : " []: boom"
```

**After**

```
--- PASS: TestMapInputsEWrapsErrorWithFileAndIndex/internal_annotations
--- PASS: TestMapInputsEWrapsErrorWithFileAndIndex/legacy_annotations
ok  	sigs.k8s.io/kustomize/kyaml/inpututil	0.041s
```

The `kyaml/inpututil` package had no tests; this adds one covering both the
internal and legacy annotation forms. All 34 packages in the `kyaml` module
still pass.
