### PR TITLE
fix: apply $patch: replace to list elements when patch lists are prepended

### DIFF
--- a/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
+++ b/api/filters/patchstrategicmerge/patchstrategicmerge_test.go
@@ -429,6 +429,52 @@ spec:
         image: replace
 `,
 		},
+		"replace list element - directive": {
+			input: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: test
+        env:
+        - name: KEEP
+          value: old
+      - name: sidecar
+        image: sidecar
+`,
+			patch: yaml.MustParse(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        $patch: replace
+        image: replace
+`),
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myDeploy
+spec:
+  template:
+    spec:
+      containers:
+      - name: test
+        image: replace
+      - name: sidecar
+        image: sidecar
+`,
+		},
 		"merge list - directive": {
 			input: `
 apiVersion: apps/v1

--- a/kyaml/yaml/merge2/list_test.go
+++ b/kyaml/yaml/merge2/list_test.go
@@ -304,6 +304,46 @@ spec:
           - name: foo3
 `,
 	},
+	{description: `replace k8s deployment container element -- $patch directive`,
+		source: `
+    apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo1
+            $patch: replace
+            image: new
+`,
+		dest: `
+    apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo1
+            image: old
+            ports:
+            - containerPort: 80
+          - name: foo2
+`,
+		expected: `
+    apiVersion: apps/v1
+    kind: Deployment
+    spec:
+      template:
+        spec:
+          containers:
+          - name: foo1
+            image: new
+          - name: foo2
+`,
+		mergeOptions: yaml.MergeOptions{
+			ListIncreaseDirection: yaml.MergeOptionsListPrepend,
+		},
+	},
 	{description: `remove k8s deployment containers -- $patch directive`,
 		source: `
     apiVersion: apps/v1

--- a/kyaml/yaml/walk/associative_sequence.go
+++ b/kyaml/yaml/walk/associative_sequence.go
@@ -16,12 +16,20 @@ import (
 // src and dst should be both sequence node. key is used to call ElementSetter.
 // ElementSetter will use key-value pair to find and set the element in sequence
 // node.
-func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
+// When overwrite is false, dst's own copy of an element is kept instead of
+// src's, so src only contributes the elements dst is missing and the ordering
+// of the ones it already has.
+func appendListNode(dst, src *yaml.RNode, keys []string, overwrite bool) (*yaml.RNode, error) {
 	var err error
 	for _, elem := range src.Content() {
 		// If key is empty, we know this is a scalar value and we can directly set the
 		// node
 		if keys[0] == "" {
+			if !overwrite {
+				if existing := dst.ElementList(keys, []string{elem.Value}); existing != nil {
+					elem = existing.YNode()
+				}
+			}
 			_, err = dst.Pipe(yaml.ElementSetter{
 				Element: elem,
 				Keys:    []string{""},
@@ -51,6 +59,14 @@ func appendListNode(dst, src *yaml.RNode, keys []string) (*yaml.RNode, error) {
 				continue
 			}
 			v = append(v, valueNode.YNode().Value)
+		}
+
+		// dst already holds this element and its copy is the merged one, so
+		// setting src's pre-merge copy below would undo the merge.
+		if !overwrite {
+			if existing := dst.ElementList(keys, v); existing != nil {
+				elem = existing.YNode()
+			}
 		}
 
 		// When there are multiple keys, ElementSetter appends the node to dst
@@ -232,11 +248,13 @@ func (l *Walker) setAssociativeSequenceElements(valuesList [][]string, keys []st
 	if len(valuesList) > 0 {
 		if l.MergeOptions.ListIncreaseDirection == yaml.MergeOptionsListPrepend {
 			// items from patches are needed to be prepended. so we append the
-			// dest to itemsToBeAdded
-			dest, err = appendListNode(itemsToBeAdded, dest, validKeys)
+			// dest to itemsToBeAdded. itemsToBeAdded already holds the merged
+			// result for every element walked above, so dest only supplies the
+			// elements that were not walked at all.
+			dest, err = appendListNode(itemsToBeAdded, dest, validKeys, false)
 		} else {
 			// append the items
-			dest, err = appendListNode(dest, itemsToBeAdded, validKeys)
+			dest, err = appendListNode(dest, itemsToBeAdded, validKeys, true)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A `$patch: replace` directive on an individual associative list element is silently dropped when the list is merged with `MergeOptionsListPrepend`. `api/filters/patchstrategicmerge` uses that direction, so this is not limited to direct kyaml callers — plain `kustomize build` is affected:

```yaml
# base container
- name: nginx
  image: nginx:1.0
  env:
  - name: KEEP_ME
    value: "old"

# patch
- name: nginx
  $patch: replace
  image: nginx:2.0
```

v5.8.x emits the base container untouched: the patch is a no-op, with no error. #5255 looks like the same bug reported from the CLI side.

`setAssociativeSequenceElements` walks every element of both sources into `itemsToBeAdded`, then folds the two lists together with `appendListNode`. For Append the merged items are written over `dest`; for Prepend the arguments are swapped to get the ordering right, so `dest` is written over the merged items instead. Ordinary merges survive that, because merging mutates `dest`'s nodes in place and the write-back is a no-op. `$patch: replace` does not: `Merger.VisitMap` returns the patch node rather than the mutated `dest` node, so `dest`'s pre-merge copy wins.

The fix keeps `dest`'s own copy of an element instead of overwriting it when folding in the prepend direction. `src` is still walked in full, so it keeps contributing the elements `dest` lacks and, for multi-key lists, the ordering pass that `appendListNode` performs by removing and re-adding each element. That ordering behaviour is load-bearing — the existing `list map keys - protocol only present on some ports` case (#3513) depends on it — so only the node being set changes, not the traversal.

`$patch: delete` on a list element is not affected: that path removes the element from `dest` before the fold, so there is nothing to write back.

Fixes #6146

**Prior art**: @rm3l opened #6147 for the same issue and got to the root cause first — the
argument swap in the prepend path — and the analysis in #6146 is theirs. I found that PR only
after opening this one. The approaches differ: #6147 adds `appendMissingListNode`, which skips
elements already present in `dest`, and that also skips the remove-then-re-add cycle that orders
multi-key lists, so it breaks `TestFilter/list_map_keys_-_protocol_only_present_on_some_ports`
in the `api` module (details in #6147). This PR keeps the traversal intact and only changes which
node gets set. Maintainers should take whichever they prefer; I am happy to close this one.

**Testing**:

Per the contributing guide this is split into two commits: the first adds the regression tests and fails, the second fixes them.

- `kyaml/yaml/merge2/list_test.go`: `replace k8s deployment container element -- $patch directive`, the direct unit case with `ListPrepend`.
- `api/filters/patchstrategicmerge/patchstrategicmerge_test.go`: `replace list element - directive`, covering the path `kustomize build` actually takes.

Run from the repo root: `go test ./...` in `kyaml`, `api`, `kustomize` and `cmd/config`, plus `golangci-lint run` on the touched packages. The only failures are pre-existing and environmental on my machine (the `TestFnContainer*` and `cmd/config` e2e tests need Docker; `api/provenance` needs release ldflags) — they fail identically on `master`.

/kind bug
